### PR TITLE
Add prometheus

### DIFF
--- a/examples/examples.cabal
+++ b/examples/examples.cabal
@@ -13,7 +13,7 @@ build-type:          Simple
 
 common config
   default-language:    Haskell2010
-  ghc-options:         -fplugin GHC.TypeLits.Normalise -fplugin GHC.TypeLits.KnownNat.Solver -fplugin GHC.TypeLits.Extra.Solver -fconstraint-solver-iterations=0
+  ghc-options:         -fplugin GHC.TypeLits.Normalise -fplugin GHC.TypeLits.KnownNat.Solver -fplugin GHC.TypeLits.Extra.Solver -fconstraint-solver-iterations=0 -rtsopts
   build-depends:       base >= 4.7 && < 5
                      , hasktorch
                     --  , ghc-typelits-extra >= 0.3.1
@@ -49,6 +49,8 @@ library static-mnist
                      , libtorch-ffi
                      , hvega
                      , random >= 1.1
+                     , prometheus-client
+                     , prometheus-metrics-ghc
 
 test-suite spec
   import:             config

--- a/examples/static-mnist-mlp/Main.hs
+++ b/examples/static-mnist-mlp/Main.hs
@@ -139,6 +139,7 @@ train
    . _
   => IO ()
 train = do
+  Monitoring.initPrometheus
   let (numIters, printEvery) = (1000000, 250)
       dropoutProb            = 0.5
   (trainingData, testData) <- I.initMnist
@@ -177,6 +178,7 @@ train = do
                   metrics' = metric : metrics
               Monitoring.printLosses metric
               Monitoring.plotLosses "loss.html" metrics'
+              Monitoring.putPrometheus
               return metrics'
             else return metrics
 

--- a/examples/static-mnist/Monitoring.hs
+++ b/examples/static-mnist/Monitoring.hs
@@ -13,6 +13,10 @@ module Monitoring where
 import           GHC.TypeLits
 import           Graphics.Vega.VegaLite
 
+import qualified Data.ByteString.Lazy as BS
+import qualified Prometheus as P
+import qualified Prometheus.Metric.GHC as P
+
 import qualified Torch.Device                  as D
 import qualified Torch.DType                   as D
 import qualified Torch.Tensor                  as D
@@ -91,3 +95,14 @@ printLosses (i, Metric {..}) =
         <> show (asFloat testLoss)
         <> ". Test error-rate: "
         <> show (asFloat testError)
+
+
+initPrometheus :: IO ()
+initPrometheus = do
+  _ <- P.register P.ghcMetrics
+  return ()
+  
+
+putPrometheus :: IO ()
+putPrometheus =
+  P.exportMetricsAsText >>= BS.writeFile "/var/lib/prometheus/node-exporter/ghc.prom"

--- a/stack.yaml
+++ b/stack.yaml
@@ -21,3 +21,4 @@ extra-lib-dirs:
 
 extra-deps:
 - template-0.2.0.10@sha256:f822de4d34c45bc84b33a61bc112c15fedee6fa6dc414c62b10456395a868f85
+- prometheus-metrics-ghc-1.0.0@sha256:0f4ecbefa810bd847e66c498ab3387bf21e426525a7c9a94841973c582719ba3,1231


### PR DESCRIPTION
This PR adds prometheus-metrics of GHC to check memory-management with GC.

static-mnist-mlp's result is below.
It seems program calls GC many times, but memory is not released.
![image](https://user-images.githubusercontent.com/2469618/68619964-d9814f00-050f-11ea-9685-f8a21837d8a9.png)
