### PR TITLE
Move some CI-builds to github-actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ workflows:
   version: 2
   build:
     jobs:
-      - "stack-build"
-      - "cabal-build"
+#      - "stack-build"
       - "osx-stack-build"
-      - "nix-build"
+#      - "cabal-build"
+#      - "nix-build"

--- a/.github/workflows/cabal-linux.yml
+++ b/.github/workflows/cabal-linux.yml
@@ -1,0 +1,37 @@
+name: cabal-linux
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v1
+    - name: Setup packages
+      run: |
+        sudo apt update -qq
+        sudo apt -y --allow-downgrades --allow-remove-essential --allow-change-held-packages install locales software-properties-common apt-transport-https
+        sudo add-apt-repository -y ppa:hvr/ghc
+        sudo apt update -qq
+        sudo apt -y --allow-downgrades --allow-remove-essential --allow-change-held-packages install build-essential zlib1g-dev liblapack-dev libblas-dev ghc-8.6.5 cabal-install-head devscripts debhelper python3-pip cmake curl wget unzip git libtinfo-dev python3 python3-yaml
+        update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+    - name: Setup repos
+      run: |
+        git submodule init && git submodule update
+    - name: Build
+      run: |
+        export PATH=/opt/ghc/bin:$PATH
+        source setenv
+        pushd deps/ ; ./get-deps.sh -a cpu -c; popd
+        ./setup-cabal.sh
+        cabal new-update
+        cabal new-install hspec-discover
+        cabal new-build all --jobs=2 --write-ghc-environment-files=always
+    - name: Test
+      run: |
+        export PATH=/opt/ghc/bin:$PATH
+        source setenv
+        cabal new-test all --jobs=2 --write-ghc-environment-files=always
+        cabal new-exec codegen-exe
+        cabal exec xor_mlp

--- a/.github/workflows/cabal-linux.yml
+++ b/.github/workflows/cabal-linux.yml
@@ -15,7 +15,6 @@ jobs:
         sudo add-apt-repository -y ppa:hvr/ghc
         sudo apt update -qq
         sudo apt -y --allow-downgrades --allow-remove-essential --allow-change-held-packages install build-essential zlib1g-dev liblapack-dev libblas-dev ghc-8.6.5 cabal-install-head devscripts debhelper python3-pip cmake curl wget unzip git libtinfo-dev python3 python3-yaml
-        update-alternatives --install /usr/bin/python python /usr/bin/python3 1
     - name: Setup repos
       run: |
         git submodule init && git submodule update

--- a/.github/workflows/nix-linux.yml
+++ b/.github/workflows/nix-linux.yml
@@ -1,11 +1,11 @@
-name: Haskell CI
+name: nix-linux
 
 on: [push, pull_request]
 
 jobs:
   build:
 
-    runs-on: macOS-latest
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - name: Setup nix
@@ -14,10 +14,10 @@ jobs:
         curl https://nixos.org/nix/install | sh
     - name: Setup cachix
       run: |
-        . /Users/runner/.nix-profile/etc/profile.d/nix.sh
+        . ~/.nix-profile/etc/profile.d/nix.sh
         nix-env -iA cachix -f https://cachix.org/api/v1/install
     - name: Build
       run: |
-        . /Users/runner/.nix-profile/etc/profile.d/nix.sh
+        . ~/.nix-profile/etc/profile.d/nix.sh
         cachix use pytorch-world
         nix-build

--- a/.github/workflows/nix-macos.yml
+++ b/.github/workflows/nix-macos.yml
@@ -1,0 +1,23 @@
+name: nix-macos
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: macOS-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Setup nix
+      run: |
+        git submodule init && git submodule update
+        curl https://nixos.org/nix/install | sh
+    - name: Setup cachix
+      run: |
+        . /Users/runner/.nix-profile/etc/profile.d/nix.sh
+        nix-env -iA cachix -f https://cachix.org/api/v1/install
+    - name: Build
+      run: |
+        . /Users/runner/.nix-profile/etc/profile.d/nix.sh
+        cachix use pytorch-world
+        nix-build

--- a/.github/workflows/stack-linux.yml
+++ b/.github/workflows/stack-linux.yml
@@ -1,0 +1,34 @@
+name: stack-linux
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v1
+    - name: Setup packages
+      run: |
+        sudo apt update -qq
+        sudo apt -y --allow-downgrades --allow-remove-essential --allow-change-held-packages install cmake curl wget unzip git libtinfo-dev python3 python3-yaml
+        wget -qO- https://get.haskellstack.org/ | sh
+        update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+    - name: Setup repos
+      run: |
+        git submodule init && git submodule update
+    - name: Build
+      run: |
+        export PATH=/opt/ghc/bin:$PATH
+        source setenv
+        pushd deps/ ; ./get-deps.sh -a cpu -c; popd
+        stack build
+    - name: Test
+      run: |
+        export PATH=/opt/ghc/bin:$PATH
+        source setenv
+        stack test codegen
+        stack test libtorch-ffi
+        stack test hasktorch
+        stack exec codegen-exe
+        stack exec xor_mlp

--- a/.github/workflows/stack-linux.yml
+++ b/.github/workflows/stack-linux.yml
@@ -13,7 +13,6 @@ jobs:
         sudo apt update -qq
         sudo apt -y --allow-downgrades --allow-remove-essential --allow-change-held-packages install cmake curl wget unzip git libtinfo-dev python3 python3-yaml
         wget -qO- https://get.haskellstack.org/ | sh
-        update-alternatives --install /usr/bin/python python /usr/bin/python3 1
     - name: Setup repos
       run: |
         git submodule init && git submodule update


### PR DESCRIPTION
Sometimes, CI fails for not enough memory.
Circleci's instance has 4GB. Github-actions's one has [7GB](https://github.com/features/actions
).
So this PR changes CI-instances into github-actions's one.
I remain "osx-stack-build" on circleci, because the build is stable.(I do not know why it is stable.)
and  CircleCi is usable to debug. It can allow ssh-login.

