### PR TITLE
Changed the requirement of gcc-6 to gcc-7 when building on Mac

### DIFF
--- a/vendor/build-error-handler.sh
+++ b/vendor/build-error-handler.sh
@@ -5,13 +5,13 @@ mkdir -p ./build
 
 case "$(uname)" in
     "Darwin")
-        if ! [ -x "$(command -v gcc-6)" ]; then
-            echo 'Error: gcc-6 is not installed, use homebrew to install it.' >&2
+        if ! [ -x "$(command -v gcc-7)" ]; then
+            echo 'Error: gcc-7 is not installed, use homebrew to install it.' >&2
             exit 1
         fi
         echo "Running as OSX ..."
-        CXX=g++-6
-        CC=gcc-6
+        CXX=g++-7
+        CC=gcc-7
         EXTENSION=dylib
         DLARG=-dynamiclib
         ;;


### PR DESCRIPTION
Match the compiler requirement in `build-aten.sh` and `build-error-handler.sh` when building on Mac.