### PR TITLE
Drop -D_GLIBCXX_USE_CXX11_ABI=0

### DIFF
--- a/deps/get-deps.sh
+++ b/deps/get-deps.sh
@@ -76,17 +76,17 @@ if [ "$SKIP_DOWNLOAD" = 0 ] ; then
       ;;
     "Linux")
       if [ "$USE_NIGHTLY" = 1 ] ; then
-        wget https://download.pytorch.org/libtorch/nightly/${COMPUTE_ARCH}/libtorch-shared-with-deps-latest.zip
-        unzip libtorch-shared-with-deps-latest.zip
-        rm libtorch-shared-with-deps-latest.zip
+        wget https://download.pytorch.org/libtorch/nightly/${COMPUTE_ARCH}/libtorch-cxx11-abi-shared-with-deps-latest.zip
+        unzip libtorch-cxx11-abi-shared-with-deps-latest.zip
+        rm libtorch-cxx11-abi-shared-with-deps-latest.zip
       elif [ "$USE_BINARY_FOR_CI" = 1 ] ; then
-        wget https://github.com/hasktorch/libtorch-binary-for-ci/releases/download/${VERSION}/${COMPUTE_ARCH}-libtorch-shared-with-deps-latest.zip
-        unzip ${COMPUTE_ARCH}-libtorch-shared-with-deps-latest.zip
-        rm ${COMPUTE_ARCH}-libtorch-shared-with-deps-latest.zip
+        wget https://github.com/hasktorch/libtorch-binary-for-ci/releases/download/${VERSION}/${COMPUTE_ARCH}-libtorch-cxx11-abi-shared-with-deps-latest.zip
+        unzip ${COMPUTE_ARCH}-libtorch-cxx11-abi-shared-with-deps-latest.zip
+        rm ${COMPUTE_ARCH}-libtorch-cxx11-abi-shared-with-deps-latest.zip
       else
-        wget https://download.pytorch.org/libtorch/${COMPUTE_ARCH}/libtorch-shared-with-deps-${VERSION}.zip
-        unzip libtorch-shared-with-deps-${VERSION}.zip
-        rm libtorch-shared-with-deps-${VERSION}.zip
+        wget https://download.pytorch.org/libtorch/${COMPUTE_ARCH}/libtorch-cxx11-abi-shared-with-deps-${VERSION}.zip
+        unzip libtorch-cxx11-abi-shared-with-deps-${VERSION}.zip
+        rm libtorch-cxx11-abi-shared-with-deps-${VERSION}.zip
       fi
       wget https://github.com/intel/mkl-dnn/releases/download/v0.17.2/mklml_lnx_2019.0.1.20181227.tgz
       tar -xzf mklml_lnx_2019.0.1.20181227.tgz

--- a/libtorch-ffi/libtorch-ffi.cabal
+++ b/libtorch-ffi/libtorch-ffi.cabal
@@ -71,11 +71,11 @@ library
  extra-ghci-libraries: stdc++
  if os(darwin)
   ld-options: -Wl,-keep_dwarf_unwind
-  ghc-options:       -optc-D_GLIBCXX_USE_CXX11_ABI=0 -optc-std=c++11 -optc-xc++
+  ghc-options:       -optc-std=c++11 -optc-xc++
  else
-  ghc-options:       -optc-D_GLIBCXX_USE_CXX11_ABI=0 -optc-std=c++11
- cc-options:        -D_GLIBCXX_USE_CXX11_ABI=0 -std=c++11
- cxx-options:       -D_GLIBCXX_USE_CXX11_ABI=0 -std=c++11
+  ghc-options:       -optc-std=c++11
+ cc-options:        -std=c++11
+ cxx-options:       -std=c++11
  default-extensions:          Strict
                             , StrictData
 
@@ -100,10 +100,10 @@ test-suite spec
                      , safe-exceptions
   if os(darwin)
     ld-options: -Wl,-keep_dwarf_unwind
-    ghc-options:       -optc-D_GLIBCXX_USE_CXX11_ABI=0 -optc-std=c++11 -optc-xc++
+    ghc-options:       -optc-std=c++11 -optc-xc++
   else
-    ghc-options:       -optc-D_GLIBCXX_USE_CXX11_ABI=0 -optc-std=c++11
-  cc-options:        -D_GLIBCXX_USE_CXX11_ABI=0 -std=c++11
-  cxx-options:       -D_GLIBCXX_USE_CXX11_ABI=0 -std=c++11
+    ghc-options:       -optc-std=c++11
+  cc-options:        -std=c++11
+  cxx-options:       -std=c++11
   default-extensions:          Strict
                              , StrictData


### PR DESCRIPTION
libtorch begins to provide binaries using C++11ABI.
(Old C++ABI with  -D_GLIBCXX_USE_CXX11_ABI=0 is to keep backward compatibility for nvcc using gcc-4.)
https://discuss.pytorch.org/t/issues-linking-with-libtorch-c-11-abi/29510/2
https://github.com/hasktorch/hasktorch/pull/162

This PR changes the C++ABI to C++11ABI.
