### PR TITLE
Introduced dispRawRealFloat for pretty printing 1d and 2d DoubleTensor.

### DIFF
--- a/core/hasktorch-core.cabal
+++ b/core/hasktorch-core.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 0bb57a602fbb24941b65c14496be40f7f24089484bc2bf5287cc612450c9a991
+-- hash: 2ae078d447c6ec69055085d5899a175e1e3249190e4875685997f032cf6d33aa
 
 name:           hasktorch-core
 version:        0.1.0.0
@@ -33,6 +33,7 @@ library
     , hasktorch-raw
     , managed >=1.0.0 && <1.1
     , microlens >=0.4.8.1
+    , numeric-limits
     , safe-exceptions >=0.1.0.0
     , singletons >=2.2
     , text >=1.2.2.2
@@ -99,6 +100,7 @@ test-suite spec
     , hspec
     , managed >=1.0.0 && <1.1
     , microlens >=0.4.8.1
+    , numeric-limits
     , safe-exceptions >=0.1.0.0
     , singletons >=2.2
     , text >=1.2.2.2

--- a/core/package.yaml
+++ b/core/package.yaml
@@ -26,6 +26,7 @@ dependencies:
 - typelits-witnesses >=0.2.3.0
 - dimensions >= 0.3.2.0
 - containers 
+- numeric-limits
 
 library:
   source-dirs:

--- a/core/src/Torch/Raw/Internal.hs
+++ b/core/src/Torch/Raw/Internal.hs
@@ -20,6 +20,13 @@ type instance HaskReal CTHIntTensor = CInt
 type instance HaskReal CTHLongTensor = CLong
 type instance HaskReal CTHShortTensor = CShort
 
+type instance HaskReal CTHByteStorage = CChar
+type instance HaskReal CTHDoubleStorage = CDouble
+type instance HaskReal CTHFloatStorage = CFloat
+type instance HaskReal CTHIntStorage = CInt
+type instance HaskReal CTHLongStorage = CLong
+type instance HaskReal CTHShortStorage = CShort
+
 -- | the "accreal" type of the bytetensor -- notation is taken from TH.
 type family HaskAccReal t
 type instance HaskAccReal CTHByteTensor = CLong

--- a/core/src/Torch/Raw/Storage.hs
+++ b/core/src/Torch/Raw/Storage.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TypeSynonymInstances #-}
+
 module Torch.Raw.Storage
   ( THStorage(..)
   , module X
@@ -5,13 +7,20 @@ module Torch.Raw.Storage
 
 import Torch.Raw.Internal as X
 
+import qualified THByteStorage as S
+import qualified THDoubleStorage as S
+import qualified THFloatStorage as S
+import qualified THIntStorage as S 
+import qualified THLongStorage as S
+import qualified THShortStorage as S
+
 -- CTHDoubleStorage -> CDouble
 class THStorage t where
   c_data :: Ptr t -> IO (Ptr CDouble)
   c_size :: Ptr t -> CPtrdiff
   -- c_elementSize :: CSize
   c_set :: Ptr t -> CPtrdiff -> CDouble -> IO ()
-  c_get :: Ptr t -> CPtrdiff -> CDouble
+  c_get :: Ptr t -> CPtrdiff -> (HaskReal t)
   c_new :: IO (Ptr t)
   c_newWithSize :: CPtrdiff -> IO (Ptr t)
   c_newWithSize1 :: CDouble -> IO (Ptr t)
@@ -51,3 +60,23 @@ class THStorage t where
   p_free :: FunPtr (Ptr t -> IO ())
   p_resize :: FunPtr (Ptr t -> CPtrdiff -> IO ())
   p_fill :: FunPtr (Ptr t -> CDouble -> IO ())
+
+
+-- TODO: Complete the implementations
+instance THStorage CTHByteStorage where
+  c_get = S.c_THByteStorage_get
+
+instance THStorage CTHDoubleStorage where
+  c_get = S.c_THDoubleStorage_get
+
+instance THStorage CTHFloatStorage where
+  c_get = S.c_THFloatStorage_get
+
+instance THStorage CTHIntStorage where
+  c_get = S.c_THIntStorage_get
+
+instance THStorage CTHLongStorage where
+  c_get = S.c_THLongStorage_get
+
+instance THStorage CTHShortStorage where
+  c_get = S.c_THShortStorage_get

--- a/core/src/generic/Torch/Core/Tensor/Dynamic/Double.hs
+++ b/core/src/generic/Torch/Core/Tensor/Dynamic/Double.hs
@@ -78,7 +78,7 @@ instance DynamicTH TensorDouble where
   shape = td_shape
 
 td_p :: TensorDouble -> IO ()
-td_p t = withForeignPtr (getForeign t) Gen.dispRaw
+td_p t = withForeignPtr (getForeign t) Gen.dispRawRealFloat
 
 -- | Initialize a tensor of arbitrary dimension from a list
 -- FIXME(stites): This should go in MonadThrow

--- a/stack.yaml
+++ b/stack.yaml
@@ -12,6 +12,7 @@ packages:
 
 extra-deps:
 - dimensions-0.3.2.0
+- numeric-limits-0.1.0.0
 
 flags: {}
 


### PR DESCRIPTION
`printTensor` on 1d and 2d double tensors now print properly formatted values.

Closes #53.