### PR TITLE
make nix overlay accessible

### DIFF
--- a/nix/shared.nix
+++ b/nix/shared.nix
@@ -158,7 +158,7 @@ let
     };
 in
   rec {
-    inherit nullIfDarwin;
+    inherit nullIfDarwin overlayShared;
 
     inherit (pkgs.haskell.packages."${compiler}")
       hasktorch-codegen


### PR DESCRIPTION
With this PR, the nix overlay can be imported and combined with other overlays.
E.g. to setup jupyterWith with hasktorch you can then do:

```
hasktorchOverlay = (import ./hasktorch/nix/shared.nix { compiler = "ghc865"; }).overlayShared;
haskellOverlay = import ./haskell-overlay.nix;
pkgs = import nixpkgsPath {overlays = [ hasktorchOverlay haskellOverlay ]; config={allowUnfree=true;};};
```

`haskellOverlay` is a custom overlay that adds other packages on top of the hasktorch changes.