### PR TITLE
Update TH Reference in codegen/Readme.md

### DIFF
--- a/codegen/README.md
+++ b/codegen/README.md
@@ -26,7 +26,7 @@ For details on the TH library's pseudo-templating preprocessor mechanism for
 underlying the generic modules, see [Adam Paszke's
 writeup](https://apaszke.github.io/torch-internals.html).
 
-[th]: https://github.com/pytorch/pytorch/tree/master/torch/lib/TH
+[th]: https://github.com/pytorch/pytorch/tree/master/aten/src/TH
 
 <!-- project directory links -->
 


### PR DESCRIPTION
Fixed a dead link to TH in the codegen/Readme.md so it now points to the TH library within the PyTorch project.