### PR TITLE
nixified hasktorch projects using cabal2nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ deps/mklml
 cabal.project.local
 cabal.project.freeze
 venv/
+**/dist/
 
 *.swp
 *.lock

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ cabal.project.local
 cabal.project.freeze
 venv/
 **/dist/
+**/result
 
 *.swp
 *.lock

--- a/codegen/default.nix
+++ b/codegen/default.nix
@@ -1,0 +1,1 @@
+(import ../nix/shared.nix { }).hasktorch-codegen

--- a/codegen/shell.nix
+++ b/codegen/shell.nix
@@ -1,0 +1,1 @@
+(import ../nix/shared.nix { }).shell-hasktorch-codegen

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,9 @@
+let
+  shared = import ./nix/shared.nix { };
+in
+  { inherit (shared)
+      libtorch-ffi
+      hasktorch
+      hasktorch-codegen
+    ;
+  }

--- a/hasktorch/default.nix
+++ b/hasktorch/default.nix
@@ -1,0 +1,1 @@
+(import ../nix/shared.nix { }).hasktorch

--- a/hasktorch/shell.nix
+++ b/hasktorch/shell.nix
@@ -1,0 +1,1 @@
+(import ../nix/shared.nix { }).shell-hasktorch

--- a/libtorch-ffi/default.nix
+++ b/libtorch-ffi/default.nix
@@ -1,0 +1,1 @@
+(import ../nix/shared.nix { }).libtorch-ffi

--- a/libtorch-ffi/libtorch-ffi.cabal
+++ b/libtorch-ffi/libtorch-ffi.cabal
@@ -64,10 +64,7 @@ library
                     , sysinfo
                     , async
  extra-libraries:     stdc++
-                    , c10
-                    , iomp5
-                    , mklml
-                    , torch
+                    , libtorch-cuda
  extra-ghci-libraries: stdc++
  if os(darwin)
   ld-options: -Wl,-keep_dwarf_unwind

--- a/libtorch-ffi/libtorch-ffi.cabal
+++ b/libtorch-ffi/libtorch-ffi.cabal
@@ -64,15 +64,18 @@ library
                     , sysinfo
                     , async
  extra-libraries:     stdc++
-                    , pytorch
+                    , c10
+                    -- , iomp5
+                    -- , mklml
+                    , torch
  extra-ghci-libraries: stdc++
  if os(darwin)
   ld-options: -Wl,-keep_dwarf_unwind
-  ghc-options:       -optc-D_GLIBCXX_USE_CXX11_ABI=0 -optc-std=c++11 -optc-xc++
+  ghc-options:       -optc-std=c++11 -optc-xc++
  else
-  ghc-options:       -optc-D_GLIBCXX_USE_CXX11_ABI=0 -optc-std=c++11
- cc-options:        -D_GLIBCXX_USE_CXX11_ABI=0 -std=c++11
- cxx-options:       -D_GLIBCXX_USE_CXX11_ABI=0 -std=c++11
+  ghc-options:       -optc-std=c++11
+ cc-options:        -std=c++11
+ cxx-options:       -std=c++11
  default-extensions:          Strict
                             , StrictData
 

--- a/libtorch-ffi/libtorch-ffi.cabal
+++ b/libtorch-ffi/libtorch-ffi.cabal
@@ -64,7 +64,7 @@ library
                     , sysinfo
                     , async
  extra-libraries:     stdc++
-                    , libtorch-cuda
+                    , pytorch
  extra-ghci-libraries: stdc++
  if os(darwin)
   ld-options: -Wl,-keep_dwarf_unwind

--- a/libtorch-ffi/shell.nix
+++ b/libtorch-ffi/shell.nix
@@ -1,0 +1,1 @@
+(import ../nix/shared.nix { }).shell-libtorch-ffi

--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,0 +1,7 @@
+{
+  "url": "https://github.com/NixOS/nixpkgs-channels",
+  "rev": "973a2705351605915bda866f01f65c8fae304985",
+  "date": "2019-07-16T21:39:25+03:00",
+  "sha256": "06sp132w8difm9kjz71gh9q6pbcy3k9l8cbzpab44m5mwsm0z8x9",
+  "fetchSubmodules": false
+}

--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,7 +1,7 @@
 {
-  "url": "https://github.com/NixOS/nixpkgs-channels",
-  "rev": "973a2705351605915bda866f01f65c8fae304985",
-  "date": "2019-07-16T21:39:25+03:00",
-  "sha256": "06sp132w8difm9kjz71gh9q6pbcy3k9l8cbzpab44m5mwsm0z8x9",
+  "url": "https://github.com/NixOS/nixpkgs.git",
+  "rev": "9420c33455c5b3e0876813bdd739bc75b3ccbd8a",
+  "date": "2019-08-29T15:38:10-04:00",
+  "sha256": "0l82qfcmip0mfijcxssaliyxayfh0c11bk66yhwna1ixc0s0jjd2",
   "fetchSubmodules": false
 }

--- a/nix/shared.nix
+++ b/nix/shared.nix
@@ -1,0 +1,106 @@
+{ compiler ? "ghc865" }:
+
+let
+  overlayShared = pkgsNew: pkgsOld: {
+    libtorch-cuda =
+      let src = pkgsOld.fetchFromGitHub {
+          owner  = "stites";
+          repo   = "pytorch-world";
+          rev    = "4c4bd205e47477c723209f3677bddceabb614237";
+          sha256 = "1zqhm0874gfs1qp3glc1i1dswlrksby1wf9dr4pclkabs0smbqxc";
+        };
+      in
+      (import "${src}/release.nix" { }).libtorch-cuda;
+    haskell = pkgsOld.haskell // {
+      packages = pkgsOld.haskell.packages // {
+        "${compiler}" = pkgsOld.haskell.packages."${compiler}".override (old: {
+            overrides =
+              let
+                failOnAllWarnings = pkgsOld.haskell.lib.failOnAllWarnings;
+                overrideExtraLibraries = drv: xs: pkgsOld.haskell.lib.overrideCabal drv (drv: { extraLibraries = xs; });
+
+                extension =
+                  haskellPackagesNew: haskellPackagesOld: {
+                    hasktorch =
+                      # failOnAllWarnings
+                        (haskellPackagesNew.callCabal2nix
+                          "hasktorch"
+                          ../hasktorch
+                          { }
+                        );
+                    hasktorch-codegen =
+                      failOnAllWarnings
+                        (haskellPackagesNew.callCabal2nix
+                          "codegen"
+                          ../codegen
+                          { }
+                        );
+                    libtorch-ffi =
+                      # failOnAllWarnings
+                        (haskellPackagesNew.callCabal2nix
+                          "libtorch-ffi"
+                          ../libtorch-ffi
+                          { }
+                        );
+                    inline-c =
+                      # failOnAllWarnings
+                        (haskellPackagesNew.callCabal2nix
+                          "inline-c"
+                          ../inline-c/inline-c
+                          { }
+                        );
+                    inline-c-cpp =
+                      # failOnAllWarnings
+                        (haskellPackagesNew.callCabal2nix
+                          "inline-c-cpp"
+                          ../inline-c/inline-c-cpp
+                          { }
+                        );
+                  };
+
+              in
+                pkgsNew.lib.fold
+                  pkgsNew.lib.composeExtensions
+                  (old.overrides or (_: _: {}))
+                  [ (pkgsNew.haskell.lib.packagesFromDirectory { directory = ./.; })
+
+                    extension
+                  ];
+          }
+        );
+      };
+    };
+  };
+
+  bootstrap = import <nixpkgs> { };
+
+  nixpkgs = builtins.fromJSON (builtins.readFile ./nixpkgs.json);
+
+  src = bootstrap.fetchFromGitHub {
+    owner = "NixOS";
+    repo  = "nixpkgs";
+    inherit (nixpkgs) rev sha256;
+  };
+
+  pkgs = import src {
+    config = {};
+    overlays = [ overlayShared ];
+  };
+
+in
+  rec {
+    inherit (pkgs.haskell.packages."${compiler}")
+      hasktorch
+      hasktorch-codegen
+      libtorch-ffi
+      inline-c
+      inline-c-cpp
+    ;
+
+    shell-hasktorch = (pkgs.haskell.lib.doBenchmark pkgs.haskell.packages."${compiler}".hasktorch).env;
+    shell-hasktorch-codegen = (pkgs.haskell.lib.doBenchmark pkgs.haskell.packages."${compiler}".hasktorch-codegen).env;
+    shell-libtorch-ffi = (pkgs.haskell.lib.doBenchmark pkgs.haskell.packages."${compiler}".libtorch-ffi).env;
+    shell-inline-c = (pkgs.haskell.lib.doBenchmark pkgs.haskell.packages."${compiler}".inline-c).env;
+    shell-inline-c-cpp = (pkgs.haskell.lib.doBenchmark pkgs.haskell.packages."${compiler}".inline-c-cpp).env;
+  }
+

--- a/nix/shared.nix
+++ b/nix/shared.nix
@@ -2,20 +2,24 @@
 
 let
   overlayShared = pkgsNew: pkgsOld: {
-    libtorch-cuda =
-      let src = pkgsOld.fetchFromGitHub {
-          owner  = "stites";
-          repo   = "pytorch-world";
-          rev    = "4c4bd205e47477c723209f3677bddceabb614237";
-          sha256 = "1zqhm0874gfs1qp3glc1i1dswlrksby1wf9dr4pclkabs0smbqxc";
-        };
-      in
-      (import "${src}/release.nix" { }).libtorch-cuda;
+    #libtorch-cuda =
+    #  let src = pkgsOld.fetchFromGitHub {
+    #      owner  = "stites";
+    #      repo   = "pytorch-world";
+    #      rev    = "4c4bd205e47477c723209f3677bddceabb614237";
+    #      sha256 = "1zqhm0874gfs1qp3glc1i1dswlrksby1wf9dr4pclkabs0smbqxc";
+    #    };
+    #  in
+    #  (import "${src}/release.nix" { }).libtorch-cuda;
+    pytorch = pkgsOld.python3Packages.pytorchWithoutCuda.override {
+      mklSupport = true;
+    };
     haskell = pkgsOld.haskell // {
       packages = pkgsOld.haskell.packages // {
         "${compiler}" = pkgsOld.haskell.packages."${compiler}".override (old: {
             overrides =
               let
+                dontCheck = pkgsOld.haskell.lib.dontCheck;
                 failOnAllWarnings = pkgsOld.haskell.lib.failOnAllWarnings;
                 overrideExtraLibraries = drv: xs: pkgsOld.haskell.lib.overrideCabal drv (drv: { extraLibraries = xs; });
 
@@ -83,7 +87,7 @@ let
   };
 
   pkgs = import src {
-    config = {};
+    config = { allowUnsupportedSystem = true; allowUnfree = true; };
     overlays = [ overlayShared ];
   };
 

--- a/nix/sysinfo.nix
+++ b/nix/sysinfo.nix
@@ -1,0 +1,11 @@
+{ mkDerivation, base, hspec, hspec-expectations, stdenv }:
+mkDerivation {
+  pname = "sysinfo";
+  version = "0.1.1";
+  sha256 = "0afa9nv1sf1c4w2d9ysm0ass4a48na1mb3x9ri3nb5c6s7r41ns6";
+  libraryHaskellDepends = [ base ];
+  testHaskellDepends = [ base hspec hspec-expectations ];
+  description = "Haskell Interface for getting overall system statistics";
+  license = stdenv.lib.licenses.bsd3;
+  doCheck = false;
+}

--- a/release.nix
+++ b/release.nix
@@ -1,0 +1,7 @@
+let
+  shared = import ./nix/shared.nix { };
+in
+  { inherit (shared)
+      hasktorch
+    ;
+  }


### PR DESCRIPTION
alternative to #164 using cabal2nix and extensive sharing between derivations.
it’s the same approach that Gabriel Gonzales used for dhall, see https://github.com/dhall-lang/dhall-haskell/blob/master/nix/shared.nix.

@wavewave @stites @junjihashimoto pls let me know what you think :)
