### PR TITLE
typos and tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .DS_Store
 logo/
 *.#*
+vendor/build/

--- a/HLint.hs
+++ b/HLint.hs
@@ -1,0 +1,10 @@
+module HLint(hint) where
+
+import "hint" HLint.Default
+import "hint" HLint.Dollar
+import "hint" HLint.HLint
+
+ignore "Eta reduce"
+ignore "Redundant do"
+ignore "Use camelCase"
+ignore "Redundant bracket"

--- a/README.md
+++ b/README.md
@@ -23,24 +23,13 @@ contributing developers at the current time.**
 | [`tools/`][tools] | Misc tools
 | [`vendor/`][vendor] | 3rd party dependencies as git submodules (links to TH C and other libraries)
 
-[codegen]: ./codegen/
-[core]: ./core/
-[examples]: ./examples/
-[interface]: ./interface/
-[nn]: ./nn/
-[output]: ./output/
-[raw]: ./raw/
-[tests]: ./tests/
-[tools]: ./tools/
-[vendor]: ./vendor/
-
 ## Build Instructions
 
 Currently building hasktorch is only supported on OSX and linux. To start,
 retrieve git submodules (includes TorcH library) with:
 
 ```
-git submodule update --init --recursive`
+git submodule update --init --recursive
 ```
 
 A recent version of the gcc C compiler is used to build the TorcH C library. If
@@ -64,7 +53,7 @@ stack build
 If everything built, you should be able to run tests successfully:
 
 ```
-stack test torch-tests
+stack test hasktorch-tests
 ```
 
 ## Code Generation
@@ -118,3 +107,19 @@ https://github.com/austinvhuang/hasktorch/projects/1
 
 - [Automatic Propagation of Uncertainty with AD](https://blog.jle.im/entry/automatic-propagation-of-uncertainty-with-ad.html)
 - [Automatic Differentiation is Trivial in Haskell](http://www.danielbrice.net/blog/2015-12-01/])
+
+
+<!-- project directory links -->
+
+[codegen]: ./codegen/
+[core]: ./core/
+[examples]: ./examples/
+[interface]: ./interface/
+[nn]: ./nn/
+[output]: ./output/
+[raw]: ./raw/
+[tests]: ./tests/
+[tools]: ./tools/
+[vendor]: ./vendor/
+
+

--- a/TODO.md
+++ b/TODO.md
@@ -4,6 +4,3 @@ In progress:
 - Add HSpec tests for core THTensor ops
 - Start THMath binding
 
-Finished
-
-- X Basic CI

--- a/codegen-and-rebuild.sh
+++ b/codegen-and-rebuild.sh
@@ -1,8 +1,15 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
 
-stack build torch-codegen
+stack build hasktorch-codegen || {
+  echo "can't build torch-codegen, exiting early"
+  exit 1
+}
+
 stack exec codegen-concrete
 stack exec codegen-generic
-cd output; ./refresh.sh; cd ..
+
+# use a subshell here to jump back to project root (SC2103)
+( cd output || exit 1; ./refresh.sh )
+
 stack clean
 stack build

--- a/codegen/README.md
+++ b/codegen/README.md
@@ -1,7 +1,9 @@
 # codegen
 
 Parse source files from the [TH][th] library and generate low-level bindings in
-Haskell. Warning - these parsers are just "good enough" to process their
-intended inputs, not robust enough for general purpose use. TODO: look into
-whether [bindings-DSL](https://hackage.haskell.org/package/bindings-DSL) might
-provide a more robust approach.
+Haskell.
+
+Warning - these parsers are just "good enough" to process their
+intended inputs, not robust enough for general purpose use.
+
+[th]: https://github.com/pytorch/pytorch/tree/master/torch/lib/TH

--- a/codegen/hasktorch-codegen.cabal
+++ b/codegen/hasktorch-codegen.cabal
@@ -49,4 +49,4 @@ source-repository head
   type:     git
   location: https://github.com/austinvhuang/hasktorch
 
-  
+

--- a/output/refresh.sh
+++ b/output/refresh.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 rsync -arv ./raw/src/*.hs ../raw/src/
 rsync -arv ./raw/src/generic/*.hs ../raw/src/generic/


### PR DESCRIPTION
So I did a first pass reading through the library and came across these typos and tweaks. I'll add some comments inline.

Some little things that might be nice, now that there will be more eyes on this project:
- unifying scripts into a Makefile
- adding hlint (included) -- I've started with some defaults to ignore. There are a lot of lints given the autogenerated code -- I would just say hlint suggestions should be treated as "guidelines."
- moving a lot of the little tests in individual files (like [this one](https://github.com/austinvhuang/hasktorch/blob/master/core/src/TensorRaw.hs#L150)) into package-level test suites seperate from `tests/`. I get the sense that the `tests/` folder is kind of like the "end-to-end" checks.
- Centralize TODO comments (and the TODO.md) to tickets or project cards.
- maybe work under a `Torch.*` module in core?

I mentioned this earlier, but I had a bit of trouble getting stack to honor the `extra-lib-dirs` while running `stack test`, putting `libTH.so` on my `LD_LIBRARY_PATH` works fine (and via package manager), but it was a little odd. I'm thinking some work on test suites might clear this up.