### PR TITLE
hasktorch as a nix package

### DIFF
--- a/hasktorch/default.nix
+++ b/hasktorch/default.nix
@@ -1,0 +1,19 @@
+{ mkDerivation, base, finite-typelits, ghc-typelits-knownnat, hspec
+, hspec-discover, libtorch-ffi, mtl, QuickCheck, reflection
+, safe-exceptions, stdenv
+}:
+mkDerivation {
+  pname = "hasktorch";
+  version = "0.2.0.0";
+  src = ./.;
+  libraryHaskellDepends = [
+    base finite-typelits ghc-typelits-knownnat libtorch-ffi mtl
+    reflection safe-exceptions
+  ];
+  testHaskellDepends = [
+    base hspec hspec-discover mtl QuickCheck reflection safe-exceptions
+  ];
+  homepage = "https://github.com/hasktorch/hasktorch#readme";
+  description = "initial implementation for hasktorch based on libtorch";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/libtorch-ffi/default.nix
+++ b/libtorch-ffi/default.nix
@@ -1,0 +1,27 @@
+{ mkDerivation, async, base, bytestring, containers, hspec
+, hspec-discover, inline-c, inline-c-cpp, mkl
+, optparse-applicative, safe-exceptions, stdenv, sysinfo
+, template-haskell, torch
+}:
+mkDerivation {
+  pname = "libtorch-ffi";
+  version = "1.1.0.0";
+  src = ./.;
+  libraryHaskellDepends = [
+    async base bytestring containers inline-c inline-c-cpp
+    optparse-applicative safe-exceptions sysinfo template-haskell
+  ];
+  librarySystemDepends = [ mkl torch ];
+  testHaskellDepends = [
+    base containers hspec hspec-discover inline-c inline-c-cpp
+    optparse-applicative safe-exceptions
+  ];
+
+  configureFlags = [ "--extra-include-dirs=${torch}/include/torch/csrc/api/include" ];
+
+  doHaddock = false;
+
+  homepage = "https://github.com/hasktorch/hasktorch#readme";
+  description = "test out alternative options for ffi interface to libtorch 1.x";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/libtorch-ffi/libtorch-ffi.cabal
+++ b/libtorch-ffi/libtorch-ffi.cabal
@@ -71,11 +71,11 @@ library
  extra-ghci-libraries: stdc++
  if os(darwin)
   ld-options: -Wl,-keep_dwarf_unwind
-  ghc-options:       -optc-D_GLIBCXX_USE_CXX11_ABI=0 -optc-std=c++11 -optc-xc++
+  ghc-options:       -optc-D_GLIBCXX_USE_CXX11_ABI=1 -optc-std=c++11 -optc-xc++
  else
-  ghc-options:       -optc-D_GLIBCXX_USE_CXX11_ABI=0 -optc-std=c++11
- cc-options:        -D_GLIBCXX_USE_CXX11_ABI=0 -std=c++11
- cxx-options:       -D_GLIBCXX_USE_CXX11_ABI=0 -std=c++11
+  ghc-options:       -optc-D_GLIBCXX_USE_CXX11_ABI=1 -optc-std=c++11
+ cc-options:        -D_GLIBCXX_USE_CXX11_ABI=1 -std=c++11
+ cxx-options:       -D_GLIBCXX_USE_CXX11_ABI=1 -std=c++11
  default-extensions:          Strict
                             , StrictData
 

--- a/libtorch-ffi/libtorch-ffi.cabal
+++ b/libtorch-ffi/libtorch-ffi.cabal
@@ -71,11 +71,11 @@ library
  extra-ghci-libraries: stdc++
  if os(darwin)
   ld-options: -Wl,-keep_dwarf_unwind
-  ghc-options:       -optc-D_GLIBCXX_USE_CXX11_ABI=1 -optc-std=c++11 -optc-xc++
+  ghc-options:       -optc-std=c++11 -optc-xc++
  else
-  ghc-options:       -optc-D_GLIBCXX_USE_CXX11_ABI=1 -optc-std=c++11
- cc-options:        -D_GLIBCXX_USE_CXX11_ABI=1 -std=c++11
- cxx-options:       -D_GLIBCXX_USE_CXX11_ABI=1 -std=c++11
+  ghc-options:       -optc-std=c++11
+ cc-options:         -std=c++11
+ cxx-options:        -std=c++11
  default-extensions:          Strict
                             , StrictData
 

--- a/libtorch-ffi/libtorch-ffi.cabal
+++ b/libtorch-ffi/libtorch-ffi.cabal
@@ -65,8 +65,8 @@ library
                     , async
  extra-libraries:     stdc++
                     , c10
-                    , iomp5
-                    , mklml
+                    -- , iomp5   -- for now
+                    -- , mklml
                     , torch
  extra-ghci-libraries: stdc++
  if os(darwin)

--- a/libtorch-ffi/libtorch-ffi.cabal
+++ b/libtorch-ffi/libtorch-ffi.cabal
@@ -65,8 +65,8 @@ library
                     , async
  extra-libraries:     stdc++
                     , c10
-                    -- , iomp5   -- for now
-                    -- , mklml
+                    , iomp5
+                    -- , mklml -- for now. not yet clear about mkl-dnn.
                     , torch
  extra-ghci-libraries: stdc++
  if os(darwin)

--- a/nix/inline-c-cpp.nix
+++ b/nix/inline-c-cpp.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, base, containers, hspec, inline-c, safe-exceptions
+, stdenv, template-haskell
+}:
+mkDerivation {
+  pname = "inline-c-cpp";
+  version = "0.3.0.1";
+  src = ../inline-c/inline-c-cpp;
+  libraryHaskellDepends = [
+    base containers inline-c safe-exceptions template-haskell
+  ];
+  testHaskellDepends = [
+    base containers hspec inline-c safe-exceptions
+  ];
+  description = "Lets you embed C++ code into Haskell";
+  license = stdenv.lib.licenses.mit;
+}

--- a/nix/inline-c.nix
+++ b/nix/inline-c.nix
@@ -1,0 +1,24 @@
+{ mkDerivation, ansi-wl-pprint, base, bytestring, containers
+, hashable, hspec, mtl, parsec, parsers, QuickCheck
+, raw-strings-qq, regex-posix, stdenv, template-haskell
+, transformers, unordered-containers, vector
+}:
+mkDerivation {
+  pname = "inline-c";
+  version = "0.7.0.1";
+  src = ../inline-c/inline-c;
+  isLibrary = true;
+  isExecutable = false;
+  libraryHaskellDepends = [
+    ansi-wl-pprint base bytestring containers hashable mtl parsec
+    parsers template-haskell transformers unordered-containers vector
+  ];
+  executableSystemDepends = [];
+  testHaskellDepends = [
+    ansi-wl-pprint base containers hashable hspec parsers QuickCheck
+    raw-strings-qq regex-posix template-haskell transformers
+    unordered-containers vector
+  ];
+  description = "Write Haskell source files including C code inline. No FFI required.";
+  license = stdenv.lib.licenses.mit;
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import <nixpkgs> {} }:
+{ pkgs ? import <nixpkgs> { config.allowUnfree = true; } }:
 
 with pkgs;
 
@@ -7,14 +7,20 @@ let
   hsenv = haskellPackages.ghcWithPackages (p: with p; [
     cabal-install
     ansi-wl-pprint
+    async
     bytestring
     containers
+    exceptions
     hashable
     mtl
+    optparse-applicative
     parsec
     parsers
+    safe-exceptions
+    sysinfo
     template-haskell
     transformers
+    transformers-compat
     unordered-containers
     vector
   ]);
@@ -23,6 +29,6 @@ in
 
 stdenv.mkDerivation {
   name = "hasktorch-dev";
-  buildInputs = [ hsenv ];
+  buildInputs = [ hsenv mkl ];
 
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import <nixpkgs> { config.allowUnfree = true; } }:
+{ pkgs ? import <nixpkgs> { config.allowUnfree = true; config.allowUnsupportedSystem = true; } }:
 
 with pkgs;
 
@@ -29,6 +29,6 @@ in
 
 stdenv.mkDerivation {
   name = "hasktorch-dev";
-  buildInputs = [ hsenv mkl ];
+  buildInputs = [ hsenv python3Packages.pytorchWithoutCuda ];
 
 }

--- a/shell.nix
+++ b/shell.nix
@@ -41,18 +41,21 @@ let
     vector
   ]);
 
+  pytorch = python3Packages.pytorchWithoutCuda.override {
+    mklSupport = true; inherit mkl;
+  };
+
 in
 
 stdenv.mkDerivation {
   name = "hasktorch-dev";
-  buildInputs = [ hsenv mkl python3Packages.pytorchWithoutCuda ];
+  buildInputs = [ hsenv pytorch pytorch.dev mkl ];
+
+  # pytorch.dev has include files in a non-standard way.
+  # For development, we use CPATH to fix it.
   shellHook =
-    let
-      libtorch_path = "${python3Packages.pytorchWithoutCuda}/lib/${python3Packages.python.libPrefix}/site-packages/torch";
-    in
   ''
-    export CPATH=${libtorch_path}/include/torch/csrc/api/include
-    export LD_LIBRARY_PATH=${libtorch_path}/lib
+    export CPATH=${pytorch.dev}/include/torch/csrc/api/include
   '';
 
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,28 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+with pkgs;
+
+let
+
+  hsenv = haskellPackages.ghcWithPackages (p: with p; [
+    cabal-install
+    ansi-wl-pprint
+    bytestring
+    containers
+    hashable
+    mtl
+    parsec
+    parsers
+    template-haskell
+    transformers
+    unordered-containers
+    vector
+  ]);
+
+in
+
+stdenv.mkDerivation {
+  name = "hasktorch-dev";
+  buildInputs = [ hsenv ];
+
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,14 @@
-{ pkgs ? import <nixpkgs> { config.allowUnfree = true; config.allowUnsupportedSystem = true; } }:
+{ pkgs ?
+   let
+     # revision: https://github.com/NixOS/nixpkgs/pull/65041
+     rev = "9420c33455c5b3e0876813bdd739bc75b3ccbd8a";
+     url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
+     # nix-prefetch-url --unpack ${url}
+     sha256 = "0l82qfcmip0mfijcxssaliyxayfh0c11bk66yhwna1ixc0s0jjd2";
+     nixpkgs = builtins.fetchTarball { inherit url sha256; };
+   in
+     import nixpkgs { config.allowUnfree = true; config.allowUnsupportedSystem = true; }
+}:
 
 with pkgs;
 

--- a/shell.nix
+++ b/shell.nix
@@ -39,6 +39,9 @@ in
 
 stdenv.mkDerivation {
   name = "hasktorch-dev";
-  buildInputs = [ hsenv python3Packages.pytorchWithoutCuda ];
+  buildInputs = [ hsenv mkl python3Packages.pytorchWithoutCuda ];
+  shellHook = ''
+    export CPATH=${python3Packages.pytorchWithoutCuda}/lib/${python3Packages.python.libPrefix}/site-packages/torch/include/torch/csrc/api/include
+  '';
 
 }

--- a/shell.nix
+++ b/shell.nix
@@ -53,8 +53,7 @@ stdenv.mkDerivation {
 
   # pytorch.dev has include files in a non-standard way.
   # For development, we use CPATH to fix it.
-  shellHook =
-  ''
+  shellHook = ''
     export CPATH=${pytorch.dev}/include/torch/csrc/api/include
   '';
 

--- a/shell.nix
+++ b/shell.nix
@@ -21,11 +21,17 @@ let
     bytestring
     containers
     exceptions
+    finite-typelits
+    ghc-typelits-knownnat
     hashable
+    hspec
+    hspec-discover
     mtl
     optparse-applicative
     parsec
     parsers
+    QuickCheck
+    reflection
     safe-exceptions
     sysinfo
     template-haskell
@@ -40,8 +46,13 @@ in
 stdenv.mkDerivation {
   name = "hasktorch-dev";
   buildInputs = [ hsenv mkl python3Packages.pytorchWithoutCuda ];
-  shellHook = ''
-    export CPATH=${python3Packages.pytorchWithoutCuda}/lib/${python3Packages.python.libPrefix}/site-packages/torch/include/torch/csrc/api/include
+  shellHook =
+    let
+      libtorch_path = "${python3Packages.pytorchWithoutCuda}/lib/${python3Packages.python.libPrefix}/site-packages/torch";
+    in
+  ''
+    export CPATH=${libtorch_path}/include/torch/csrc/api/include
+    export LD_LIBRARY_PATH=${libtorch_path}/lib
   '';
 
 }

--- a/user-shell.nix
+++ b/user-shell.nix
@@ -26,6 +26,7 @@ let
       libtorch-ffi = self.callPackage ./libtorch-ffi {
         torch = pytorch.dev;
       };
+      hasktorch = self.callPackage ./hasktorch {};
     };
   };
 
@@ -33,13 +34,18 @@ let
     inline-c
     inline-c-cpp
     libtorch-ffi
+    hasktorch
+    # add any dependencies for your project
+    random
+    call-stack
+    hspec
   ]);
 
 in
 
 stdenv.mkDerivation {
   name = "hasktorch-env";
-  buildInputs = [ hsenv ];
+  buildInputs = [ hsenv pytorch.dev mkl ];
 
   shellHook = ''
   '';

--- a/user-shell.nix
+++ b/user-shell.nix
@@ -15,16 +15,24 @@
 with pkgs;
 
 let
+  pytorch = python3Packages.pytorchWithoutCuda.override {
+    mklSupport = true; inherit mkl;
+  };
+
   myHaskellPackages = haskellPackages.override {
     overrides = self: super: {
       inline-c = self.callPackage ./nix/inline-c.nix {};
       inline-c-cpp = self.callPackage ./nix/inline-c-cpp.nix {};
+      libtorch-ffi = self.callPackage ./libtorch-ffi {
+        torch = pytorch.dev;
+      };
     };
   };
 
   hsenv = myHaskellPackages.ghcWithPackages (p: with p; [
     inline-c
     inline-c-cpp
+    libtorch-ffi
   ]);
 
 in

--- a/user-shell.nix
+++ b/user-shell.nix
@@ -1,0 +1,39 @@
+## User shell for using hasktorch as a user
+
+{ pkgs ?
+   let
+     # revision: https://github.com/NixOS/nixpkgs/pull/65041
+     rev = "9420c33455c5b3e0876813bdd739bc75b3ccbd8a";
+     url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
+     # nix-prefetch-url --unpack ${url}
+     sha256 = "0l82qfcmip0mfijcxssaliyxayfh0c11bk66yhwna1ixc0s0jjd2";
+     nixpkgs = builtins.fetchTarball { inherit url sha256; };
+   in
+     import nixpkgs { config.allowUnfree = true; config.allowUnsupportedSystem = true; }
+}:
+
+with pkgs;
+
+let
+  myHaskellPackages = haskellPackages.override {
+    overrides = self: super: {
+      inline-c = self.callPackage ./nix/inline-c.nix {};
+      inline-c-cpp = self.callPackage ./nix/inline-c-cpp.nix {};
+    };
+  };
+
+  hsenv = myHaskellPackages.ghcWithPackages (p: with p; [
+    inline-c
+    inline-c-cpp
+  ]);
+
+in
+
+stdenv.mkDerivation {
+  name = "hasktorch-env";
+  buildInputs = [ hsenv ];
+
+  shellHook = ''
+  '';
+
+}


### PR DESCRIPTION
On top of #162, I packaged hasktorch 0.0.2 as a nix package, also with libtorch-ffi as a nix package.
For user (not a hasktorch developer), I created `user-shell.nix` which set up the dependencies for using hasktorch by running 
```
$ nix-shell user-shell.nix
```