### PR TITLE
Add tds_eye to generate identity matrix

### DIFF
--- a/core/src/generic/Torch/Core/Tensor/Static/DoubleMath.hs
+++ b/core/src/generic/Torch/Core/Tensor/Static/DoubleMath.hs
@@ -23,6 +23,7 @@ module Torch.Core.Tensor.Static.DoubleMath
 
   , tds_fill
   , tds_fill_
+  , tds_eye
 
   , tds_addConst
   , tds_subConst
@@ -230,6 +231,16 @@ tds_fill value tensor = unsafePerformIO $
 tds_fill_ :: Real a => a -> (TDS d) -> IO ()
 tds_fill_ value tensor =
   withForeignPtr (getForeign tensor) (inplaceFill realToFrac value)
+
+tds_eye :: forall n . (KnownNatDim n) => TDS '[n, n]
+tds_eye = unsafePerformIO $ do
+  _ <- withForeignPtr (getForeign nt) (\t -> c_THDoubleTensor_eye t n n)
+  pure nt
+  where
+    nt :: TDS '[n, n]
+    nt = tds_new
+    n = round ((realToFrac $ natVal (Proxy :: Proxy n)) :: Double)
+{-# NOINLINE tds_eye #-}
 
 tds_addConst :: (SingDimensions d, Real p) => TDS d -> p -> TDS d
 tds_addConst mtx val = apply1_ tAdd mtx val


### PR DESCRIPTION
Just that, I'm writing functions as I'm needing them to write some models and examples.

Any comments and suggestions welcome! Specifically about type constraints to avoid `KnownNatDim` probably.