### PR TITLE
Add CI-integration of haddock

### DIFF
--- a/.github/workflows/nix-haddock-linux.yml
+++ b/.github/workflows/nix-haddock-linux.yml
@@ -1,4 +1,4 @@
-name: nix-haddoc-linux
+name: nix-haddock-linux
 on:
   push:
     branches:

--- a/.github/workflows/nix-haddock-linux.yml
+++ b/.github/workflows/nix-haddock-linux.yml
@@ -1,10 +1,12 @@
 name: nix-haddock-linux
-on: [push, pull_request]
 
-#on:
-#  push:
-#    branches:
-#      - master
+# If you need to debug this action, use following action.
+# on: [push, pull_request]
+
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   build:

--- a/.github/workflows/nix-haddock-linux.yml
+++ b/.github/workflows/nix-haddock-linux.yml
@@ -17,6 +17,7 @@ jobs:
         git submodule init && git submodule update
     - name: Build
       run: |
+        nix-env -i cachix
         cachix use hasktorch
         nix-build -A hasktorch-docs
     - name: Deploy

--- a/.github/workflows/nix-haddock-linux.yml
+++ b/.github/workflows/nix-haddock-linux.yml
@@ -1,0 +1,28 @@
+name: nix-haddoc-linux
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: cachix/install-nix-action@v6
+    - name: Setup repo
+      run: |
+        git submodule init && git submodule update
+    - name: Build
+      run: |
+        cachix use hasktorch
+        nix-build -A hasktorch-docs
+    - name: Deploy
+      uses: peaceiris/actions-gh-pages@v2.5.0
+      env:
+        ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+        # PERSONAL_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
+        # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        EXTERNAL_REPOSITORY: hasktorch/hasktorch.github.io
+        PUBLISH_BRANCH: master
+        PUBLISH_DIR: ./result/share/doc

--- a/.github/workflows/nix-haddock-linux.yml
+++ b/.github/workflows/nix-haddock-linux.yml
@@ -1,8 +1,10 @@
 name: nix-haddock-linux
-on:
-  push:
-    branches:
-      - master
+on: [push, pull_request]
+
+#on:
+#  push:
+#    branches:
+#      - master
 
 jobs:
   build:

--- a/default.nix
+++ b/default.nix
@@ -6,6 +6,7 @@ in
       libtorch-ffi_cpu
       hasktorch_cpu
       hasktorch-examples_cpu
+      hasktorch-docs
     ;
 
     ${shared.nullIfDarwin "libtorch-ffi_cudatoolkit_9_2"} = shared.libtorch-ffi_cudatoolkit_9_2;

--- a/nix/haddock-combine.nix
+++ b/nix/haddock-combine.nix
@@ -1,0 +1,59 @@
+{ runCommand, lib, haskellPackages }:
+{ hspkgs # Haskell packages to make documentation for. Only those with a "doc" output will be used.
+  # Note: we do not provide arbitrary additional Haddock options, as these would not be 
+  # applied consistently, since we're reusing the already built Haddock for the packages.
+, prologue ? null # Optionally, a file to be used for the Haddock "--prologue" option.
+}: 
+let 
+  hsdocs = builtins.map (x: x.doc) (builtins.filter (x: x ? doc) hspkgs); 
+in runCommand "haddock-join" { buildInputs = [ hsdocs ]; } ''
+  # Merge all the docs from the packages. We don't use symlinkJoin because:
+  # - We are going to want to redistribute this, so we don't want any symlinks.
+  # - We want to be selective about what we copy (we don't need the hydra 
+  #   tarballs from the other packages, for example.
+  mkdir -p "$out/share/doc"
+  for pkg in ${lib.concatStringsSep " " hsdocs}; do
+    cp -R $pkg/share/doc/* "$out/share/doc"
+  done
+  # We're going to sed all the files so they'd better be writable!
+  chmod -R +w $out/share/doc
+
+  # We're now going to rewrite all the pre-generated Haddock HTML output
+  # so that links point to the appropriate place within our combined output,
+  # rather than into the store.
+  root=$out/share/doc
+  for f in $(find $out -name "*.html"); do
+    # Replace all links to the docs we're processing with relative links 
+    # to the root of the doc directory we're creating - the rest of the link is
+    # the same.
+    # Also, it's not a a file:// link now because it's a relative URL instead
+    # of an absolute one.
+    relpath=$(realpath --relative-to=$(dirname $f) --no-symlinks $root)
+    pkgsRegex="${"file://(" + (lib.concatStringsSep "|" hsdocs) + ")/share/doc"}"
+    sed -i -r "s,$pkgsRegex,$relpath,g" "$f"
+    # Now also replace the index/contents links so they point to (what will be) 
+    # the combined ones instead.
+    # Match the enclosing quotes to make sure the regex for index.html doesn't also match
+    # the trailing part of doc-index.html
+    sed -i -r "s,\"index\.html\",\"$relpath/share/doc/index.html\",g" "$f"
+    sed -i -r "s,\"doc-index\.html\",\"$relpath/share/doc/doc-index.html\",g" "$f"
+  done
+
+  # Move to the docdir. We do this so that we can give relative docpaths to
+  # Haddock so it will generate relative (relocatable) links in the index.
+  cd $out/share/doc
+  # Collect all the interface files and their docpaths (in this case
+  # we can just use the enclosing directory).
+  interfaceOpts=()
+  for interfaceFile in $(find . -name "*.haddock"); do
+    docdir=$(dirname $interfaceFile)
+    interfaceOpts+=("--read-interface=$docdir,$interfaceFile")
+  done
+
+  # Generate the contents and index
+  ${haskellPackages.ghc}/bin/haddock \
+    --gen-contents \
+    --gen-index \
+    ${lib.optionalString (prologue != null) "--prologue ${prologue}"} \
+    "''${interfaceOpts[@]}"
+''

--- a/nix/shared.nix
+++ b/nix/shared.nix
@@ -174,7 +174,17 @@ in
       hasktorch-examples_cudatoolkit_9_2
       hasktorch-examples_cudatoolkit_10_1
     ;
-    hasktorch-docs = ((import ./haddock-combine.nix {runCommand = pkgs.runCommand; lib = pkgs.lib; haskellPackages = pkgs.haskellPackages;}) {hspkgs = [pkgs.haskell.packages."${compiler}".hasktorch_cpu];});
+    hasktorch-docs = (
+      (import ./haddock-combine.nix {
+        runCommand = pkgs.runCommand;
+        lib = pkgs.lib;
+        haskellPackages = pkgs.haskellPackages;
+      }) {hspkgs = [
+            pkgs.haskell.packages."${compiler}".hasktorch_cpu
+            pkgs.haskell.packages."${compiler}".libtorch-ffi_cpu
+          ];
+         }
+    );
     shell-hasktorch-codegen = (pkgs.haskell.lib.doBenchmark pkgs.haskell.packages."${compiler}".hasktorch-codegen).env;
     shell-inline-c = (pkgs.haskell.lib.doBenchmark pkgs.haskell.packages."${compiler}".inline-c).env;
     shell-inline-c-cpp = (pkgs.haskell.lib.doBenchmark pkgs.haskell.packages."${compiler}".inline-c-cpp).env;

--- a/nix/shared.nix
+++ b/nix/shared.nix
@@ -174,7 +174,7 @@ in
       hasktorch-examples_cudatoolkit_9_2
       hasktorch-examples_cudatoolkit_10_1
     ;
-
+    hasktorch-docs = ((import ./haddock-combine.nix {runCommand = pkgs.runCommand; lib = pkgs.lib; haskellPackages = pkgs.haskellPackages;}) {hspkgs = [pkgs.haskell.packages."${compiler}".hasktorch_cpu];});
     shell-hasktorch-codegen = (pkgs.haskell.lib.doBenchmark pkgs.haskell.packages."${compiler}".hasktorch-codegen).env;
     shell-inline-c = (pkgs.haskell.lib.doBenchmark pkgs.haskell.packages."${compiler}".inline-c).env;
     shell-inline-c-cpp = (pkgs.haskell.lib.doBenchmark pkgs.haskell.packages."${compiler}".inline-c-cpp).env;


### PR DESCRIPTION
This pr builds haddock by using nix, then it deploys the docs to hasktorch.github.io repo. 
The nix script generating haddock is the same as plutus's one (https://github.com/input-output-hk/plutus/blob/master/nix/haddock-combine.nix).
