### PR TITLE
Rename Static to Typed

### DIFF
--- a/examples/static-mnist-cnn/Main.hs
+++ b/examples/static-mnist-cnn/Main.hs
@@ -36,10 +36,10 @@ import qualified ATen.Class                    as ATen
 import qualified ATen.Type                     as ATen
 import qualified ATen.Managed.Type.Tensor      as ATen
 import qualified ATen.Managed.Type.Context     as ATen
-import           Torch.Static
-import           Torch.Static.Native
-import           Torch.Static.Factories
-import           Torch.Static.NN
+import           Torch.Typed
+import           Torch.Typed.Native
+import           Torch.Typed.Factories
+import           Torch.Typed.NN
 import qualified Torch.Autograd                as A
 import qualified Torch.NN                      as A
 import qualified Torch.DType                   as D
@@ -76,16 +76,16 @@ cnn
   -> Tensor dtype '[batchSize, I.DataDim]
   -> Tensor dtype '[batchSize, I.ClassDim]
 cnn CNN {..} =
-  Torch.Static.NN.linear fc1
+  Torch.Typed.NN.linear fc1
     . relu
-    . Torch.Static.NN.linear fc0
+    . Torch.Typed.NN.linear fc0
     . reshape @'[batchSize, 4*4*50]
     . maxPool2d @KernelSize @Strides @NoPadding
     . relu
-    . Torch.Static.NN.conv2d @NoStrides @NoPadding conv1
+    . Torch.Typed.NN.conv2d @NoStrides @NoPadding conv1
     . maxPool2d @KernelSize @Strides @NoPadding
     . relu
-    . Torch.Static.NN.conv2d @NoStrides @NoPadding conv0
+    . Torch.Typed.NN.conv2d @NoStrides @NoPadding conv0
     . unsqueeze @1
     . reshape @'[batchSize, I.Rows, I.Cols]
 

--- a/examples/static-mnist-mlp/Main.hs
+++ b/examples/static-mnist-mlp/Main.hs
@@ -33,10 +33,10 @@ import qualified ATen.Class                    as ATen
 import qualified ATen.Type                     as ATen
 import qualified ATen.Managed.Type.Tensor      as ATen
 import qualified ATen.Managed.Type.Context     as ATen
-import           Torch.Static
-import           Torch.Static.Native     hiding ( linear )
-import           Torch.Static.Factories
-import           Torch.Static.NN
+import           Torch.Typed
+import           Torch.Typed.Native     hiding ( linear )
+import           Torch.Typed.Factories
+import           Torch.Typed.NN
 import qualified Torch.Autograd                as A
 import qualified Torch.NN                      as A
 import qualified Torch.DType                   as D
@@ -81,10 +81,10 @@ mlp
 mlp MLP {..} train input =
   return
     .   linear mlpLayer2
-    =<< Torch.Static.NN.dropout mlpDropout train
+    =<< Torch.Typed.NN.dropout mlpDropout train
     .   tanh
     .   linear mlpLayer1
-    =<< Torch.Static.NN.dropout mlpDropout train
+    =<< Torch.Typed.NN.dropout mlpDropout train
     .   tanh
     .   linear mlpLayer0
     =<< pure input

--- a/examples/static-mnist/Image.hs
+++ b/examples/static-mnist/Image.hs
@@ -15,8 +15,8 @@ import qualified Data.ByteString.Internal      as BSI
 import           GHC.TypeLits
 
 import           ATen.Cast
-import           Torch.Static
-import           Torch.Static.Native
+import           Torch.Typed
+import           Torch.Typed.Native
 import qualified Torch.DType                   as D
 import qualified Torch.Tensor                  as D
 import qualified Torch.TensorOptions           as D

--- a/examples/static-xor-mlp/Main.hs
+++ b/examples/static-xor-mlp/Main.hs
@@ -32,10 +32,10 @@ import           Data.Reflection
 import           GHC.Generics
 import           GHC.TypeLits
 
-import           Torch.Static
-import           Torch.Static.Native     hiding ( linear )
-import           Torch.Static.Factories
-import           Torch.Static.NN
+import           Torch.Typed
+import           Torch.Typed.Native     hiding ( linear )
+import           Torch.Typed.Factories
+import           Torch.Typed.NN
 import qualified Torch.Autograd                as A
 import qualified Torch.NN                      as A
 import qualified Torch.DType                   as D

--- a/examples/test/ImageSpec.hs
+++ b/examples/test/ImageSpec.hs
@@ -12,7 +12,7 @@ import Control.Exception.Safe
 import Control.Monad.State.Strict
 
 import qualified Image as I
-import Torch.Static
+import Torch.Typed
 import qualified Torch.Tensor as D
 import GHC.Generics
 

--- a/hasktorch/hasktorch.cabal
+++ b/hasktorch/hasktorch.cabal
@@ -20,10 +20,10 @@ library
                     , Torch.Functions
                     , Torch.Functions.Native
                     , Torch.Autograd
-                    , Torch.Static
-                    , Torch.Static.Factories
-                    , Torch.Static.Native
-                    , Torch.Static.NN
+                    , Torch.Typed
+                    , Torch.Typed.Factories
+                    , Torch.Typed.Native
+                    , Torch.Typed.NN
                     , Torch.NN
                     , Torch.Scalar
                     , Torch.Backend
@@ -57,7 +57,7 @@ test-suite spec
                     , SparseSpec
                     , TensorSpec
                     , NNSpec
-                    , StaticSpec
+                    , TypedSpec
                     , DimnameSpec
   default-language: Haskell2010
   build-depends:      base >= 4.7 && < 5

--- a/hasktorch/src/Torch/Typed.hs
+++ b/hasktorch/src/Torch/Typed.hs
@@ -18,7 +18,7 @@
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE FunctionalDependencies #-}
 
-module Torch.Static where
+module Torch.Typed where
 
 import           Prelude                 hiding ( (.), id )
 import           Control.Arrow
@@ -153,7 +153,7 @@ instance (KnownDType dtype, KnownNat h, TensorOptions dtype t) => TensorOptions 
   optionsRuntimeShape = (natValI @h : optionsRuntimeShape @dtype @t)
 
 --------------------------------------------------------------------------------
--- Dynamic -> Static typecasts
+-- Dynamic -> Typed typecasts
 --------------------------------------------------------------------------------
 
 -- type family Flip (constraint :: a -> b -> Constraint) (fst :: b) (snd :: a) :: Constraint where

--- a/hasktorch/src/Torch/Typed/Factories.hs
+++ b/hasktorch/src/Torch/Typed/Factories.hs
@@ -16,7 +16,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE NoStarIsType #-}
 
-module Torch.Static.Factories where
+module Torch.Typed.Factories where
 
 import Prelude hiding (sin)
 import Control.Arrow ((&&&))
@@ -34,7 +34,7 @@ import qualified Torch.TensorFactories as D
 import qualified Torch.Functions as D
 import qualified Torch.DType as D
 import qualified Torch.TensorOptions as D
-import Torch.Static
+import Torch.Typed
 
 zeros :: forall dtype shape. (TensorOptions dtype shape) => Tensor dtype shape
 zeros = UnsafeMkTensor $ D.zeros (optionsRuntimeShape @dtype @shape) (D.withDType (optionsRuntimeDType @dtype @shape) D.defaultOpts)

--- a/hasktorch/src/Torch/Typed/NN.hs
+++ b/hasktorch/src/Torch/Typed/NN.hs
@@ -16,7 +16,7 @@
 {-# LANGUAGE PartialTypeSignatures #-}
 {-# OPTIONS_GHC -Wno-partial-type-signatures #-}
 
-module Torch.Static.NN where
+module Torch.Typed.NN where
 
 import           Control.Monad.State.Strict
 import           GHC.TypeLits
@@ -27,9 +27,9 @@ import qualified Torch.NN                      as A
 import qualified Torch.Autograd                as A
 import qualified Torch.Tensor                  as A
 import qualified Torch.DType                   as D
-import           Torch.Static
-import           Torch.Static.Factories
-import           Torch.Static.Native
+import           Torch.Typed
+import           Torch.Typed.Factories
+import           Torch.Typed.Native
 
 newtype Parameter dtype shape = Parameter A.IndependentTensor deriving (Show)
 
@@ -91,7 +91,7 @@ linear
   -> Tensor _ _
   -> Tensor _ _
 linear Linear {..} input =
-  Torch.Static.Native.linear' (toDependent linearWeight) (toDependent linearBias) input
+  Torch.Typed.Native.linear' (toDependent linearWeight) (toDependent linearBias) input
 
 instance A.Parameterized (Linear dtype inputFeatures outputFeatures)
 
@@ -120,7 +120,7 @@ data Dropout where
 
 dropout :: Dropout -> Bool -> Tensor dtype shape -> IO (Tensor dtype shape)
 dropout Dropout {..} dropoutTrain =
-  Torch.Static.Native.dropout dropoutProb dropoutTrain
+  Torch.Typed.Native.dropout dropoutProb dropoutTrain
 
 instance A.Parameterized Dropout
 
@@ -217,7 +217,7 @@ conv1d
   => Conv1d _ _ _ _
   -> Tensor _ _
   -> Tensor _ _
-conv1d Conv1d {..} input = Torch.Static.Native.conv1d @stride @padding
+conv1d Conv1d {..} input = Torch.Typed.Native.conv1d @stride @padding
   (toDependent conv1dWeight)
   (toDependent conv1dBias)
   input
@@ -263,7 +263,7 @@ conv2d
   => Conv2d _ _ _ _ _
   -> Tensor _ _
   -> Tensor _ _
-conv2d Conv2d {..} input = Torch.Static.Native.conv2d @stride @padding
+conv2d Conv2d {..} input = Torch.Typed.Native.conv2d @stride @padding
   (toDependent conv2dWeight)
   (toDependent conv2dBias)
   input
@@ -310,7 +310,7 @@ conv3d
   => Conv3d _ _ _ _ _ _
   -> Tensor _ _
   -> Tensor _ _
-conv3d Conv3d {..} input = Torch.Static.Native.conv3d @stride @padding
+conv3d Conv3d {..} input = Torch.Typed.Native.conv3d @stride @padding
   (toDependent conv3dWeight)
   (toDependent conv3dBias)
   input
@@ -356,7 +356,7 @@ layerNorm
   => LayerNorm dtype normalizedShape
   -> Tensor dtype shape
   -> Tensor dtype shape
-layerNorm LayerNorm {..} = Torch.Static.Native.layerNorm @normalizedShape
+layerNorm LayerNorm {..} = Torch.Typed.Native.layerNorm @normalizedShape
   (toDependent layerNormWeight)
   (toDependent layerNormBias)
   layerNormEps

--- a/hasktorch/src/Torch/Typed/Native.hs
+++ b/hasktorch/src/Torch/Typed/Native.hs
@@ -15,7 +15,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE NoStarIsType #-}
 
-module Torch.Static.Native where
+module Torch.Typed.Native where
 
 import           Prelude                 hiding ( all
                                                 , any
@@ -73,8 +73,8 @@ import           Torch.Functions                ( Reduction(..)
                                                 , isUpper
                                                 , kOne
                                                 )
-import           Torch.Static
-import           Torch.Static.Factories
+import           Torch.Typed
+import           Torch.Typed.Factories
 
 
 type family DTypeIsNotHalf (dtype :: D.DType) :: Constraint where
@@ -1603,7 +1603,7 @@ linear'
   -> Tensor dtype '[outputFeatures]
   -> Tensor dtype shape
   -> Tensor dtype shape'
--- linear' weight bias input = Torch.Static.add (matmul input $ transpose @0 @1 weight) bias
+-- linear' weight bias input = Torch.Typed.add (matmul input $ transpose @0 @1 weight) bias
 linear' weight bias input = unsafePerformIO $ cast3 ATen.linear_ttt input weight bias
 
 -- | mkldnnLinear

--- a/hasktorch/test/TypedSpec.hs
+++ b/hasktorch/test/TypedSpec.hs
@@ -16,7 +16,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE NoStarIsType #-}
 
-module StaticSpec (spec) where
+module TypedSpec (spec) where
 
 import Test.Hspec
 import Test.QuickCheck
@@ -27,9 +27,9 @@ import qualified Torch.Tensor as D
 import qualified Torch.TensorFactories as D
 import qualified Torch.Functions as D
 import qualified Torch.DType as D
-import Torch.Static
-import Torch.Static.Factories
-import Torch.Static.Native
+import Torch.Typed
+import Torch.Typed.Factories
+import Torch.Typed.Native
 import qualified Torch.TensorOptions as D
 import Data.Reflection
 

--- a/hasktorch/test/doctests.hs
+++ b/hasktorch/test/doctests.hs
@@ -14,6 +14,6 @@ main = doctest
   , "-fplugin GHC.TypeLits.Extra.Solver"
   , "-fconstraint-solver-iterations=0"
   , "-isrc"
-  , "src/Torch/Static/Factories"
-  , "src/Torch/Static/Native"
+  , "src/Torch/Typed/Factories"
+  , "src/Torch/Typed/Native"
   ]


### PR DESCRIPTION
When people hear static on deep learning context, they think of static graph.
hasktorch does not create static graph. 
static of hastorch means statically typed data.
This pr renames static to typed, because it is confusing.

