### PR TITLE
Add stack.yaml

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,23 @@
+resolver: lts-13.2
+
+packages:
+- ffi/ffi/th/
+- ffi/ffi/thc/
+- ffi/types/th/
+- ffi/types/thc/
+- hasktorch/
+- indef/
+- signatures/
+- signatures/partial/
+- signatures/support/
+- signatures/types/
+
+extra-deps:
+- dimensions-1.0.1.1
+
+extra-include-dirs:
+  - ffi/deps/aten/build/include
+
+extra-lib-dirs:
+  - ffi/deps/aten/build/lib
+


### PR DESCRIPTION
This PR is trial to use stack. 
But following error happens.

```
> stack build
...
Building all executables for `hasktorch-signatures' once. After a successful build of all of them, only specified executables will be rebuilt.
hasktorch-signatures        > configure (lib + internal-lib + exe)
hasktorch-signatures        > Configuring hasktorch-signatures-0.0.1.0...
hasktorch-signatures        > Error:
hasktorch-signatures        >     The following packages are broken because other packages they depend on are missing. These broken packages must be rebuilt before they can be used.
hasktorch-signatures        > planned package hasktorch-signatures-0.0.1.0 is broken due to missing package hasktorch-signatures-partial-0.0.1.0-FkbKtqZSXzwLiEkfE3RTVZ+4wgymxdvbu48ub
hasktorch-signatures        > planned package hasktorch-signatures-0.0.1.0 is broken due to missing package hasktorch-signatures-partial-0.0.1.0-FkbKtqZSXzwLiEkfE3RTVZ+Eini2ZdVHrv2yF
hasktorch-signatures        > planned package hasktorch-signatures-0.0.1.0 is broken due to missing package hasktorch-signatures-partial-0.0.1.0-FkbKtqZSXzwLiEkfE3RTVZ+CeHBBWsdvNA1KE
hasktorch-signatures        > planned package hasktorch-signatures-0.0.1.0 is broken due to missing package hasktorch-signatures-partial-0.0.1.0-FkbKtqZSXzwLiEkfE3RTVZ+JJWdgvcZNIYFde
hasktorch-signatures        > planned package hasktorch-signatures-0.0.1.0 is broken due to missing package hasktorch-signatures-partial-0.0.1.0-FkbKtqZSXzwLiEkfE3RTVZ+4armw0d584q7vA
hasktorch-signatures        > planned package hasktorch-signatures-0.0.1.0 is broken due to missing package hasktorch-signatures-partial-0.0.1.0-FkbKtqZSXzwLiEkfE3RTVZ+5JnLirPLHIOFSv
hasktorch-signatures        > planned package hasktorch-signatures-0.0.1.0 is broken due to missing package hasktorch-signatures-partial-0.0.1.0-FkbKtqZSXzwLiEkfE3RTVZ+6n2x9a9EtLxGQi
hasktorch-signatures        > planned package hasktorch-signatures-0.0.1.0 is broken due to missing package hasktorch-signatures-partial-0.0.1.0-FkbKtqZSXzwLiEkfE3RTVZ+LKZrGARs75HJPQ
hasktorch-signatures        > planned package hasktorch-signatures-0.0.1.0 is broken due to missing package hasktorch-signatures-partial-0.0.1.0-FkbKtqZSXzwLiEkfE3RTVZ+5OyVmYeSdjB19F
hasktorch-signatures        > planned package hasktorch-signatures-0.0.1.0 is broken due to missing package hasktorch-signatures-partial-0.0.1.0-FkbKtqZSXzwLiEkfE3RTVZ+IuZq5bMJvKTARY
hasktorch-signatures        > planned package hasktorch-signatures-0.0.1.0 is broken due to missing package hasktorch-signatures-partial-0.0.1.0-FkbKtqZSXzwLiEkfE3RTVZ+9VQdccrNwqrLP9
hasktorch-signatures        > planned package hasktorch-signatures-0.0.1.0 is broken due to missing package hasktorch-signatures-partial-0.0.1.0-FkbKtqZSXzwLiEkfE3RTVZ+4SCFSbKW2FYbD6
hasktorch-signatures        > planned package hasktorch-signatures-0.0.1.0 is broken due to missing package hasktorch-signatures-partial-0.0.1.0-FkbKtqZSXzwLiEkfE3RTVZ+HukoqrlfWvm16y
hasktorch-signatures        >

--  While building package hasktorch-signatures-0.0.1.0 using:
      /home/junji-hashimoto/.stack/setup-exe-cache/x86_64-linux/Cabal-simple_mPHDZzAJ_2.4.0.1_ghc-8.6.3 --builddir=.stack-work/dist/x86_64-linux/Cabal-2.4.0.1 configure --user --pacs
    Process exited with code: ExitFailure 1
Progress 8/10

```
