### PR TITLE
typed gradients and optimizers

### DIFF
--- a/examples/static-mnist-cnn/Main.hs
+++ b/examples/static-mnist-cnn/Main.hs
@@ -44,6 +44,8 @@ import           Torch.Typed.Native      hiding ( linear
                                                 )
 import           Torch.Typed.Factories
 import           Torch.Typed.NN
+import           Torch.Typed.Optim
+import           Torch.Typed.Parameter
 import qualified Torch.Autograd                as A
 import qualified Torch.NN                      as A
 import qualified Torch.Device                  as D
@@ -118,9 +120,11 @@ train'
    . _
   => IO ()
 train' = do
+  let learningRate = 0.1
   ATen.manual_seed_L 123
-  init <- A.sample (CNNSpec @ 'D.Float @device)
-  train @BatchSize init (\state _ input -> return $ cnn state input) "static-mnist-cnn.pt"
+  initModel <- A.sample (CNNSpec @ 'D.Float @device)
+  let initOptim = mkAdam 0 0.9 0.999 (flattenParameters initModel)
+  train @BatchSize @device initModel initOptim (\model _ input -> return $ cnn model input) learningRate "static-mnist-cnn.pt"
 
 main :: IO ()
 main = do

--- a/hasktorch/hasktorch.cabal
+++ b/hasktorch/hasktorch.cabal
@@ -31,6 +31,8 @@ library
                     , Torch.Typed.NN.Recurrent.LSTM
                     , Torch.Typed.Tensor
                     , Torch.Typed.Parameter
+                    , Torch.Typed.Autograd
+                    , Torch.Typed.Optim
                     , Torch.NN
                     , Torch.Scalar
                     , Torch.Backend

--- a/hasktorch/hasktorch.cabal
+++ b/hasktorch/hasktorch.cabal
@@ -33,6 +33,7 @@ library
                     , Torch.Typed.Parameter
                     , Torch.Typed.Autograd
                     , Torch.Typed.Optim
+                    , Torch.Typed.Serialize
                     , Torch.NN
                     , Torch.Scalar
                     , Torch.Backend

--- a/hasktorch/src/Torch/Typed/Autograd.hs
+++ b/hasktorch/src/Torch/Typed/Autograd.hs
@@ -25,10 +25,12 @@ type family GradR (parameters :: [a]) (dtype :: D.DType) (device :: (D.DeviceTyp
   GradR '[] _ _ = '[]
   GradR (Parameter device dtype shape ': parameters) dtype device = Tensor device dtype shape ': GradR parameters dtype device
 
+-- | calculate gradients of a zero-dimensional tensor with respect to a list of parameters
 grad
-  :: forall dtype device parameters gradients
+  :: forall dtype device parameters gradients tensors
    . ( gradients ~ GradR parameters dtype device
-     , HMap' ToDependent parameters gradients
+     , tensors ~ gradients
+     , HMap' ToDependent parameters tensors
      , ATen.Castable (HList gradients) [D.ATenTensor]
      )
   => Tensor device dtype '[]

--- a/hasktorch/src/Torch/Typed/Autograd.hs
+++ b/hasktorch/src/Torch/Typed/Autograd.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE FlexibleContexts #-}
+
+module Torch.Typed.Autograd where
+
+import           Data.HList
+import           GHC.TypeLits
+import           System.IO.Unsafe
+
+import           ATen.Cast
+import qualified Torch.Managed.Autograd
+import qualified Torch.DType                   as D
+import qualified Torch.Device                  as D
+import qualified Torch.Tensor                  as D
+import           Torch.Typed.Tensor
+import           Torch.Typed.Parameter
+
+type family GradR (parameters :: [a]) (dtype :: D.DType) (device :: (D.DeviceType, Nat)) :: [a] where
+  GradR '[] _ _ = '[]
+  GradR (Parameter device dtype shape ': parameters) dtype device = Tensor device dtype shape ': GradR parameters dtype device
+
+grad
+  :: forall dtype device parameters gradients
+   . ( gradients ~ GradR parameters dtype device
+     , HMap ToDependent parameters gradients
+     , HFoldrM IO TensorListFold [D.ATenTensor] gradients
+     , Apply
+         TensorListUnfold
+         [D.ATenTensor]
+         (HUnfoldMRes IO [D.ATenTensor] gradients)
+     , HUnfoldM
+         IO
+         TensorListUnfold
+         (HUnfoldMRes IO [D.ATenTensor] gradients)
+         gradients
+     )
+  => Tensor device dtype '[]
+  -> HList parameters
+  -> HList gradients
+grad y inputs = unsafePerformIO $ cast2
+  Torch.Managed.Autograd.grad
+  y
+  (hmap ToDependent inputs :: HList gradients)

--- a/hasktorch/src/Torch/Typed/Aux.hs
+++ b/hasktorch/src/Torch/Typed/Aux.hs
@@ -28,10 +28,10 @@ natValInt16 :: forall n . KnownNat n => I.Int16
 natValInt16 = fromIntegral $ natVal $ Proxy @n
 
 type family Fst (t :: (a, b)) :: a where
-  Fst '(x, _) = x
+  Torch.Typed.Aux.Fst '(x, _) = x
 
 type family Snd (t :: (a, b)) :: b where
-  Snd '(_, x) = x
+  Torch.Typed.Aux.Snd '(_, x) = x
 
 type family Fst3 (t :: (a, b, c)) :: a where
   Fst3 '(x, _, _) = x

--- a/hasktorch/src/Torch/Typed/NN/Recurrent/LSTM.hs
+++ b/hasktorch/src/Torch/Typed/NN/Recurrent/LSTM.hs
@@ -27,19 +27,20 @@
 
 module Torch.Typed.NN.Recurrent.LSTM where
 
-import qualified ATen.Cast                     as ATen
-import qualified ATen.Class                    as ATen
-import qualified ATen.Managed.Type.Tensor      as ATen
-import qualified ATen.Type                     as ATen
+import           Prelude                 hiding ( tanh )
 import           Data.Kind
 import           Data.HList
 import           Foreign.ForeignPtr
 import           GHC.Generics
 import           GHC.TypeLits
 import           GHC.TypeLits.Extra
-import           Prelude                 hiding ( tanh )
 import           System.Environment
 import           System.IO.Unsafe
+
+import qualified ATen.Cast                     as ATen
+import qualified ATen.Class                    as ATen
+import qualified ATen.Managed.Type.Tensor      as ATen
+import qualified ATen.Type                     as ATen
 import qualified Torch.Autograd                as A
 import qualified Torch.Device                  as D
 import qualified Torch.DType                   as D
@@ -459,10 +460,8 @@ lstm
      , hxShape ~ '[numLayers * NumberOfDirections directionality, batchSize, hiddenSize]
      , Parameterized (LSTM inputSize hiddenSize numLayers directionality dtype device) parameters
      , tensorParameters ~ LSTMR inputSize hiddenSize numLayers directionality dtype device
-     , HFoldrM IO TensorListFold [D.ATenTensor] tensorParameters
-     , Apply TensorListUnfold [D.ATenTensor] (HUnfoldMRes IO [D.ATenTensor] tensorParameters)
-     , HUnfoldM IO TensorListUnfold (HUnfoldMRes IO [D.ATenTensor] tensorParameters) tensorParameters
-     , HMap ToDependent parameters tensorParameters
+     , ATen.Castable (HList tensorParameters) [D.ATenTensor]
+     , HMap' ToDependent parameters tensorParameters
      )
   => Bool
   -> LSTMWithInit
@@ -494,7 +493,7 @@ lstm dropoutOn (LSTMWithConstInit lstm@(LSTM _ (Dropout dropoutProb)) cc hc) inp
     @tensorParameters
     @dtype
     @device
-    (hmap ToDependent . flattenParameters $ lstm)
+    (hmap' ToDependent . flattenParameters $ lstm)
     dropoutProb
     dropoutOn
     (cc', hc')
@@ -528,7 +527,7 @@ lstm dropoutOn (LSTMWithLearnedInit lstm@(LSTM _ (Dropout dropoutProb)) cc hc) i
     @tensorParameters
     @dtype
     @device
-    (hmap ToDependent . flattenParameters $ lstm)
+    (hmap' ToDependent . flattenParameters $ lstm)
     dropoutProb
     dropoutOn
     (cc', hc')
@@ -579,10 +578,8 @@ lstmWithDropout, lstmWithoutDropout
      , hxShape ~ '[numLayers * NumberOfDirections directionality, batchSize, hiddenSize]
      , Parameterized (LSTM inputSize hiddenSize numLayers directionality dtype device) parameters
      , tensorParameters ~ LSTMR inputSize hiddenSize numLayers directionality dtype device
-     , HFoldrM IO TensorListFold [D.ATenTensor] tensorParameters
-     , Apply TensorListUnfold [D.ATenTensor] (HUnfoldMRes IO [D.ATenTensor] tensorParameters)
-     , HUnfoldM IO TensorListUnfold (HUnfoldMRes IO [D.ATenTensor] tensorParameters) tensorParameters
-     , HMap ToDependent parameters tensorParameters
+     , ATen.Castable (HList tensorParameters) [D.ATenTensor]
+     , HMap' ToDependent parameters tensorParameters
      )
   => LSTMWithInit
        inputSize

--- a/hasktorch/src/Torch/Typed/Native.hs
+++ b/hasktorch/src/Torch/Typed/Native.hs
@@ -60,14 +60,15 @@ import           System.IO.Unsafe
 import           Data.Singletons.Prelude.List   ( Product )
 
 import           Foreign.ForeignPtr
-import qualified ATen.Managed.Native           as ATen
-import qualified ATen.Managed.Type.Tensor      as ATen
-import qualified ATen.Managed.Type.Scalar      as ATen
-import qualified ATen.Managed.Type.Tuple       as ATen
 import qualified ATen.Const                    as ATen
 import qualified ATen.Type                     as ATen
-import qualified ATen.Managed.Cast
-import           ATen.Cast
+import qualified ATen.Cast                     as ATen
+import qualified ATen.Class                    as ATen
+import qualified ATen.Managed.Cast             as ATen.Managed
+import qualified ATen.Managed.Native           as ATen.Managed
+import qualified ATen.Managed.Type.Tensor      as ATen.Managed
+import qualified ATen.Managed.Type.Scalar      as ATen.Managed
+import qualified ATen.Managed.Type.Tuple       as ATen.Managed
 
 import qualified Torch.Tensor                  as D
 import qualified Torch.TensorFactories         as D
@@ -125,7 +126,7 @@ sumAll
      )
   => Tensor device dtype  shape -- ^ input
   -> Tensor device dtype' '[] -- ^ output
-sumAll input = unsafePerformIO $ cast1 ATen.sum_t input
+sumAll input = unsafePerformIO $ ATen.cast1 ATen.Managed.sum_t input
 
 -- | sumDim
 -- >>> dtype &&& shape $ sumDim @0 (ones :: CPUTensor 'D.Float '[3,4,5])
@@ -141,7 +142,7 @@ sumDim
      )
   => Tensor device dtype  shape -- ^ input
   -> Tensor device dtype' shape' -- ^ output
-sumDim input = unsafePerformIO $ cast2 ATen.sum_tl input (natValI @d)
+sumDim input = unsafePerformIO $ ATen.cast2 ATen.Managed.sum_tl input (natValI @d)
 
 -- | abs
 -- >>> dtype &&& shape $ abs (ones :: CPUTensor 'D.Float '[2,2])
@@ -151,7 +152,7 @@ abs
    . (DTypeIsNotHalf device dtype, DTypeIsNotBool device dtype)
   => Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
-abs input = unsafePerformIO $ cast1 ATen.abs_t input
+abs input = unsafePerformIO $ ATen.cast1 ATen.Managed.abs_t input
 
 -- | ceil
 -- >>> dtype &&& shape $ ceil (ones :: CPUTensor 'D.Float '[2,2])
@@ -161,7 +162,7 @@ ceil
    . (StandardFloatingPointDTypeValidation device dtype)
   => Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
-ceil input = unsafePerformIO $ cast1 ATen.ceil_t input
+ceil input = unsafePerformIO $ ATen.cast1 ATen.Managed.ceil_t input
 
 -- | floor
 -- >>> dtype &&& shape $ floor (ones :: CPUTensor 'D.Float '[2,2])
@@ -171,7 +172,7 @@ floor
    . (StandardFloatingPointDTypeValidation device dtype)
   => Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
-floor input = unsafePerformIO $ cast1 ATen.floor_t input
+floor input = unsafePerformIO $ ATen.cast1 ATen.Managed.floor_t input
 
 -- TODO: better error messages, "Couldn't match type ‘'False’ with ‘'True’" isn't great
 type family AllDimsPositive (shape :: [Nat]) :: Constraint where
@@ -193,7 +194,7 @@ min
      )
   => Tensor device dtype shape -- ^ input
   -> Tensor device dtype '[] -- ^ output
-min input = unsafePerformIO $ cast1 ATen.min_t input
+min input = unsafePerformIO $ ATen.cast1 ATen.Managed.min_t input
 
 -- | max
 -- >>> dtype &&& shape $ max (ones :: CPUTensor 'D.Float '[2,2])
@@ -205,7 +206,7 @@ max
     )
   => Tensor device dtype shape -- ^ input
   -> Tensor device dtype '[] -- ^ output
-max input = unsafePerformIO $ cast1 ATen.max_t input
+max input = unsafePerformIO $ ATen.cast1 ATen.Managed.max_t input
 
 -- | median
 -- >>> dtype &&& shape $ median (ones :: CPUTensor 'D.Float '[2,2])
@@ -217,17 +218,59 @@ median
     )
   => Tensor device dtype shape -- ^ input
   -> Tensor device dtype '[] -- ^ output
-median input = unsafePerformIO $ cast1 ATen.median_t input
+median input = unsafePerformIO $ ATen.cast1 ATen.Managed.median_t input
+
+-- | cadd
+-- TODO: what dtypes is this defined for?
+-- TODO: what scalar types is this defined for?
+-- >>> dtype &&& shape $ cadd 1 (ones :: CPUTensor 'D.Float '[2,2])
+-- (Float,[2,2])
+cadd
+  :: forall a shape dtype device
+   . D.Scalar a
+  => a -- ^ scalar input
+  -> Tensor device dtype shape -- ^ tensor input
+  -> Tensor device dtype shape -- ^ output
+cadd a input = unsafePerformIO $ ATen.cast2 ATen.Managed.add_ts input a
+
+-- | csub
+-- TODO: what dtypes is this defined for?
+-- TODO: what scalar types is this defined for?
+-- >>> dtype &&& shape $ csub 1 (ones :: CPUTensor 'D.Float '[2,2])
+-- (Float,[2,2])
+csub
+  :: forall a shape dtype device
+   . D.Scalar a
+  => a -- ^ scalar input
+  -> Tensor device dtype shape -- ^ tensor input
+  -> Tensor device dtype shape -- ^ output
+csub a input = unsafePerformIO $ ATen.cast2 ATen.Managed.sub_ts input a
 
 -- | cmul
--- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
+-- TODO: what dtypes is this defined for?
+-- TODO: what scalar types is this defined for?
+-- >>> dtype &&& shape $ cmul 2 (ones :: CPUTensor 'D.Float '[2,2])
+-- (Float,[2,2])
 cmul
   :: forall a shape dtype device
    . D.Scalar a
   => a -- ^ scalar input
   -> Tensor device dtype shape -- ^ tensor input
   -> Tensor device dtype shape -- ^ output
-cmul a input = unsafePerformIO $ cast2 ATen.mul_ts input a
+cmul a input = unsafePerformIO $ ATen.cast2 ATen.Managed.mul_ts input a
+
+-- | cdiv
+-- TODO: what dtypes is this defined for?
+-- TODO: what scalar types is this defined for?
+-- >>> dtype &&& shape $ cdiv 2 (ones :: CPUTensor 'D.Float '[2,2])
+-- (Float,[2,2])
+cdiv
+  :: forall a shape dtype device
+   . D.Scalar a
+  => a -- ^ scalar input
+  -> Tensor device dtype shape -- ^ tensor input
+  -> Tensor device dtype shape -- ^ output
+cdiv a input = unsafePerformIO $ ATen.cast2 ATen.Managed.div_ts input a
 
 -- | erf
 -- >>> dtype &&& shape $ erf (ones :: CPUTensor 'D.Float '[3,2])
@@ -237,7 +280,7 @@ erf
    . (StandardFloatingPointDTypeValidation device dtype)
   => Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
-erf input = unsafePerformIO $ cast1 ATen.erf_t input
+erf input = unsafePerformIO $ ATen.cast1 ATen.Managed.erf_t input
 
 -- | exp
 -- >>> dtype &&& shape $ exp (ones :: CPUTensor 'D.Float '[3,2])
@@ -247,7 +290,7 @@ exp
    . (StandardFloatingPointDTypeValidation device dtype)
   => Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
-exp input = unsafePerformIO $ cast1 ATen.exp_t input
+exp input = unsafePerformIO $ ATen.cast1 ATen.Managed.exp_t input
 
 -- | log1p
 -- >>> dtype &&& shape $ log1p (ones :: CPUTensor 'D.Float '[3,2])
@@ -257,7 +300,7 @@ log1p
    . (StandardFloatingPointDTypeValidation device dtype)
   => Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
-log1p input = unsafePerformIO $ cast1 ATen.log1p_t input
+log1p input = unsafePerformIO $ ATen.cast1 ATen.Managed.log1p_t input
 
 -- | log2
 -- >>> dtype &&& shape $ log2 (ones :: CPUTensor 'D.Float '[3,2])
@@ -267,7 +310,7 @@ log2
    . (StandardFloatingPointDTypeValidation device dtype)
   => Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
-log2 input = unsafePerformIO $ cast1 ATen.log2_t input
+log2 input = unsafePerformIO $ ATen.cast1 ATen.Managed.log2_t input
 
 -- | log10
 -- >>> dtype &&& shape $ log10 (ones :: CPUTensor 'D.Float '[3,2])
@@ -277,7 +320,7 @@ log10
    . (StandardFloatingPointDTypeValidation device dtype)
   => Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
-log10 input = unsafePerformIO $ cast1 ATen.log10_t input
+log10 input = unsafePerformIO $ ATen.cast1 ATen.Managed.log10_t input
 
 -- | pow
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -289,7 +332,7 @@ pow
   => a -- ^ power
   -> Tensor device dtype shape -- ^ input tensor
   -> Tensor device dtype shape -- ^ output tensor
-pow a input = unsafePerformIO $ cast2 ATen.pow_ts input a
+pow a input = unsafePerformIO $ ATen.cast2 ATen.Managed.pow_ts input a
 
 -- | relu activation function
 -- >>> dtype &&& shape $ relu (ones :: CPUTensor 'D.Float '[3,2])
@@ -299,7 +342,7 @@ relu
    . (StandardFloatingPointDTypeValidation device dtype)
   => Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
-relu input = unsafePerformIO $ cast1 ATen.relu_t input
+relu input = unsafePerformIO $ ATen.cast1 ATen.Managed.relu_t input
 
 -- | selu
 -- >>> dtype &&& shape $ selu (ones :: CPUTensor 'D.Float '[3,2])
@@ -309,7 +352,7 @@ selu
    . (StandardFloatingPointDTypeValidation device dtype)
   => Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
-selu input = unsafePerformIO $ cast1 ATen.selu_t input
+selu input = unsafePerformIO $ ATen.cast1 ATen.Managed.selu_t input
 
 -- | mish
 -- `mish` is a smooth activation function, see https://arxiv.org/abs/1908.08681 for details.
@@ -333,7 +376,7 @@ sigmoid
    . (StandardFloatingPointDTypeValidation device dtype)
   => Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
-sigmoid input = unsafePerformIO $ cast1 ATen.sigmoid_t input
+sigmoid input = unsafePerformIO $ ATen.cast1 ATen.Managed.sigmoid_t input
 
 -- | sin
 -- >>> dtype &&& shape $ sin (ones :: CPUTensor 'D.Float '[3,2])
@@ -343,7 +386,7 @@ sin
    . (StandardFloatingPointDTypeValidation device dtype)
   => Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
-sin input = unsafePerformIO $ cast1 ATen.sin_t input
+sin input = unsafePerformIO $ ATen.cast1 ATen.Managed.sin_t input
 
 -- | sinh
 -- >>> dtype &&& shape $ sinh (ones :: CPUTensor 'D.Float '[3,2])
@@ -353,7 +396,7 @@ sinh
    . (StandardFloatingPointDTypeValidation device dtype)
   => Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
-sinh input = unsafePerformIO $ cast1 ATen.sinh_t input
+sinh input = unsafePerformIO $ ATen.cast1 ATen.Managed.sinh_t input
 
 -- | cos
 -- >>> dtype &&& shape $ cos (ones :: CPUTensor 'D.Float '[3,2])
@@ -363,7 +406,7 @@ cos
    . (StandardFloatingPointDTypeValidation device dtype)
   => Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
-cos input = unsafePerformIO $ cast1 ATen.cos_t input
+cos input = unsafePerformIO $ ATen.cast1 ATen.Managed.cos_t input
 
 -- | sqrt
 sqrt
@@ -371,7 +414,7 @@ sqrt
    . (StandardFloatingPointDTypeValidation device dtype)
   => Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
-sqrt input = unsafePerformIO $ cast1 ATen.sqrt_t input
+sqrt input = unsafePerformIO $ ATen.cast1 ATen.Managed.sqrt_t input
 
 -- | tanh
 tanh
@@ -379,7 +422,7 @@ tanh
    . (StandardFloatingPointDTypeValidation device dtype)
   => Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
-tanh input = unsafePerformIO $ cast1 ATen.tanh_t input
+tanh input = unsafePerformIO $ ATen.cast1 ATen.Managed.tanh_t input
 
 -- | toDType
 -- TODO: since we have Torch.Typed.Tensor.toType, do we need this one?
@@ -390,7 +433,7 @@ toDType
    . (KnownDType dtype')
   => Tensor device dtype  shape -- ^ input
   -> Tensor device dtype' shape -- ^ output
-toDType input = unsafePerformIO $ cast4 ATen.tensor_to_sbb input (dtypeVal @dtype') False False
+toDType input = unsafePerformIO $ ATen.cast4 ATen.Managed.tensor_to_sbb input (dtypeVal @dtype') False False
 
 type family SqueezeAll (shape :: [Nat]) :: [Nat] where
   SqueezeAll '[] = '[]
@@ -405,7 +448,7 @@ squeezeAll
    . (shape' ~ SqueezeAll shape)
   => Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape' -- ^ output
-squeezeAll input = unsafePerformIO $ cast1 ATen.squeeze_t input
+squeezeAll input = unsafePerformIO $ ATen.cast1 ATen.Managed.squeeze_t input
 
 -- | ConditionalReduction
 -- >>> :kind! ConditionalReduction '[3,2] ReduceNone
@@ -446,8 +489,8 @@ binaryCrossEntropy
   -> Tensor device dtype shape -- ^ prediction
   -> Tensor device dtype shape -- ^ target
   -> Tensor device dtype shape' -- ^ output
-binaryCrossEntropy weight prediction target = unsafePerformIO $ cast4
-  ATen.binary_cross_entropy_tttl
+binaryCrossEntropy weight prediction target = unsafePerformIO $ ATen.cast4
+  ATen.Managed.binary_cross_entropy_tttl
   prediction
   target
   weight
@@ -470,8 +513,8 @@ mseLoss
   => Tensor device dtype shape -- ^ prediction
   -> Tensor device dtype shape -- ^ target
   -> Tensor device dtype shape' -- ^ output
-mseLoss prediction target = unsafePerformIO $ cast3
-  ATen.mse_loss_ttl
+mseLoss prediction target = unsafePerformIO $ ATen.cast3
+  ATen.Managed.mse_loss_ttl
   prediction
   target
   (reductionVal @reduction)
@@ -491,7 +534,7 @@ softmax
   => Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
 softmax input = unsafePerformIO
-  $ cast3 ATen.softmax_tls input (natValI @dim) (dtypeVal @dtype)
+  $ ATen.cast3 ATen.Managed.softmax_tls input (natValI @dim) (dtypeVal @dtype)
 
 -- | logSoftmax
 -- >>> t = ones :: CPUTensor 'D.Float '[2,2]
@@ -508,7 +551,7 @@ logSoftmax
   => Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
 logSoftmax input = unsafePerformIO
-  $ cast3 ATen.log_softmax_tls input (natValI @dim) (dtypeVal @dtype)
+  $ ATen.cast3 ATen.Managed.log_softmax_tls input (natValI @dim) (dtypeVal @dtype)
 
 type family Square (shape :: [Nat]) :: [Nat] where
   Square (n:n:'[])   = '[n,n]
@@ -554,7 +597,7 @@ inverse
      )
   => Tensor device dtype shape -- ^ inverse
   -> Tensor device dtype shape' -- ^ output
-inverse input = unsafePerformIO $ cast1 ATen.inverse_t input
+inverse input = unsafePerformIO $ ATen.cast1 ATen.Managed.inverse_t input
 
 type family SymeigDTypeIsValid (device :: (D.DeviceType, Nat)) (dtype :: D.DType) :: Constraint where
   SymeigDTypeIsValid '( 'D.CPU, 0)            dtype = ( DTypeIsFloatingPoint '( 'D.CPU, 0) dtype
@@ -595,7 +638,7 @@ symeig
      , Tensor device dtype shape''
      ) -- ^ eigenvalues and eigenvectors
 symeig eigenvectors upper input = unsafePerformIO
-  $ cast3 ATen.symeig_tbb input eigenvectors boolUpper
+  $ ATen.cast3 ATen.Managed.symeig_tbb input eigenvectors boolUpper
   where boolUpper = isUpper upper
 
 data EigenVectors = EnableEigenVectors | DisableEigenVectors
@@ -651,7 +694,7 @@ eig
      , Tensor device dtype shape
      ) -- ^ eigenvalues and eigenvectors
 eig input =
-  unsafePerformIO $ cast2 ATen.eig_tb input (enableEigenVectors @eigenvectors)
+  unsafePerformIO $ ATen.cast2 ATen.Managed.eig_tb input (enableEigenVectors @eigenvectors)
 
 type family SVDShapes (shape :: [Nat]) (reduced :: ReducedSVD) :: ([Nat], [Nat], [Nat]) where
   SVDShapes '[0, n]    'ThinSVD = '( '[0, 0],          '[0],          '[n, n])
@@ -732,7 +775,7 @@ svd
      , Tensor device dtype shapeV
      ) -- ^ (batched) output tuple of `u`, `s`, and `v`
 svd input =
-  unsafePerformIO $ cast3 ATen.svd_tbb input (reducedSVD @reduced) True
+  unsafePerformIO $ ATen.cast3 ATen.Managed.svd_tbb input (reducedSVD @reduced) True
 
 type family CholeskyDTypeIsValid (device :: (D.DeviceType, Nat)) (dtype :: D.DType) :: Constraint where
   CholeskyDTypeIsValid '( 'D.CPU, 0)            dtype = ( DTypeIsFloatingPoint '( 'D.CPU, 0) dtype
@@ -762,7 +805,7 @@ cholesky
   => Tri -- ^ indicate whether to return an upper or lower triangular matrix.
   -> Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape' -- ^ output
-cholesky upper input = unsafePerformIO $ cast2 ATen.cholesky_tb input boolUpper
+cholesky upper input = unsafePerformIO $ ATen.cast2 ATen.Managed.cholesky_tb input boolUpper
   where boolUpper = isUpper upper
 
 -- | choleskyInverse
@@ -785,7 +828,7 @@ choleskyInverse
   -> Tensor device dtype '[n, n] -- ^ the input 2-D tensor `u`, an upper or lower triangular Cholesky factor
   -> Tensor device dtype '[n, n] -- ^ the output 2-D tensor
 choleskyInverse upper input = unsafePerformIO
-  $ cast2 ATen.cholesky_inverse_tb input boolUpper
+  $ ATen.cast2 ATen.Managed.cholesky_inverse_tb input boolUpper
   where boolUpper = isUpper upper
 
 -- | choleskySolve
@@ -813,7 +856,7 @@ choleskySolve
   -> Tensor device dtype m_m -- ^ the (batched) input 2-D tensor `u`, an upper or lower triangular Cholesky factor
   -> Tensor device dtype m_k -- ^ the (batched) output 2-D tensor
 choleskySolve upper b u = unsafePerformIO
-  $ cast3 ATen.cholesky_solve_ttb b u boolUpper
+  $ ATen.cast3 ATen.Managed.cholesky_solve_ttb b u boolUpper
   where boolUpper = isUpper upper
 
 type family SolveDTypeIsValid (device :: (D.DeviceType, Nat)) (dtype :: D.DType) :: Constraint where
@@ -854,7 +897,7 @@ solve
   -> ( Tensor device dtype m_k
      , Tensor device dtype m_m
      ) -- ^ the (batched) outputs c and lu
-solve b a = unsafePerformIO $ cast2 ATen.solve_tt b a
+solve b a = unsafePerformIO $ ATen.cast2 ATen.Managed.solve_tt b a
 
 -- | geqrf
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -886,7 +929,7 @@ geqrf
   -> ( Tensor device dtype '[m, n]
      , Tensor device dtype '[Min m n]
      ) -- ^ tuple `(a, tau)` of output matrices
-geqrf input = unsafePerformIO $ cast1 ATen.geqrf_t input
+geqrf input = unsafePerformIO $ ATen.cast1 ATen.Managed.geqrf_t input
 
 -- | orgqr
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -904,7 +947,7 @@ orgqr
    . Tensor device dtype '[m, n]
   -> Tensor device dtype '[Min m n]
   -> Tensor device dtype '[m, n]
-orgqr a tau = unsafePerformIO $ cast2 ATen.orgqr_tt a tau
+orgqr a tau = unsafePerformIO $ ATen.cast2 ATen.Managed.orgqr_tt a tau
 
 -- | sign
 -- works for all dtypes
@@ -914,7 +957,7 @@ sign
   :: forall shape dtype device
    . Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
-sign input = unsafePerformIO $ cast1 ATen.sign_t input
+sign input = unsafePerformIO $ ATen.cast1 ATen.Managed.sign_t input
 
 type family SetValue (shape :: [Nat]) (i :: Nat) (j :: Nat)  :: [Nat] where
   SetValue '[]     _ _ = '[]
@@ -952,7 +995,7 @@ transpose
   => Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape' -- ^ output
 transpose input =
-  unsafePerformIO $ cast3 ATen.transpose_tll input (natValI @n) (natValI @m)
+  unsafePerformIO $ ATen.cast3 ATen.Managed.transpose_tll input (natValI @n) (natValI @m)
 
 -- | transpose2d, special case for a 2D tensor
 -- >>> dtype &&& shape $ transpose2D (ones :: CPUTensor 'D.Float '[3,2])
@@ -964,7 +1007,7 @@ transpose2D
 transpose2D = transpose @0 @1
 
 -- diag :: Tensor device dtype shape -> Int -> Tensor device dtype shape
--- diag t index = unsafePerformIO $ (cast2 ATen.tensor_diag_l) t index
+-- diag t index = unsafePerformIO $ (ATen.cast2 ATen.Managed.tensor_diag_l) t index
 
 -- | all
 -- See https://pytorch.org/docs/stable/tensors.html#torch.BoolTensor.all.
@@ -983,7 +1026,7 @@ all
   :: forall shape device
    . Tensor device 'D.Bool shape -- ^ input
   -> Tensor device 'D.Bool '[] -- ^ output
-all input = unsafePerformIO $ cast1 ATen.all_t input
+all input = unsafePerformIO $ ATen.cast1 ATen.Managed.all_t input
 
 -- | any
 -- See https://pytorch.org/docs/stable/tensors.html#torch.BoolTensor.any.
@@ -1002,7 +1045,7 @@ any
   :: forall shape device
    . Tensor device 'D.Bool shape -- ^ input
   -> Tensor device 'D.Bool '[] -- ^ output
-any input = unsafePerformIO $ cast1 ATen.any_t input
+any input = unsafePerformIO $ ATen.cast1 ATen.Managed.any_t input
 
 data KeepOrDropDim = KeepDim | DropDim
 
@@ -1044,7 +1087,7 @@ all'
   => Tensor device 'D.Bool shape -- ^ input
   -> Tensor device 'D.Bool shape' -- ^ output
 all' input = unsafePerformIO
-  $ cast3 ATen.all_tlb input (natValI @dim) (keepOrDropDimVal @keepOrDropDim)
+  $ ATen.cast3 ATen.Managed.all_tlb input (natValI @dim) (keepOrDropDimVal @keepOrDropDim)
 
 -- | any'
 -- See https://pytorch.org/docs/stable/tensors.html#torch.BoolTensor.any.
@@ -1069,7 +1112,7 @@ any'
      )
   => Tensor device 'D.Bool shape -- ^ input
   -> Tensor device 'D.Bool shape' -- ^ output
-any' input = unsafePerformIO $ cast3 ATen.any_tlb input (natValI @dim) (keepOrDropDimVal @keepOrDropDim)
+any' input = unsafePerformIO $ ATen.cast3 ATen.Managed.any_tlb input (natValI @dim) (keepOrDropDimVal @keepOrDropDim)
 
 -- | dropout
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -1100,7 +1143,7 @@ dropout
   -> Bool -- ^ whether or not to activate dropout
   -> Tensor device dtype shape -- ^ input
   -> IO (Tensor device dtype shape) -- ^ output
-dropout p train input = cast3 ATen.dropout_tdb input p train
+dropout p train input = ATen.cast3 ATen.Managed.dropout_tdb input p train
 
 -- | featureDropout
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -1116,7 +1159,7 @@ featureDropout
   -> Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
 featureDropout p train input =
-  unsafePerformIO $ cast3 ATen.feature_dropout_tdb input p train
+  unsafePerformIO $ ATen.cast3 ATen.Managed.feature_dropout_tdb input p train
 
 -- | alphaDropout
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -1132,7 +1175,7 @@ alphaDropout
   -> Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
 alphaDropout p train input =
-  unsafePerformIO $ cast3 ATen.alpha_dropout_tdb input p train
+  unsafePerformIO $ ATen.cast3 ATen.Managed.alpha_dropout_tdb input p train
 
 -- | featureAlphaDropout
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -1148,7 +1191,7 @@ featureAlphaDropout
   -> Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
 featureAlphaDropout p train input =
-  unsafePerformIO $ cast3 ATen.feature_alpha_dropout_tdb input p train
+  unsafePerformIO $ ATen.cast3 ATen.Managed.feature_alpha_dropout_tdb input p train
 
 -- | acos
 -- >>> dtype &&& shape $ acos (ones :: CPUTensor 'D.Float '[3,2])
@@ -1158,7 +1201,7 @@ acos
    . (StandardFloatingPointDTypeValidation device dtype)
   => Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
-acos input = unsafePerformIO $ cast1 ATen.acos_t input
+acos input = unsafePerformIO $ ATen.cast1 ATen.Managed.acos_t input
 
 -- | avgPool1d
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -1182,7 +1225,7 @@ avgPool1d
      )
   => Tensor device dtype '[batchSize, channelSize, inputSize] -- ^ input
   -> Tensor device dtype '[batchSize, channelSize, outputSize] -- ^ output
-avgPool1d input = unsafePerformIO $ cast6 ATen.avg_pool1d_tlllbb
+avgPool1d input = unsafePerformIO $ ATen.cast6 ATen.Managed.avg_pool1d_tlllbb
   input
   (natValI @kernelSize)
   (natValI @stride)
@@ -1203,7 +1246,7 @@ adaptiveAvgPool1d
   => Tensor device dtype '[batchSize, channelSize, inputSize] -- ^ input
   -> Tensor device dtype '[batchSize, channelSize, outputSize] -- ^ output
 adaptiveAvgPool1d input = unsafePerformIO
-  $ cast2 ATen.adaptive_avg_pool1d_tl input (natValI @outputSize)
+  $ ATen.cast2 ATen.Managed.adaptive_avg_pool1d_tl input (natValI @outputSize)
 
 -- | adaptiveMaxPool1d
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -1222,7 +1265,7 @@ adaptiveMaxPool1d
      , Tensor device 'D.Int64 '[batchSize, channelSize, outputSize]
      ) -- ^ output
 adaptiveMaxPool1d input = unsafePerformIO
-  $ cast2 ATen.adaptive_max_pool1d_tl input (natValI @outputSize)
+  $ ATen.cast2 ATen.Managed.adaptive_max_pool1d_tl input (natValI @outputSize)
 
 -- | addmv
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -1244,7 +1287,7 @@ addmv
   -> Tensor device dtype '[m] -- ^ vector
   -> Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape' -- ^ output
-addmv beta alpha mat vec input = unsafePerformIO $ cast5 ATen.addmv_tttss input mat vec beta alpha
+addmv beta alpha mat vec input = unsafePerformIO $ ATen.cast5 ATen.Managed.addmv_tttss input mat vec beta alpha
 
 -- | addr
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -1266,10 +1309,10 @@ addr
   -> Tensor device dtype '[m] -- ^ second input vector
   -> Tensor device dtype shape -- ^ input tensor
   -> Tensor device dtype shape' -- ^ output tensor
-addr beta alpha vec1 vec2 input = unsafePerformIO $ cast5 ATen.addr_tttss input vec1 vec2 beta alpha
+addr beta alpha vec1 vec2 input = unsafePerformIO $ ATen.cast5 ATen.Managed.addr_tttss input vec1 vec2 beta alpha
 
 -- affine_grid_generator :: Tensor device dtype shape -> [Int] -> Tensor device dtype shape
--- affine_grid_generator _theta _size = unsafePerformIO $ (cast2 ATen.affine_grid_generator_tl) _theta _size
+-- affine_grid_generator _theta _size = unsafePerformIO $ (ATen.cast2 ATen.Managed.affine_grid_generator_tl) _theta _size
 
 -- | allclose
 -- >>> allclose 0.1 0.1 True (ones :: CPUTensor 'D.Float '[3,3]) (ones :: CPUTensor 'D.Float '[3,3])
@@ -1283,7 +1326,7 @@ allclose
   -> Tensor device dtype shape -- ^ other input tensor
   -> Bool -- ^ output
 allclose rtol atol equalNaN input other =
-  unsafePerformIO $ cast5 ATen.allclose_ttddb input other rtol atol equalNaN
+  unsafePerformIO $ ATen.cast5 ATen.Managed.allclose_ttddb input other rtol atol equalNaN
 
 -- | argmax
 -- See https://pytorch.org/docs/stable/torch.html#torch.argmax.
@@ -1308,7 +1351,7 @@ argmax
      )
   => Tensor device dtype    shape -- ^ input
   -> Tensor device 'D.Int64 shape' -- ^ output
-argmax input = unsafePerformIO $ cast3 ATen.argmax_tlb
+argmax input = unsafePerformIO $ ATen.cast3 ATen.Managed.argmax_tlb
                                        input
                                        (natValI @dim)
                                        (keepOrDropDimVal @keepOrDropDim)
@@ -1336,13 +1379,13 @@ argmin
     )
   => Tensor device dtype    shape -- ^ input
   -> Tensor device 'D.Int64 shape' -- ^ output
-argmin input = unsafePerformIO $ cast3 ATen.argmin_tlb
+argmin input = unsafePerformIO $ ATen.cast3 ATen.Managed.argmin_tlb
                                        input
                                        (natValI @dim)
                                        (keepOrDropDimVal @keepOrDropDim)
 
 -- as_strided :: Tensor device dtype shape -> [Int] -> [Int] -> Int -> Tensor device dtype shape
--- as_strided _input _size _stride _storage_offset = unsafePerformIO $ (cast4 ATen.as_strided_tlll) _input _size _stride _storage_offset
+-- as_strided _input _size _stride _storage_offset = unsafePerformIO $ (ATen.cast4 ATen.Managed.as_strided_tlll) _input _size _stride _storage_offset
 
 -- | asin
 -- >>> dtype &&& shape $ asin (ones :: CPUTensor 'D.Float '[3,2])
@@ -1352,7 +1395,7 @@ asin
    . (StandardFloatingPointDTypeValidation device dtype)
   => Tensor device dtype shape
   -> Tensor device dtype shape
-asin input = unsafePerformIO $ cast1 ATen.asin_t input
+asin input = unsafePerformIO $ ATen.cast1 ATen.Managed.asin_t input
 
 -- | atan
 -- >>> dtype &&& shape $ atan (ones :: CPUTensor 'D.Float '[3,2])
@@ -1362,7 +1405,7 @@ atan
    . (StandardFloatingPointDTypeValidation device dtype)
   => Tensor device dtype shape
   -> Tensor device dtype shape
-atan input = unsafePerformIO $ cast1 ATen.atan_t input
+atan input = unsafePerformIO $ ATen.cast1 ATen.Managed.atan_t input
 
 -- | baddbmm
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -1384,19 +1427,19 @@ baddbmm
   -> Tensor device dtype '[batchSize, k, m] -- ^ second batch
   -> Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape' -- ^ output
-baddbmm beta alpha batch1 batch2 input = unsafePerformIO $ cast5 ATen.baddbmm_tttss input batch1 batch2 beta alpha
+baddbmm beta alpha batch1 batch2 input = unsafePerformIO $ ATen.cast5 ATen.Managed.baddbmm_tttss input batch1 batch2 beta alpha
 
 -- batch_norm :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Bool -> Double -> Double -> Bool -> Tensor device dtype shape
--- batch_norm _input _weight _bias _running_mean _running_var _training _momentum _eps _cudnn_enabled = unsafePerformIO $ (cast9 ATen.batch_norm_tttttbddb) _input _weight _bias _running_mean _running_var _training _momentum _eps _cudnn_enabled
+-- batch_norm _input _weight _bias _running_mean _running_var _training _momentum _eps _cudnn_enabled = unsafePerformIO $ (ATen.cast9 ATen.Managed.batch_norm_tttttbddb) _input _weight _bias _running_mean _running_var _training _momentum _eps _cudnn_enabled
 
 -- bilinear :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape
--- bilinear _input1 _input2 _weight _bias = unsafePerformIO $ (cast4 ATen.bilinear_tttt) _input1 _input2 _weight _bias
+-- bilinear _input1 _input2 _weight _bias = unsafePerformIO $ (ATen.cast4 ATen.Managed.bilinear_tttt) _input1 _input2 _weight _bias
 
 -- binary_cross_entropy_with_logits :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Int -> Tensor device dtype shape
--- binary_cross_entropy_with_logits _input _target _weight _pos_weight _reduction = unsafePerformIO $ (cast5 ATen.binary_cross_entropy_with_logits_ttttl) _input _target _weight _pos_weight _reduction
+-- binary_cross_entropy_with_logits _input _target _weight _pos_weight _reduction = unsafePerformIO $ (ATen.cast5 ATen.Managed.binary_cross_entropy_with_logits_ttttl) _input _target _weight _pos_weight _reduction
 
 -- bincount :: Tensor device dtype shape -> Tensor device dtype shape -> Int -> Tensor device dtype shape
--- bincount _input _weights _minlength = unsafePerformIO $ (cast3 ATen.bincount_ttl) _input _weights _minlength
+-- bincount _input _weights _minlength = unsafePerformIO $ (ATen.cast3 ATen.Managed.bincount_ttl) _input _weights _minlength
 
 -- | bitwise_not
 -- >>> dtype &&& shape $ bitwiseNot (ones :: CPUTensor 'D.Bool [3,3])
@@ -1405,7 +1448,7 @@ bitwiseNot
   :: forall shape device
    . Tensor device 'D.Bool shape
   -> Tensor device 'D.Bool shape
-bitwiseNot input = unsafePerformIO $ cast1 ATen.bitwise_not_t input
+bitwiseNot input = unsafePerformIO $ ATen.cast1 ATen.Managed.bitwise_not_t input
 
 -- | batched matrix multiplication
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -1416,7 +1459,7 @@ bmm
    . Tensor device dtype '[batchSize, n, k] -- ^ input
   -> Tensor device dtype '[batchSize, k, m] -- ^ other input
   -> Tensor device dtype '[batchSize, n, m] -- ^ output
-bmm input other = unsafePerformIO $ cast2 ATen.bmm_tt input other
+bmm input other = unsafePerformIO $ ATen.cast2 ATen.Managed.bmm_tt input other
 
 -- | BroadcastTensorsImpl
 -- >>> type Ty = BroadcastTensorsImpl '[] 'Nothing
@@ -1471,16 +1514,12 @@ type BroadcastTensors tensors
 broadcastTensors
   :: forall tensors tensors'
    . ( tensors' ~ BroadcastTensors tensors
-     , HFoldrM IO TensorListFold [D.ATenTensor] tensors
-     , Apply TensorListUnfold [D.ATenTensor] (HUnfoldMRes IO [D.ATenTensor] tensors)
-     , HUnfoldM IO TensorListUnfold (HUnfoldMRes IO [D.ATenTensor] tensors) tensors
-     , HFoldrM IO TensorListFold [D.ATenTensor] tensors'
-     , Apply TensorListUnfold [D.ATenTensor] (HUnfoldMRes IO [D.ATenTensor] tensors')
-     , HUnfoldM IO TensorListUnfold (HUnfoldMRes IO [D.ATenTensor] tensors') tensors'
+     , ATen.Castable (HList tensors)  [D.ATenTensor]
+     , ATen.Castable (HList tensors') [D.ATenTensor]
      )
   => HList tensors -- ^ input list of tensors
   -> HList tensors' -- ^ output list of tensors
-broadcastTensors tensors = unsafePerformIO $ cast1 ATen.broadcast_tensors_l tensors
+broadcastTensors tensors = unsafePerformIO $ ATen.cast1 ATen.Managed.broadcast_tensors_l tensors
 
 type family CatImpl (dim :: Nat) (tensors :: [a]) (acc :: Maybe ([Nat], D.DType, (D.DeviceType, Nat))) :: Maybe ([Nat], D.DType, (D.DeviceType, Nat)) where
   CatImpl _   '[]                                    acc = acc
@@ -1556,16 +1595,14 @@ cat
   :: forall dim shape dtype device tensors
    . ( KnownNat dim
      , '(shape, dtype, device) ~ Cat dim tensors
-     , HFoldrM IO TensorListFold [D.ATenTensor] tensors
-     , Apply TensorListUnfold [D.ATenTensor] (HUnfoldMRes IO [D.ATenTensor] tensors)
-     , HUnfoldM IO TensorListUnfold (HUnfoldMRes IO [D.ATenTensor] tensors) tensors
+     , ATen.Castable (HList tensors) [D.ATenTensor]
      )
   => HList tensors -- ^ input list of tensors
   -> Tensor device dtype shape -- ^ output tensor
-cat tensors = unsafePerformIO $ cast2 ATen.cat_ll tensors (natValI @dim :: Int)
+cat tensors = unsafePerformIO $ ATen.cast2 ATen.Managed.cat_ll tensors (natValI @dim :: Int)
 
 -- chain_matmul :: [Tensor device dtype shape] -> Tensor device dtype shape
--- chain_matmul _matrices = unsafePerformIO $ (cast1 ATen.chain_matmul_l) _matrices
+-- chain_matmul _matrices = unsafePerformIO $ (ATen.cast1 ATen.Managed.chain_matmul_l) _matrices
 
 type family ChunkImpl (chunkShapes :: Maybe [[Nat]]) (dtype :: D.DType) (device :: (D.DeviceType, Nat)) :: Maybe a where
   ChunkImpl (Just '[])               _     _     = Just '[]
@@ -1651,14 +1688,12 @@ chunk
    . ( KnownNat chunks
      , KnownNat dim
      , tensorChunks ~ Chunk chunks dim shape dtype device
-     , HFoldrM IO TensorListFold [D.ATenTensor] tensorChunks
-     , Apply TensorListUnfold [D.ATenTensor] (HUnfoldMRes IO [D.ATenTensor] tensorChunks)
-     , HUnfoldM IO TensorListUnfold (HUnfoldMRes IO [D.ATenTensor] tensorChunks) tensorChunks
+     , ATen.Castable (HList tensorChunks) [D.ATenTensor]
      )
   => Tensor device dtype shape -- ^ input tensor
   -> HList tensorChunks -- ^ output list of tensors
 chunk input = unsafePerformIO
-  $ cast3 ATen.chunk_tll input (natValI @chunks :: Int) (natValI @dim :: Int)
+  $ ATen.cast3 ATen.Managed.chunk_tll input (natValI @chunks :: Int) (natValI @dim :: Int)
 
 -- | clamp
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -1671,7 +1706,7 @@ clamp
   -> Float -- ^ maximum value
   -> Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
-clamp min max input = unsafePerformIO $ cast3 ATen.clamp_tss input min max
+clamp min max input = unsafePerformIO $ ATen.cast3 ATen.Managed.clamp_tss input min max
 
 -- | clampMax
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -1683,7 +1718,7 @@ clampMax
    . Float -- ^ maximum value
   -> Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
-clampMax max input = unsafePerformIO $ cast2 ATen.clamp_max_ts input max
+clampMax max input = unsafePerformIO $ ATen.cast2 ATen.Managed.clamp_max_ts input max
 
 -- | clampMin
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -1695,7 +1730,7 @@ clampMin
    . Float -- ^ minimum value
   -> Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
-clampMin min input = unsafePerformIO $ cast2 ATen.clamp_min_ts input min
+clampMin min input = unsafePerformIO $ ATen.cast2 ATen.Managed.clamp_min_ts input min
 
 -- | cudnnIsAcceptable
 -- TODO: calling this probably makes only sense when the device is CUDA
@@ -1704,25 +1739,25 @@ cudnnIsAcceptable
    . Tensor device dtype shape -- ^ input
   -> Bool -- ^ output
 cudnnIsAcceptable input =
-  unsafePerformIO $ cast1 ATen.cudnn_is_acceptable_t input
+  unsafePerformIO $ ATen.cast1 ATen.Managed.cudnn_is_acceptable_t input
 
 -- constant_pad_nd :: Tensor device dtype shape -> [Int] -> Float -> Tensor device dtype shape
--- constant_pad_nd _input _pad _value = unsafePerformIO $ (cast3 ATen.constant_pad_nd_tls) _input _pad _value
+-- constant_pad_nd _input _pad _value = unsafePerformIO $ (ATen.cast3 ATen.Managed.constant_pad_nd_tls) _input _pad _value
 
 constantPadNd1d
   :: forall (pad :: (Nat, Nat)) n dtype device
-   . (All KnownNat '[Fst pad, Snd pad, n])
+   . (All KnownNat '[Torch.Typed.Aux.Fst pad, Torch.Typed.Aux.Snd pad, n])
   => Float
   -> Tensor device dtype '[n]
-  -> Tensor device dtype '[n + Fst pad + Snd pad]
-constantPadNd1d value input = unsafePerformIO $ cast3
-  ATen.constant_pad_nd_tls
+  -> Tensor device dtype '[n + Torch.Typed.Aux.Fst pad + Torch.Typed.Aux.Snd pad]
+constantPadNd1d value input = unsafePerformIO $ ATen.cast3
+  ATen.Managed.constant_pad_nd_tls
   input
-  ([natValI @(Fst pad), natValI @(Snd pad)] :: [Int])
+  ([natValI @(Torch.Typed.Aux.Fst pad), natValI @(Torch.Typed.Aux.Snd pad)] :: [Int])
   value
 
 -- convolution :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> [Int] -> [Int] -> [Int] -> Bool -> [Int] -> Int -> Tensor device dtype shape
--- convolution _input _weight _bias _stride _padding _dilation _transposed _output_padding _groups = unsafePerformIO $ (cast9 ATen.convolution_tttlllbll) _input _weight _bias _stride _padding _dilation _transposed _output_padding _groups
+-- convolution _input _weight _bias _stride _padding _dilation _transposed _output_padding _groups = unsafePerformIO $ (ATen.cast9 ATen.Managed.convolution_tttlllbll) _input _weight _bias _stride _padding _dilation _transposed _output_padding _groups
 
 type ConvSideCheck h k d (p :: Nat) o =
   (
@@ -1775,7 +1810,7 @@ conv1d
   -> Tensor device dtype '[outputChannelSize] -- ^ bias
   -> Tensor device dtype '[batchSize, inputChannelSize, inputSize] -- ^ input
   -> Tensor device dtype '[batchSize, outputChannelSize, outputSize] -- ^ output
-conv1d weight bias input = unsafePerformIO $ cast7 ATen.conv1d_tttllll
+conv1d weight bias input = unsafePerformIO $ ATen.cast7 ATen.Managed.conv1d_tttllll
                                                    input
                                                    weight
                                                    bias
@@ -1801,28 +1836,28 @@ conv2d
             outputSize0 outputSize1
             dtype
             device
-   . ( All KnownNat '[ Fst stride, Snd stride
-                     , Fst padding, Snd padding
+   . ( All KnownNat '[ Torch.Typed.Aux.Fst stride, Torch.Typed.Aux.Snd stride
+                     , Torch.Typed.Aux.Fst padding, Torch.Typed.Aux.Snd padding
                      , inputChannelSize, outputChannelSize
                      , kernelSize0, kernelSize1
                      , inputSize0, inputSize1
                      , batchSize
                      , outputSize0, outputSize1
                      ]
-     , ConvSideCheck inputSize0 kernelSize0 (Fst stride) (Fst padding) outputSize0
-     , ConvSideCheck inputSize1 kernelSize1 (Snd stride) (Snd padding) outputSize1
+     , ConvSideCheck inputSize0 kernelSize0 (Torch.Typed.Aux.Fst stride) (Torch.Typed.Aux.Fst padding) outputSize0
+     , ConvSideCheck inputSize1 kernelSize1 (Torch.Typed.Aux.Snd stride) (Torch.Typed.Aux.Snd padding) outputSize1
      )
   => Tensor device dtype '[outputChannelSize, inputChannelSize, kernelSize0, kernelSize1] -- ^ weight
   -> Tensor device dtype '[outputChannelSize] -- ^ bias
   -> Tensor device dtype '[batchSize, inputChannelSize, inputSize0, inputSize1] -- ^ input
   -> Tensor device dtype '[batchSize, outputChannelSize, outputSize0, outputSize1] -- ^ output
-conv2d weight bias input = unsafePerformIO $ cast7
-  ATen.conv2d_tttllll
+conv2d weight bias input = unsafePerformIO $ ATen.cast7
+  ATen.Managed.conv2d_tttllll
   input
   weight
   bias
-  ([natValI @(Fst stride), natValI @(Snd stride)] :: [Int])
-  ([natValI @(Fst padding), natValI @(Snd padding)] :: [Int])
+  ([natValI @(Torch.Typed.Aux.Fst stride),  natValI @(Torch.Typed.Aux.Snd stride)]  :: [Int])
+  ([natValI @(Torch.Typed.Aux.Fst padding), natValI @(Torch.Typed.Aux.Snd padding)] :: [Int])
   ([1, 1] :: [Int])
   (1 :: Int)
 
@@ -1858,8 +1893,8 @@ conv3d
   -> Tensor device dtype '[outputChannelSize] -- ^ bias
   -> Tensor device dtype '[batchSize, inputChannelSize, inputSize0, inputSize1, inputSize2] -- ^ input
   -> Tensor device dtype '[batchSize, outputChannelSize, outputSize0, outputSize1, outputSize2] -- ^ output
-conv3d weight bias input = unsafePerformIO $ cast7
-  ATen.conv3d_tttllll
+conv3d weight bias input = unsafePerformIO $ ATen.cast7
+  ATen.Managed.conv3d_tttllll
   input
   weight
   bias
@@ -1886,10 +1921,10 @@ convTBC
   -> Tensor device dtype '[timeSize, batchSize, inputChannels]
   -> Tensor device dtype '[timeSize+padding*2+1-kernelSize, batchSize, outputChannels]
 convTBC weight bias input =
-  unsafePerformIO $ cast4 ATen.conv_tbc_tttl input weight bias (natValI @padding)
+  unsafePerformIO $ ATen.cast4 ATen.Managed.conv_tbc_tttl input weight bias (natValI @padding)
 
 -- conv_transpose1d :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Int -> Int -> Int -> Int -> Int -> Tensor device dtype shape
--- conv_transpose1d _input _weight _bias _stride _padding _output_padding _groups _dilation = unsafePerformIO $ (cast8 ATen.conv_transpose1d_tttlllll) _input _weight _bias _stride _padding _output_padding _groups _dilation
+-- conv_transpose1d _input _weight _bias _stride _padding _output_padding _groups _dilation = unsafePerformIO $ (ATen.cast8 ATen.Managed.conv_transpose1d_tttlllll) _input _weight _bias _stride _padding _output_padding _groups _dilation
 
 -- | cosh
 -- >>> dtype &&& shape $ cosh (ones :: CPUTensor 'D.Float '[3,2])
@@ -1899,25 +1934,25 @@ cosh
    . (StandardFloatingPointDTypeValidation device dtype)
   => Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
-cosh input = unsafePerformIO $ cast1 ATen.cosh_t input
+cosh input = unsafePerformIO $ ATen.cast1 ATen.Managed.cosh_t input
 
 -- cosine_embedding_loss :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Double -> Int -> Tensor device dtype shape
--- cosine_embedding_loss _input1 _input2 _target _margin _reduction = unsafePerformIO $ (cast5 ATen.cosine_embedding_loss_tttdl) _input1 _input2 _target _margin _reduction
+-- cosine_embedding_loss _input1 _input2 _target _margin _reduction = unsafePerformIO $ (ATen.cast5 ATen.Managed.cosine_embedding_loss_tttdl) _input1 _input2 _target _margin _reduction
 
 -- cudnn_affine_grid_generator :: Tensor device dtype shape -> Int -> Int -> Int -> Int -> Tensor device dtype shape
--- cudnn_affine_grid_generator _theta _N _C _H _W = unsafePerformIO $ (cast5 ATen.cudnn_affine_grid_generator_tllll) _theta _N _C _H _W
+-- cudnn_affine_grid_generator _theta _N _C _H _W = unsafePerformIO $ (ATen.cast5 ATen.Managed.cudnn_affine_grid_generator_tllll) _theta _N _C _H _W
 
 -- cudnn_batch_norm :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Bool -> Double -> Double -> (Tensor device dtype shape,Tensor device dtype shape,Tensor device dtype shape)
--- cudnn_batch_norm _input _weight _bias _running_mean _running_var _training _exponential_average_factor _epsilon = unsafePerformIO $ (cast8 ATen.cudnn_batch_norm_tttttbdd) _input _weight _bias _running_mean _running_var _training _exponential_average_factor _epsilon
+-- cudnn_batch_norm _input _weight _bias _running_mean _running_var _training _exponential_average_factor _epsilon = unsafePerformIO $ (ATen.cast8 ATen.Managed.cudnn_batch_norm_tttttbdd) _input _weight _bias _running_mean _running_var _training _exponential_average_factor _epsilon
 
 -- cudnn_convolution :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> [Int] -> [Int] -> [Int] -> Int -> Bool -> Bool -> Tensor device dtype shape
--- cudnn_convolution _input _weight _bias _padding _stride _dilation _groups _benchmark _deterministic = unsafePerformIO $ (cast9 ATen.cudnn_convolution_tttllllbb) _input _weight _bias _padding _stride _dilation _groups _benchmark _deterministic
+-- cudnn_convolution _input _weight _bias _padding _stride _dilation _groups _benchmark _deterministic = unsafePerformIO $ (ATen.cast9 ATen.Managed.cudnn_convolution_tttllllbb) _input _weight _bias _padding _stride _dilation _groups _benchmark _deterministic
 
 -- cudnn_convolution_transpose :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> [Int] -> [Int] -> [Int] -> [Int] -> Int -> Bool -> Bool -> Tensor device dtype shape
--- cudnn_convolution_transpose _input _weight _bias _padding _output_padding _stride _dilation _groups _benchmark _deterministic = unsafePerformIO $ (cast10 ATen.cudnn_convolution_transpose_tttlllllbb) _input _weight _bias _padding _output_padding _stride _dilation _groups _benchmark _deterministic
+-- cudnn_convolution_transpose _input _weight _bias _padding _output_padding _stride _dilation _groups _benchmark _deterministic = unsafePerformIO $ (ATen.ATen.cast10 ATen.Managed.cudnn_convolution_transpose_tttlllllbb) _input _weight _bias _padding _output_padding _stride _dilation _groups _benchmark _deterministic
 
 -- cudnn_grid_sampler :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape
--- cudnn_grid_sampler _input _grid = unsafePerformIO $ (cast2 ATen.cudnn_grid_sampler_tt) _input _grid
+-- cudnn_grid_sampler _input _grid = unsafePerformIO $ (ATen.cast2 ATen.Managed.cudnn_grid_sampler_tt) _input _grid
 
 -- | Det
 -- >>> :kind! Det '[2,2]
@@ -1941,22 +1976,22 @@ det
   :: forall shape dtype device
    . Tensor device dtype shape -- ^ input
   -> Tensor device dtype (Det shape) -- ^ output
-det input = unsafePerformIO $ cast1 ATen.det_t input
+det input = unsafePerformIO $ ATen.cast1 ATen.Managed.det_t input
 
 -- diag_embed :: Tensor device dtype shape -> Int -> Int -> Int -> Tensor device dtype shape
--- diag_embed _input _offset _dim1 _dim2 = unsafePerformIO $ (cast4 ATen.diag_embed_tlll) _input _offset _dim1 _dim2
+-- diag_embed _input _offset _dim1 _dim2 = unsafePerformIO $ (ATen.cast4 ATen.Managed.diag_embed_tlll) _input _offset _dim1 _dim2
 
 -- diagflat :: Tensor device dtype shape -> Int -> Tensor device dtype shape
--- diagflat _input _offset = unsafePerformIO $ (cast2 ATen.diagflat_tl) _input _offset
+-- diagflat _input _offset = unsafePerformIO $ (ATen.cast2 ATen.Managed.diagflat_tl) _input _offset
 
 -- diagonal :: Tensor device dtype shape -> Int -> Int -> Int -> Tensor device dtype shape
--- diagonal _input _offset _dim1 _dim2 = unsafePerformIO $ (cast4 ATen.diagonal_tlll) _input _offset _dim1 _dim2
+-- diagonal _input _offset _dim1 _dim2 = unsafePerformIO $ (ATen.cast4 ATen.Managed.diagonal_tlll) _input _offset _dim1 _dim2
 
 -- dot :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape
--- dot _input _tensor = unsafePerformIO $ (cast2 ATen.dot_tt) _input _tensor
+-- dot _input _tensor = unsafePerformIO $ (ATen.cast2 ATen.Managed.dot_tt) _input _tensor
 
 -- einsum :: String -> [Tensor device dtype shape] -> Tensor device dtype shape
--- einsum _equation _tensors = unsafePerformIO $ (cast2 ATen.einsum_sl) _equation _tensors
+-- einsum _equation _tensors = unsafePerformIO $ (ATen.cast2 ATen.Managed.einsum_sl) _equation _tensors
 
 class KnownMaybeNat (n :: Maybe Nat) where
   maybeNatVal :: Maybe Integer
@@ -1998,14 +2033,14 @@ embedding
   -> Tensor device 'D.Int64 shape -- ^ indices
   -> Tensor device dtype    (Reverse (embedDim ': Reverse shape)) -- ^ output
 embedding scaleGradByFreq sparse weights indices =
-  unsafePerformIO $ cast5 ATen.embedding_ttlbb weights indices paddingIdx scaleGradByFreq sparse
+  unsafePerformIO $ ATen.cast5 ATen.Managed.embedding_ttlbb weights indices paddingIdx scaleGradByFreq sparse
  where paddingIdx :: Int
        paddingIdx = case maybeNatVal @paddingIdx of
                       Just idx -> fromIntegral idx
                       Nothing  -> -1
 
 -- embedding_bag :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Bool -> Int -> Bool -> Tensor device dtype shape -> (Tensor device dtype shape,Tensor device dtype shape,Tensor device dtype shape,Tensor device dtype shape)
--- embedding_bag _weight _indices _offsets _scale_grad_by_freq _mode _sparse _per_sample_weights = unsafePerformIO $ (cast7 ATen.embedding_bag_tttblbt) _weight _indices _offsets _scale_grad_by_freq _mode _sparse _per_sample_weights
+-- embedding_bag _weight _indices _offsets _scale_grad_by_freq _mode _sparse _per_sample_weights = unsafePerformIO $ (ATen.cast7 ATen.Managed.embedding_bag_tttblbt) _weight _indices _offsets _scale_grad_by_freq _mode _sparse _per_sample_weights
 
 -- | emptyLike
 -- TODO: this seems quite unsafe, the values of this tensor will be random
@@ -2016,7 +2051,7 @@ emptyLike
   :: forall shape dtype device
    . Tensor device dtype shape -- ^ input
   -> IO (Tensor device dtype shape) -- ^ output
-emptyLike input = cast1 ATen.empty_like_t input
+emptyLike input = ATen.cast1 ATen.Managed.empty_like_t input
 
 -- | erfc
 -- >>> dtype &&& shape $ erfc (ones :: CPUTensor 'D.Float '[3,2])
@@ -2026,7 +2061,7 @@ erfc
    . (StandardFloatingPointDTypeValidation device dtype)
   => Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
-erfc input = unsafePerformIO $ cast1 ATen.erfc_t input
+erfc input = unsafePerformIO $ ATen.cast1 ATen.Managed.erfc_t input
 
 -- | expm1
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -2037,7 +2072,7 @@ expm1
    . (StandardFloatingPointDTypeValidation device dtype)
   => Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
-expm1 input = unsafePerformIO $ cast1 ATen.expm1_t input
+expm1 input = unsafePerformIO $ ATen.cast1 ATen.Managed.expm1_t input
 
 -- | expand
 -- TODO: figure out what the boolean value does
@@ -2058,10 +2093,10 @@ expand
   => Bool -- ^ some boolean value with unknown function
   -> Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape' -- ^ output
-expand someBool input = unsafePerformIO $ cast3 ATen.tensor_expand_lb input (shapeVal @shape') someBool
+expand someBool input = unsafePerformIO $ ATen.cast3 ATen.Managed.tensor_expand_lb input (shapeVal @shape') someBool
 
 -- flatten :: Tensor device dtype shape -> Int -> Int -> Tensor device dtype shape
--- flatten _input _start_dim _end_dim = unsafePerformIO $ (cast3 ATen.flatten_tll) _input _start_dim _end_dim
+-- flatten _input _start_dim _end_dim = unsafePerformIO $ (ATen.cast3 ATen.Managed.flatten_tll) _input _start_dim _end_dim
 
 -- | flattenAll
 -- >>> t = flattenAll (ones :: CPUTensor 'D.Float '[3,2])
@@ -2075,7 +2110,7 @@ flattenAll
   => Tensor device dtype shape -- ^ input
   -> Tensor device dtype '[Product shape] -- ^ output
 flattenAll input =
-  unsafePerformIO $ cast3 ATen.flatten_tll input (0 :: Int) (-1 :: Int)
+  unsafePerformIO $ ATen.cast3 ATen.Managed.flatten_tll input (0 :: Int) (-1 :: Int)
 
 -- | frac
 -- >>> dtype &&& shape $ frac (ones :: CPUTensor 'D.Float '[3,2])
@@ -2085,7 +2120,7 @@ frac
    . (StandardFloatingPointDTypeValidation device dtype)
   => Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
-frac input = unsafePerformIO $ cast1 ATen.frac_t input
+frac input = unsafePerformIO $ ATen.cast1 ATen.Managed.frac_t input
 
 -- | full like
 -- >>> dtype &&& shape $ fullLike 3.0 (ones :: CPUTensor 'D.Float '[3,2])
@@ -2096,49 +2131,49 @@ fullLike
   -> Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
 fullLike fillValue input =
-  unsafePerformIO $ cast2 ATen.full_like_ts input fillValue
+  unsafePerformIO $ ATen.cast2 ATen.Managed.full_like_ts input fillValue
 
 -- grid_sampler :: Tensor device dtype shape -> Tensor device dtype shape -> Int -> Int -> Tensor device dtype shape
--- grid_sampler _input _grid _interpolation_mode _padding_mode = unsafePerformIO $ (cast4 ATen.grid_sampler_ttll) _input _grid _interpolation_mode _padding_mode
+-- grid_sampler _input _grid _interpolation_mode _padding_mode = unsafePerformIO $ (ATen.cast4 ATen.Managed.grid_sampler_ttll) _input _grid _interpolation_mode _padding_mode
 
 -- grid_sampler_2d :: Tensor device dtype shape -> Tensor device dtype shape -> Int -> Int -> Tensor device dtype shape
--- grid_sampler_2d _input _grid _interpolation_mode _padding_mode = unsafePerformIO $ (cast4 ATen.grid_sampler_2d_ttll) _input _grid _interpolation_mode _padding_mode
+-- grid_sampler_2d _input _grid _interpolation_mode _padding_mode = unsafePerformIO $ (ATen.cast4 ATen.Managed.grid_sampler_2d_ttll) _input _grid _interpolation_mode _padding_mode
 
 -- grid_sampler_3d :: Tensor device dtype shape -> Tensor device dtype shape -> Int -> Int -> Tensor device dtype shape
--- grid_sampler_3d _input _grid _interpolation_mode _padding_mode = unsafePerformIO $ (cast4 ATen.grid_sampler_3d_ttll) _input _grid _interpolation_mode _padding_mode
+-- grid_sampler_3d _input _grid _interpolation_mode _padding_mode = unsafePerformIO $ (ATen.cast4 ATen.Managed.grid_sampler_3d_ttll) _input _grid _interpolation_mode _padding_mode
 
 -- hinge_embedding_loss :: Tensor device dtype shape -> Tensor device dtype shape -> Double -> Int -> Tensor device dtype shape
--- hinge_embedding_loss _input _target _margin _reduction = unsafePerformIO $ (cast4 ATen.hinge_embedding_loss_ttdl) _input _target _margin _reduction
+-- hinge_embedding_loss _input _target _margin _reduction = unsafePerformIO $ (ATen.cast4 ATen.Managed.hinge_embedding_loss_ttdl) _input _target _margin _reduction
 
 -- ger :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape
--- ger _input _vec2 = unsafePerformIO $ (cast2 ATen.ger_tt) _input _vec2
+-- ger _input _vec2 = unsafePerformIO $ (ATen.cast2 ATen.Managed.ger_tt) _input _vec2
 
 -- group_norm :: Tensor device dtype shape -> Int -> Tensor device dtype shape -> Tensor device dtype shape -> Double -> Bool -> Tensor device dtype shape
--- group_norm _input _num_groups _weight _bias _eps _cudnn_enabled = unsafePerformIO $ (cast6 ATen.group_norm_tlttdb) _input _num_groups _weight _bias _eps _cudnn_enabled
+-- group_norm _input _num_groups _weight _bias _eps _cudnn_enabled = unsafePerformIO $ (ATen.cast6 ATen.Managed.group_norm_tlttdb) _input _num_groups _weight _bias _eps _cudnn_enabled
 
 -- fft :: Tensor device dtype shape -> Int -> Bool -> Tensor device dtype shape
--- fft _input _signal_ndim _normalized = unsafePerformIO $ (cast3 ATen.fft_tlb) _input _signal_ndim _normalized
+-- fft _input _signal_ndim _normalized = unsafePerformIO $ (ATen.cast3 ATen.Managed.fft_tlb) _input _signal_ndim _normalized
 
 -- ifft :: Tensor device dtype shape -> Int -> Bool -> Tensor device dtype shape
--- ifft _input _signal_ndim _normalized = unsafePerformIO $ (cast3 ATen.ifft_tlb) _input _signal_ndim _normalized
+-- ifft _input _signal_ndim _normalized = unsafePerformIO $ (ATen.cast3 ATen.Managed.ifft_tlb) _input _signal_ndim _normalized
 
 -- rfft :: Tensor device dtype shape -> Int -> Bool -> Bool -> Tensor device dtype shape
--- rfft _input _signal_ndim _normalized _onesided = unsafePerformIO $ (cast4 ATen.rfft_tlbb) _input _signal_ndim _normalized _onesided
+-- rfft _input _signal_ndim _normalized _onesided = unsafePerformIO $ (ATen.cast4 ATen.Managed.rfft_tlbb) _input _signal_ndim _normalized _onesided
 
 -- irfft :: Tensor device dtype shape -> Int -> Bool -> Bool -> [Int] -> Tensor device dtype shape
--- irfft _input _signal_ndim _normalized _onesided _signal_sizes = unsafePerformIO $ (cast5 ATen.irfft_tlbbl) _input _signal_ndim _normalized _onesided _signal_sizes
+-- irfft _input _signal_ndim _normalized _onesided _signal_sizes = unsafePerformIO $ (ATen.cast5 ATen.Managed.irfft_tlbbl) _input _signal_ndim _normalized _onesided _signal_sizes
 
 -- index :: Tensor device dtype shape -> [Tensor device dtype shape] -> Tensor device dtype shape
--- index _input _indices = unsafePerformIO $ (cast2 ATen.index_tl) _input _indices
+-- index _input _indices = unsafePerformIO $ (ATen.cast2 ATen.Managed.index_tl) _input _indices
 
 -- index_copy :: Tensor device dtype shape -> Int -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape
--- index_copy _input _dim _index _source = unsafePerformIO $ (cast4 ATen.index_copy_tltt) _input _dim _index _source
+-- index_copy _input _dim _index _source = unsafePerformIO $ (ATen.cast4 ATen.Managed.index_copy_tltt) _input _dim _index _source
 
 -- index_put :: Tensor device dtype shape -> [Tensor device dtype shape] -> Tensor device dtype shape -> Bool -> Tensor device dtype shape
--- index_put _input _indices _values _accumulate = unsafePerformIO $ (cast4 ATen.index_put_tltb) _input _indices _values _accumulate
+-- index_put _input _indices _values _accumulate = unsafePerformIO $ (ATen.cast4 ATen.Managed.index_put_tltb) _input _indices _values _accumulate
 
 -- instance_norm :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Bool -> Double -> Double -> Bool -> Tensor device dtype shape
--- instance_norm _input _weight _bias _running_mean _running_var _use_input_stats _momentum _eps _cudnn_enabled = unsafePerformIO $ (cast9 ATen.instance_norm_tttttbddb) _input _weight _bias _running_mean _running_var _use_input_stats _momentum _eps _cudnn_enabled
+-- instance_norm _input _weight _bias _running_mean _running_var _use_input_stats _momentum _eps _cudnn_enabled = unsafePerformIO $ (ATen.cast9 ATen.Managed.instance_norm_tttttbddb) _input _weight _bias _running_mean _running_var _use_input_stats _momentum _eps _cudnn_enabled
 
 -- | isclose
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -2153,7 +2188,7 @@ isclose
   -> Tensor device dtype   shape -- ^ other input tensor
   -> Tensor device 'D.Bool shape -- ^ output
 isclose rtol atol equalNaN input other =
-  unsafePerformIO $ cast5 ATen.isclose_ttddb input other rtol atol equalNaN
+  unsafePerformIO $ ATen.cast5 ATen.Managed.isclose_ttddb input other rtol atol equalNaN
 
 -- | is NaN
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -2163,14 +2198,14 @@ isNaN
   :: forall shape dtype device
    . Tensor device dtype   shape -- ^ input
   -> Tensor device 'D.Bool shape -- ^ output
-isNaN input = unsafePerformIO $ cast1 ATen.isnan_t input
+isNaN input = unsafePerformIO $ ATen.cast1 ATen.Managed.isnan_t input
 
 -- | is distributed
 isDistributed
   :: forall shape dtype device
    . Tensor device dtype shape  -- ^ input
   -> Bool -- ^ output
-isDistributed input = unsafePerformIO $ cast1 ATen.is_distributed_t input
+isDistributed input = unsafePerformIO $ ATen.cast1 ATen.Managed.is_distributed_t input
 
 -- | is floating point
 -- TODO: this can be decided statically
@@ -2178,21 +2213,21 @@ isFloatingPoint
   :: forall shape dtype device
    . Tensor device dtype shape  -- ^ input
   -> Bool -- ^ output
-isFloatingPoint input = unsafePerformIO $ cast1 ATen.is_floating_point_t input
+isFloatingPoint input = unsafePerformIO $ ATen.cast1 ATen.Managed.is_floating_point_t input
 
 -- | is complex
 isComplex
   :: forall shape dtype device
    . Tensor device dtype shape  -- ^ input
   -> Bool -- ^ output
-isComplex input = unsafePerformIO $ cast1 ATen.is_complex_t input
+isComplex input = unsafePerformIO $ ATen.cast1 ATen.Managed.is_complex_t input
 
 -- | is non-zero
 isNonZero
   :: forall shape dtype device
    . Tensor device dtype shape  -- ^ input
   -> Bool -- ^ output
-isNonZero input = unsafePerformIO $ cast1 ATen.is_nonzero_t input
+isNonZero input = unsafePerformIO $ ATen.cast1 ATen.Managed.is_nonzero_t input
 
 -- | is same size
 -- TODO: this can be decided statically
@@ -2202,19 +2237,19 @@ isSameSize
   -> Tensor device dtype shape' -- ^ other input tensor
   -> Bool -- ^ output
 isSameSize input other =
-  unsafePerformIO $ cast2 ATen.is_same_size_tt input other
+  unsafePerformIO $ ATen.cast2 ATen.Managed.is_same_size_tt input other
 
 isSigned
   :: forall shape dtype device
    . Tensor device dtype shape -- ^ input
   -> Bool -- ^ output
-isSigned input = unsafePerformIO $ cast1 ATen.is_signed_t input
+isSigned input = unsafePerformIO $ ATen.cast1 ATen.Managed.is_signed_t input
 
 -- kl_div :: Tensor device dtype shape -> Tensor device dtype shape -> Int -> Tensor device dtype shape
--- kl_div _input _target _reduction = unsafePerformIO $ (cast3 ATen.kl_div_ttl) _input _target _reduction
+-- kl_div _input _target _reduction = unsafePerformIO $ (ATen.cast3 ATen.Managed.kl_div_ttl) _input _target _reduction
 
 -- kthvalue :: Tensor device dtype shape -> Int -> Int -> Bool -> (Tensor device dtype shape,Tensor device dtype shape)
--- kthvalue _input _k _dim _keepdim = unsafePerformIO $ (cast4 ATen.kthvalue_tllb) _input _k _dim _keepdim
+-- kthvalue _input _k _dim _keepdim = unsafePerformIO $ (ATen.cast4 ATen.Managed.kthvalue_tllb) _input _k _dim _keepdim
 
 -- | EndsWith
 -- >>> :kind! EndsWith '[1] '[1]
@@ -2255,8 +2290,8 @@ layerNorm
   -> Double -- ^ eps
   -> Tensor device dtype shape -- ^ input tensor
   -> Tensor device dtype shape -- ^ output tensor
-layerNorm weight bias eps input = unsafePerformIO $ cast6
-  ATen.layer_norm_tlttdb
+layerNorm weight bias eps input = unsafePerformIO $ ATen.cast6
+  ATen.Managed.layer_norm_tlttdb
   input
   (shapeVal @normalizedShape)
   weight
@@ -2268,7 +2303,7 @@ layerNorm weight bias eps input = unsafePerformIO $ cast6
   )
 
 -- native_layer_norm :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Int -> Int -> Double -> (Tensor device dtype shape,Tensor device dtype shape,Tensor device dtype shape)
--- native_layer_norm _input _weight _bias _M _N _eps = unsafePerformIO $ (cast6 ATen.native_layer_norm_tttlld) _input _weight _bias _M _N _eps
+-- native_layer_norm _input _weight _bias _M _N _eps = unsafePerformIO $ (ATen.cast6 ATen.Managed.native_layer_norm_tttlld) _input _weight _bias _M _N _eps
 
 -- | linear
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -2287,7 +2322,7 @@ linear
   -> Tensor device dtype '[outputFeatures]
   -> Tensor device dtype '[batchSize, inputFeatures]
   -> Tensor device dtype '[batchSize, outputFeatures]
-linear weight bias input = unsafePerformIO $ cast3 ATen.linear_ttt input weight bias
+linear weight bias input = unsafePerformIO $ ATen.cast3 ATen.Managed.linear_ttt input weight bias
 
 -- | linear'
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -2331,7 +2366,7 @@ linear'
   -> Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape' -- ^ output
 -- linear' weight bias input = Torch.Static.add (matmul input $ transpose @0 @1 weight) bias
-linear' weight bias input = unsafePerformIO $ cast3 ATen.linear_ttt input weight bias
+linear' weight bias input = unsafePerformIO $ ATen.cast3 ATen.Managed.linear_ttt input weight bias
 
 -- | mkldnnLinear
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -2352,25 +2387,25 @@ mkldnnLinear
   -> Tensor device dtype '[outputFeatures] -- ^ bias
   -> Tensor device dtype '[batchSize, inputFeatures] -- ^ input
   -> Tensor device dtype '[batchSize, outputFeatures] -- ^ output
-mkldnnLinear weight bias input = unsafePerformIO $ cast3 ATen.mkldnn_linear_ttt input weight bias
+mkldnnLinear weight bias input = unsafePerformIO $ ATen.cast3 ATen.Managed.mkldnn_linear_ttt input weight bias
 
 -- fbgemm_linear_int8_weight :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Float -> Float -> Tensor device dtype shape -> Tensor device dtype shape
--- fbgemm_linear_int8_weight _input _weight _packed _col_offsets _weight_scale _weight_zero_point _bias = unsafePerformIO $ (cast7 ATen.fbgemm_linear_int8_weight_ttttsst) _input _weight _packed _col_offsets _weight_scale _weight_zero_point _bias
+-- fbgemm_linear_int8_weight _input _weight _packed _col_offsets _weight_scale _weight_zero_point _bias = unsafePerformIO $ (ATen.cast7 ATen.Managed.fbgemm_linear_int8_weight_ttttsst) _input _weight _packed _col_offsets _weight_scale _weight_zero_point _bias
 
 -- fbgemm_linear_quantize_weight :: Tensor device dtype shape -> (Tensor device dtype shape,Tensor device dtype shape,Double,Int)
--- fbgemm_linear_quantize_weight _input = unsafePerformIO $ (cast1 ATen.fbgemm_linear_quantize_weight_t) _input
+-- fbgemm_linear_quantize_weight _input = unsafePerformIO $ (ATen.cast1 ATen.Managed.fbgemm_linear_quantize_weight_t) _input
 
 -- fbgemm_pack_gemm_matrix_fp16 :: Tensor device dtype shape -> Tensor device dtype shape
--- fbgemm_pack_gemm_matrix_fp16 _input = unsafePerformIO $ (cast1 ATen.fbgemm_pack_gemm_matrix_fp16_t) _input
+-- fbgemm_pack_gemm_matrix_fp16 _input = unsafePerformIO $ (ATen.cast1 ATen.Managed.fbgemm_pack_gemm_matrix_fp16_t) _input
 
 -- fbgemm_linear_fp16_weight :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape
--- fbgemm_linear_fp16_weight _input _packed_weight _bias = unsafePerformIO $ (cast3 ATen.fbgemm_linear_fp16_weight_ttt) _input _packed_weight _bias
+-- fbgemm_linear_fp16_weight _input _packed_weight _bias = unsafePerformIO $ (ATen.cast3 ATen.Managed.fbgemm_linear_fp16_weight_ttt) _input _packed_weight _bias
 
 -- fbgemm_pack_quantized_matrix :: Tensor device dtype shape -> Int -> Int -> Tensor device dtype shape
--- fbgemm_pack_quantized_matrix _input _K _N = unsafePerformIO $ (cast3 ATen.fbgemm_pack_quantized_matrix_tll) _input _K _N
+-- fbgemm_pack_quantized_matrix _input _K _N = unsafePerformIO $ (ATen.cast3 ATen.Managed.fbgemm_pack_quantized_matrix_tll) _input _K _N
 
 -- fbgemm_is_cpu_supported :: Bool
--- fbgemm_is_cpu_supported  = unsafePerformIO $ (cast0 ATen.fbgemm_is_cpu_supported) 
+-- fbgemm_is_cpu_supported  = unsafePerformIO $ (cast0 ATen.Managed.fbgemm_is_cpu_supported) 
 
 -- | log
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -2381,7 +2416,7 @@ log
   :: forall shape dtype device
    . Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
-log input = unsafePerformIO $ cast1 ATen.log_t input
+log input = unsafePerformIO $ ATen.cast1 ATen.Managed.log_t input
 
 -- | logDet
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -2395,7 +2430,7 @@ logDet
    . (shape' ~ Det shape)
   => Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape' -- ^ output
-logDet input = unsafePerformIO $ cast1 ATen.logdet_t input
+logDet input = unsafePerformIO $ ATen.cast1 ATen.Managed.logdet_t input
 
 -- | logarithm of the sum of the exponentials
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -2423,13 +2458,13 @@ logSumExp
      )
   => Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape' -- ^ output
-logSumExp input = unsafePerformIO $ cast3 ATen.logsumexp_tlb
+logSumExp input = unsafePerformIO $ ATen.cast3 ATen.Managed.logsumexp_tlb
                                           input
                                           (natValI @dim)
                                           (keepOrDropDimVal @keepOrDropDim)
 
 -- margin_ranking_loss :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Double -> Int -> Tensor device dtype shape
--- margin_ranking_loss _input1 _input2 _target _margin _reduction = unsafePerformIO $ (cast5 ATen.margin_ranking_loss_tttdl) _input1 _input2 _target _margin _reduction
+-- margin_ranking_loss _input1 _input2 _target _margin _reduction = unsafePerformIO $ (ATen.cast5 ATen.Managed.margin_ranking_loss_tttdl) _input1 _input2 _target _margin _reduction
 
 -- | matrixPower
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -2443,7 +2478,7 @@ matrixPower
   => Int -- ^ power
   -> Tensor device dtype shape -- ^ input matrix
   -> Tensor device dtype shape' -- ^ output
-matrixPower n input = unsafePerformIO $ cast2 ATen.matrix_power_tl input n
+matrixPower n input = unsafePerformIO $ ATen.cast2 ATen.Managed.matrix_power_tl input n
 
 -- | maxValues
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -2464,7 +2499,7 @@ maxValues
     )
   => Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape' -- ^ output
-maxValues input = unsafePerformIO $ cast3 ATen.max_values_tlb
+maxValues input = unsafePerformIO $ ATen.cast3 ATen.Managed.max_values_tlb
                                           input
                                           (natValI @dim)
                                           (keepOrDropDimVal @keepOrDropDim)
@@ -2488,7 +2523,7 @@ minValues
      )
   => Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape' -- ^ output
-minValues input = unsafePerformIO $ cast3 ATen.min_values_tlb
+minValues input = unsafePerformIO $ ATen.cast3 ATen.Managed.min_values_tlb
                                           input
                                           (natValI @dim)
                                           (keepOrDropDimVal @keepOrDropDim)
@@ -2513,7 +2548,7 @@ maxPool1d
      )
   => Tensor device dtype '[batchSize, channelSize, inputSize] -- ^ input
   -> Tensor device dtype '[batchSize, channelSize, outputSize] -- ^ output
-maxPool1d input = unsafePerformIO $ cast6 ATen.max_pool1d_tllllb
+maxPool1d input = unsafePerformIO $ ATen.cast6 ATen.Managed.max_pool1d_tllllb
                                           input
                                           (natValI @kernelSize)
                                           (natValI @stride)
@@ -2522,7 +2557,7 @@ maxPool1d input = unsafePerformIO $ cast6 ATen.max_pool1d_tllllb
                                           False
 
 -- max_pool1d_with_indices :: Tensor device dtype shape -> Int -> Int -> Int -> Int -> Bool -> (Tensor device dtype shape,Tensor device dtype shape)
--- max_pool1d_with_indices _input _kernel_size _stride _padding _dilation _ceil_mode = unsafePerformIO $ (cast6 ATen.max_pool1d_with_indices_tllllb) _input _kernel_size _stride _padding _dilation _ceil_mode
+-- max_pool1d_with_indices _input _kernel_size _stride _padding _dilation _ceil_mode = unsafePerformIO $ (ATen.cast6 ATen.Managed.max_pool1d_with_indices_tllllb) _input _kernel_size _stride _padding _dilation _ceil_mode
 
 -- | maxPool2d
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -2533,24 +2568,24 @@ maxPool1d input = unsafePerformIO $ cast6 ATen.max_pool1d_tllllb
 -- t :: Tensor '( 'D.CPU, 0) 'D.Float '[1, 3, 4, 5]
 maxPool2d
   :: forall kernelSize stride padding channelSize inputSize0 inputSize1 batchSize outputSize0 outputSize1 dtype device
-   . ( All KnownNat '[ Fst kernelSize, Snd kernelSize
-                     , Fst stride, Snd stride
-                     , Fst padding, Snd padding
+   . ( All KnownNat '[ Torch.Typed.Aux.Fst kernelSize, Torch.Typed.Aux.Snd kernelSize
+                     , Torch.Typed.Aux.Fst stride, Torch.Typed.Aux.Snd stride
+                     , Torch.Typed.Aux.Fst padding, Torch.Typed.Aux.Snd padding
                      , channelSize
                      , inputSize0, inputSize1
                      , batchSize
                      ]
-     , ConvSideCheck inputSize0 (Fst kernelSize) (Fst stride) (Fst padding) outputSize0
-     , ConvSideCheck inputSize1 (Snd kernelSize) (Snd stride) (Snd padding) outputSize1
+     , ConvSideCheck inputSize0 (Torch.Typed.Aux.Fst kernelSize) (Torch.Typed.Aux.Fst stride) (Torch.Typed.Aux.Fst padding) outputSize0
+     , ConvSideCheck inputSize1 (Torch.Typed.Aux.Snd kernelSize) (Torch.Typed.Aux.Snd stride) (Torch.Typed.Aux.Snd padding) outputSize1
      )
   => Tensor device dtype '[batchSize, channelSize, inputSize0, inputSize1] -- ^ input
   -> Tensor device dtype '[batchSize, channelSize, outputSize0, outputSize1] -- ^ output
-maxPool2d input = unsafePerformIO $ cast6
-  ATen.max_pool2d_tllllb
+maxPool2d input = unsafePerformIO $ ATen.cast6
+  ATen.Managed.max_pool2d_tllllb
   input
-  ([natValI @(Fst kernelSize), natValI @(Snd kernelSize)] :: [Int])
-  ([natValI @(Fst stride), natValI @(Snd stride)] :: [Int])
-  ([natValI @(Fst padding), natValI @(Snd padding)] :: [Int])
+  ([natValI @(Torch.Typed.Aux.Fst kernelSize), natValI @(Torch.Typed.Aux.Snd kernelSize)] :: [Int])
+  ([natValI @(Torch.Typed.Aux.Fst stride),     natValI @(Torch.Typed.Aux.Snd stride)]     :: [Int])
+  ([natValI @(Torch.Typed.Aux.Fst padding),    natValI @(Torch.Typed.Aux.Snd padding)]    :: [Int])
   ([1, 1] :: [Int])
   False
 
@@ -2565,24 +2600,24 @@ maxPool2d input = unsafePerformIO $ cast6
 -- -- t :: Tensor '( 'D.CPU, 0) 'D.Float '[1, 3, 4, 5]
 mkldnnMaxPool2d
   :: forall kernelSize stride padding channelSize inputSize0 inputSize1 batchSize outputSize0 outputSize1 dtype device
-   . ( All KnownNat '[ Fst kernelSize, Snd kernelSize
-                     , Fst stride, Snd stride
-                     , Fst padding, Snd padding
+   . ( All KnownNat '[ Torch.Typed.Aux.Fst kernelSize, Torch.Typed.Aux.Snd kernelSize
+                     , Torch.Typed.Aux.Fst stride, Torch.Typed.Aux.Snd stride
+                     , Torch.Typed.Aux.Fst padding, Torch.Typed.Aux.Snd padding
                      , channelSize
                      , inputSize0, inputSize1
                      , batchSize
                      ]
-     , ConvSideCheck inputSize0 (Fst kernelSize) (Fst stride) (Fst padding) outputSize0
-     , ConvSideCheck inputSize1 (Snd kernelSize) (Snd stride) (Snd padding) outputSize1
+     , ConvSideCheck inputSize0 (Torch.Typed.Aux.Fst kernelSize) (Torch.Typed.Aux.Fst stride) (Torch.Typed.Aux.Fst padding) outputSize0
+     , ConvSideCheck inputSize1 (Torch.Typed.Aux.Snd kernelSize) (Torch.Typed.Aux.Snd stride) (Torch.Typed.Aux.Snd padding) outputSize1
      )
   => Tensor device dtype '[batchSize, channelSize, inputSize0, inputSize1] -- ^ input
   -> Tensor device dtype '[batchSize, channelSize, outputSize0, outputSize1] -- ^ output
-mkldnnMaxPool2d input = unsafePerformIO $ cast6
-  ATen.mkldnn_max_pool2d_tllllb
+mkldnnMaxPool2d input = unsafePerformIO $ ATen.cast6
+  ATen.Managed.mkldnn_max_pool2d_tllllb
   input
-  ([natValI @(Fst kernelSize), natValI @(Snd kernelSize)] :: [Int])
-  ([natValI @(Fst stride), natValI @(Snd stride)] :: [Int])
-  ([natValI @(Fst padding), natValI @(Snd padding)] :: [Int])
+  ([natValI @(Torch.Typed.Aux.Fst kernelSize), natValI @(Torch.Typed.Aux.Snd kernelSize)] :: [Int])
+  ([natValI @(Torch.Typed.Aux.Fst stride),     natValI @(Torch.Typed.Aux.Snd stride)]     :: [Int])
+  ([natValI @(Torch.Typed.Aux.Fst padding),    natValI @(Torch.Typed.Aux.Snd padding)]    :: [Int])
   ([1, 1] :: [Int])
   False
 
@@ -2596,24 +2631,24 @@ mkldnnMaxPool2d input = unsafePerformIO $ cast6
 -- -- t :: Tensor 'D.Float '[1, 3, 4, 5]
 quantizedMaxPool2d
   :: forall kernelSize stride padding channelSize inputSize0 inputSize1 batchSize outputSize0 outputSize1 dtype device
-   . ( All KnownNat '[ Fst kernelSize, Snd kernelSize
-                     , Fst stride, Snd stride
-                     , Fst padding, Snd padding
+   . ( All KnownNat '[ Torch.Typed.Aux.Fst kernelSize, Torch.Typed.Aux.Snd kernelSize
+                     , Torch.Typed.Aux.Fst stride, Torch.Typed.Aux.Snd stride
+                     , Torch.Typed.Aux.Fst padding, Torch.Typed.Aux.Snd padding
                      , channelSize
                      , inputSize0, inputSize1
                      , batchSize
                      ]
-     , ConvSideCheck inputSize0 (Fst kernelSize) (Fst stride) (Fst padding) outputSize0
-     , ConvSideCheck inputSize1 (Snd kernelSize) (Snd stride) (Snd padding) outputSize1
+     , ConvSideCheck inputSize0 (Torch.Typed.Aux.Fst kernelSize) (Torch.Typed.Aux.Fst stride) (Torch.Typed.Aux.Fst padding) outputSize0
+     , ConvSideCheck inputSize1 (Torch.Typed.Aux.Snd kernelSize) (Torch.Typed.Aux.Snd stride) (Torch.Typed.Aux.Snd padding) outputSize1
      )
   => Tensor device dtype '[batchSize, channelSize, inputSize0, inputSize1] -- ^ input
   -> Tensor device dtype '[batchSize, channelSize, outputSize0, outputSize1] -- ^ output
-quantizedMaxPool2d input = unsafePerformIO $ cast5
-  ATen.quantized_max_pool2d_tllll
+quantizedMaxPool2d input = unsafePerformIO $ ATen.cast5
+  ATen.Managed.quantized_max_pool2d_tllll
   input
-  ([natValI @(Fst kernelSize), natValI @(Snd kernelSize)] :: [Int])
-  ([natValI @(Fst stride), natValI @(Snd stride)] :: [Int])
-  ([natValI @(Fst padding), natValI @(Snd padding)] :: [Int])
+  ([natValI @(Torch.Typed.Aux.Fst kernelSize), natValI @(Torch.Typed.Aux.Snd kernelSize)] :: [Int])
+  ([natValI @(Torch.Typed.Aux.Fst stride),     natValI @(Torch.Typed.Aux.Snd stride)]     :: [Int])
+  ([natValI @(Torch.Typed.Aux.Fst padding),    natValI @(Torch.Typed.Aux.Snd padding)]    :: [Int])
   ([1, 1] :: [Int])
 
 -- | maxPool3d
@@ -2643,8 +2678,8 @@ maxPool3d
      )
   => Tensor device dtype '[batchSize, channelSize, inputSize0, inputSize1, inputSize2] -- ^ input
   -> Tensor device dtype '[batchSize, channelSize, outputSize0, outputSize1, outputSize2] -- ^ output
-maxPool3d input = unsafePerformIO $ cast6
-  ATen.max_pool3d_tllllb
+maxPool3d input = unsafePerformIO $ ATen.cast6
+  ATen.Managed.max_pool3d_tllllb
   input
   ([ natValI @(Fst3 kernelSize)
    , natValI @(Snd3 kernelSize)
@@ -2673,25 +2708,25 @@ maskedFill
   -> Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape'' -- ^ output
 maskedFill mask value input =
-  unsafePerformIO $ cast3 ATen.masked_fill_tts input mask value
+  unsafePerformIO $ ATen.cast3 ATen.Managed.masked_fill_tts input mask value
 
 -- mkldnn_convolution :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> [Int] -> [Int] -> [Int] -> Int -> Tensor device dtype shape
--- mkldnn_convolution _input _weight _bias _padding _stride _dilation _groups = unsafePerformIO $ (cast7 ATen.mkldnn_convolution_tttllll) _input _weight _bias _padding _stride _dilation _groups
+-- mkldnn_convolution _input _weight _bias _padding _stride _dilation _groups = unsafePerformIO $ (ATen.cast7 ATen.Managed.mkldnn_convolution_tttllll) _input _weight _bias _padding _stride _dilation _groups
 
 -- miopen_batch_norm :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Bool -> Double -> Double -> (Tensor device dtype shape,Tensor device dtype shape,Tensor device dtype shape)
--- miopen_batch_norm _input _weight _bias _running_mean _running_var _training _exponential_average_factor _epsilon = unsafePerformIO $ (cast8 ATen.miopen_batch_norm_tttttbdd) _input _weight _bias _running_mean _running_var _training _exponential_average_factor _epsilon
+-- miopen_batch_norm _input _weight _bias _running_mean _running_var _training _exponential_average_factor _epsilon = unsafePerformIO $ (ATen.cast8 ATen.Managed.miopen_batch_norm_tttttbdd) _input _weight _bias _running_mean _running_var _training _exponential_average_factor _epsilon
 
 -- miopen_convolution :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> [Int] -> [Int] -> [Int] -> Int -> Bool -> Bool -> Tensor device dtype shape
--- miopen_convolution _input _weight _bias _padding _stride _dilation _groups _benchmark _deterministic = unsafePerformIO $ (cast9 ATen.miopen_convolution_tttllllbb) _input _weight _bias _padding _stride _dilation _groups _benchmark _deterministic
+-- miopen_convolution _input _weight _bias _padding _stride _dilation _groups _benchmark _deterministic = unsafePerformIO $ (ATen.cast9 ATen.Managed.miopen_convolution_tttllllbb) _input _weight _bias _padding _stride _dilation _groups _benchmark _deterministic
 
 -- miopen_convolution_transpose :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> [Int] -> [Int] -> [Int] -> [Int] -> Int -> Bool -> Bool -> Tensor device dtype shape
--- miopen_convolution_transpose _input _weight _bias _padding _output_padding _stride _dilation _groups _benchmark _deterministic = unsafePerformIO $ (cast10 ATen.miopen_convolution_transpose_tttlllllbb) _input _weight _bias _padding _output_padding _stride _dilation _groups _benchmark _deterministic
+-- miopen_convolution_transpose _input _weight _bias _padding _output_padding _stride _dilation _groups _benchmark _deterministic = unsafePerformIO $ (ATen.ATen.cast10 ATen.Managed.miopen_convolution_transpose_tttlllllbb) _input _weight _bias _padding _output_padding _stride _dilation _groups _benchmark _deterministic
 
 -- miopen_depthwise_convolution :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> [Int] -> [Int] -> [Int] -> Int -> Bool -> Bool -> Tensor device dtype shape
--- miopen_depthwise_convolution _input _weight _bias _padding _stride _dilation _groups _benchmark _deterministic = unsafePerformIO $ (cast9 ATen.miopen_depthwise_convolution_tttllllbb) _input _weight _bias _padding _stride _dilation _groups _benchmark _deterministic
+-- miopen_depthwise_convolution _input _weight _bias _padding _stride _dilation _groups _benchmark _deterministic = unsafePerformIO $ (ATen.cast9 ATen.Managed.miopen_depthwise_convolution_tttllllbb) _input _weight _bias _padding _stride _dilation _groups _benchmark _deterministic
 
 -- miopen_rnn :: Tensor device dtype shape -> [Tensor device dtype shape] -> Int -> Tensor device dtype shape -> Tensor device dtype shape -> Int -> Int -> Int -> Bool -> Double -> Bool -> Bool -> [Int] -> Tensor device dtype shape -> (Tensor device dtype shape,Tensor device dtype shape,Tensor device dtype shape,Tensor device dtype shape,Tensor device dtype shape)
--- miopen_rnn _input _weight _weight_stride0 _hx _cx _mode _hidden_size _num_layers _batch_first _dropout _train _bidirectional _batch_sizes _dropout_state = unsafePerformIO $ (cast14 ATen.miopen_rnn_tllttlllbdbblt) _input _weight _weight_stride0 _hx _cx _mode _hidden_size _num_layers _batch_first _dropout _train _bidirectional _batch_sizes _dropout_state
+-- miopen_rnn _input _weight _weight_stride0 _hx _cx _mode _hidden_size _num_layers _batch_first _dropout _train _bidirectional _batch_sizes _dropout_state = unsafePerformIO $ (ATen.ATen.cast14 ATen.Managed.miopen_rnn_tllttlllbdbblt) _input _weight _weight_stride0 _hx _cx _mode _hidden_size _num_layers _batch_first _dropout _train _bidirectional _batch_sizes _dropout_state
 
 -- | matrix-matrix multiplication
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -2702,10 +2737,10 @@ mm
    . Tensor device dtype '[n, k] -- ^ first input matrix
   -> Tensor device dtype '[k, m] -- ^ second input matrix
   -> Tensor device dtype '[n, m] -- ^ output matrix
-mm a b = unsafePerformIO $ cast2 ATen.mm_tt a b
+mm a b = unsafePerformIO $ ATen.cast2 ATen.Managed.mm_tt a b
 
 -- mode :: Tensor device dtype shape -> Int -> Bool -> (Tensor device dtype shape,Tensor device dtype shape)
--- mode _input _dim _keepdim = unsafePerformIO $ (cast3 ATen.mode_tlb) _input _dim _keepdim
+-- mode _input _dim _keepdim = unsafePerformIO $ (ATen.cast3 ATen.Managed.mode_tlb) _input _dim _keepdim
 
 -- | matrix-vector multiplication
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -2716,31 +2751,31 @@ mv
    . Tensor device dtype '[n, m] -- ^ input matrix
   -> Tensor device dtype '[m] -- ^ input vector
   -> Tensor device dtype '[n] -- ^ output vector
-mv input vec = unsafePerformIO $ cast2 ATen.mv_tt input vec
+mv input vec = unsafePerformIO $ ATen.cast2 ATen.Managed.mv_tt input vec
 
 -- mvlgamma :: Tensor device dtype shape -> Int -> Tensor device dtype shape
--- mvlgamma _input _p = unsafePerformIO $ (cast2 ATen.mvlgamma_tl) _input _p
+-- mvlgamma _input _p = unsafePerformIO $ (ATen.cast2 ATen.Managed.mvlgamma_tl) _input _p
 
 -- narrow :: Tensor device dtype shape -> Int -> Int -> Int -> Tensor device dtype shape
--- narrow _input _dim _start _length = unsafePerformIO $ (cast4 ATen.narrow_tlll) _input _dim _start _length
+-- narrow _input _dim _start _length = unsafePerformIO $ (ATen.cast4 ATen.Managed.narrow_tlll) _input _dim _start _length
 
 -- native_batch_norm :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Bool -> Double -> Double -> (Tensor device dtype shape,Tensor device dtype shape,Tensor device dtype shape)
--- native_batch_norm _input _weight _bias _running_mean _running_var _training _momentum _eps = unsafePerformIO $ (cast8 ATen.native_batch_norm_tttttbdd) _input _weight _bias _running_mean _running_var _training _momentum _eps
+-- native_batch_norm _input _weight _bias _running_mean _running_var _training _momentum _eps = unsafePerformIO $ (ATen.cast8 ATen.Managed.native_batch_norm_tttttbdd) _input _weight _bias _running_mean _running_var _training _momentum _eps
 
 -- batch_norm_stats :: Tensor device dtype shape -> Double -> (Tensor device dtype shape,Tensor device dtype shape)
--- batch_norm_stats _input _eps = unsafePerformIO $ (cast2 ATen.batch_norm_stats_td) _input _eps
+-- batch_norm_stats _input _eps = unsafePerformIO $ (ATen.cast2 ATen.Managed.batch_norm_stats_td) _input _eps
 
 -- batch_norm_elemt :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Double -> Tensor device dtype shape
--- batch_norm_elemt _input _weight _bias _mean _invstd _eps = unsafePerformIO $ (cast6 ATen.batch_norm_elemt_tttttd) _input _weight _bias _mean _invstd _eps
+-- batch_norm_elemt _input _weight _bias _mean _invstd _eps = unsafePerformIO $ (ATen.cast6 ATen.Managed.batch_norm_elemt_tttttd) _input _weight _bias _mean _invstd _eps
 
 -- batch_norm_gather_stats :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Double -> Double -> Int -> (Tensor device dtype shape,Tensor device dtype shape)
--- batch_norm_gather_stats _input _mean _invstd _running_mean _running_var _momentum _eps _count = unsafePerformIO $ (cast8 ATen.batch_norm_gather_stats_tttttddl) _input _mean _invstd _running_mean _running_var _momentum _eps _count
+-- batch_norm_gather_stats _input _mean _invstd _running_mean _running_var _momentum _eps _count = unsafePerformIO $ (ATen.cast8 ATen.Managed.batch_norm_gather_stats_tttttddl) _input _mean _invstd _running_mean _running_var _momentum _eps _count
 
 -- batch_norm_gather_stats_with_counts :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Double -> Double -> [Int] -> (Tensor device dtype shape,Tensor device dtype shape)
--- batch_norm_gather_stats_with_counts _input _mean _invstd _running_mean _running_var _momentum _eps _counts = unsafePerformIO $ (cast8 ATen.batch_norm_gather_stats_with_counts_tttttddl) _input _mean _invstd _running_mean _running_var _momentum _eps _counts
+-- batch_norm_gather_stats_with_counts _input _mean _invstd _running_mean _running_var _momentum _eps _counts = unsafePerformIO $ (ATen.cast8 ATen.Managed.batch_norm_gather_stats_with_counts_tttttddl) _input _mean _invstd _running_mean _running_var _momentum _eps _counts
 
 -- batch_norm_update_stats :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Double -> (Tensor device dtype shape,Tensor device dtype shape)
--- batch_norm_update_stats _input _running_mean _running_var _momentum = unsafePerformIO $ (cast4 ATen.batch_norm_update_stats_tttd) _input _running_mean _running_var _momentum
+-- batch_norm_update_stats _input _running_mean _running_var _momentum = unsafePerformIO $ (ATen.cast4 ATen.Managed.batch_norm_update_stats_tttd) _input _running_mean _running_var _momentum
 
 -- | onesLike
 -- >>> dtype &&& shape $ onesLike (ones :: CPUTensor 'D.Float '[3,4,5])
@@ -2749,31 +2784,31 @@ onesLike
   :: forall shape dtype device
    . Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
-onesLike input = unsafePerformIO $ cast1 ATen.ones_like_t input
+onesLike input = unsafePerformIO $ ATen.cast1 ATen.Managed.ones_like_t input
 
 -- pairwise_distance :: Tensor device dtype shape -> Tensor device dtype shape -> Double -> Double -> Bool -> Tensor device dtype shape
--- pairwise_distance _x1 _x2 _p _eps _keepdim = unsafePerformIO $ (cast5 ATen.pairwise_distance_ttddb) _x1 _x2 _p _eps _keepdim
+-- pairwise_distance _x1 _x2 _p _eps _keepdim = unsafePerformIO $ (ATen.cast5 ATen.Managed.pairwise_distance_ttddb) _x1 _x2 _p _eps _keepdim
 
 -- cdist :: Tensor device dtype shape -> Tensor device dtype shape -> Double -> Tensor device dtype shape
--- cdist _x1 _x2 _p = unsafePerformIO $ (cast3 ATen.cdist_ttd) _x1 _x2 _p
+-- cdist _x1 _x2 _p = unsafePerformIO $ (ATen.cast3 ATen.Managed.cdist_ttd) _x1 _x2 _p
 
 -- pdist :: Tensor device dtype shape -> Double -> Tensor device dtype shape
--- pdist _input _p = unsafePerformIO $ (cast2 ATen.pdist_td) _input _p
+-- pdist _input _p = unsafePerformIO $ (ATen.cast2 ATen.Managed.pdist_td) _input _p
 
 -- cosine_similarity :: Tensor device dtype shape -> Tensor device dtype shape -> Int -> Double -> Tensor device dtype shape
--- cosine_similarity _x1 _x2 _dim _eps = unsafePerformIO $ (cast4 ATen.cosine_similarity_ttld) _x1 _x2 _dim _eps
+-- cosine_similarity _x1 _x2 _dim _eps = unsafePerformIO $ (ATen.cast4 ATen.Managed.cosine_similarity_ttld) _x1 _x2 _dim _eps
 
 -- pixel_shuffle :: Tensor device dtype shape -> Int -> Tensor device dtype shape
--- pixel_shuffle _input _upscale_factor = unsafePerformIO $ (cast2 ATen.pixel_shuffle_tl) _input _upscale_factor
+-- pixel_shuffle _input _upscale_factor = unsafePerformIO $ (ATen.cast2 ATen.Managed.pixel_shuffle_tl) _input _upscale_factor
 
 -- pin_memory :: Tensor device dtype shape -> Tensor device dtype shape
--- pin_memory _input = unsafePerformIO $ (cast1 ATen.pin_memory_t) _input
+-- pin_memory _input = unsafePerformIO $ (ATen.cast1 ATen.Managed.pin_memory_t) _input
 
 -- pinverse :: Tensor device dtype shape -> Double -> Tensor device dtype shape
--- pinverse _input _rcond = unsafePerformIO $ (cast2 ATen.pinverse_td) _input _rcond
+-- pinverse _input _rcond = unsafePerformIO $ (ATen.cast2 ATen.Managed.pinverse_td) _input _rcond
 
 -- poisson_nll_loss :: Tensor device dtype shape -> Tensor device dtype shape -> Bool -> Bool -> Double -> Int -> Tensor device dtype shape
--- poisson_nll_loss _input _target _log_input _full _eps _reduction = unsafePerformIO $ (cast6 ATen.poisson_nll_loss_ttbbdl) _input _target _log_input _full _eps _reduction
+-- poisson_nll_loss _input _target _log_input _full _eps _reduction = unsafePerformIO $ (ATen.cast6 ATen.Managed.poisson_nll_loss_ttbbdl) _input _target _log_input _full _eps _reduction
 
 -- | randLike
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -2784,7 +2819,7 @@ randLike
   :: forall shape dtype device
    . Tensor device dtype shape -- ^ input
   -> IO (Tensor device dtype shape) -- ^ output
-randLike = cast1 ATen.rand_like_t
+randLike = ATen.cast1 ATen.Managed.rand_like_t
 
 -- | randnLike
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -2795,10 +2830,10 @@ randnLike
   :: forall shape dtype device
    . Tensor device dtype shape -- ^ input
   -> IO (Tensor device dtype shape) -- ^ output
-randnLike = cast1 ATen.randn_like_t
+randnLike = ATen.cast1 ATen.Managed.randn_like_t
 
 -- reciprocal :: Tensor device dtype shape -> Tensor device dtype shape
--- reciprocal _input = unsafePerformIO $ (cast1 ATen.reciprocal_t) _input
+-- reciprocal _input = unsafePerformIO $ (ATen.cast1 ATen.Managed.reciprocal_t) _input
 
 -- | negate
 -- TODO: probably not defined for `D.Bool` tensors
@@ -2808,7 +2843,7 @@ neg
   :: forall shape dtype device
    . Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
-neg input = unsafePerformIO $ cast1 ATen.neg_t input
+neg input = unsafePerformIO $ ATen.cast1 ATen.Managed.neg_t input
 
 -- | round
 -- TODO: probably only defined for floating point tensors
@@ -2818,7 +2853,7 @@ round
   :: forall shape dtype device
    . Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
-round input = unsafePerformIO $ cast1 ATen.round_t input
+round input = unsafePerformIO $ ATen.cast1 ATen.Managed.round_t input
 
 -- | prelu activation function
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -2829,7 +2864,7 @@ prelu
    . Tensor device dtype '[] -- ^ weight
   -> Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
-prelu weight input = unsafePerformIO $ cast2 ATen.prelu_tt input weight
+prelu weight input = unsafePerformIO $ ATen.cast2 ATen.Managed.prelu_tt input weight
 
 type family GeluDTypeIsValid (device :: (D.DeviceType, Nat)) (dtype :: D.DType) :: Constraint where
   GeluDTypeIsValid '( 'D.CPU, 0)            dtype = ( DTypeIsFloatingPoint '( 'D.CPU, 0) dtype
@@ -2848,10 +2883,10 @@ gelu
    . (GeluDTypeIsValid device dtype)
   => Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
-gelu input = unsafePerformIO $ cast1 ATen.gelu_t input
+gelu input = unsafePerformIO $ ATen.cast1 ATen.Managed.gelu_t input
 
 -- hardshrink :: Tensor device dtype shape -> Float -> Tensor device dtype shape
--- hardshrink _input _lambd = unsafePerformIO $ (cast2 ATen.hardshrink_ts) _input _lambd
+-- hardshrink _input _lambd = unsafePerformIO $ (ATen.cast2 ATen.Managed.hardshrink_ts) _input _lambd
 
 -- | rsqrt
 -- >>> dtype &&& shape $ rsqrt (ones :: CPUTensor 'D.Float '[3,2])
@@ -2861,7 +2896,7 @@ rsqrt
    . (StandardFloatingPointDTypeValidation device dtype)
   => Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
-rsqrt input = unsafePerformIO $ cast1 ATen.rsqrt_t input
+rsqrt input = unsafePerformIO $ ATen.cast1 ATen.Managed.rsqrt_t input
 
 -- | celu activation function
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -2872,25 +2907,25 @@ celu
    . Float -- ^ alpha
   -> Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
-celu alpha input = unsafePerformIO $ cast2 ATen.celu_ts input alpha
+celu alpha input = unsafePerformIO $ ATen.cast2 ATen.Managed.celu_ts input alpha
 
 -- slice :: Tensor device dtype shape -> Int -> Int -> Int -> Int -> Tensor device dtype shape
--- slice _input _dim _start _end _step = unsafePerformIO $ (cast5 ATen.slice_tllll) _input _dim _start _end _step
+-- slice _input _dim _start _end _step = unsafePerformIO $ (ATen.cast5 ATen.Managed.slice_tllll) _input _dim _start _end _step
 
 -- slogdet :: Tensor device dtype shape -> (Tensor device dtype shape,Tensor device dtype shape)
--- slogdet _input = unsafePerformIO $ (cast1 ATen.slogdet_t) _input
+-- slogdet _input = unsafePerformIO $ (ATen.cast1 ATen.Managed.slogdet_t) _input
 
 -- smm :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape
--- smm _input _mat2 = unsafePerformIO $ (cast2 ATen.smm_tt) _input _mat2
+-- smm _input _mat2 = unsafePerformIO $ (ATen.cast2 ATen.Managed.smm_tt) _input _mat2
 
 -- split :: Tensor device dtype shape -> Int -> Int -> [Tensor device dtype shape]
--- split _input _split_size _dim = unsafePerformIO $ (cast3 ATen.split_tll) _input _split_size _dim
+-- split _input _split_size _dim = unsafePerformIO $ (ATen.cast3 ATen.Managed.split_tll) _input _split_size _dim
 
 -- split_with_sizes :: Tensor device dtype shape -> [Int] -> Int -> [Tensor device dtype shape]
--- split_with_sizes _input _split_sizes _dim = unsafePerformIO $ (cast3 ATen.split_with_sizes_tll) _input _split_sizes _dim
+-- split_with_sizes _input _split_sizes _dim = unsafePerformIO $ (ATen.cast3 ATen.Managed.split_with_sizes_tll) _input _split_sizes _dim
 
 -- sspaddmm :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Float -> Float -> Tensor device dtype shape
--- sspaddmm _input _mat1 _mat2 _beta _alpha = unsafePerformIO $ (cast5 ATen.sspaddmm_tttss) _input _mat1 _mat2 _beta _alpha
+-- sspaddmm _input _mat1 _mat2 _beta _alpha = unsafePerformIO $ (ATen.cast5 ATen.Managed.sspaddmm_tttss) _input _mat1 _mat2 _beta _alpha
 
 type family StackImpl (dim :: Nat) (tensors :: [a]) (count :: Nat) :: Maybe ([Nat], D.DType, (D.DeviceType, Nat)) where
   StackImpl dim '[]                                                                 count = Nothing
@@ -2974,22 +3009,20 @@ stack
   :: forall dim shape dtype device tensors
    . ( KnownNat dim
      , '(shape, dtype, device) ~ Stack dim tensors
-     , HFoldrM IO TensorListFold [D.ATenTensor] tensors
-     , Apply TensorListUnfold [D.ATenTensor] (HUnfoldMRes IO [D.ATenTensor] tensors)
-     , HUnfoldM IO TensorListUnfold (HUnfoldMRes IO [D.ATenTensor] tensors) tensors
+     , ATen.Castable (HList tensors) [D.ATenTensor]
      )
   => HList tensors -- ^ input list of tensors
   -> Tensor device dtype shape -- ^ output
-stack tensors = unsafePerformIO $ cast2 ATen.stack_ll tensors (natValI @dim :: Int)
+stack tensors = unsafePerformIO $ ATen.cast2 ATen.Managed.stack_ll tensors (natValI @dim :: Int)
 
 -- stft :: Tensor device dtype shape -> Int -> Int -> Int -> Tensor device dtype shape -> Bool -> Bool -> Tensor device dtype shape
--- stft _input _n_fft _hop_length _win_length _window _normalized _onesided = unsafePerformIO $ (cast7 ATen.stft_tllltbb) _input _n_fft _hop_length _win_length _window _normalized _onesided
+-- stft _input _n_fft _hop_length _win_length _window _normalized _onesided = unsafePerformIO $ (ATen.cast7 ATen.Managed.stft_tllltbb) _input _n_fft _hop_length _win_length _window _normalized _onesided
 
 -- stride :: Tensor device dtype shape -> Int -> Int
--- stride _input _dim = unsafePerformIO $ (cast2 ATen.stride_tl) _input _dim
+-- stride _input _dim = unsafePerformIO $ (ATen.cast2 ATen.Managed.stride_tl) _input _dim
 
 -- t :: Tensor device dtype shape -> Tensor device dtype shape
--- t _input = unsafePerformIO $ (cast1 ATen.t_t) _input
+-- t _input = unsafePerformIO $ (ATen.cast1 ATen.Managed.t_t) _input
 
 -- | tan
 -- >>> dtype &&& shape $ tan (ones :: CPUTensor 'D.Float '[3,2])
@@ -2999,28 +3032,28 @@ tan
    . (StandardFloatingPointDTypeValidation device dtype)
   => Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
-tan input = unsafePerformIO $ cast1 ATen.tan_t input
+tan input = unsafePerformIO $ ATen.cast1 ATen.Managed.tan_t input
 
 -- tensordot :: Tensor device dtype shape -> Tensor device dtype shape -> [Int] -> [Int] -> Tensor device dtype shape
--- tensordot _input _other _dims_input _dims_other = unsafePerformIO $ (cast4 ATen.tensordot_ttll) _input _other _dims_input _dims_other
+-- tensordot _input _other _dims_input _dims_other = unsafePerformIO $ (ATen.cast4 ATen.Managed.tensordot_ttll) _input _other _dims_input _dims_other
 
 -- threshold :: Tensor device dtype shape -> Float -> Float -> Tensor device dtype shape
--- threshold _input _threshold _value = unsafePerformIO $ (cast3 ATen.threshold_tss) _input _threshold _value
+-- threshold _input _threshold _value = unsafePerformIO $ (ATen.cast3 ATen.Managed.threshold_tss) _input _threshold _value
 
 -- one_hot :: Tensor device dtype shape -> Int -> Tensor device dtype shape
--- one_hot _input _num_classes = unsafePerformIO $ (cast2 ATen.one_hot_tl) _input _num_classes
+-- one_hot _input _num_classes = unsafePerformIO $ (ATen.cast2 ATen.Managed.one_hot_tl) _input _num_classes
 
 -- flip :: Tensor device dtype shape -> [Int] -> Tensor device dtype shape
--- flip _input _dims = unsafePerformIO $ (cast2 ATen.flip_tl) _input _dims
+-- flip _input _dims = unsafePerformIO $ (ATen.cast2 ATen.Managed.flip_tl) _input _dims
 
 -- roll :: Tensor device dtype shape -> Int -> Int -> Tensor device dtype shape
--- roll _input _shifts _dims = unsafePerformIO $ (cast3 ATen.roll_tll) _input _shifts _dims
+-- roll _input _shifts _dims = unsafePerformIO $ (ATen.cast3 ATen.Managed.roll_tll) _input _shifts _dims
 
 -- rot90 :: Tensor device dtype shape -> Int -> [Int] -> Tensor device dtype shape
--- rot90 _input _k _dims = unsafePerformIO $ (cast3 ATen.rot90_tll) _input _k _dims
+-- rot90 _input _k _dims = unsafePerformIO $ (ATen.cast3 ATen.Managed.rot90_tll) _input _k _dims
 
 -- triplet_margin_loss :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Double -> Double -> Double -> Bool -> Int -> Tensor device dtype shape
--- triplet_margin_loss _anchor _positive _negative _margin _p _eps _swap _reduction = unsafePerformIO $ (cast8 ATen.triplet_margin_loss_tttdddbl) _anchor _positive _negative _margin _p _eps _swap _reduction
+-- triplet_margin_loss _anchor _positive _negative _margin _p _eps _swap _reduction = unsafePerformIO $ (ATen.cast8 ATen.Managed.triplet_margin_loss_tttdddbl) _anchor _positive _negative _margin _p _eps _swap _reduction
 
 -- | trunc
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -3031,16 +3064,16 @@ trunc
    . (StandardFloatingPointDTypeValidation device dtype)
   => Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
-trunc input = unsafePerformIO $ cast1 ATen.trunc_t input
+trunc input = unsafePerformIO $ ATen.cast1 ATen.Managed.trunc_t input
 
 -- unique_dim :: Tensor device dtype shape -> Int -> Bool -> Bool -> Bool -> (Tensor device dtype shape,Tensor device dtype shape,Tensor device dtype shape)
--- unique_dim _input _dim _sorted _return_inverse _return_counts = unsafePerformIO $ (cast5 ATen.unique_dim_tlbbb) _input _dim _sorted _return_inverse _return_counts
+-- unique_dim _input _dim _sorted _return_inverse _return_counts = unsafePerformIO $ (ATen.cast5 ATen.Managed.unique_dim_tlbbb) _input _dim _sorted _return_inverse _return_counts
 
 -- unique_consecutive :: Tensor device dtype shape -> Bool -> Bool -> Int -> (Tensor device dtype shape,Tensor device dtype shape,Tensor device dtype shape)
--- unique_consecutive _input _return_inverse _return_counts _dim = unsafePerformIO $ (cast4 ATen.unique_consecutive_tbbl) _input _return_inverse _return_counts _dim
+-- unique_consecutive _input _return_inverse _return_counts _dim = unsafePerformIO $ (ATen.cast4 ATen.Managed.unique_consecutive_tbbl) _input _return_inverse _return_counts _dim
 
 -- unique_dim_consecutive :: Tensor device dtype shape -> Int -> Bool -> Bool -> (Tensor device dtype shape,Tensor device dtype shape,Tensor device dtype shape)
--- unique_dim_consecutive _input _dim _return_inverse _return_counts = unsafePerformIO $ (cast4 ATen.unique_dim_consecutive_tlbb) _input _dim _return_inverse _return_counts
+-- unique_dim_consecutive _input _dim _return_inverse _return_counts = unsafePerformIO $ (ATen.cast4 ATen.Managed.unique_dim_consecutive_tlbb) _input _dim _return_inverse _return_counts
 
 -- | UnsqueezeImpl
 -- >>> :kind! UnsqueezeImpl '[4] 0
@@ -3084,16 +3117,16 @@ unsqueeze
    . (KnownNat dim, shape' ~ Unsqueeze shape dim)
   => Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape' -- ^ output
-unsqueeze input = unsafePerformIO $ cast2 ATen.unsqueeze_tl input (natValI @dim)
+unsqueeze input = unsafePerformIO $ ATen.cast2 ATen.Managed.unsqueeze_tl input (natValI @dim)
 
 -- where' :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape
--- where' _condition _input _other = unsafePerformIO $ (cast3 ATen.where_ttt) _condition _input _other
+-- where' _condition _input _other = unsafePerformIO $ (ATen.cast3 ATen.Managed.where_ttt) _condition _input _other
 
 -- where_ :: Tensor device dtype shape -> [Tensor device dtype shape]
--- where_ _condition = unsafePerformIO $ (cast1 ATen.where_t) _condition
+-- where_ _condition = unsafePerformIO $ (ATen.cast1 ATen.Managed.where_t) _condition
 
 -- norm_except_dim :: Tensor device dtype shape -> Int -> Int -> Tensor device dtype shape
--- norm_except_dim _v _pow _dim = unsafePerformIO $ (cast3 ATen.norm_except_dim_tll) _v _pow _dim
+-- norm_except_dim _v _pow _dim = unsafePerformIO $ (ATen.cast3 ATen.Managed.norm_except_dim_tll) _v _pow _dim
 
 -- | zerosLike
 -- >>> dtype &&& shape $ zerosLike (ones :: CPUTensor 'D.Float '[3,4,5])
@@ -3102,10 +3135,10 @@ zerosLike
   :: forall shape dtype device
    . Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
-zerosLike input = unsafePerformIO $ cast1 ATen.zeros_like_t input
+zerosLike input = unsafePerformIO $ ATen.cast1 ATen.Managed.zeros_like_t input
 
 -- native_norm :: Tensor device dtype shape -> Float -> Tensor device dtype shape
--- native_norm _input _p = unsafePerformIO $ (cast2 ATen.native_norm_ts) _input _p
+-- native_norm _input _p = unsafePerformIO $ (ATen.cast2 ATen.Managed.native_norm_ts) _input _p
 
 -- | clone
 -- >>> t <- clone (ones :: CPUTensor 'D.Float '[3,2])
@@ -3115,10 +3148,10 @@ clone
   :: forall shape dtype device
    . Tensor device dtype shape
   -> IO (Tensor device dtype shape)
-clone input = cast1 ATen.clone_t input
+clone input = ATen.cast1 ATen.Managed.clone_t input
 
 -- s_native_addmm :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Float -> Float -> Tensor device dtype shape
--- s_native_addmm _input _mat1 _mat2 _beta _alpha = unsafePerformIO $ (cast5 ATen.s_native_addmm_tttss) _input _mat1 _mat2 _beta _alpha
+-- s_native_addmm _input _mat1 _mat2 _beta _alpha = unsafePerformIO $ (ATen.cast5 ATen.Managed.s_native_addmm_tttss) _input _mat1 _mat2 _beta _alpha
 
 -- | addmm
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -3139,10 +3172,10 @@ addmm
   -> Tensor device dtype '[k, m] -- ^ second input matrix
   -> Tensor device dtype shape -- ^ input tensor
   -> Tensor device dtype shape' -- ^ output tensor
-addmm beta alpha mat1 mat2 input = unsafePerformIO $ cast5 ATen.addmm_tttss input mat1 mat2 beta alpha
+addmm beta alpha mat1 mat2 input = unsafePerformIO $ ATen.cast5 ATen.Managed.addmm_tttss input mat1 mat2 beta alpha
 
 -- hspmm :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape
--- hspmm _mat1 _mat2 = unsafePerformIO $ (cast2 ATen.hspmm_tt) _mat1 _mat2
+-- hspmm _mat1 _mat2 = unsafePerformIO $ (ATen.cast2 ATen.Managed.hspmm_tt) _mat1 _mat2
 
 -- | numel
 -- TODO: since this is decidable at compile time, this should probably be calculated from the tensor type instead
@@ -3150,22 +3183,22 @@ numel
   :: forall shape dtype device
    . Tensor device dtype shape -- ^ input
   -> Int -- ^ output
-numel input = unsafePerformIO $ cast1 ATen.numel_t input
+numel input = unsafePerformIO $ ATen.cast1 ATen.Managed.numel_t input
 
 -- unbind :: Tensor device dtype shape -> Int -> [Tensor device dtype shape]
--- unbind _input _dim = unsafePerformIO $ (cast2 ATen.unbind_tl) _input _dim
+-- unbind _input _dim = unsafePerformIO $ (ATen.cast2 ATen.Managed.unbind_tl) _input _dim
 
 -- mkldnn_reorder_conv2d_weight :: Tensor device dtype shape -> (Int,Int) -> (Int,Int) -> (Int,Int) -> Int -> Tensor device dtype shape
--- mkldnn_reorder_conv2d_weight _input _padding _stride _dilation _groups = unsafePerformIO $ (cast5 ATen.mkldnn_reorder_conv2d_weight_tllll) _input _padding _stride _dilation _groups
+-- mkldnn_reorder_conv2d_weight _input _padding _stride _dilation _groups = unsafePerformIO $ (ATen.cast5 ATen.Managed.mkldnn_reorder_conv2d_weight_tllll) _input _padding _stride _dilation _groups
 
 --quantize_linear :: Tensor device dtype shape -> Double -> Int -> DType -> Tensor device dtype shape
---quantize_linear _input _scale _zero_point _dtype = unsafePerformIO $ (cast4 ATen.quantize_linear_tdls) _input _scale _zero_point _dtype
+--quantize_linear _input _scale _zero_point _dtype = unsafePerformIO $ (ATen.cast4 ATen.Managed.quantize_linear_tdls) _input _scale _zero_point _dtype
 
 --quantize_linear_per_channel :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> [Int] -> DType -> Tensor device dtype shape
---quantize_linear_per_channel _input _scales _zero_points _axis _dtype = unsafePerformIO $ (cast5 ATen.quantize_linear_per_channel_tttls) _input _scales _zero_points _axis _dtype
+--quantize_linear_per_channel _input _scales _zero_points _axis _dtype = unsafePerformIO $ (ATen.cast5 ATen.Managed.quantize_linear_per_channel_tttls) _input _scales _zero_points _axis _dtype
 
 -- dequantize :: Tensor device dtype shape -> Tensor device dtype shape
--- dequantize _input = unsafePerformIO $ (cast1 ATen.dequantize_t) _input
+-- dequantize _input = unsafePerformIO $ (ATen.cast1 ATen.Managed.dequantize_t) _input
 
 -- | qScale
 -- TODO: are there any restrictions on the dtype?
@@ -3173,7 +3206,7 @@ qScale
   :: forall shape dtype device
    . Tensor device dtype shape -- ^ input
   -> Double -- ^ output
-qScale input = unsafePerformIO $ cast1 ATen.q_scale_t input
+qScale input = unsafePerformIO $ ATen.cast1 ATen.Managed.q_scale_t input
 
 -- | qZeroPoint
 -- TODO: are there any restrictions on the dtype?
@@ -3181,22 +3214,22 @@ qZeroPoint
   :: forall shape dtype device
    . Tensor device dtype shape -- ^ input
   -> Int -- ^ output
-qZeroPoint input = unsafePerformIO $ cast1 ATen.q_zero_point_t input
+qZeroPoint input = unsafePerformIO $ ATen.cast1 ATen.Managed.q_zero_point_t input
 
 -- int_repr :: Tensor device dtype shape -> Tensor device dtype shape
--- int_repr _input = unsafePerformIO $ (cast1 ATen.int_repr_t) _input
+-- int_repr _input = unsafePerformIO $ (ATen.cast1 ATen.Managed.int_repr_t) _input
 
 -- fake_quantize_per_tensor_affine :: Tensor device dtype shape -> Double -> Int -> Int -> Int -> Tensor device dtype shape
--- fake_quantize_per_tensor_affine _input _scale _zero_point _quant_min _quant_max = unsafePerformIO $ (cast5 ATen.fake_quantize_per_tensor_affine_tdlll) _input _scale _zero_point _quant_min _quant_max
+-- fake_quantize_per_tensor_affine _input _scale _zero_point _quant_min _quant_max = unsafePerformIO $ (ATen.cast5 ATen.Managed.fake_quantize_per_tensor_affine_tdlll) _input _scale _zero_point _quant_min _quant_max
 
 -- meshgrid :: [Tensor device dtype shape] -> [Tensor device dtype shape]
--- meshgrid _tensors = unsafePerformIO $ (cast1 ATen.meshgrid_l) _tensors
+-- meshgrid _tensors = unsafePerformIO $ (ATen.cast1 ATen.Managed.meshgrid_l) _tensors
 
 -- cartesian_prod :: [Tensor device dtype shape] -> Tensor device dtype shape
--- cartesian_prod _tensors = unsafePerformIO $ (cast1 ATen.cartesian_prod_l) _tensors
+-- cartesian_prod _tensors = unsafePerformIO $ (ATen.cast1 ATen.Managed.cartesian_prod_l) _tensors
 
 -- combinations :: Tensor device dtype shape -> Int -> Bool -> Tensor device dtype shape
--- combinations _input _r _with_replacement = unsafePerformIO $ (cast3 ATen.combinations_tlb) _input _r _with_replacement
+-- combinations _input _r _with_replacement = unsafePerformIO $ (ATen.cast3 ATen.Managed.combinations_tlb) _input _r _with_replacement
 
 -- | The directional specification of a recurrent function
 --
@@ -3308,9 +3341,7 @@ lstm
      , outputShape ~ RNNShape shapeOrder seqLen batchSize outputSize
      , hxShape ~ '[numLayers * NumberOfDirections directionality, batchSize, hiddenSize]
      , tensorParameters ~ LSTMR inputSize hiddenSize numLayers directionality dtype device
-     , HFoldrM IO TensorListFold [D.ATenTensor] tensorParameters
-     , Apply TensorListUnfold [D.ATenTensor] (HUnfoldMRes IO [D.ATenTensor] tensorParameters)
-     , HUnfoldM IO TensorListUnfold (HUnfoldMRes IO [D.ATenTensor] tensorParameters) tensorParameters
+     , ATen.Castable (HList tensorParameters) [D.ATenTensor]
      )
   => HList tensorParameters
   -> Double
@@ -3321,8 +3352,8 @@ lstm
      , Tensor device dtype hxShape
      , Tensor device dtype hxShape
      )
-lstm tensorParameters dropoutProb dropoutOn (cc, hc) input = unsafePerformIO $ cast9
-  ATen.lstm_tllbldbbb
+lstm tensorParameters dropoutProb dropoutOn (cc, hc) input = unsafePerformIO $ ATen.cast9
+  ATen.Managed.lstm_tllbldbbb
   input
   hx
   tensorParameters
@@ -3357,47 +3388,47 @@ lstmCell
      )
 lstmCell wi wh bi bh (cc, hc) input =
   unsafePerformIO
-    $ cast6 ATen.lstm_cell_tltttt input hx wi wh bi bh
+    $ ATen.cast6 ATen.Managed.lstm_cell_tltttt input hx wi wh bi bh
   where hx = [cc, hc] :: [Tensor device dtype '[batchSize, hiddenSize]]
 
 -- gru_cell :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape
--- gru_cell _input _hx _w_ih _w_hh _b_ih _b_hh = unsafePerformIO $ (cast6 ATen.gru_cell_tttttt) _input _hx _w_ih _w_hh _b_ih _b_hh
+-- gru_cell _input _hx _w_ih _w_hh _b_ih _b_hh = unsafePerformIO $ (ATen.cast6 ATen.Managed.gru_cell_tttttt) _input _hx _w_ih _w_hh _b_ih _b_hh
 
 -- rnn_tanh_cell :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape
--- rnn_tanh_cell _input _hx _w_ih _w_hh _b_ih _b_hh = unsafePerformIO $ (cast6 ATen.rnn_tanh_cell_tttttt) _input _hx _w_ih _w_hh _b_ih _b_hh
+-- rnn_tanh_cell _input _hx _w_ih _w_hh _b_ih _b_hh = unsafePerformIO $ (ATen.cast6 ATen.Managed.rnn_tanh_cell_tttttt) _input _hx _w_ih _w_hh _b_ih _b_hh
 
 -- rnn_relu_cell :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape
--- rnn_relu_cell _input _hx _w_ih _w_hh _b_ih _b_hh = unsafePerformIO $ (cast6 ATen.rnn_relu_cell_tttttt) _input _hx _w_ih _w_hh _b_ih _b_hh
+-- rnn_relu_cell _input _hx _w_ih _w_hh _b_ih _b_hh = unsafePerformIO $ (ATen.cast6 ATen.Managed.rnn_relu_cell_tttttt) _input _hx _w_ih _w_hh _b_ih _b_hh
 
 -- quantized_lstm :: Tensor device dtype shape -> [Tensor device dtype shape] -> [Tensor device dtype shape] -> Bool -> Int -> Double -> Bool -> Bool -> Bool -> DType -> (Tensor device dtype shape,Tensor device dtype shape,Tensor device dtype shape)
--- quantized_lstm _input _hx _params _has_biases _num_layers _dropout _train _bidirectional _batch_first _dtype = unsafePerformIO $ (cast10 ATen.quantized_lstm_tllbldbbbs) _input _hx _params _has_biases _num_layers _dropout _train _bidirectional _batch_first _dtype
+-- quantized_lstm _input _hx _params _has_biases _num_layers _dropout _train _bidirectional _batch_first _dtype = unsafePerformIO $ (ATen.ATen.cast10 ATen.Managed.quantized_lstm_tllbldbbbs) _input _hx _params _has_biases _num_layers _dropout _train _bidirectional _batch_first _dtype
 
 -- quantized_lstm_cell :: Tensor device dtype shape -> [Tensor device dtype shape] -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Float -> Float -> Float -> Float -> (Tensor device dtype shape,Tensor device dtype shape)
--- quantized_lstm_cell _input _hx _w_ih _w_hh _b_ih _b_hh _packed_ih _packed_hh _col_offsets_ih _col_offsets_hh _scale_ih _scale_hh _zero_point_ih _zero_point_hh = unsafePerformIO $ (cast14 ATen.quantized_lstm_cell_tlttttttttssss) _input _hx _w_ih _w_hh _b_ih _b_hh _packed_ih _packed_hh _col_offsets_ih _col_offsets_hh _scale_ih _scale_hh _zero_point_ih _zero_point_hh
+-- quantized_lstm_cell _input _hx _w_ih _w_hh _b_ih _b_hh _packed_ih _packed_hh _col_offsets_ih _col_offsets_hh _scale_ih _scale_hh _zero_point_ih _zero_point_hh = unsafePerformIO $ (ATen.ATen.cast14 ATen.Managed.quantized_lstm_cell_tlttttttttssss) _input _hx _w_ih _w_hh _b_ih _b_hh _packed_ih _packed_hh _col_offsets_ih _col_offsets_hh _scale_ih _scale_hh _zero_point_ih _zero_point_hh
 
 -- quantized_gru_cell :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Float -> Float -> Float -> Float -> Tensor device dtype shape
--- quantized_gru_cell _input _hx _w_ih _w_hh _b_ih _b_hh _packed_ih _packed_hh _col_offsets_ih _col_offsets_hh _scale_ih _scale_hh _zero_point_ih _zero_point_hh = unsafePerformIO $ (cast14 ATen.quantized_gru_cell_ttttttttttssss) _input _hx _w_ih _w_hh _b_ih _b_hh _packed_ih _packed_hh _col_offsets_ih _col_offsets_hh _scale_ih _scale_hh _zero_point_ih _zero_point_hh
+-- quantized_gru_cell _input _hx _w_ih _w_hh _b_ih _b_hh _packed_ih _packed_hh _col_offsets_ih _col_offsets_hh _scale_ih _scale_hh _zero_point_ih _zero_point_hh = unsafePerformIO $ (ATen.ATen.cast14 ATen.Managed.quantized_gru_cell_ttttttttttssss) _input _hx _w_ih _w_hh _b_ih _b_hh _packed_ih _packed_hh _col_offsets_ih _col_offsets_hh _scale_ih _scale_hh _zero_point_ih _zero_point_hh
 
 -- quantized_rnn_relu_cell :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Float -> Float -> Float -> Float -> Tensor device dtype shape
--- quantized_rnn_relu_cell _input _hx _w_ih _w_hh _b_ih _b_hh _packed_ih _packed_hh _col_offsets_ih _col_offsets_hh _scale_ih _scale_hh _zero_point_ih _zero_point_hh = unsafePerformIO $ (cast14 ATen.quantized_rnn_relu_cell_ttttttttttssss) _input _hx _w_ih _w_hh _b_ih _b_hh _packed_ih _packed_hh _col_offsets_ih _col_offsets_hh _scale_ih _scale_hh _zero_point_ih _zero_point_hh
+-- quantized_rnn_relu_cell _input _hx _w_ih _w_hh _b_ih _b_hh _packed_ih _packed_hh _col_offsets_ih _col_offsets_hh _scale_ih _scale_hh _zero_point_ih _zero_point_hh = unsafePerformIO $ (ATen.ATen.cast14 ATen.Managed.quantized_rnn_relu_cell_ttttttttttssss) _input _hx _w_ih _w_hh _b_ih _b_hh _packed_ih _packed_hh _col_offsets_ih _col_offsets_hh _scale_ih _scale_hh _zero_point_ih _zero_point_hh
 
 -- quantized_rnn_tanh_cell :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Float -> Float -> Float -> Float -> Tensor device dtype shape
--- quantized_rnn_tanh_cell _input _hx _w_ih _w_hh _b_ih _b_hh _packed_ih _packed_hh _col_offsets_ih _col_offsets_hh _scale_ih _scale_hh _zero_point_ih _zero_point_hh = unsafePerformIO $ (cast14 ATen.quantized_rnn_tanh_cell_ttttttttttssss) _input _hx _w_ih _w_hh _b_ih _b_hh _packed_ih _packed_hh _col_offsets_ih _col_offsets_hh _scale_ih _scale_hh _zero_point_ih _zero_point_hh
+-- quantized_rnn_tanh_cell _input _hx _w_ih _w_hh _b_ih _b_hh _packed_ih _packed_hh _col_offsets_ih _col_offsets_hh _scale_ih _scale_hh _zero_point_ih _zero_point_hh = unsafePerformIO $ (ATen.ATen.cast14 ATen.Managed.quantized_rnn_tanh_cell_ttttttttttssss) _input _hx _w_ih _w_hh _b_ih _b_hh _packed_ih _packed_hh _col_offsets_ih _col_offsets_hh _scale_ih _scale_hh _zero_point_ih _zero_point_hh
 
 -- masked_scatter :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape
--- masked_scatter _input _mask _source = unsafePerformIO $ (cast3 ATen.masked_scatter_ttt) _input _mask _source
+-- masked_scatter _input _mask _source = unsafePerformIO $ (ATen.cast3 ATen.Managed.masked_scatter_ttt) _input _mask _source
 
 -- index_add :: Tensor device dtype shape -> Int -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape
--- index_add _input _dim _index _source = unsafePerformIO $ (cast4 ATen.index_add_tltt) _input _dim _index _source
+-- index_add _input _dim _index _source = unsafePerformIO $ (ATen.cast4 ATen.Managed.index_add_tltt) _input _dim _index _source
 
 -- scatter_add :: Tensor device dtype shape -> Int -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape
--- scatter_add _input _dim _index _src = unsafePerformIO $ (cast4 ATen.scatter_add_tltt) _input _dim _index _src
+-- scatter_add _input _dim _index _src = unsafePerformIO $ (ATen.cast4 ATen.Managed.scatter_add_tltt) _input _dim _index _src
 
 -- addbmm :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Float -> Float -> Tensor device dtype shape
--- addbmm _input _batch1 _batch2 _beta _alpha = unsafePerformIO $ (cast5 ATen.addbmm_tttss) _input _batch1 _batch2 _beta _alpha
+-- addbmm _input _batch1 _batch2 _beta _alpha = unsafePerformIO $ (ATen.cast5 ATen.Managed.addbmm_tttss) _input _batch1 _batch2 _beta _alpha
 
 -- cross :: Tensor device dtype shape -> Tensor device dtype shape -> Int -> Tensor device dtype shape
--- cross _input _other _dim = unsafePerformIO $ (cast3 ATen.cross_ttl) _input _other _dim
+-- cross _input _other _dim = unsafePerformIO $ (ATen.cast3 ATen.Managed.cross_ttl) _input _other _dim
 
 type family MatrixOrMatrixBatch (shape :: [Nat]) :: [Nat] where
   MatrixOrMatrixBatch (n : m : '[])     = '[n, m]
@@ -3419,7 +3450,7 @@ triu
   => Int -- ^ diagonal
   -> Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
-triu diagonal input = unsafePerformIO $ cast2 ATen.triu_tl input diagonal
+triu diagonal input = unsafePerformIO $ ATen.cast2 ATen.Managed.triu_tl input diagonal
 
 -- | tril
 -- TODO: tril is not implemented for D.Bool, or maybe numeric type is lifted?
@@ -3436,49 +3467,49 @@ tril
   => Int -- ^ diagonal
   -> Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
-tril diagonal input = unsafePerformIO $ cast2 ATen.tril_tl input diagonal
+tril diagonal input = unsafePerformIO $ ATen.cast2 ATen.Managed.tril_tl input diagonal
 
 -- trace :: Tensor device dtype shape -> Tensor device dtype shape
--- trace _input = unsafePerformIO $ (cast1 ATen.trace_t) _input
+-- trace _input = unsafePerformIO $ (ATen.cast1 ATen.Managed.trace_t) _input
 
 -- take :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape
--- take _input _index = unsafePerformIO $ (cast2 ATen.take_tt) _input _index
+-- take _input _index = unsafePerformIO $ (ATen.cast2 ATen.Managed.take_tt) _input _index
 
 -- index_select :: Tensor device dtype shape -> Int -> Tensor device dtype shape -> Tensor device dtype shape
--- index_select _input _dim _index = unsafePerformIO $ (cast3 ATen.index_select_tlt) _input _dim _index
+-- index_select _input _dim _index = unsafePerformIO $ (ATen.cast3 ATen.Managed.index_select_tlt) _input _dim _index
 
 -- masked_select :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape
--- masked_select _input _mask = unsafePerformIO $ (cast2 ATen.masked_select_tt) _input _mask
+-- masked_select _input _mask = unsafePerformIO $ (ATen.cast2 ATen.Managed.masked_select_tt) _input _mask
 
 -- nonzero :: Tensor device dtype shape -> Tensor device dtype shape
--- nonzero _input = unsafePerformIO $ (cast1 ATen.nonzero_t) _input
+-- nonzero _input = unsafePerformIO $ (ATen.cast1 ATen.Managed.nonzero_t) _input
 
 -- nonzero_numpy :: Tensor device dtype shape -> [Tensor device dtype shape]
--- nonzero_numpy _input = unsafePerformIO $ (cast1 ATen.nonzero_numpy_t) _input
+-- nonzero_numpy _input = unsafePerformIO $ (ATen.cast1 ATen.Managed.nonzero_numpy_t) _input
 
 -- gather :: Tensor device dtype shape -> Int -> Tensor device dtype shape -> Bool -> Tensor device dtype shape
--- gather _input _dim _index _sparse_grad = unsafePerformIO $ (cast4 ATen.gather_tltb) _input _dim _index _sparse_grad
+-- gather _input _dim _index _sparse_grad = unsafePerformIO $ (ATen.cast4 ATen.Managed.gather_tltb) _input _dim _index _sparse_grad
 
 -- addcmul :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Float -> Tensor device dtype shape
--- addcmul _input _tensor1 _tensor2 _value = unsafePerformIO $ (cast4 ATen.addcmul_ttts) _input _tensor1 _tensor2 _value
+-- addcmul _input _tensor1 _tensor2 _value = unsafePerformIO $ (ATen.cast4 ATen.Managed.addcmul_ttts) _input _tensor1 _tensor2 _value
 
 -- addcdiv :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Float -> Tensor device dtype shape
--- addcdiv _input _tensor1 _tensor2 _value = unsafePerformIO $ (cast4 ATen.addcdiv_ttts) _input _tensor1 _tensor2 _value
+-- addcdiv _input _tensor1 _tensor2 _value = unsafePerformIO $ (ATen.cast4 ATen.Managed.addcdiv_ttts) _input _tensor1 _tensor2 _value
 
 -- lstsq :: Tensor device dtype shape -> Tensor device dtype shape -> (Tensor device dtype shape,Tensor device dtype shape)
--- lstsq _input _A = unsafePerformIO $ (cast2 ATen.lstsq_tt) _input _A
+-- lstsq _input _A = unsafePerformIO $ (ATen.cast2 ATen.Managed.lstsq_tt) _input _A
 
 -- triangular_solve :: Tensor device dtype shape -> Tensor device dtype shape -> Bool -> Bool -> Bool -> (Tensor device dtype shape,Tensor device dtype shape)
--- triangular_solve _input _A _upper _transpose _unitriangular = unsafePerformIO $ (cast5 ATen.triangular_solve_ttbbb) _input _A _upper _transpose _unitriangular
+-- triangular_solve _input _A _upper _transpose _unitriangular = unsafePerformIO $ (ATen.cast5 ATen.Managed.triangular_solve_ttbbb) _input _A _upper _transpose _unitriangular
 
 -- qr :: Tensor device dtype shape -> Bool -> (Tensor device dtype shape,Tensor device dtype shape)
--- qr _input _some = unsafePerformIO $ (cast2 ATen.qr_tb) _input _some
+-- qr _input _some = unsafePerformIO $ (ATen.cast2 ATen.Managed.qr_tb) _input _some
 
 -- ormqr :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Bool -> Bool -> Tensor device dtype shape
--- ormqr _input _input2 _input3 _left _transpose = unsafePerformIO $ (cast5 ATen.ormqr_tttbb) _input _input2 _input3 _left _transpose
+-- ormqr _input _input2 _input3 _left _transpose = unsafePerformIO $ (ATen.cast5 ATen.Managed.ormqr_tttbb) _input _input2 _input3 _left _transpose
 
 -- lu_solve :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape
--- lu_solve _input _LU_data _LU_pivots = unsafePerformIO $ (cast3 ATen.lu_solve_ttt) _input _LU_data _LU_pivots
+-- lu_solve _input _LU_data _LU_pivots = unsafePerformIO $ (ATen.cast3 ATen.Managed.lu_solve_ttt) _input _LU_data _LU_pivots
 
 -- | lgamma function
 -- >>> dtype &&& shape $ lgamma (ones :: CPUTensor 'D.Float '[3,2])
@@ -3488,7 +3519,7 @@ lgamma
    . (StandardFloatingPointDTypeValidation device dtype)
   => Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
-lgamma input = unsafePerformIO $ cast1 ATen.lgamma_t input
+lgamma input = unsafePerformIO $ ATen.cast1 ATen.Managed.lgamma_t input
 
 -- | digamma function
 -- >>> dtype &&& shape $ digamma (ones :: CPUTensor 'D.Float '[3,2])
@@ -3498,7 +3529,7 @@ digamma
    . (StandardFloatingPointDTypeValidation device dtype)
   => Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
-digamma input = unsafePerformIO $ cast1 ATen.digamma_t input
+digamma input = unsafePerformIO $ ATen.cast1 ATen.Managed.digamma_t input
 
 -- | polygamma function
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -3507,7 +3538,7 @@ polygamma
    . Int -- ^ order
   -> Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
-polygamma n input = unsafePerformIO $ cast2 ATen.polygamma_lt n input
+polygamma n input = unsafePerformIO $ ATen.cast2 ATen.Managed.polygamma_lt n input
 
 -- | inverse of the error function
 -- >>> dtype &&& shape $ erfinv (ones :: CPUTensor 'D.Float '[3,2])
@@ -3517,16 +3548,16 @@ erfinv
    . (StandardFloatingPointDTypeValidation device dtype)
   => Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
-erfinv input = unsafePerformIO $ cast1 ATen.erfinv_t input
+erfinv input = unsafePerformIO $ ATen.cast1 ATen.Managed.erfinv_t input
 
 -- dist :: Tensor device dtype shape -> Tensor device dtype shape -> Float -> Tensor device dtype shape
--- dist _input _other _p = unsafePerformIO $ (cast3 ATen.dist_tts) _input _other _p
+-- dist _input _other _p = unsafePerformIO $ (ATen.cast3 ATen.Managed.dist_tts) _input _other _p
 
 -- atan2 :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape
--- atan2 _input _other = unsafePerformIO $ (cast2 ATen.atan2_tt) _input _other
+-- atan2 _input _other = unsafePerformIO $ (ATen.cast2 ATen.Managed.atan2_tt) _input _other
 
 -- histc :: Tensor device dtype shape -> Int -> Float -> Float -> Tensor device dtype shape
--- histc _input _bins _min _max = unsafePerformIO $ (cast4 ATen.histc_tlss) _input _bins _min _max
+-- histc _input _bins _min _max = unsafePerformIO $ (ATen.cast4 ATen.Managed.histc_tlss) _input _bins _min _max
 
 -- | minAll
 -- >>> dtype &&& shape $ minAll (ones :: CPUTensor 'D.Float '[2,2])
@@ -3535,7 +3566,7 @@ minAll
   :: forall shape dtype device
    . Tensor device dtype shape -- ^ input
   -> Tensor device dtype '[] -- ^ output
-minAll input = unsafePerformIO $ cast1 ATen.min_t input
+minAll input = unsafePerformIO $ ATen.cast1 ATen.Managed.min_t input
 
 type family DropValue (shape :: [Nat]) (i :: Nat) :: [Nat] where
   DropValue '[]     _ = TypeError (Text "Can not find a element in the list.")
@@ -3557,7 +3588,7 @@ minDim
   -> ( Tensor device dtype    (DropValue shape d)
      , Tensor device 'D.Int64 (DropValue shape d)
      ) -- ^ output
-minDim input = unsafePerformIO $ cast2 ATen.min_tl input (natValI @d)
+minDim input = unsafePerformIO $ ATen.cast2 ATen.Managed.min_tl input (natValI @d)
 
 -- | maxAll
 -- >>> dtype &&& shape $ maxAll (ones :: CPUTensor 'D.Float '[2,2])
@@ -3566,7 +3597,7 @@ maxAll
   :: forall shape dtype device
    . Tensor device dtype shape -- ^ input
   -> Tensor device dtype '[] -- ^ output
-maxAll input = unsafePerformIO $ cast1 ATen.max_t input
+maxAll input = unsafePerformIO $ ATen.cast1 ATen.Managed.max_t input
 
 -- | maxDim
 -- >>> t = ones :: CPUTensor 'D.Float '[3,4,5]
@@ -3583,7 +3614,7 @@ maxDim
   -> ( Tensor device dtype    (DropValue shape d)
      , Tensor device 'D.Int64 (DropValue shape d)
      ) -- ^ output
-maxDim input = unsafePerformIO $ cast2 ATen.max_tl input (natValI @d)
+maxDim input = unsafePerformIO $ ATen.cast2 ATen.Managed.max_tl input (natValI @d)
 
 -- | medianAll
 -- >>> dtype &&& shape $ medianAll (ones :: CPUTensor 'D.Float '[2,2])
@@ -3592,7 +3623,7 @@ medianAll
   :: forall shape dtype device
    . Tensor device dtype shape -- ^ input
   -> Tensor device dtype '[] -- ^ output
-medianAll input = unsafePerformIO $ cast1 ATen.median_t input
+medianAll input = unsafePerformIO $ ATen.cast1 ATen.Managed.median_t input
 
 -- | medianDim
 -- >>> t = ones :: CPUTensor 'D.Float '[3,4,5]
@@ -3609,7 +3640,7 @@ medianDim
   -> ( Tensor device dtype    (DropValue shape d)
      , Tensor device 'D.Int64 (DropValue shape d)
      ) -- ^ output
-medianDim input = unsafePerformIO $ cast2 ATen.median_tl input (natValI @d)
+medianDim input = unsafePerformIO $ ATen.cast2 ATen.Managed.median_tl input (natValI @d)
 
 -- | median
 -- See https://pytorch.org/docs/stable/torch.html#torch.median.
@@ -3623,28 +3654,28 @@ median'
   -> ( Tensor device dtype    (ConditionalDropDimension shape dim keepOrDropDim)
      , Tensor device 'D.Int64 (ConditionalDropDimension shape dim keepOrDropDim)
      )
-median' input = unsafePerformIO $ cast3 ATen.median_tlb
+median' input = unsafePerformIO $ ATen.cast3 ATen.Managed.median_tlb
                                         input
                                         (natValI @dim)
                                         (keepOrDropDimVal @keepOrDropDim)
 
 -- sort :: Tensor device dtype shape -> Int -> Bool -> (Tensor device dtype shape,Tensor device dtype shape)
--- sort _input _dim _descending = unsafePerformIO $ (cast3 ATen.sort_tlb) _input _dim _descending
+-- sort _input _dim _descending = unsafePerformIO $ (ATen.cast3 ATen.Managed.sort_tlb) _input _dim _descending
 
 -- argsort :: Tensor device dtype shape -> Int -> Bool -> Tensor device dtype shape
--- argsort _input _dim _descending = unsafePerformIO $ (cast3 ATen.argsort_tlb) _input _dim _descending
+-- argsort _input _dim _descending = unsafePerformIO $ (ATen.cast3 ATen.Managed.argsort_tlb) _input _dim _descending
 
 -- topk :: Tensor device dtype shape -> Int -> Int -> Bool -> Bool -> (Tensor device dtype shape,Tensor device dtype shape)
--- topk _input _k _dim _largest _sorted = unsafePerformIO $ (cast5 ATen.topk_tllbb) _input _k _dim _largest _sorted
+-- topk _input _k _dim _largest _sorted = unsafePerformIO $ (ATen.cast5 ATen.Managed.topk_tllbb) _input _k _dim _largest _sorted
 
 -- renorm :: Tensor device dtype shape -> Float -> Int -> Float -> Tensor device dtype shape
--- renorm _input _p _dim _maxnorm = unsafePerformIO $ (cast4 ATen.renorm_tsls) _input _p _dim _maxnorm
+-- renorm _input _p _dim _maxnorm = unsafePerformIO $ (ATen.cast4 ATen.Managed.renorm_tsls) _input _p _dim _maxnorm
 
 -- equal :: Tensor device dtype shape -> Tensor device dtype shape -> Bool
--- equal _input _other = unsafePerformIO $ (cast2 ATen.equal_tt) _input _other
+-- equal _input _other = unsafePerformIO $ (ATen.cast2 ATen.Managed.equal_tt) _input _other
 
 -- alias :: Tensor device dtype shape -> Tensor device dtype shape
--- alias _input = unsafePerformIO $ (cast1 ATen.alias_t) _input
+-- alias _input = unsafePerformIO $ (ATen.cast1 ATen.Managed.alias_t) _input
 
 -- | L1 loss
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -3659,13 +3690,13 @@ l1Loss
   -> Tensor device dtype shape -- ^ target
   -> Tensor device dtype (ConditionalReduction shape reduction) -- ^ loss
 l1Loss prediction target = unsafePerformIO
-  $ cast3 ATen.l1_loss_ttl prediction target (reductionVal @reduction)
+  $ ATen.cast3 ATen.Managed.l1_loss_ttl prediction target (reductionVal @reduction)
 
 -- multi_margin_loss :: Tensor device dtype shape -> Tensor device dtype shape -> Float -> Float -> Tensor device dtype shape -> Int -> Tensor device dtype shape
--- multi_margin_loss _input _target _p _margin _weight _reduction = unsafePerformIO $ (cast6 ATen.multi_margin_loss_ttsstl) _input _target _p _margin _weight _reduction
+-- multi_margin_loss _input _target _p _margin _weight _reduction = unsafePerformIO $ (ATen.cast6 ATen.Managed.multi_margin_loss_ttsstl) _input _target _p _margin _weight _reduction
 
 -- multilabel_margin_loss :: Tensor device dtype shape -> Tensor device dtype shape -> Int -> Tensor device dtype shape
--- multilabel_margin_loss _input _target _reduction = unsafePerformIO $ (cast3 ATen.multilabel_margin_loss_ttl) _input _target _reduction
+-- multilabel_margin_loss _input _target _reduction = unsafePerformIO $ (ATen.cast3 ATen.Managed.multilabel_margin_loss_ttl) _input _target _reduction
 
 -- | negative log likelihood loss
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -3707,13 +3738,13 @@ nllLoss
   -> Tensor device 'D.Int64 (n ': ds) -- ^ target
   -> Tensor device dtype    (ConditionalReduction (n ': ds) reduction) -- ^ loss
 nllLoss weight ignoreIndex prediction target = case shapeVal @ds of
-  [] -> unsafePerformIO $ cast5 ATen.nll_loss_tttll
+  [] -> unsafePerformIO $ ATen.cast5 ATen.Managed.nll_loss_tttll
                                 prediction
                                 target
                                 weight
                                 (reductionVal @reduction)
                                 ignoreIndex
-  [_h, _w] -> unsafePerformIO $ cast5 ATen.nll_loss2d_tttll
+  [_h, _w] -> unsafePerformIO $ ATen.cast5 ATen.Managed.nll_loss2d_tttll
                                       prediction
                                       target
                                       weight
@@ -3726,7 +3757,7 @@ nllLoss weight ignoreIndex prediction target = case shapeVal @ds of
     t'      = [1, foldl (*) h t]
     input'  = D.reshape (toDynamic prediction) (natValI @n : natValI @c : t')
     target' = D.reshape (toDynamic target) (natValI @n : t')
-    out     = unsafePerformIO $ cast5 ATen.nll_loss2d_tttll
+    out     = unsafePerformIO $ ATen.cast5 ATen.Managed.nll_loss2d_tttll
                                       input'
                                       target'
                                       weight
@@ -3746,7 +3777,7 @@ smoothL1Loss
   -> Tensor device dtype shape -- ^ target
   -> Tensor device dtype (ConditionalReduction shape reduction) -- ^ loss
 smoothL1Loss prediction target = unsafePerformIO
-  $ cast3 ATen.smooth_l1_loss_ttl prediction target (reductionVal @reduction)
+  $ ATen.cast3 ATen.Managed.smooth_l1_loss_ttl prediction target (reductionVal @reduction)
 
 -- | soft margin loss
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -3760,8 +3791,8 @@ softMarginLoss
   => Tensor device dtype shape -- ^ prediction
   -> Tensor device dtype shape -- ^ target
   -> Tensor device dtype (ConditionalReduction shape reduction) -- ^ loss
-softMarginLoss prediciton target = unsafePerformIO $ cast3
-  ATen.soft_margin_loss_ttl
+softMarginLoss prediciton target = unsafePerformIO $ ATen.cast3
+  ATen.Managed.soft_margin_loss_ttl
   prediciton
   target
   (reductionVal @reduction)
@@ -3778,7 +3809,7 @@ elu
   -> Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
 elu alpha scale inputScale input =
-  unsafePerformIO $ cast4 ATen.elu_tsss input alpha scale inputScale
+  unsafePerformIO $ ATen.cast4 ATen.Managed.elu_tsss input alpha scale inputScale
 
 -- |
 -- -- >>> dtype &&& shape $ glu (ones :: CPUTensor 'D.Float '[3,2]) 1
@@ -3786,7 +3817,7 @@ elu alpha scale inputScale input =
 -- -- >>> dtype &&& shape $ glu (ones :: CPUTensor 'D.Float '[3,2]) 3
 -- -- (Float,[3,2])
 -- glu :: Tensor device dtype shape -> Int -> Tensor device dtype shape
--- glu _input _dim = unsafePerformIO $ (cast2 ATen.glu_tl) _input _dim
+-- glu _input _dim = unsafePerformIO $ (ATen.cast2 ATen.Managed.glu_tl) _input _dim
 
 -- | hard tanh
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -3799,10 +3830,10 @@ hardTanh
   -> Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
 hardTanh min_val max_val input =
-  unsafePerformIO $ cast3 ATen.hardtanh_tss input min_val max_val
+  unsafePerformIO $ ATen.cast3 ATen.Managed.hardtanh_tss input min_val max_val
 
 -- leaky_relu :: Tensor device dtype shape -> Float -> Tensor device dtype shape
--- leaky_relu _input _negative_slope = unsafePerformIO $ (cast2 ATen.leaky_relu_ts) _input _negative_slope
+-- leaky_relu _input _negative_slope = unsafePerformIO $ (ATen.cast2 ATen.Managed.leaky_relu_ts) _input _negative_slope
 
 -- | logarithm of the sigmoid
 -- >>> dtype &&& shape $ logSigmoid (ones :: CPUTensor 'D.Float '[3,2])
@@ -3812,7 +3843,7 @@ logSigmoid
    . (StandardFloatingPointDTypeValidation device dtype)
   => Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
-logSigmoid input = unsafePerformIO $ cast1 ATen.log_sigmoid_t input
+logSigmoid input = unsafePerformIO $ ATen.cast1 ATen.Managed.log_sigmoid_t input
 
 -- | softplus
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -3826,7 +3857,7 @@ softplus
   -> a
   -> Tensor device dtype shape
   -> Tensor device dtype shape
-softplus beta threshold input = unsafePerformIO $ cast3 ATen.softplus_tss input beta threshold
+softplus beta threshold input = unsafePerformIO $ ATen.cast3 ATen.Managed.softplus_tss input beta threshold
 
 -- | soft shrink
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -3838,7 +3869,7 @@ softShrink
   -> Tensor device dtype shape -- ^ input
   -> Tensor device dtype shape -- ^ output
 softShrink lambda input =
-  unsafePerformIO $ cast2 ATen.softshrink_ts input lambda
+  unsafePerformIO $ ATen.cast2 ATen.Managed.softshrink_ts input lambda
 
 -- | adaptive averaged 2-D pooling
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -3852,15 +3883,15 @@ adaptiveAvgPool2d
    . ( All KnownNat '[ channelSize
                      , inputSize0, inputSize1
                      , batchSize
-                     , Fst outputSize, Snd outputSize
+                     , Torch.Typed.Aux.Fst outputSize, Torch.Typed.Aux.Snd outputSize
                      ]
      )
   => Tensor device dtype '[batchSize, channelSize, inputSize0, inputSize1] -- ^ input
-  -> Tensor device dtype '[batchSize, channelSize, Fst outputSize, Snd outputSize] -- ^ output
-adaptiveAvgPool2d input = unsafePerformIO $ cast2
-  ATen.adaptive_avg_pool2d_tl
+  -> Tensor device dtype '[batchSize, channelSize, Torch.Typed.Aux.Fst outputSize, Torch.Typed.Aux.Snd outputSize] -- ^ output
+adaptiveAvgPool2d input = unsafePerformIO $ ATen.cast2
+  ATen.Managed.adaptive_avg_pool2d_tl
   input
-  ([natValI @(Fst outputSize), natValI @(Snd outputSize)] :: [Int])
+  ([natValI @(Torch.Typed.Aux.Fst outputSize), natValI @(Torch.Typed.Aux.Snd outputSize)] :: [Int])
 
 -- | MKLDNN adaptive averaged 2-D pooling
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -3878,15 +3909,15 @@ mkldnnAdaptiveAvgPool2d
    . ( All KnownNat '[ channelSize
                      , inputSize0, inputSize1
                      , batchSize
-                     , Fst outputSize, Snd outputSize
+                     , Torch.Typed.Aux.Fst outputSize, Torch.Typed.Aux.Snd outputSize
                      ]
      )
   => Tensor device dtype '[batchSize, channelSize, inputSize0, inputSize1] -- ^ input
-  -> Tensor device dtype '[batchSize, channelSize, Fst outputSize, Snd outputSize] -- ^ output
-mkldnnAdaptiveAvgPool2d input = unsafePerformIO $ cast2
-  ATen.adaptive_avg_pool2d_tl
+  -> Tensor device dtype '[batchSize, channelSize, Torch.Typed.Aux.Fst outputSize, Torch.Typed.Aux.Snd outputSize] -- ^ output
+mkldnnAdaptiveAvgPool2d input = unsafePerformIO $ ATen.cast2
+  ATen.Managed.adaptive_avg_pool2d_tl
   input
-  ([natValI @(Fst outputSize), natValI @(Snd outputSize)] :: [Int])
+  ([natValI @(Torch.Typed.Aux.Fst outputSize), natValI @(Torch.Typed.Aux.Snd outputSize)] :: [Int])
 
 -- | adaptive averaged 3-D pooling
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -3910,8 +3941,8 @@ adaptiveAvgPool3d
      )
   => Tensor device dtype '[batchSize, channelSize, inputSize0, inputSize1, inputSize2] -- ^ input
   -> Tensor device dtype '[batchSize, channelSize, Fst3 outputSize, Snd3 outputSize, Trd3 outputSize] -- ^ output
-adaptiveAvgPool3d input = unsafePerformIO $ cast2
-  ATen.adaptive_avg_pool3d_tl
+adaptiveAvgPool3d input = unsafePerformIO $ ATen.cast2
+  ATen.Managed.adaptive_avg_pool3d_tl
   input
   ([ natValI @(Fst3 outputSize)
    , natValI @(Snd3 outputSize)
@@ -3931,17 +3962,17 @@ adaptiveMaxPool2d
    . ( All KnownNat '[ channelSize
                      , inputSize0, inputSize1
                      , batchSize
-                     , Fst outputSize, Snd outputSize
+                     , Torch.Typed.Aux.Fst outputSize, Torch.Typed.Aux.Snd outputSize
                      ]
      )
   => Tensor device dtype '[batchSize, channelSize, inputSize0, inputSize1] -- ^ input
-  -> ( Tensor device dtype    '[batchSize, channelSize, Fst outputSize, Snd outputSize]
-     , Tensor device 'D.Int64 '[batchSize, channelSize, Fst outputSize, Snd outputSize]
+  -> ( Tensor device dtype    '[batchSize, channelSize, Torch.Typed.Aux.Fst outputSize, Torch.Typed.Aux.Snd outputSize]
+     , Tensor device 'D.Int64 '[batchSize, channelSize, Torch.Typed.Aux.Fst outputSize, Torch.Typed.Aux.Snd outputSize]
      ) -- ^ output
-adaptiveMaxPool2d input = unsafePerformIO $ cast2
-  ATen.adaptive_max_pool2d_tl
+adaptiveMaxPool2d input = unsafePerformIO $ ATen.cast2
+  ATen.Managed.adaptive_max_pool2d_tl
   input
-  ([natValI @(Fst outputSize), natValI @(Snd outputSize)] :: [Int])
+  ([natValI @(Torch.Typed.Aux.Fst outputSize), natValI @(Torch.Typed.Aux.Snd outputSize)] :: [Int])
 
 -- | adaptive 3-D max-pool
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -3967,7 +3998,7 @@ adaptiveMaxPool3d
   -> ( Tensor device dtype    '[batchSize, channelSize, Fst3 outputSize, Snd3 outputSize, Trd3 outputSize]
      , Tensor device 'D.Int64 '[batchSize, channelSize, Fst3 outputSize, Snd3 outputSize, Trd3 outputSize]
      ) -- ^ output
-adaptiveMaxPool3d input = unsafePerformIO $ (cast2 ATen.adaptive_max_pool3d_tl)
+adaptiveMaxPool3d input = unsafePerformIO $ (ATen.cast2 ATen.Managed.adaptive_max_pool3d_tl)
   input
   ([ natValI @(Fst3 outputSize)
    , natValI @(Snd3 outputSize)
@@ -3992,24 +4023,24 @@ avgPool2d
             outputSize0 outputSize1
             dtype
             device
-   . ( All KnownNat '[ Fst kernelSize, Snd kernelSize
-                     , Fst stride, Snd stride
-                     , Fst padding, Snd padding
+   . ( All KnownNat '[ Torch.Typed.Aux.Fst kernelSize, Torch.Typed.Aux.Snd kernelSize
+                     , Torch.Typed.Aux.Fst stride, Torch.Typed.Aux.Snd stride
+                     , Torch.Typed.Aux.Fst padding, Torch.Typed.Aux.Snd padding
                      , channelSize
                      , inputSize0, inputSize1
                      , batchSize
                      ]
-     , ConvSideCheck inputSize0 (Fst kernelSize) (Fst stride) (Fst padding) outputSize0
-     , ConvSideCheck inputSize1 (Snd kernelSize) (Snd stride) (Snd padding) outputSize1
+     , ConvSideCheck inputSize0 (Torch.Typed.Aux.Fst kernelSize) (Torch.Typed.Aux.Fst stride) (Torch.Typed.Aux.Fst padding) outputSize0
+     , ConvSideCheck inputSize1 (Torch.Typed.Aux.Snd kernelSize) (Torch.Typed.Aux.Snd stride) (Torch.Typed.Aux.Snd padding) outputSize1
      )
   => Tensor device dtype '[batchSize, channelSize, inputSize0, inputSize1] -- ^ input
   -> Tensor device dtype '[batchSize, channelSize, outputSize0, outputSize1] -- ^ output
-avgPool2d input = unsafePerformIO $ cast7
-  ATen.avg_pool2d_tlllbbl
+avgPool2d input = unsafePerformIO $ ATen.cast7
+  ATen.Managed.avg_pool2d_tlllbbl
   input
-  ([natValI @(Fst kernelSize), natValI @(Snd kernelSize)] :: [Int])
-  ([natValI @(Fst stride), natValI @(Snd stride)] :: [Int])
-  ([natValI @(Fst padding), natValI @(Snd padding)] :: [Int])
+  ([natValI @(Torch.Typed.Aux.Fst kernelSize), natValI @(Torch.Typed.Aux.Snd kernelSize)] :: [Int])
+  ([natValI @(Torch.Typed.Aux.Fst stride),     natValI @(Torch.Typed.Aux.Snd stride)]     :: [Int])
+  ([natValI @(Torch.Typed.Aux.Fst padding),    natValI @(Torch.Typed.Aux.Snd padding)]    :: [Int])
   False
   True
   (1 :: Int)
@@ -4044,8 +4075,8 @@ avgPool3d
      )
   => Tensor device dtype '[batchSize, channelSize, inputSize0, inputSize1, inputSize2] -- ^ input
   -> Tensor device dtype '[batchSize, channelSize, outputSize0, outputSize1, outputSize2] -- ^ output
-avgPool3d input = unsafePerformIO $ cast7
-  ATen.avg_pool3d_tlllbbl
+avgPool3d input = unsafePerformIO $ ATen.cast7
+  ATen.Managed.avg_pool3d_tlllbbl
   input
   ([ natValI @(Fst3 kernelSize)
    , natValI @(Snd3 kernelSize)
@@ -4059,67 +4090,67 @@ avgPool3d input = unsafePerformIO $ cast7
   (1 :: Int)
 
 -- fractional_max_pool2d :: Tensor device dtype shape -> (Int,Int) -> (Int,Int) -> Tensor device dtype shape -> (Tensor device dtype shape,Tensor device dtype shape)
--- fractional_max_pool2d _input _kernel_size _output_size _random_samples = unsafePerformIO $ (cast4 ATen.fractional_max_pool2d_tllt) _input _kernel_size _output_size _random_samples
+-- fractional_max_pool2d _input _kernel_size _output_size _random_samples = unsafePerformIO $ (ATen.cast4 ATen.Managed.fractional_max_pool2d_tllt) _input _kernel_size _output_size _random_samples
 
 -- fractional_max_pool3d :: Tensor device dtype shape -> (Int,Int,Int) -> (Int,Int,Int) -> Tensor device dtype shape -> (Tensor device dtype shape,Tensor device dtype shape)
--- fractional_max_pool3d _input _kernel_size _output_size _random_samples = unsafePerformIO $ (cast4 ATen.fractional_max_pool3d_tllt) _input _kernel_size _output_size _random_samples
+-- fractional_max_pool3d _input _kernel_size _output_size _random_samples = unsafePerformIO $ (ATen.cast4 ATen.Managed.fractional_max_pool3d_tllt) _input _kernel_size _output_size _random_samples
 
 -- max_pool2d_with_indices :: Tensor device dtype shape -> (Int,Int) -> (Int,Int) -> (Int,Int) -> (Int,Int) -> Bool -> (Tensor device dtype shape,Tensor device dtype shape)
--- max_pool2d_with_indices _input _kernel_size _stride _padding _dilation _ceil_mode = unsafePerformIO $ (cast6 ATen.max_pool2d_with_indices_tllllb) _input _kernel_size _stride _padding _dilation _ceil_mode
+-- max_pool2d_with_indices _input _kernel_size _stride _padding _dilation _ceil_mode = unsafePerformIO $ (ATen.cast6 ATen.Managed.max_pool2d_with_indices_tllllb) _input _kernel_size _stride _padding _dilation _ceil_mode
 
 -- max_pool3d_with_indices :: Tensor device dtype shape -> (Int,Int,Int) -> (Int,Int,Int) -> (Int,Int,Int) -> (Int,Int,Int) -> Bool -> (Tensor device dtype shape,Tensor device dtype shape)
--- max_pool3d_with_indices _input _kernel_size _stride _padding _dilation _ceil_mode = unsafePerformIO $ (cast6 ATen.max_pool3d_with_indices_tllllb) _input _kernel_size _stride _padding _dilation _ceil_mode
+-- max_pool3d_with_indices _input _kernel_size _stride _padding _dilation _ceil_mode = unsafePerformIO $ (ATen.cast6 ATen.Managed.max_pool3d_with_indices_tllllb) _input _kernel_size _stride _padding _dilation _ceil_mode
 
 -- max_unpool2d :: Tensor device dtype shape -> Tensor device dtype shape -> (Int,Int) -> Tensor device dtype shape
--- max_unpool2d _input _indices _output_size = unsafePerformIO $ (cast3 ATen.max_unpool2d_ttl) _input _indices _output_size
+-- max_unpool2d _input _indices _output_size = unsafePerformIO $ (ATen.cast3 ATen.Managed.max_unpool2d_ttl) _input _indices _output_size
 
 -- max_unpool3d :: Tensor device dtype shape -> Tensor device dtype shape -> (Int,Int,Int) -> (Int,Int,Int) -> (Int,Int,Int) -> Tensor device dtype shape
--- max_unpool3d _input _indices _output_size _stride _padding = unsafePerformIO $ (cast5 ATen.max_unpool3d_ttlll) _input _indices _output_size _stride _padding
+-- max_unpool3d _input _indices _output_size _stride _padding = unsafePerformIO $ (ATen.cast5 ATen.Managed.max_unpool3d_ttlll) _input _indices _output_size _stride _padding
 
 -- reflection_pad1d :: Tensor device dtype shape -> (Int,Int) -> Tensor device dtype shape
--- reflection_pad1d _input _padding = unsafePerformIO $ (cast2 ATen.reflection_pad1d_tl) _input _padding
+-- reflection_pad1d _input _padding = unsafePerformIO $ (ATen.cast2 ATen.Managed.reflection_pad1d_tl) _input _padding
 
 -- reflection_pad2d :: Tensor device dtype shape -> (Int,Int,Int,Int) -> Tensor device dtype shape
--- reflection_pad2d _input _padding = unsafePerformIO $ (cast2 ATen.reflection_pad2d_tl) _input _padding
+-- reflection_pad2d _input _padding = unsafePerformIO $ (ATen.cast2 ATen.Managed.reflection_pad2d_tl) _input _padding
 
 -- replication_pad1d :: Tensor device dtype shape -> (Int,Int) -> Tensor device dtype shape
--- replication_pad1d _input _padding = unsafePerformIO $ (cast2 ATen.replication_pad1d_tl) _input _padding
+-- replication_pad1d _input _padding = unsafePerformIO $ (ATen.cast2 ATen.Managed.replication_pad1d_tl) _input _padding
 
 -- replication_pad2d :: Tensor device dtype shape -> (Int,Int,Int,Int) -> Tensor device dtype shape
--- replication_pad2d _input _padding = unsafePerformIO $ (cast2 ATen.replication_pad2d_tl) _input _padding
+-- replication_pad2d _input _padding = unsafePerformIO $ (ATen.cast2 ATen.Managed.replication_pad2d_tl) _input _padding
 
 -- replication_pad3d :: Tensor device dtype shape -> (Int,Int,Int,Int,Int,Int) -> Tensor device dtype shape
--- replication_pad3d _input _padding = unsafePerformIO $ (cast2 ATen.replication_pad3d_tl) _input _padding
+-- replication_pad3d _input _padding = unsafePerformIO $ (ATen.cast2 ATen.Managed.replication_pad3d_tl) _input _padding
 
 -- upsample_linear1d :: Tensor device dtype shape -> Int -> Bool -> Tensor device dtype shape
--- upsample_linear1d _input _output_size _align_corners = unsafePerformIO $ (cast3 ATen.upsample_linear1d_tlb) _input _output_size _align_corners
+-- upsample_linear1d _input _output_size _align_corners = unsafePerformIO $ (ATen.cast3 ATen.Managed.upsample_linear1d_tlb) _input _output_size _align_corners
 
 -- upsample_bilinear2d :: Tensor device dtype shape -> (Int,Int) -> Bool -> Tensor device dtype shape
--- upsample_bilinear2d _input _output_size _align_corners = unsafePerformIO $ (cast3 ATen.upsample_bilinear2d_tlb) _input _output_size _align_corners
+-- upsample_bilinear2d _input _output_size _align_corners = unsafePerformIO $ (ATen.cast3 ATen.Managed.upsample_bilinear2d_tlb) _input _output_size _align_corners
 
 -- upsample_bicubic2d :: Tensor device dtype shape -> (Int,Int) -> Bool -> Tensor device dtype shape
--- upsample_bicubic2d _input _output_size _align_corners = unsafePerformIO $ (cast3 ATen.upsample_bicubic2d_tlb) _input _output_size _align_corners
+-- upsample_bicubic2d _input _output_size _align_corners = unsafePerformIO $ (ATen.cast3 ATen.Managed.upsample_bicubic2d_tlb) _input _output_size _align_corners
 
 -- upsample_trilinear3d :: Tensor device dtype shape -> (Int,Int,Int) -> Bool -> Tensor device dtype shape
--- upsample_trilinear3d _input _output_size _align_corners = unsafePerformIO $ (cast3 ATen.upsample_trilinear3d_tlb) _input _output_size _align_corners
+-- upsample_trilinear3d _input _output_size _align_corners = unsafePerformIO $ (ATen.cast3 ATen.Managed.upsample_trilinear3d_tlb) _input _output_size _align_corners
 
 -- upsample_nearest1d :: Tensor device dtype shape -> Int -> Tensor device dtype shape
--- upsample_nearest1d _input _output_size = unsafePerformIO $ (cast2 ATen.upsample_nearest1d_tl) _input _output_size
+-- upsample_nearest1d _input _output_size = unsafePerformIO $ (ATen.cast2 ATen.Managed.upsample_nearest1d_tl) _input _output_size
 
 -- upsample_nearest2d :: Tensor device dtype shape -> (Int,Int) -> Tensor device dtype shape
--- upsample_nearest2d _input _output_size = unsafePerformIO $ (cast2 ATen.upsample_nearest2d_tl) _input _output_size
+-- upsample_nearest2d _input _output_size = unsafePerformIO $ (ATen.cast2 ATen.Managed.upsample_nearest2d_tl) _input _output_size
 
 -- upsample_nearest3d :: Tensor device dtype shape -> (Int,Int,Int) -> Tensor device dtype shape
--- upsample_nearest3d _input _output_size = unsafePerformIO $ (cast2 ATen.upsample_nearest3d_tl) _input _output_size
+-- upsample_nearest3d _input _output_size = unsafePerformIO $ (ATen.cast2 ATen.Managed.upsample_nearest3d_tl) _input _output_size
 
 -- conv_dilated2d :: Tensor device dtype shape -> Tensor device dtype shape -> (Int,Int) -> Tensor device dtype shape -> (Int,Int) -> (Int,Int) -> (Int,Int) -> Tensor device dtype shape
--- conv_dilated2d _input _weight _kernel_size _bias _stride _padding _dilation = unsafePerformIO $ (cast7 ATen.conv_dilated2d_ttltlll) _input _weight _kernel_size _bias _stride _padding _dilation
+-- conv_dilated2d _input _weight _kernel_size _bias _stride _padding _dilation = unsafePerformIO $ (ATen.cast7 ATen.Managed.conv_dilated2d_ttltlll) _input _weight _kernel_size _bias _stride _padding _dilation
 
 -- conv_dilated3d :: Tensor device dtype shape -> Tensor device dtype shape -> (Int,Int,Int) -> Tensor device dtype shape -> (Int,Int,Int) -> (Int,Int,Int) -> (Int,Int,Int) -> Tensor device dtype shape
--- conv_dilated3d _input _weight _kernel_size _bias _stride _padding _dilation = unsafePerformIO $ (cast7 ATen.conv_dilated3d_ttltlll) _input _weight _kernel_size _bias _stride _padding _dilation
+-- conv_dilated3d _input _weight _kernel_size _bias _stride _padding _dilation = unsafePerformIO $ (ATen.cast7 ATen.Managed.conv_dilated3d_ttltlll) _input _weight _kernel_size _bias _stride _padding _dilation
 
 -- col2im :: Tensor device dtype shape -> (Int,Int) -> (Int,Int) -> (Int,Int) -> (Int,Int) -> (Int,Int) -> Tensor device dtype shape
--- col2im _input _output_size _kernel_size _dilation _padding _stride = unsafePerformIO $ (cast6 ATen.col2im_tlllll) _input _output_size _kernel_size _dilation _padding _stride
+-- col2im _input _output_size _kernel_size _dilation _padding _stride = unsafePerformIO $ (ATen.cast6 ATen.Managed.col2im_tlllll) _input _output_size _kernel_size _dilation _padding _stride
 
 -- im2col :: Tensor device dtype shape -> (Int,Int) -> (Int,Int) -> (Int,Int) -> (Int,Int) -> Tensor device dtype shape
--- im2col _input _kernel_size _dilation _padding _stride = unsafePerformIO $ (cast5 ATen.im2col_tllll) _input _kernel_size _dilation _padding _stride
+-- im2col _input _kernel_size _dilation _padding _stride = unsafePerformIO $ (ATen.cast5 ATen.Managed.im2col_tllll) _input _kernel_size _dilation _padding _stride

--- a/hasktorch/src/Torch/Typed/Optim.hs
+++ b/hasktorch/src/Torch/Typed/Optim.hs
@@ -1,0 +1,98 @@
+{-# LANGUAGE RecordWildCards #-}
+
+module Torch.Typed.Optim where
+
+import           Control.Monad.State
+import           Prelude                 hiding ( sqrt )
+
+import           Torch.Tensor
+import           Torch.Functions
+import           Torch.Autograd
+import           Torch.NN
+
+type LearningRate = Tensor
+newtype Gradients = Gradients [Tensor] deriving Show
+
+grad' t p = Gradients (grad t p)
+
+class Optimizer o where step :: LearningRate -> Gradients -> [Tensor] -> o -> ([Tensor], o)
+
+--
+-- Gradient Descent
+--
+
+data GD = GD deriving Show
+
+-- | Stateless gradient descent step
+gd :: LearningRate -> Gradients -> [Tensor] -> [Tensor]
+gd lr (Gradients gradients) parameters = zipWith step parameters gradients
+  where step p dp = p - (lr * dp)
+
+-- | Gradient descent step with a dummy state variable
+gd' :: LearningRate -> Gradients -> [Tensor] -> GD -> ([Tensor], GD)
+gd' lr gradients depParameters dummy = (gd lr gradients depParameters, dummy)
+
+instance Optimizer GD where
+  step = gd'
+
+--
+-- Gradient Descent with Momentum
+--
+
+data GDM = GDM { beta :: Float, momentum :: [Tensor] } deriving Show
+
+-- gradient descent with momentum step
+gdm
+  :: LearningRate -- ^ learning rate
+  -> Gradients -- ^ model parameter gradients
+  -> [Tensor] -- ^ model parameters
+  -> GDM -- ^ beta & momentum
+  -> ([Tensor], GDM) -- ^ returns new parameters + updated momentum
+gdm lr (Gradients gradients) parameters (GDM beta momentum) =
+  (fmap fst runStep, GDM beta (fmap snd runStep))
+ where
+  step p dp z = let z' = mulScalar z beta + dp in (p - lr * z', z')
+  runStep = (zipWith3 step) parameters gradients momentum
+
+instance Optimizer GDM where
+  step = gdm
+
+--
+-- Adam
+--
+
+-- | State representation for Adam Optimizer
+data Adam = Adam {
+    beta1 :: Float, -- 1st moment forgetting factor
+    beta2 :: Float, -- 2nd moment forgetting factor
+    m1 :: [Tensor], -- 1st moment
+    m2 :: [Tensor], -- 2nd moment
+    iter :: Int -- iteration
+    } deriving Show
+
+-- | Adam step
+adam
+  :: LearningRate  -- ^ learning rate
+  -> Gradients -- ^ model parameter gradients
+  -> [Tensor] -- ^ model parameters
+  -> Adam -- ^ adam parameters - beta1, beta2, moments, iteration
+  -> ([Tensor], Adam) -- ^ returns new parameters + updated adam parameters
+adam lr (Gradients gradients) parameters Adam {..} =
+  (parameters', Adam beta1 beta2 m1' m2' (iter + 1))
+ where
+        -- decaying averages of 1st & 2nd moments
+  f1 m1 dp = mulScalar m1 beta1 + mulScalar dp (1 - beta1)
+  f2 m2 dp = mulScalar m2 beta2 + mulScalar (dp * dp) (1 - beta2)
+  m1' = zipWith f1 m1 gradients
+  m2' = zipWith f2 m2 gradients
+  -- bias adjustment
+  a beta m = divScalar m (1 - beta ^ (iter + 1))
+  a1  = fmap (a beta1) m1'
+  a2  = fmap (a beta2) m2'
+  -- parameter update
+  eps = 1e-37
+  update prevParam a1' a2' = prevParam - lr * a1' / (sqrt a2' + eps)
+  parameters' = zipWith3 update parameters a1 a2
+
+instance Optimizer Adam where
+  step = adam

--- a/hasktorch/src/Torch/Typed/Parameter.hs
+++ b/hasktorch/src/Torch/Typed/Parameter.hs
@@ -49,8 +49,8 @@ toDependent (Parameter t) = UnsafeMkTensor $ A.toDependent t
 
 data ToDependent = ToDependent
 
-instance Apply ToDependent (Parameter device dtype shape) (Tensor device dtype shape) where
-  apply _ = toDependent
+instance Apply' ToDependent (Parameter device dtype shape) (Tensor device dtype shape) where
+  apply' _ = toDependent
 
 makeIndependent
   :: forall shape dtype device
@@ -60,8 +60,8 @@ makeIndependent t = Parameter <$> A.makeIndependent (toDynamic t)
 
 data MakeIndependent = MakeIndependent
 
-instance Apply MakeIndependent (Tensor device dtype shape) (IO (Parameter device dtype shape)) where
-  apply _ = makeIndependent
+instance Apply' MakeIndependent (Tensor device dtype shape) (IO (Parameter device dtype shape)) where
+  apply' _ = makeIndependent
 
 class Parameterized
   (f :: Type)

--- a/hasktorch/src/Torch/Typed/Serialize.hs
+++ b/hasktorch/src/Torch/Typed/Serialize.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE FlexibleContexts #-}
+
+module Torch.Typed.Serialize where
+
+import Data.HList
+import           Foreign.ForeignPtr
+
+import qualified Torch.Managed.Serialize as S
+import Torch.Typed.Tensor
+import qualified ATen.Class                    as ATen
+import qualified ATen.Cast                     as ATen
+import qualified ATen.Type                     as ATen
+
+save
+  :: forall tensors
+   . (ATen.Castable (HList tensors) (ForeignPtr ATen.TensorList))
+  => HList tensors
+  -> FilePath
+  -> IO ()
+save inputs file = ATen.cast2 S.save inputs file
+
+load
+  :: forall tensors
+   . (ATen.Castable (HList tensors) (ForeignPtr ATen.TensorList))
+  => FilePath
+  -> IO (HList tensors)
+load file = ATen.cast1 S.load file


### PR DESCRIPTION
I added typed optimizers to the core hasktorch lib and used them for the typed mnist mlp example. Please have a look in `Torch.Typed.Autograd` and `Torch.Typed.Optim`. I still want to implement a test suite based on the test functions @austinvhuang used for the `Optimizers` example module and following some of the tests in pytorch, cf. https://github.com/pytorch/pytorch/blob/master/test/test_optim.py.

The mlp code compiles fine and runs without error, but learning isn't working yet:
```
[nix-shell:~/Projects/thirdParty/hasktorch/examples/static-mnist]$ DEVICE="cpu" ../dist/build/static-mnist-mlp/static-mnist-mlp
Iteration: 250. Training batch loss: 2.7391508. Test loss: 1.8653502. Test error-rate: 0.56799316
Iteration: 500. Training batch loss: 3.7517178. Test loss: 2.6845038. Test error-rate: 0.5695801
Iteration: 750. Training batch loss: 2.5789738. Test loss: 1.9683098. Test error-rate: 0.66186523
Iteration: 1000. Training batch loss: 3.3718398. Test loss: 2.5216846. Test error-rate: 0.633667
Iteration: 1250. Training batch loss: 4.0687294. Test loss: 3.5834208. Test error-rate: 0.5814209
Iteration: 1500. Training batch loss: 3.7929404. Test loss: 3.1979089. Test error-rate: 0.70129395
Iteration: 1750. Training batch loss: 2.2915678. Test loss: 1.7558963. Test error-rate: 0.63964844
Iteration: 2000. Training batch loss: 2.4241033. Test loss: 1.9236282. Test error-rate: 0.60131836
Iteration: 2250. Training batch loss: 3.0669777. Test loss: 2.4795806. Test error-rate: 0.80407715
```
The reason is unknown. Maybe there's a bug in the implementation of `Adam` and `GDM`. `GD` works fine. Additional tests should help clarifying.