### PR TITLE
Rename the package-name from ffi to libtorch-ffi

### DIFF
--- a/codegen/codegen.cabal
+++ b/codegen/codegen.cabal
@@ -2,7 +2,7 @@ name:                codegen
 version:             0.1.0.0
 synopsis:            parse torch yaml spec files, generate code
 -- description:
-homepage:            https://github.com/githubuser/ffi-experimental#readme
+homepage:            https://github.com/hasktorch/hasktorch#readme
 license:             BSD3
 author:              Austin Huang
 maintainer:          hasktorch@gmail.com

--- a/examples/examples.cabal
+++ b/examples/examples.cabal
@@ -2,7 +2,7 @@ name:                examples
 version:             0.2.0.0
 synopsis:            examples for the new version of hasktorch
 -- description:
-homepage:            https://github.com/githubuser/ffi-experimental#readme
+homepage:            https://github.com/hasktorch/hasktorch#readme
 license:             BSD3
 author:              Austin Huang
 maintainer:          hasktorch@gmail.com
@@ -30,7 +30,7 @@ executable elman
   build-depends:       base >= 4.7 && < 5
                      , hasktorch
                      , mtl
-                     , ffi
+                     , libtorch-ffi
 
 
 executable regression
@@ -40,7 +40,7 @@ executable regression
   build-depends:       base >= 4.7 && < 5
                      , hasktorch
                      , mtl
-                     , ffi
+                     , libtorch-ffi
 
 executable cnn
   hs-source-dirs:      cnn

--- a/ffi/libtorch-ffi.cabal
+++ b/ffi/libtorch-ffi.cabal
@@ -1,8 +1,9 @@
-name:                ffi
-version:             0.1.0.0
-synopsis:            test out alternative options for ffi interface to libtorch 1.0
+name:                libtorch-ffi
+version:             1.1.0.0
+-- The prefix(1.1) of this version("1.1.0.0") is the same as libtorch's one.
+synopsis:            test out alternative options for ffi interface to libtorch 1.x
 -- description:
-homepage:            https://github.com/githubuser/ffi-experimental#readme
+homepage:            https://github.com/hasktorch/hasktorch#readme
 license:             BSD3
 author:              Austin Huang
 maintainer:          hasktorch@gmail.com
@@ -102,7 +103,7 @@ test-suite spec
                      , inline-c
                      , optparse-applicative >= 0.14.3.0
                      , containers
-                     , ffi
+                     , libtorch-ffi
                      , hspec
                      , hspec-discover
                      , safe-exceptions

--- a/hasktorch/hasktorch.cabal
+++ b/hasktorch/hasktorch.cabal
@@ -2,7 +2,7 @@ name:                hasktorch
 version:             0.2.0.0
 synopsis:            initial implementation for hasktorch based on libtorch
 -- description:
-homepage:            https://github.com/githubuser/ffi-experimental#readme
+homepage:            https://github.com/hasktorch/hasktorch#readme
 license:             BSD3
 author:              Austin Huang
 maintainer:          hasktorch@gmail.com
@@ -30,7 +30,7 @@ library
  default-language:    Haskell2010
  ghc-options:         -fplugin GHC.TypeLits.KnownNat.Solver -fconstraint-solver-iterations=0
  build-depends:       base >= 4.7 && < 5
-                    , ffi
+                    , libtorch-ffi
                     , finite-typelits
                     , ghc-typelits-knownnat
                     , mtl


### PR DESCRIPTION
Before uploading this package to hackage, this pr renames `ffi`-package to `libtorch-ffi`-package.
