### PR TITLE
WIP: shell.nix that provides all the dependencies

### DIFF
--- a/libtorch-ffi/libtorch-ffi.cabal
+++ b/libtorch-ffi/libtorch-ffi.cabal
@@ -71,11 +71,11 @@ library
  extra-ghci-libraries: stdc++
  if os(darwin)
   ld-options: -Wl,-keep_dwarf_unwind
-  ghc-options:       -optc-D_GLIBCXX_USE_CXX11_ABI=0 -optc-std=c++11 -optc-xc++
+  ghc-options:       -optc-D_GLIBCXX_USE_CXX11_ABI=1 -optc-std=c++11 -optc-xc++
  else
-  ghc-options:       -optc-D_GLIBCXX_USE_CXX11_ABI=0 -optc-std=c++11
- cc-options:        -D_GLIBCXX_USE_CXX11_ABI=0 -std=c++11
- cxx-options:       -D_GLIBCXX_USE_CXX11_ABI=0 -std=c++11
+  ghc-options:       -optc-D_GLIBCXX_USE_CXX11_ABI=1 -optc-std=c++11
+ cc-options:        -D_GLIBCXX_USE_CXX11_ABI=1 -std=c++11
+ cxx-options:       -D_GLIBCXX_USE_CXX11_ABI=1 -std=c++11
  default-extensions:          Strict
                             , StrictData
 

--- a/libtorch-ffi/libtorch-ffi.cabal
+++ b/libtorch-ffi/libtorch-ffi.cabal
@@ -71,11 +71,11 @@ library
  extra-ghci-libraries: stdc++
  if os(darwin)
   ld-options: -Wl,-keep_dwarf_unwind
-  ghc-options:       -optc-D_GLIBCXX_USE_CXX11_ABI=1 -optc-std=c++11 -optc-xc++
+  ghc-options:       -optc-std=c++11 -optc-xc++
  else
-  ghc-options:       -optc-D_GLIBCXX_USE_CXX11_ABI=1 -optc-std=c++11
- cc-options:        -D_GLIBCXX_USE_CXX11_ABI=1 -std=c++11
- cxx-options:       -D_GLIBCXX_USE_CXX11_ABI=1 -std=c++11
+  ghc-options:       -optc-std=c++11
+ cc-options:         -std=c++11
+ cxx-options:        -std=c++11
  default-extensions:          Strict
                             , StrictData
 

--- a/libtorch-ffi/libtorch-ffi.cabal
+++ b/libtorch-ffi/libtorch-ffi.cabal
@@ -65,8 +65,8 @@ library
                     , async
  extra-libraries:     stdc++
                     , c10
-                    , iomp5
-                    , mklml
+                    -- , iomp5   -- for now
+                    -- , mklml
                     , torch
  extra-ghci-libraries: stdc++
  if os(darwin)

--- a/libtorch-ffi/libtorch-ffi.cabal
+++ b/libtorch-ffi/libtorch-ffi.cabal
@@ -65,8 +65,8 @@ library
                     , async
  extra-libraries:     stdc++
                     , c10
-                    -- , iomp5   -- for now
-                    -- , mklml
+                    , iomp5
+                    -- , mklml -- for now. not yet clear about mkl-dnn.
                     , torch
  extra-ghci-libraries: stdc++
  if os(darwin)

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import <nixpkgs> {} }:
+{ pkgs ? import <nixpkgs> { config.allowUnfree = true; } }:
 
 with pkgs;
 
@@ -7,14 +7,20 @@ let
   hsenv = haskellPackages.ghcWithPackages (p: with p; [
     cabal-install
     ansi-wl-pprint
+    async
     bytestring
     containers
+    exceptions
     hashable
     mtl
+    optparse-applicative
     parsec
     parsers
+    safe-exceptions
+    sysinfo
     template-haskell
     transformers
+    transformers-compat
     unordered-containers
     vector
   ]);
@@ -23,6 +29,6 @@ in
 
 stdenv.mkDerivation {
   name = "hasktorch-dev";
-  buildInputs = [ hsenv ];
+  buildInputs = [ hsenv mkl ];
 
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import <nixpkgs> { config.allowUnfree = true; } }:
+{ pkgs ? import <nixpkgs> { config.allowUnfree = true; config.allowUnsupportedSystem = true; } }:
 
 with pkgs;
 
@@ -29,6 +29,6 @@ in
 
 stdenv.mkDerivation {
   name = "hasktorch-dev";
-  buildInputs = [ hsenv mkl ];
+  buildInputs = [ hsenv python3Packages.pytorchWithoutCuda ];
 
 }

--- a/shell.nix
+++ b/shell.nix
@@ -41,18 +41,21 @@ let
     vector
   ]);
 
+  pytorch = python3Packages.pytorchWithoutCuda.override {
+    mklSupport = true; inherit mkl;
+  };
+
 in
 
 stdenv.mkDerivation {
   name = "hasktorch-dev";
-  buildInputs = [ hsenv mkl python3Packages.pytorchWithoutCuda ];
+  buildInputs = [ hsenv pytorch pytorch.dev mkl ];
+
+  # pytorch.dev has include files in a non-standard way.
+  # For development, we use CPATH to fix it.
   shellHook =
-    let
-      libtorch_path = "${python3Packages.pytorchWithoutCuda}/lib/${python3Packages.python.libPrefix}/site-packages/torch";
-    in
   ''
-    export CPATH=${libtorch_path}/include/torch/csrc/api/include
-    export LD_LIBRARY_PATH=${libtorch_path}/lib
+    export CPATH=${pytorch.dev}/include/torch/csrc/api/include
   '';
 
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,28 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+with pkgs;
+
+let
+
+  hsenv = haskellPackages.ghcWithPackages (p: with p; [
+    cabal-install
+    ansi-wl-pprint
+    bytestring
+    containers
+    hashable
+    mtl
+    parsec
+    parsers
+    template-haskell
+    transformers
+    unordered-containers
+    vector
+  ]);
+
+in
+
+stdenv.mkDerivation {
+  name = "hasktorch-dev";
+  buildInputs = [ hsenv ];
+
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,14 @@
-{ pkgs ? import <nixpkgs> { config.allowUnfree = true; config.allowUnsupportedSystem = true; } }:
+{ pkgs ?
+   let
+     # revision: https://github.com/NixOS/nixpkgs/pull/65041
+     rev = "9420c33455c5b3e0876813bdd739bc75b3ccbd8a";
+     url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
+     # nix-prefetch-url --unpack ${url}
+     sha256 = "0l82qfcmip0mfijcxssaliyxayfh0c11bk66yhwna1ixc0s0jjd2";
+     nixpkgs = builtins.fetchTarball { inherit url sha256; };
+   in
+     import nixpkgs { config.allowUnfree = true; config.allowUnsupportedSystem = true; }
+}:
 
 with pkgs;
 

--- a/shell.nix
+++ b/shell.nix
@@ -39,6 +39,9 @@ in
 
 stdenv.mkDerivation {
   name = "hasktorch-dev";
-  buildInputs = [ hsenv python3Packages.pytorchWithoutCuda ];
+  buildInputs = [ hsenv mkl python3Packages.pytorchWithoutCuda ];
+  shellHook = ''
+    export CPATH=${python3Packages.pytorchWithoutCuda}/lib/${python3Packages.python.libPrefix}/site-packages/torch/include/torch/csrc/api/include
+  '';
 
 }

--- a/shell.nix
+++ b/shell.nix
@@ -21,11 +21,17 @@ let
     bytestring
     containers
     exceptions
+    finite-typelits
+    ghc-typelits-knownnat
     hashable
+    hspec
+    hspec-discover
     mtl
     optparse-applicative
     parsec
     parsers
+    QuickCheck
+    reflection
     safe-exceptions
     sysinfo
     template-haskell
@@ -40,8 +46,13 @@ in
 stdenv.mkDerivation {
   name = "hasktorch-dev";
   buildInputs = [ hsenv mkl python3Packages.pytorchWithoutCuda ];
-  shellHook = ''
-    export CPATH=${python3Packages.pytorchWithoutCuda}/lib/${python3Packages.python.libPrefix}/site-packages/torch/include/torch/csrc/api/include
+  shellHook =
+    let
+      libtorch_path = "${python3Packages.pytorchWithoutCuda}/lib/${python3Packages.python.libPrefix}/site-packages/torch";
+    in
+  ''
+    export CPATH=${libtorch_path}/include/torch/csrc/api/include
+    export LD_LIBRARY_PATH=${libtorch_path}/lib
   '';
 
 }


### PR DESCRIPTION
To make hasktorch buildable simply.
```
$ nix-shell shell.nix
$ cabal new-build hasktorch
```

Note: this is not yet finalized since I disabled `mkl` and adjusted C++11 ABI flag. I would like to have some discussion about them.