### PR TITLE
add cabal v1/v2 + stack workflows to shared.nix shellHook

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Internals (for contributing developers):
 
 ## Getting Started
 
+### on OSX or Ubuntu-like OS's
+
 The following steps run a toy linear regression example, assuming the hasktorch repository has just been cloned.
 
 Starting at the top-level directory of the project, go to the `deps/` (dependencies) directory and run the `get-deps.sh` shell script to retrieve project dependencies with the following commands:
@@ -46,6 +48,15 @@ source setenv
 ```
 
 Note `source setenv` should be run from the top-level directory of the repo.
+
+### on NixOS
+
+```
+(cd hasktorch && nix-shell)
+```
+If you are running cabal or stack to develop hasktorch, there is a shell hook to tell you which `extra-lib-dirs` and `extra-include-dirs` fields to include in your stack.yaml or cabal.project.local
+
+### Building examples
 
 Finally, try building and running the linear regression example:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hasktorch 0.2 Pre-Release
 
-Hasktorch is a library for tensors and neural networks in Haskell. It is an independent open source community project which leverages the core C++ libraries shared by PyTorch. 
+Hasktorch is a library for tensors and neural networks in Haskell. It is an independent open source community project which leverages the core C++ libraries shared by PyTorch.
 
 This project is in early development and should only be used by contributing developers. Expect substantial changes to the library API as it evolves. Contributions and PRs are welcome.
 
@@ -49,12 +49,20 @@ source setenv
 
 Note `source setenv` should be run from the top-level directory of the repo.
 
-### on NixOS
+### via nix-shell
 
 ```
-(cd hasktorch && nix-shell)
+nix-shell ./hasktorch/shell.nix
 ```
-If you are running cabal or stack to develop hasktorch, there is a shell hook to tell you which `extra-lib-dirs` and `extra-include-dirs` fields to include in your stack.yaml or cabal.project.local
+
+Will get you into a development environment for hasktorch using the CPU backend.
+On NixOS you may also pass in a `cudaVersion` argument of `9` or `10` to provision a CUDA environment:
+
+```
+nix-shell ./hasktorch/shell.nix --arg cudaVersion 9 # or 10
+```
+
+If you are running cabal or stack to develop hasktorch, there is a shell hook to tell you which `extra-lib-dirs` and `extra-include-dirs` fields to include in your stack.yaml or cabal.project.local. This hook will also explain how to create a cabal.project.freeze file.
 
 ### Building examples
 
@@ -69,14 +77,14 @@ For additional examples, see the `examples/` directory.
 
 ## Contributing
 
-We welcome new contributors. 
+We welcome new contributors.
 
 Contact Austin Huang or Sam Stites for access to the [hasktorch slack channel][slack]. You can send an email to [hasktorch@gmail.com][email] or on twitter as [@austinvhuang][austin-twitter] and [@SamStites][sam-twitter].
 
 [email]:mailto:hasktorch@gmail.com
 [austin-twitter]:https://twitter.com/austinvhuang
 [sam-twitter]:https://twitter.com/samstites
-[slack]:https://hasktorch.slack.com 
+[slack]:https://hasktorch.slack.com
 [gitter-dh]:https://gitter.im/dataHaskell/Lobby
 
 ## Developer Information

--- a/examples/shell.nix
+++ b/examples/shell.nix
@@ -1,1 +1,11 @@
-(import ../nix/shared.nix { }).shell-hasktorch-examples_cpu
+{ cudaVersion ? null }:
+let
+  shared = import ../nix/shared.nix { };
+in
+assert cudaVersion == null || cudaVersion == 9 || cudaVersion == 10;
+
+if cudaVersion == null
+then shared.shell-hasktorch-examples_cpu
+else if cudaVersion == 9
+  then shared.shell-hasktorch-examples_cudatoolkit_9_2
+  else shared.shell-hasktorch-examples_cudatoolkit_10_1

--- a/hasktorch/shell.nix
+++ b/hasktorch/shell.nix
@@ -1,1 +1,5 @@
-(import ../nix/shared.nix { }).shell-hasktorch_cpu
+{ withCuda ? true }:
+
+if withCuda
+  then (import ../nix/shared.nix { }).shell-hasktorch_cudatoolkit_10_1
+  else (import ../nix/shared.nix { }).shell-hasktorch_cpu

--- a/hasktorch/shell.nix
+++ b/hasktorch/shell.nix
@@ -1,5 +1,11 @@
-{ withCuda ? false }:
+{ cudaVersion ? null }:
+let
+  shared = import ../nix/shared.nix { };
+in
+assert cudaVersion == null || cudaVersion == 9 || cudaVersion == 10;
 
-if withCuda
-  then (import ../nix/shared.nix { }).shell-hasktorch_cudatoolkit_10_1
-  else (import ../nix/shared.nix { }).shell-hasktorch_cpu
+if cudaVersion == null
+then shared.shell-hasktorch_cpu
+else if cudaVersion == 9
+  then shared.shell-hasktorch_cudatoolkit_9_2
+  else shared.shell-hasktorch_cudatoolkit_10_1

--- a/hasktorch/shell.nix
+++ b/hasktorch/shell.nix
@@ -1,4 +1,4 @@
-{ withCuda ? true }:
+{ withCuda ? false }:
 
 if withCuda
   then (import ../nix/shared.nix { }).shell-hasktorch_cudatoolkit_10_1

--- a/nix/shared.nix
+++ b/nix/shared.nix
@@ -194,9 +194,9 @@ let
           nl
           (echo "as well as a freeze file from stack's resolver:")
           # $(which curl) is used to bypass an alias to 'curl'. This is safe so long as we use gnu's which
-          (echo "$(which curl) https://www.stackage.org/${findAndReplaceLTS (splitString "\n" (readFile ../stack.yaml))}/cabal.config \\")
-          (echo "  | sed -e 's/inline-c ==.*,/inline-c ==0.9.0.0,/g' -e 's/inline-c-cpp ==.*,/inline-c-cpp ==0.4.0.0,/g' \\")
-          (echo "  > cabal.project.freeze")
+          (echo ''$(which curl) https://www.stackage.org/${findAndReplaceLTS (splitString "\n" (readFile ../stack.yaml))}/cabal.config \\ '')
+          (echo ("   "+''  | sed -e 's/inline-c ==.*,/inline-c ==0.9.0.0,/g' -e 's/inline-c-cpp ==.*,/inline-c-cpp ==0.4.0.0,/g' \\ ''))
+          (echo ("   "+''  > cabal.project.freeze''))
           nl
         ];
         buildInputs = with pkgs; old.buildInputs ++ [ zlib.dev zlib.out ];

--- a/nix/shared.nix
+++ b/nix/shared.nix
@@ -154,8 +154,46 @@ let
   fixcpath = libtorch: old: old // {
       shellHook = ''
         export CPATH=${libtorch}/include/torch/csrc/api/include
+        echo "you may need to add `extra-include-dirs: ${libtorch}/include/torch/csrc/api/include` to your cabal.project or stack.yaml"
       '';
     };
+
+  fixmklandcpath = libtorch: old: with pkgs; old // {
+      shellHook = ''
+        export LD_PRELOAD=${mkl}/lib/libmkl_rt.so
+        export CPATH=${libtorch}/include/torch/csrc/api/include
+        echo "If you are in a nix-shell, you may still need to add the following to your local configurations"
+        echo ""
+        echo "cabal.project.local:"
+        echo "--------------------"
+        echo "  package libtorch-ffi"
+        echo "    extra-lib-dirs:     ${libtorch}/lib"
+        echo "    extra-include-dirs: ${libtorch}/include"
+        echo "    extra-include-dirs: ${libtorch}/include/torch/csrc/api/include"
+        echo ""
+        echo "stack.yaml:"
+        echo "-----------"
+        echo "  extra-lib-dirs:"
+        echo "    - ${libtorch}/lib"
+        echo "  extra-include-dirs:"
+        echo "    - ${libtorch}/include"
+        echo "    - ${libtorch}/include/torch/csrc/api/include"
+        echo ""
+        echo "If you are on NixOS using cabal v2-*, you may need to include zlib.out and zlib.dev:"
+        echo ""
+        echo "cabal.project.local:"
+        echo "--------------------"
+        echo "  package *"
+        echo "    extra-lib-dirs: ${zlib.dev}/lib"
+        echo "    extra-lib-dirs: ${zlib.out}/lib"
+        echo ""
+      '';
+      buildInputs = old.buildInputs ++ [ zlib.dev zlib.out ];
+      # zlib.dev is strictly for on NixOS from a nix-shell
+      # this is a similar patch to https://github.com/commercialhaskell/stack/issues/2975
+    };
+  doBenchmark = pkgs.haskell.lib.doBenchmark;
+  base-compiler = pkgs.haskell.packages."${compiler}";
 in
   rec {
     inherit nullIfDarwin;
@@ -185,17 +223,17 @@ in
           ];
          }
     );
-    shell-hasktorch-codegen = (pkgs.haskell.lib.doBenchmark pkgs.haskell.packages."${compiler}".hasktorch-codegen).env;
-    shell-inline-c = (pkgs.haskell.lib.doBenchmark pkgs.haskell.packages."${compiler}".inline-c).env;
-    shell-inline-c-cpp = (pkgs.haskell.lib.doBenchmark pkgs.haskell.packages."${compiler}".inline-c-cpp).env;
-    shell-libtorch-ffi_cpu = (pkgs.haskell.lib.doBenchmark pkgs.haskell.packages."${compiler}".libtorch-ffi_cpu).env.overrideAttrs (fixcpath pkgs.libtorch_cpu);
-    shell-libtorch-ffi_cudatoolkit_9_2 = (pkgs.haskell.lib.doBenchmark pkgs.haskell.packages."${compiler}".libtorch-ffi_cudatoolkit_9_2).env.overrideAttrs (fixcpath pkgs.libtorch_cudatoolkit_9_2);
-    shell-libtorch-ffi_cudatoolkit_10_1 = (pkgs.haskell.lib.doBenchmark pkgs.haskell.packages."${compiler}".libtorch-ffi_cudatoolkit_10_1).env.overrideAttrs (fixcpath pkgs.libtorch_cudatoolkit_10_1);
-    shell-hasktorch_cpu = (pkgs.haskell.lib.doBenchmark pkgs.haskell.packages."${compiler}".hasktorch_cpu).env.overrideAttrs fixmkl;
-    shell-hasktorch_cudatoolkit_9_2 = (pkgs.haskell.lib.doBenchmark pkgs.haskell.packages."${compiler}".hasktorch_cudatoolkit_9_2).env.overrideAttrs fixmkl;
-    shell-hasktorch_cudatoolkit_10_1 = (pkgs.haskell.lib.doBenchmark pkgs.haskell.packages."${compiler}".hasktorch_cudatoolkit_10_1).env.overrideAttrs fixmkl;
-    shell-hasktorch-examples_cpu = (pkgs.haskell.lib.doBenchmark pkgs.haskell.packages."${compiler}".hasktorch-examples_cpu).env.overrideAttrs fixmkl;
-    shell-hasktorch-examples_cudatoolkit_9_2 = (pkgs.haskell.lib.doBenchmark pkgs.haskell.packages."${compiler}".hasktorch-examples_cudatoolkit_9_2).env.overrideAttrs fixmkl;
-    shell-hasktorch-examples_cudatoolkit_10_1 = (pkgs.haskell.lib.doBenchmark pkgs.haskell.packages."${compiler}".hasktorch-examples_cudatoolkit_10_1).env.overrideAttrs fixmkl;
+    shell-hasktorch-codegen                   = (doBenchmark base-compiler.hasktorch-codegen).env;
+    shell-inline-c                            = (doBenchmark base-compiler.inline-c).env;
+    shell-inline-c-cpp                        = (doBenchmark base-compiler.inline-c-cpp).env;
+    shell-libtorch-ffi_cpu                    = (doBenchmark base-compiler.libtorch-ffi_cpu                   ).env.overrideAttrs(fixcpath pkgs.libtorch_cpu);
+    shell-libtorch-ffi_cudatoolkit_9_2        = (doBenchmark base-compiler.libtorch-ffi_cudatoolkit_9_2       ).env.overrideAttrs(fixcpath pkgs.libtorch_cudatoolkit_9_2);
+    shell-libtorch-ffi_cudatoolkit_10_1       = (doBenchmark base-compiler.libtorch-ffi_cudatoolkit_10_1      ).env.overrideAttrs(fixcpath pkgs.libtorch_cudatoolkit_10_1);
+    shell-hasktorch_cpu                       = (doBenchmark base-compiler.hasktorch_cpu                      ).env.overrideAttrs(fixmklandcpath pkgs.libtorch_cpu);
+    shell-hasktorch_cudatoolkit_9_2           = (doBenchmark base-compiler.hasktorch_cudatoolkit_9_2          ).env.overrideAttrs(fixmklandcpath pkgs.libtorch_cudatoolkit_9_2);
+    shell-hasktorch_cudatoolkit_10_1          = (doBenchmark base-compiler.hasktorch_cudatoolkit_10_1         ).env.overrideAttrs(fixmklandcpath pkgs.libtorch_cudatoolkit_10_1);
+    shell-hasktorch-examples_cpu              = (doBenchmark base-compiler.hasktorch-examples_cpu             ).env.overrideAttrs(fixmklandcpath pkgs.libtorch_cpu);
+    shell-hasktorch-examples_cudatoolkit_9_2  = (doBenchmark base-compiler.hasktorch-examples_cudatoolkit_9_2 ).env.overrideAttrs(fixmklandcpath pkgs.libtorch_cudatoolkit_9_2);
+    shell-hasktorch-examples_cudatoolkit_10_1 = (doBenchmark base-compiler.hasktorch-examples_cudatoolkit_10_1).env.overrideAttrs(fixmklandcpath pkgs.libtorch_cudatoolkit_10_1);
   }
 

--- a/setup-cabal.sh
+++ b/setup-cabal.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -xe
 
@@ -7,12 +7,12 @@ sed -e 's/inline-c ==.*,/inline-c ==0.9.0.0,/g' -e 's/inline-c-cpp ==.*,/inline-
 
 cat <<EOF > cabal.project.local
 
-extra-include-dirs:
-    $(pwd)/deps/libtorch/include/torch/csrc/api/include
-  , $(pwd)/deps/libtorch/include
+package libtorch-ffi
+  extra-include-dirs: $(pwd)/deps/libtorch/include/torch/csrc/api/include
+  extra-include-dirs: $(pwd)/deps/libtorch/include
+  extra-lib-dirs: $(pwd)/deps/libtorch/lib
 
-extra-lib-dirs:
-    $(pwd)/deps/libtorch/lib
-  , $(pwd)/deps/mklml/lib
+package *
+  extra-lib-dirs: $(pwd)/deps/mklml/lib
 
 EOF

--- a/stack.yaml
+++ b/stack.yaml
@@ -21,3 +21,7 @@ extra-deps:
 - template-0.2.0.10@sha256:f822de4d34c45bc84b33a61bc112c15fedee6fa6dc414c62b10456395a868f85
 - inline-c-0.9.0.0
 - inline-c-cpp-0.4.0.0
+
+nix:
+  packages: [zlib.dev, zlib.out]
+


### PR DESCRIPTION
This PR adds a nix-shell development workflow to the README and logs some suggestions for getting `stack` and `cabal v2-*` to work in a nix shell (since neither workflow uses the NixOS packagesets).

In particular, it logs [setup-cabal.sh#L5-L6](https://github.com/hasktorch/hasktorch/blob/master/setup-cabal.sh#L5-L6) in [the shellHook](https://github.com/hasktorch/hasktorch/pull/259/files#diff-c156cac2b10c7abb0ec25d4ec2622875R197-R199) which explains to a nix user how to create a freeze file. This freeze file gets the correct version of inline-c-cpp via sed and avoids cabal-hell with `show-prettyprint` (see https://github.com/hasktorch/hasktorch/pull/259#discussion_r357858259)