### PR TITLE
add HasToDevice class and instances

### DIFF
--- a/examples/static-mnist/Common.hs
+++ b/examples/static-mnist/Common.hs
@@ -83,7 +83,7 @@ errorCount
   => Tensor device 'D.Float '[batchSize, outputFeatures] -- ^ prediction
   -> Tensor device 'D.Int64 '[batchSize] -- ^ target
   -> Tensor device 'D.Float '[]
-errorCount prediction = toDType @D.Float . sumAll . ne (argmax @1 @DropDim prediction)
+errorCount prediction = Torch.Typed.Tensor.toDType @D.Float . sumAll . ne (argmax @1 @DropDim prediction)
 
 train
   :: forall (batchSize :: Nat) (device :: (D.DeviceType, Nat)) model optim gradients parameters tensors
@@ -151,7 +151,7 @@ train initModel initOptim forward learningRate ptFile = do
     let from = (index_of_batch-1) * natValI @n
         to = (index_of_batch * natValI @n) - 1
         indexes = [from .. to]
-        input  = toDevice @device $ I.getImages @n data' indexes
-        target = toDevice @device $ I.getLabels @n data' indexes
+        input  = Torch.Typed.Tensor.toDevice @device $ I.getImages @n data' indexes
+        target = Torch.Typed.Tensor.toDevice @device $ I.getLabels @n data' indexes
     prediction <- forward' input
     return (crossEntropyLoss prediction target, errorCount prediction target)

--- a/hasktorch/hasktorch.cabal
+++ b/hasktorch/hasktorch.cabal
@@ -32,6 +32,7 @@ library
                     , Torch.Typed.NN.Recurrent.LSTM
                     , Torch.Typed.Tensor
                     , Torch.Typed.Parameter
+                    , Torch.Typed.Device
                     , Torch.Typed.Autograd
                     , Torch.Typed.Optim
                     , Torch.Typed.Serialize

--- a/hasktorch/hasktorch.cabal
+++ b/hasktorch/hasktorch.cabal
@@ -33,6 +33,7 @@ library
                     , Torch.Typed.Tensor
                     , Torch.Typed.Parameter
                     , Torch.Typed.Device
+                    , Torch.Typed.DType
                     , Torch.Typed.Autograd
                     , Torch.Typed.Optim
                     , Torch.Typed.Serialize

--- a/hasktorch/src/Torch/Typed/Autograd.hs
+++ b/hasktorch/src/Torch/Typed/Autograd.hs
@@ -33,14 +33,14 @@ class HasGrad a b | a -> b where
   grad :: forall dtype device . Tensor device dtype '[] -> a -> b
   toDependent :: a -> b
 
--- instance HasGrad (Tensor dtype device shape) (Tensor dtype device shape) where
+-- instance HasGrad (Tensor device dtype shape) (Tensor device dtype shape) where
 --   grad loss input = head . unsafePerformIO $ ATen.cast2
 --     Torch.Managed.Autograd.grad
 --     loss
 --     [Torch.Typed.Autograd.toDependent input]
 --   toDependent = id
 
-instance HasGrad (Parameter dtype device shape) (Tensor dtype device shape) where
+instance HasGrad (Parameter device dtype shape) (Tensor device dtype shape) where
   grad loss input = head . unsafePerformIO $ ATen.cast2
     LibTorch.grad
     loss

--- a/hasktorch/src/Torch/Typed/DType.hs
+++ b/hasktorch/src/Torch/Typed/DType.hs
@@ -29,57 +29,57 @@ import qualified Torch.Tensor                  as D
 import           Torch.Typed.Tensor
 import           Torch.Typed.Parameter
 
-class HasToDType dtype dtype' f g | dtype dtype' f -> g, dtype dtype' g -> f where
+class HasToDType dtype' dtype f g | dtype' dtype f -> g, dtype' dtype g -> f where
+  -- >>> model <- A.sample (Torch.Typed.NN.LinearSpec @1 @1 @'D.Float @'( 'D.CPU, 0))
+  -- >>> :type Torch.Typed.DType.toDType @'D.Double @'D.Float model
+  -- Torch.Typed.DType.toDType @'D.Double @'D.Float model
+  -- :: Torch.Typed.NN.Linear 1 1 'Double '( 'CPU, 0)
   toDType :: f -> g
 
--- >>> :kind! PutDType (Torch.Typed.NN.Linear 1 1 'D.Float '( 'D.CPU, 0)) 'D.Float 'D.Double
--- PutDType (Torch.Typed.NN.Linear 1 1 'D.Float '( 'D.CPU, 0)) 'D.Float 'D.Double :: *
+-- >>> :kind! PutDType (Torch.Typed.NN.Linear 1 1 'D.Float '( 'D.CPU, 0)) 'D.Double 'D.Float
+-- PutDType (Torch.Typed.NN.Linear 1 1 'D.Float '( 'D.CPU, 0)) 'D.Double 'D.Float :: *
 -- = Torch.Typed.NN.Linear 1 1 'Double '( 'CPU, 0)
-type family PutDType (f :: k) (dtype :: D.DType) (dtype' :: D.DType) :: k where
-  PutDType (t dtype) dtype dtype' = t dtype'
-  PutDType (t a)     dtype dtype' = (PutDType t dtype dtype') a
-  PutDType t         _     _      = t
+type family PutDType (f :: k) (dtype' :: D.DType) (dtype :: D.DType) :: k where
+  PutDType (t dtype) dtype' dtype = t dtype'
+  PutDType (t a)     dtype' dtype = (PutDType t dtype' dtype) a
+  PutDType t         _      _     = t
 
 instance
-  ( g ~ PutDType f dtype dtype'
-  , f ~ PutDType g dtype' dtype
+  ( g ~ PutDType f dtype' dtype
+  , f ~ PutDType g dtype dtype'
   , Generic f
   , Generic g
-  , GHasToDType dtype dtype' (Rep f) (Rep g)
-  ) => HasToDType dtype dtype' f g where
-  -- >>> model <- A.sample (Torch.Typed.NN.LinearSpec @1 @1 @'D.Float @'( 'D.CPU, 0))
-  -- >>> :type Torch.Typed.DType.toDType @'D.Float @'D.Double model
-  -- Torch.Typed.DType.toDType @'D.Float @'D.Double model
-  -- :: Torch.Typed.NN.Linear 1 1 'Double '( 'CPU, 0)
-  toDType = to . gToDType @dtype @dtype' . from
+  , GHasToDType dtype' dtype (Rep f) (Rep g)
+  ) => HasToDType dtype' dtype f g where
+  toDType = to . gToDType @dtype' @dtype . from
 
 class GHasToDType
-  (dtype :: D.DType)
   (dtype' :: D.DType)
+  (dtype :: D.DType)
   (f :: Type -> Type)
   (g :: Type -> Type) where
   gToDType :: forall a . f a -> g a
 
 instance
-  ( GHasToDType dtype dtype' l l'
-  , GHasToDType dtype dtype' r r'
-  ) => GHasToDType dtype dtype' (l :*: r) (l' :*: r') where
+  ( GHasToDType dtype' dtype l l'
+  , GHasToDType dtype' dtype r r'
+  ) => GHasToDType dtype' dtype (l :*: r) (l' :*: r') where
   gToDType (l :*: r) =
-    let l' = gToDType @dtype @dtype' l
-        r' = gToDType @dtype @dtype' r
+    let l' = gToDType @dtype' @dtype l
+        r' = gToDType @dtype' @dtype r
     in  l' :*: r'
 
-instance {-# OVERLAPS #-} (KnownDType dtype') => HasToDType dtype dtype' (Tensor device dtype shape) (Tensor device dtype' shape) where
+instance {-# OVERLAPS #-} (KnownDType dtype') => HasToDType dtype' dtype (Tensor device dtype shape) (Tensor device dtype' shape) where
   toDType = Torch.Typed.Tensor.toDType
 
-instance {-# OVERLAPS #-} (KnownDType dtype') => HasToDType dtype dtype' (Parameter device dtype shape) (Parameter device dtype' shape) where
+instance {-# OVERLAPS #-} (KnownDType dtype') => HasToDType dtype' dtype (Parameter device dtype shape) (Parameter device dtype' shape) where
   toDType = Torch.Typed.Parameter.toDType
 
-instance {-# OVERLAPPABLE #-} (HasToDType dtype dtype' f g) => GHasToDType dtype dtype' (K1 i f) (K1 i g) where
-  gToDType = K1 . Torch.Typed.DType.toDType @dtype @dtype' . unK1
+instance {-# OVERLAPPABLE #-} (HasToDType dtype' dtype f g) => GHasToDType dtype' dtype (K1 i f) (K1 i g) where
+  gToDType = K1 . Torch.Typed.DType.toDType @dtype' @dtype . unK1
 
-instance (GHasToDType dtype dtype' f g) => GHasToDType dtype dtype' (M1 i t f) (M1 i t g) where
-  gToDType = M1 . gToDType @dtype @dtype' . unM1
+instance (GHasToDType dtype' dtype f g) => GHasToDType dtype' dtype (M1 i t f) (M1 i t g) where
+  gToDType = M1 . gToDType @dtype' @dtype . unM1
 
-instance GHasToDType dtype dtype' U1 U1 where
+instance GHasToDType dtype' dtype U1 U1 where
   gToDType = id

--- a/hasktorch/src/Torch/Typed/DType.hs
+++ b/hasktorch/src/Torch/Typed/DType.hs
@@ -1,0 +1,85 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DeriveGeneric #-}
+
+module Torch.Typed.DType where
+
+import           Torch.HList
+import           Data.Kind                    (Type)
+import           GHC.TypeLits
+import           GHC.TypeLits.Extra
+import           GHC.Generics
+import           System.IO.Unsafe
+
+import qualified Torch.Internal.Cast as ATen
+import qualified Torch.Internal.Class as ATen
+import qualified Torch.Internal.Managed.Autograd as LibTorch
+import qualified Torch.DType                   as D
+import qualified Torch.Device                  as D
+import qualified Torch.Tensor                  as D
+import           Torch.Typed.Tensor
+import           Torch.Typed.Parameter
+
+class HasToDType dtype dtype' f g | dtype dtype' f -> g, dtype dtype' g -> f where
+  toDType :: f -> g
+
+-- >>> :kind! PutDType (Torch.Typed.NN.Linear 1 1 'D.Float '( 'D.CPU, 0)) 'D.Float 'D.Double
+-- PutDType (Torch.Typed.NN.Linear 1 1 'D.Float '( 'D.CPU, 0)) 'D.Float 'D.Double :: *
+-- = Torch.Typed.NN.Linear 1 1 'Double '( 'CPU, 0)
+type family PutDType (f :: k) (dtype :: D.DType) (dtype' :: D.DType) :: k where
+  PutDType (t dtype) dtype dtype' = t dtype'
+  PutDType (t a)     dtype dtype' = (PutDType t dtype dtype') a
+  PutDType t         _     _      = t
+
+instance
+  ( g ~ PutDType f dtype dtype'
+  , f ~ PutDType g dtype' dtype
+  , Generic f
+  , Generic g
+  , GHasToDType dtype dtype' (Rep f) (Rep g)
+  ) => HasToDType dtype dtype' f g where
+  -- >>> model <- A.sample (Torch.Typed.NN.LinearSpec @1 @1 @'D.Float @'( 'D.CPU, 0))
+  -- >>> :type Torch.Typed.DType.toDType @'D.Float @'D.Double model
+  -- Torch.Typed.DType.toDType @'D.Float @'D.Double model
+  -- :: Torch.Typed.NN.Linear 1 1 'Double '( 'CPU, 0)
+  toDType = to . gToDType @dtype @dtype' . from
+
+class GHasToDType
+  (dtype :: D.DType)
+  (dtype' :: D.DType)
+  (f :: Type -> Type)
+  (g :: Type -> Type) where
+  gToDType :: forall a . f a -> g a
+
+instance
+  ( GHasToDType dtype dtype' l l'
+  , GHasToDType dtype dtype' r r'
+  ) => GHasToDType dtype dtype' (l :*: r) (l' :*: r') where
+  gToDType (l :*: r) =
+    let l' = gToDType @dtype @dtype' l
+        r' = gToDType @dtype @dtype' r
+    in  l' :*: r'
+
+instance {-# OVERLAPS #-} (KnownDType dtype') => HasToDType dtype dtype' (Tensor device dtype shape) (Tensor device dtype' shape) where
+  toDType = Torch.Typed.Tensor.toDType
+
+instance {-# OVERLAPS #-} (KnownDType dtype') => HasToDType dtype dtype' (Parameter device dtype shape) (Parameter device dtype' shape) where
+  toDType = Torch.Typed.Parameter.toDType
+
+instance {-# OVERLAPPABLE #-} (HasToDType dtype dtype' f g) => GHasToDType dtype dtype' (K1 i f) (K1 i g) where
+  gToDType = K1 . Torch.Typed.DType.toDType @dtype @dtype' . unK1
+
+instance (GHasToDType dtype dtype' f g) => GHasToDType dtype dtype' (M1 i t f) (M1 i t g) where
+  gToDType = M1 . gToDType @dtype @dtype' . unM1
+
+instance GHasToDType dtype dtype' U1 U1 where
+  gToDType = id

--- a/hasktorch/src/Torch/Typed/Device.hs
+++ b/hasktorch/src/Torch/Typed/Device.hs
@@ -29,57 +29,57 @@ import qualified Torch.Tensor                  as D
 import           Torch.Typed.Tensor
 import           Torch.Typed.Parameter
 
-class HasToDevice device device' f g | device device' f -> g, device device' g -> f where
+class HasToDevice (device' :: (D.DeviceType, Nat)) (device :: (D.DeviceType, Nat)) f g | device' device f -> g, device' device g -> f where
+  -- >>> model <- A.sample (Torch.Typed.NN.LinearSpec @1 @1 @'D.Float @'( 'D.CPU, 0))
+  -- >>> :type Torch.Typed.Device.device' @'( 'D.CUDA, 0) @'( 'D.CPU, 0) model
+  -- Torch.Typed.Device.device' @'( 'D.CUDA, 0) @'( 'D.CPU, 0) model
+  -- :: Torch.Typed.NN.Linear 1 1 'Float '( 'CUDA, 0)
   toDevice :: f -> g
 
--- >>> :kind! PutDevice (Torch.Typed.NN.Linear 1 1 'D.Float '( 'D.CPU, 0)) '( 'D.CPU, 0) '( 'D.CUDA, 0)
--- PutDevice (Torch.Typed.NN.Linear 1 1 'D.Float '( 'D.CPU, 0)) '( 'D.CPU, 0) '( 'D.CUDA, 0) :: *
+-- >>> :kind! PutDevice (Torch.Typed.NN.Linear 1 1 'D.Float '( 'D.CPU, 0)) '( 'D.CUDA, 0) '( 'D.CPU, 0)
+-- PutDevice (Torch.Typed.NN.Linear 1 1 'D.Float '( 'D.CPU, 0)) '( 'D.CUDA, 0) '( 'D.CPU, 0) :: *
 -- = Torch.Typed.NN.Linear 1 1 'Float '( 'CUDA, 0)
-type family PutDevice (f :: k) (device :: (D.DeviceType, Nat)) (device' :: (D.DeviceType, Nat)) :: k where
-  PutDevice (t device) device device' = t device'
-  PutDevice (t a)      device device' = (PutDevice t device device') a
-  PutDevice t          _      _       = t
+type family PutDevice (f :: k) (device' :: (D.DeviceType, Nat)) (device :: (D.DeviceType, Nat)) :: k where
+  PutDevice (t device) device' device = t device'
+  PutDevice (t a)      device' device = (PutDevice t device' device) a
+  PutDevice t          _       _      = t
 
 instance
-  ( g ~ PutDevice f device device'
-  , f ~ PutDevice g device' device
+  ( g ~ PutDevice f device' device
+  , f ~ PutDevice g device device'
   , Generic f
   , Generic g
-  , GHasToDevice device device' (Rep f) (Rep g)
-  ) => HasToDevice device device' f g where
-  -- >>> model <- A.sample (Torch.Typed.NN.LinearSpec @1 @1 @'D.Float @'( 'D.CPU, 0))
-  -- >>> :type Torch.Typed.Device.toDevice @'( 'D.CPU, 0) @'( 'D.CUDA, 0) model
-  -- Torch.Typed.Device.toDevice @'( 'D.CPU, 0) @'( 'D.CUDA, 0) model
-  -- :: Torch.Typed.NN.Linear 1 1 'Float '( 'CUDA, 0)
-  toDevice = to . gToDevice @device @device' . from
+  , GHasToDevice device' device (Rep f) (Rep g)
+  ) => HasToDevice device' device f g where
+  toDevice = to . gToDevice @device' @device . from
 
 class GHasToDevice
-  (device :: (D.DeviceType, Nat))
   (device' :: (D.DeviceType, Nat))
+  (device :: (D.DeviceType, Nat))
   (f :: Type -> Type)
   (g :: Type -> Type) where
   gToDevice :: forall a . f a -> g a
 
 instance
-  ( GHasToDevice device device' l l'
-  , GHasToDevice device device' r r'
-  ) => GHasToDevice device device' (l :*: r) (l' :*: r') where
+  ( GHasToDevice device' device l l'
+  , GHasToDevice device' device r r'
+  ) => GHasToDevice device' device (l :*: r) (l' :*: r') where
   gToDevice (l :*: r) =
-    let l' = gToDevice @device @device' l
-        r' = gToDevice @device @device' r
+    let l' = gToDevice @device' @device l
+        r' = gToDevice @device' @device r
     in  l' :*: r'
 
-instance {-# OVERLAPS #-} (KnownDevice device') => HasToDevice device device' (Tensor device dtype shape) (Tensor device' dtype shape) where
+instance {-# OVERLAPS #-} (KnownDevice device') => HasToDevice device' device (Tensor device dtype shape) (Tensor device' dtype shape) where
   toDevice = Torch.Typed.Tensor.toDevice
 
-instance {-# OVERLAPS #-} (KnownDevice device') => HasToDevice device device' (Parameter device dtype shape) (Parameter device' dtype shape) where
+instance {-# OVERLAPS #-} (KnownDevice device') => HasToDevice device' device (Parameter device dtype shape) (Parameter device' dtype shape) where
   toDevice = Torch.Typed.Parameter.toDevice
 
-instance {-# OVERLAPPABLE #-} (HasToDevice device device' f g) => GHasToDevice device device' (K1 i f) (K1 i g) where
-  gToDevice = K1 . Torch.Typed.Device.toDevice @device @device' . unK1
+instance {-# OVERLAPPABLE #-} (HasToDevice device' device f g) => GHasToDevice device' device (K1 i f) (K1 i g) where
+  gToDevice = K1 . Torch.Typed.Device.toDevice @device' @device . unK1
 
-instance (GHasToDevice device device' f g) => GHasToDevice device device' (M1 i t f) (M1 i t g) where
-  gToDevice = M1 . gToDevice @device @device' . unM1
+instance (GHasToDevice device' device f g) => GHasToDevice device' device (M1 i t f) (M1 i t g) where
+  gToDevice = M1 . gToDevice @device' @device . unM1
 
-instance GHasToDevice device device' U1 U1 where
+instance GHasToDevice device' device U1 U1 where
   gToDevice = id

--- a/hasktorch/src/Torch/Typed/Device.hs
+++ b/hasktorch/src/Torch/Typed/Device.hs
@@ -31,7 +31,7 @@ import           Torch.Typed.Parameter
 
 class HasToDevice (device' :: (D.DeviceType, Nat)) (device :: (D.DeviceType, Nat)) f g | device' device f -> g, device' device g -> f where
   -- >>> model <- A.sample (Torch.Typed.NN.LinearSpec @1 @1 @'D.Float @'( 'D.CPU, 0))
-  -- >>> :type Torch.Typed.Device.device' @'( 'D.CUDA, 0) @'( 'D.CPU, 0) model
+  -- >>> :type Torch.Typed.Device.toDevice @'( 'D.CUDA, 0) @'( 'D.CPU, 0) model
   -- Torch.Typed.Device.device' @'( 'D.CUDA, 0) @'( 'D.CPU, 0) model
   -- :: Torch.Typed.NN.Linear 1 1 'Float '( 'CUDA, 0)
   toDevice :: f -> g

--- a/hasktorch/src/Torch/Typed/Device.hs
+++ b/hasktorch/src/Torch/Typed/Device.hs
@@ -1,0 +1,85 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DeriveGeneric #-}
+
+module Torch.Typed.Device where
+
+import           Torch.HList
+import           Data.Kind                    (Type)
+import           GHC.TypeLits
+import           GHC.TypeLits.Extra
+import           GHC.Generics
+import           System.IO.Unsafe
+
+import qualified Torch.Internal.Cast as ATen
+import qualified Torch.Internal.Class as ATen
+import qualified Torch.Internal.Managed.Autograd as LibTorch
+import qualified Torch.DType                   as D
+import qualified Torch.Device                  as D
+import qualified Torch.Tensor                  as D
+import           Torch.Typed.Tensor
+import           Torch.Typed.Parameter
+
+class HasToDevice device device' f g | device device' f -> g, device device' g -> f where
+  toDevice :: f -> g
+
+-- >>> :kind! PutDevice (Torch.Typed.NN.Linear 1 1 'D.Float '( 'D.CPU, 0)) '( 'D.CPU, 0) '( 'D.CUDA, 0)
+-- PutDevice (Torch.Typed.NN.Linear 1 1 'D.Float '( 'D.CPU, 0)) '( 'D.CPU, 0) '( 'D.CUDA, 0) :: *
+-- = Torch.Typed.NN.Linear 1 1 'Float '( 'CUDA, 0)
+type family PutDevice (f :: k) (device :: (D.DeviceType, Nat)) (device' :: (D.DeviceType, Nat)) :: k where
+  PutDevice (t device) device device' = t device'
+  PutDevice (t a)      device device' = (PutDevice t device device') a
+  PutDevice t          _      _       = t
+
+instance
+  ( g ~ PutDevice f device device'
+  , f ~ PutDevice g device' device
+  , Generic f
+  , Generic g
+  , GHasToDevice device device' (Rep f) (Rep g)
+  ) => HasToDevice device device' f g where
+  -- >>> model <- A.sample (Torch.Typed.NN.LinearSpec @1 @1 @'D.Float @'( 'D.CPU, 0))
+  -- >>> :type Torch.Typed.Device.toDevice @'( 'D.CPU, 0) @'( 'D.CUDA, 0) model
+  -- Torch.Typed.Device.toDevice @'( 'D.CPU, 0) @'( 'D.CUDA, 0) model
+  -- :: Torch.Typed.NN.Linear 1 1 'Float '( 'CUDA, 0)
+  toDevice = to . gToDevice @device @device' . from
+
+class GHasToDevice
+  (device :: (D.DeviceType, Nat))
+  (device' :: (D.DeviceType, Nat))
+  (f :: Type -> Type)
+  (g :: Type -> Type) where
+  gToDevice :: forall a . f a -> g a
+
+instance
+  ( GHasToDevice device device' l l'
+  , GHasToDevice device device' r r'
+  ) => GHasToDevice device device' (l :*: r) (l' :*: r') where
+  gToDevice (l :*: r) =
+    let l' = gToDevice @device @device' l
+        r' = gToDevice @device @device' r
+    in  l' :*: r'
+
+instance {-# OVERLAPS #-} (KnownDevice device') => HasToDevice device device' (Tensor device dtype shape) (Tensor device' dtype shape) where
+  toDevice = Torch.Typed.Tensor.toDevice
+
+instance {-# OVERLAPS #-} (KnownDevice device') => HasToDevice device device' (Parameter device dtype shape) (Parameter device' dtype shape) where
+  toDevice = Torch.Typed.Parameter.toDevice
+
+instance {-# OVERLAPPABLE #-} (HasToDevice device device' f g) => GHasToDevice device device' (K1 i f) (K1 i g) where
+  gToDevice = K1 . Torch.Typed.Device.toDevice @device @device' . unK1
+
+instance (GHasToDevice device device' f g) => GHasToDevice device device' (M1 i t f) (M1 i t g) where
+  gToDevice = M1 . gToDevice @device @device' . unM1
+
+instance GHasToDevice device device' U1 U1 where
+  gToDevice = id

--- a/hasktorch/src/Torch/Typed/Device.hs
+++ b/hasktorch/src/Torch/Typed/Device.hs
@@ -32,7 +32,7 @@ import           Torch.Typed.Parameter
 class HasToDevice (device' :: (D.DeviceType, Nat)) (device :: (D.DeviceType, Nat)) f g | device' device f -> g, device' device g -> f where
   -- >>> model <- A.sample (Torch.Typed.NN.LinearSpec @1 @1 @'D.Float @'( 'D.CPU, 0))
   -- >>> :type Torch.Typed.Device.toDevice @'( 'D.CUDA, 0) @'( 'D.CPU, 0) model
-  -- Torch.Typed.Device.device' @'( 'D.CUDA, 0) @'( 'D.CPU, 0) model
+  -- Torch.Typed.Device.toDevice @'( 'D.CUDA, 0) @'( 'D.CPU, 0) model
   -- :: Torch.Typed.NN.Linear 1 1 'Float '( 'CUDA, 0)
   toDevice :: f -> g
 

--- a/hasktorch/src/Torch/Typed/Functional.hs
+++ b/hasktorch/src/Torch/Typed/Functional.hs
@@ -424,17 +424,6 @@ tanh
   -> Tensor device dtype shape -- ^ output
 tanh input = unsafePerformIO $ ATen.cast1 ATen.Managed.tanh_t input
 
--- | toDType
--- TODO: since we have Torch.Typed.Tensor.toType, do we need this one?
--- >>> dtype &&& shape $ toDType @'D.Double (ones :: CPUTensor 'D.Float '[2,2])
--- (Double,[2,2])
-toDType
-  :: forall dtype' dtype shape device
-   . (KnownDType dtype')
-  => Tensor device dtype  shape -- ^ input
-  -> Tensor device dtype' shape -- ^ output
-toDType input = unsafePerformIO $ ATen.cast4 ATen.Managed.tensor_to_sbb input (dtypeVal @dtype') False False
-
 type family SqueezeAll (shape :: [Nat]) :: [Nat] where
   SqueezeAll '[] = '[]
   SqueezeAll (1: xs) = SqueezeAll xs

--- a/hasktorch/src/Torch/Typed/NN.hs
+++ b/hasktorch/src/Torch/Typed/NN.hs
@@ -359,8 +359,8 @@ instance A.Parameterized (LayerNorm normalizedShape dtype device) where
   flattenParameters LayerNorm {..} =
     A.flattenParameters layerNormWeight <> A.flattenParameters layerNormBias
   replaceOwnParameters LayerNorm {..} = do
-    layerNormWeight <- Parameter <$> A.nextParameter
-    layerNormBias   <- Parameter <$> A.nextParameter
+    layerNormWeight <- UnsafeMkParameter <$> A.nextParameter
+    layerNormBias   <- UnsafeMkParameter <$> A.nextParameter
     return $ LayerNorm { .. }
 
 instance

--- a/hasktorch/src/Torch/Typed/Parameter.hs
+++ b/hasktorch/src/Torch/Typed/Parameter.hs
@@ -30,7 +30,7 @@ import           GHC.Generics
 
 import qualified Torch.NN                      as A
 import qualified Torch.Autograd                as A
-import qualified Torch.Tensor                  as A
+import qualified Torch.Tensor                  as D
 import qualified Torch.DType                   as D
 import qualified Torch.Device                  as D
 import           Torch.Typed.Aux
@@ -38,14 +38,14 @@ import           Torch.Typed.Factories
 import           Torch.Typed.Functional
 import           Torch.Typed.Tensor
 
-newtype Parameter (device :: (D.DeviceType, Nat)) (dtype :: D.DType) (shape :: [Nat]) = Parameter A.IndependentTensor
-  deriving (Show)
+newtype Parameter (device :: (D.DeviceType, Nat)) (dtype :: D.DType) (shape :: [Nat]) = UnsafeMkParameter A.IndependentTensor
+  deriving Show
 
 toDependent
   :: forall shape dtype device
    . Parameter device dtype shape
   -> Tensor device dtype shape
-toDependent (Parameter t) = UnsafeMkTensor $ A.toDependent t
+toDependent (UnsafeMkParameter t) = UnsafeMkTensor $ A.toDependent t
 
 data ToDependent = ToDependent
 
@@ -56,12 +56,19 @@ makeIndependent
   :: forall shape dtype device
    . Tensor device dtype shape
   -> IO (Parameter device dtype shape)
-makeIndependent t = Parameter <$> A.makeIndependent (toDynamic t)
+makeIndependent t = UnsafeMkParameter <$> A.makeIndependent (toDynamic t)
 
 data MakeIndependent = MakeIndependent
 
 instance Apply' MakeIndependent (Tensor device dtype shape) (IO (Parameter device dtype shape)) where
   apply' _ = makeIndependent
+
+toDevice
+  :: forall device' device dtype shape
+   . KnownDevice device'
+  => Parameter device  dtype shape
+  -> Parameter device' dtype shape
+toDevice (UnsafeMkParameter t) = UnsafeMkParameter . A.IndependentTensor . D.toDevice (deviceVal @device') . A.toDependent $ t
 
 class Parameterized
   (f :: Type)
@@ -79,7 +86,6 @@ instance
 class GParameterized
   (f :: Type -> Type)
   (as :: [Type]) | f -> as where
-
   gFlattenParameters :: f a -> HList as
   gReplaceParameters :: f a -> HList as -> f a
 
@@ -143,8 +149,8 @@ instance GParameterized U1 '[] where
 --   replaceParameters _ = id
 
 instance A.Parameterized (Parameter device dtype shape) where
-  flattenParameters (Parameter x) = [x]
-  replaceOwnParameters _ = Parameter <$> A.nextParameter
+  flattenParameters (UnsafeMkParameter x) = [x]
+  replaceOwnParameters _ = UnsafeMkParameter <$> A.nextParameter
 
 instance A.Parameterized (HList '[]) where
   flattenParameters _ = []

--- a/hasktorch/src/Torch/Typed/Parameter.hs
+++ b/hasktorch/src/Torch/Typed/Parameter.hs
@@ -70,6 +70,13 @@ toDevice
   -> Parameter device' dtype shape
 toDevice (UnsafeMkParameter t) = UnsafeMkParameter . A.IndependentTensor . D.toDevice (deviceVal @device') . A.toDependent $ t
 
+toDType
+  :: forall dtype' dtype device shape
+   . KnownDType dtype'
+  => Parameter device dtype  shape
+  -> Parameter device dtype' shape
+toDType (UnsafeMkParameter t) = UnsafeMkParameter . A.IndependentTensor . D.toType (dtypeVal @dtype') . A.toDependent $ t
+
 class Parameterized
   (f :: Type)
   (as :: [Type]) | f -> as where

--- a/hasktorch/src/Torch/Typed/Tensor.hs
+++ b/hasktorch/src/Torch/Typed/Tensor.hs
@@ -470,14 +470,14 @@ toDevice
    . KnownDevice device'
   => Tensor device  dtype shape
   -> Tensor device' dtype shape
-toDevice input = UnsafeMkTensor . D.toDevice (deviceVal @device') . toDynamic $ input
+toDevice = UnsafeMkTensor . D.toDevice (deviceVal @device') . toDynamic
 
 toType
   :: forall dtype' dtype device shape
    . KnownDType dtype'
   => Tensor device dtype  shape
   -> Tensor device dtype' shape
-toType input = UnsafeMkTensor . D.toType (dtypeVal @dtype') . toDynamic $ input
+toType = UnsafeMkTensor . D.toType (dtypeVal @dtype') . toDynamic
 
 --------------------------------------------------------------------------------
 -- Auxiliary functions for accessing tensor options as values

--- a/hasktorch/src/Torch/Typed/Tensor.hs
+++ b/hasktorch/src/Torch/Typed/Tensor.hs
@@ -432,7 +432,7 @@ instance Castable (HList l) [D.ATenTensor] => Castable (HList l) (ForeignPtr ATe
     f ts
 
 --------------------------------------------------------------------------------
--- Move backend
+-- Move tensors
 --------------------------------------------------------------------------------
 
 -- TODO: track sparsity in tensor type
@@ -450,6 +450,7 @@ toDense t = UnsafeMkTensor $ D.toDense (toDynamic t)
 --   -> Tensor device' dtype shape
 -- toMKLDNN t = UnsafeMkTensor $ D.toMKLDNN (toDynamic t)
 
+-- | move tensor to CPU
 -- TODO: can this fail?
 toCPU
   :: forall device shape dtype
@@ -457,6 +458,7 @@ toCPU
   -> CPUTensor dtype shape
 toCPU input = UnsafeMkTensor $ D.toCPU (toDynamic input)
 
+-- | move tensor to the first CUDA device
 -- TODO: what if this fails?
 toCUDA
   :: forall device' device shape dtype
@@ -464,6 +466,7 @@ toCUDA
   -> CUDATensor 0 dtype shape
 toCUDA t = UnsafeMkTensor $ D.toCUDA (toDynamic t)
 
+-- | move tensor to device
 -- TODO: what if this fails?
 toDevice
   :: forall device' device dtype shape
@@ -472,17 +475,20 @@ toDevice
   -> Tensor device' dtype shape
 toDevice = UnsafeMkTensor . D.toDevice (deviceVal @device') . toDynamic
 
-toType
+-- | change tensor data type
+toDType
   :: forall dtype' dtype device shape
    . KnownDType dtype'
   => Tensor device dtype  shape
   -> Tensor device dtype' shape
-toType = UnsafeMkTensor . D.toType (dtypeVal @dtype') . toDynamic
+toDType = UnsafeMkTensor . D.toType (dtypeVal @dtype') . toDynamic
 
 --------------------------------------------------------------------------------
 -- Auxiliary functions for accessing tensor options as values
 --------------------------------------------------------------------------------
 
+-- | returns tensor dimension
+--   uses compile-time information only
 dim
   :: forall device dtype shape
    . TensorOptions shape dtype device
@@ -490,6 +496,8 @@ dim
   -> Int
 dim t = length $ optionsRuntimeShape @shape @dtype @device
 
+-- | returns tensor shape as list
+--   uses compile-time information only
 shape
   :: forall device dtype shape
    . TensorOptions shape dtype device
@@ -497,6 +505,8 @@ shape
   -> [Int]
 shape _ = optionsRuntimeShape @shape @dtype @device
 
+-- | returns tensor data type
+--   uses compile-time information only
 dtype
   :: forall device dtype shape
    . TensorOptions shape dtype device
@@ -504,12 +514,18 @@ dtype
   -> D.DType
 dtype _ = optionsRuntimeDType @shape @dtype @device
 
+-- | returns tensor device
+--   uses compile-time information only
 device
   :: forall device dtype shape
    . TensorOptions shape dtype device
   => Tensor device dtype shape
   -> D.Device
 device _ = optionsRuntimeDevice @shape @dtype @device
+
+--------------------------------------------------------------------------------
+-- Auxiliary functions for accessing tensors as values
+--------------------------------------------------------------------------------
 
 -- TODO: figure out what device, dtype, and shape we need for this
 toInt

--- a/hasktorch/test/Torch/Typed/AutogradSpec.hs
+++ b/hasktorch/test/Torch/Typed/AutogradSpec.hs
@@ -234,7 +234,7 @@ instance
   , StandardFloatingPointDTypeValidation device dtype
   ) => Apply' (RastriginA a (Proxy device') (Proxy dtype')) (Parameter device dtype '[n]) (Tensor device' dtype' '[]) where
   apply' (RastriginA a _ _) parameter =
-    toDevice @device' . toDType @dtype' . rastriginLayer' (toDependent parameter) a $ natValI @n
+    Torch.Typed.Tensor.toDevice @device' . toDType @dtype' . rastriginLayer' (toDependent parameter) a $ natValI @n
 
 rastrigin
   :: forall a dtype device tensors parameters num ns dtypes devices shape
@@ -282,7 +282,7 @@ instance
   apply _ (a, b) _ = do
     checkDynamicTensorAttributes a
     checkDynamicTensorAttributes b
-    (toList . Just . toDevice @'( 'D.CPU, 0) . unsqueeze @0 . all)
+    (toList . Just . Torch.Typed.Tensor.toDevice @'( 'D.CPU, 0) . unsqueeze @0 . all)
         (isclose 1e-05 1e-08 False a b)
       `shouldBe` [True]
 

--- a/hasktorch/test/Torch/Typed/AutogradSpec.hs
+++ b/hasktorch/test/Torch/Typed/AutogradSpec.hs
@@ -234,7 +234,7 @@ instance
   , StandardFloatingPointDTypeValidation device dtype
   ) => Apply' (RastriginA a (Proxy device') (Proxy dtype')) (Parameter device dtype '[n]) (Tensor device' dtype' '[]) where
   apply' (RastriginA a _ _) parameter =
-    Torch.Typed.Tensor.toDevice @device' . toDType @dtype' . rastriginLayer' (toDependent parameter) a $ natValI @n
+    Torch.Typed.Tensor.toDevice @device' . Torch.Typed.Tensor.toDType @dtype' . rastriginLayer' (toDependent parameter) a $ natValI @n
 
 rastrigin
   :: forall a dtype device tensors parameters num ns dtypes devices shape

--- a/hasktorch/test/Torch/Typed/FunctionalSpec.hs
+++ b/hasktorch/test/Torch/Typed/FunctionalSpec.hs
@@ -287,7 +287,7 @@ instance ( TensorOptions shape dtype  device
  where
   apply ToDTypeSpec _ _ = do
     let t = ones @shape @dtype @device
-        t' = toDType @dtype' t
+        t' = Torch.Typed.Tensor.toDType @dtype' t
     checkDynamicTensorAttributes t'
 
 data SumAllSpec = SumAllSpec

--- a/hasktorch/test/Torch/Typed/OptimSpec.hs
+++ b/hasktorch/test/Torch/Typed/OptimSpec.hs
@@ -294,7 +294,7 @@ instance
         learningRate = 0.001
         numIter      = 50000
     (model, _optim) <- optimize initModel initOptim loss learningRate numIter
-    (toList . Just . toDevice @'( 'D.CPU, 0)) (isclose 1e-04 1e-08 False (cat @0 . hmap' ToDependent . flattenParameters $ model) ones) `shouldBe` [True, True]
+    (toList . Just . Torch.Typed.Tensor.toDevice @'( 'D.CPU, 0)) (isclose 1e-04 1e-08 False (cat @0 . hmap' ToDependent . flattenParameters $ model) ones) `shouldBe` [True, True]
     isNonZero (isclose 1e-05 1e-08 False (loss model) zeros) `shouldBe` True
   apply GDMRosenbrockSpec _ _ = do
     ATen.manual_seed_L 123
@@ -306,7 +306,7 @@ instance
         learningRate = 0.001
         numIter      = 5000
     (model, _optim) <- optimize initModel initOptim loss learningRate numIter
-    (toList . Just . toDevice @'( 'D.CPU, 0)) (isclose 1e-05 1e-08 False (cat @0 . hmap' ToDependent . flattenParameters $ model) ones) `shouldBe` [True, True]
+    (toList . Just . Torch.Typed.Tensor.toDevice @'( 'D.CPU, 0)) (isclose 1e-05 1e-08 False (cat @0 . hmap' ToDependent . flattenParameters $ model) ones) `shouldBe` [True, True]
     isNonZero (isclose 1e-05 1e-08 False (loss model) zeros) `shouldBe` True
   apply AdamRosenbrockSpec _ _ = do
     ATen.manual_seed_L 123
@@ -318,7 +318,7 @@ instance
         learningRate = 0.005
         numIter      = 10000
     (model, _optim) <- optimize initModel initOptim loss learningRate numIter
-    (toList . Just . toDevice @'( 'D.CPU, 0)) (isclose 1e-04 1e-07 False (cat @0 . hmap' ToDependent . flattenParameters $ model) ones) `shouldBe` [True, True]
+    (toList . Just . Torch.Typed.Tensor.toDevice @'( 'D.CPU, 0)) (isclose 1e-04 1e-07 False (cat @0 . hmap' ToDependent . flattenParameters $ model) ones) `shouldBe` [True, True]
     isNonZero (isclose 1e-05 1e-07 False (loss model) zeros) `shouldBe` True
 
 data OptimAckleySpec = GDAckleySpec | GDMAckleySpec | AdamAckleySpec
@@ -347,7 +347,7 @@ instance
         numIter      = 10000
     (model, _optim) <- optimize initModel initOptim loss learningRate numIter
     let finalLoss = loss model
-    (toList . Just . toDevice @'( 'D.CPU, 0)) (isclose 1e-04 1e-04 False (cat @0 . hmap' ToDependent . flattenParameters $ model) zeros) `shouldBe` [True, True]
+    (toList . Just . Torch.Typed.Tensor.toDevice @'( 'D.CPU, 0)) (isclose 1e-04 1e-04 False (cat @0 . hmap' ToDependent . flattenParameters $ model) zeros) `shouldBe` [True, True]
     isNonZero (isclose 1e-04 1e-04 False (loss model) zeros) `shouldBe` True
   apply GDMAckleySpec _ _ = do
     ATen.manual_seed_L 123
@@ -361,7 +361,7 @@ instance
         numIter      = 10000
     (model, _optim) <- optimize initModel initOptim loss learningRate numIter
     let finalLoss = loss model
-    (toList . Just . toDevice @'( 'D.CPU, 0)) (isclose 1e-04 1e-04 False (cat @0 . hmap' ToDependent . flattenParameters $ model) zeros) `shouldBe` [True, True]
+    (toList . Just . Torch.Typed.Tensor.toDevice @'( 'D.CPU, 0)) (isclose 1e-04 1e-04 False (cat @0 . hmap' ToDependent . flattenParameters $ model) zeros) `shouldBe` [True, True]
     isNonZero (isclose 1e-04 1e-04 False (loss model) zeros) `shouldBe` True
   apply AdamAckleySpec _ _ = do
     ATen.manual_seed_L 123
@@ -375,7 +375,7 @@ instance
         numIter      = 20000
     (model, _optim) <- optimize initModel initOptim loss learningRate numIter
     let finalLoss = loss model
-    (toList . Just . toDevice @'( 'D.CPU, 0)) (isclose 1e-04 1e-04 False (cat @0 . hmap' ToDependent . flattenParameters $ model) zeros) `shouldBe` [True, True]
+    (toList . Just . Torch.Typed.Tensor.toDevice @'( 'D.CPU, 0)) (isclose 1e-04 1e-04 False (cat @0 . hmap' ToDependent . flattenParameters $ model) zeros) `shouldBe` [True, True]
     isNonZero (isclose 1e-04 1e-04 False (loss model) zeros) `shouldBe` True
 
 spec = foldMap spec' availableDevices

--- a/hasktorch/test/Torch/Typed/OptimSpec.hs
+++ b/hasktorch/test/Torch/Typed/OptimSpec.hs
@@ -214,17 +214,17 @@ optimize
   -> LearningRate device dtype
   -> Int
   -> IO (model, optim)
--- optimize initModel initOptim loss learningRate numIters =
---   foldLoop (initModel, initOptim) numIters
---     $ \(model, optim) _ -> runStep model optim (loss model) learningRate
-optimize initModel initOptim loss learningRate numIters = do
-  print $ "initial model: " <> show initModel
-  print $ "initial loss:" <> show (loss initModel)
-  (finalModel, finalOptim) <- foldLoop (initModel, initOptim) numIters
+optimize initModel initOptim loss learningRate numIters =
+  foldLoop (initModel, initOptim) numIters
     $ \(model, optim) _ -> runStep model optim (loss model) learningRate
-  print $ "final model: " <> show finalModel
-  print $ "final loss:" <> show (loss finalModel)
-  pure (finalModel, finalOptim)
+-- optimize initModel initOptim loss learningRate numIters = do
+--   print $ "initial model: " <> show initModel
+--   print $ "initial loss:" <> show (loss initModel)
+--   (finalModel, finalOptim) <- foldLoop (initModel, initOptim) numIters
+--     $ \(model, optim) _ -> runStep model optim (loss model) learningRate
+--   print $ "final model: " <> show finalModel
+--   print $ "final loss:" <> show (loss finalModel)
+--   pure (finalModel, finalOptim)
 
 data OptimConvQuadSpec = GDConvQuadSpec | GDMConvQuadSpec | AdamConvQuadSpec
 
@@ -295,11 +295,11 @@ instance
         a :: Float   = 1.0
         b :: Float   = 100.0
         loss model   = rosenbrock model a b
-        learningRate = 0.001
-        numIter      = 50000
+        learningRate = 0.002
+        numIter      = 15000
     (model, _optim) <- optimize initModel' initOptim loss learningRate numIter
-    (toList . Just . Torch.Typed.Tensor.toDevice @'( 'D.CPU, 0)) (isclose 1e-04 1e-08 False (cat @0 . hmap' ToDependent . flattenParameters $ model) ones) `shouldBe` [True, True]
-    isNonZero (isclose 1e-05 1e-08 False (loss model) zeros) `shouldBe` True
+    (toList . Just . Torch.Typed.Tensor.toDevice @'( 'D.CPU, 0)) (isclose 1e-04 1e-04 False (cat @0 . hmap' ToDependent . flattenParameters $ model) ones) `shouldBe` [True, True]
+    isNonZero (isclose 1e-04 1e-04 False (loss model) zeros) `shouldBe` True
   apply GDMRosenbrockSpec _ _ = do
     ATen.manual_seed_L 123
     initModel <- A.sample (RosenbrockSpec @'D.Float @'( 'D.CPU, 0))
@@ -309,10 +309,10 @@ instance
         b :: Float   = 100.0
         loss model   = rosenbrock model a b
         learningRate = 0.001
-        numIter      = 5000
+        numIter      = 10000
     (model, _optim) <- optimize initModel' initOptim loss learningRate numIter
-    (toList . Just . Torch.Typed.Tensor.toDevice @'( 'D.CPU, 0)) (isclose 1e-05 1e-08 False (cat @0 . hmap' ToDependent . flattenParameters $ model) ones) `shouldBe` [True, True]
-    isNonZero (isclose 1e-05 1e-08 False (loss model) zeros) `shouldBe` True
+    (toList . Just . Torch.Typed.Tensor.toDevice @'( 'D.CPU, 0)) (isclose 1e-04 1e-04 False (cat @0 . hmap' ToDependent . flattenParameters $ model) ones) `shouldBe` [True, True]
+    isNonZero (isclose 1e-04 1e-04 False (loss model) zeros) `shouldBe` True
   apply AdamRosenbrockSpec _ _ = do
     ATen.manual_seed_L 123
     initModel <- A.sample (RosenbrockSpec @'D.Float @'( 'D.CPU, 0))
@@ -322,10 +322,10 @@ instance
         b :: Float   = 100.0
         loss model   = rosenbrock model a b
         learningRate = 0.005
-        numIter      = 10000
+        numIter      = 5000
     (model, _optim) <- optimize initModel' initOptim loss learningRate numIter
-    (toList . Just . Torch.Typed.Tensor.toDevice @'( 'D.CPU, 0)) (isclose 1e-04 1e-07 False (cat @0 . hmap' ToDependent . flattenParameters $ model) ones) `shouldBe` [True, True]
-    isNonZero (isclose 1e-05 1e-07 False (loss model) zeros) `shouldBe` True
+    (toList . Just . Torch.Typed.Tensor.toDevice @'( 'D.CPU, 0)) (isclose 1e-04 1e-04 False (cat @0 . hmap' ToDependent . flattenParameters $ model) ones) `shouldBe` [True, True]
+    isNonZero (isclose 1e-04 1e-04 False (loss model) zeros) `shouldBe` True
 
 data OptimAckleySpec = GDAckleySpec | GDMAckleySpec | AdamAckleySpec
 
@@ -349,8 +349,8 @@ instance
         b :: Float   = 0.2
         c :: Float   = 2 * pi
         loss model   = ackley model a b c
-        learningRate = 0.00002
-        numIter      = 10000
+        learningRate = 0.00001
+        numIter      = 5000
     (model, _optim) <- optimize initModel' initOptim loss learningRate numIter
     let finalLoss = loss model
     (toList . Just . Torch.Typed.Tensor.toDevice @'( 'D.CPU, 0)) (isclose 1e-04 1e-04 False (cat @0 . hmap' ToDependent . flattenParameters $ model) zeros) `shouldBe` [True, True]
@@ -364,8 +364,8 @@ instance
         b :: Float   = 0.2
         c :: Float   = 2 * pi
         loss model   = ackley model a b c
-        learningRate = 0.00001
-        numIter      = 10000
+        learningRate = 0.000005
+        numIter      = 5000
     (model, _optim) <- optimize initModel' initOptim loss learningRate numIter
     let finalLoss = loss model
     (toList . Just . Torch.Typed.Tensor.toDevice @'( 'D.CPU, 0)) (isclose 1e-04 1e-04 False (cat @0 . hmap' ToDependent . flattenParameters $ model) zeros) `shouldBe` [True, True]
@@ -379,8 +379,8 @@ instance
         b :: Float   = 0.2
         c :: Float   = 2 * pi
         loss model   = ackley model a b c
-        learningRate = 0.00001
-        numIter      = 20000
+        learningRate = 0.0001
+        numIter      = 2000
     (model, _optim) <- optimize initModel' initOptim loss learningRate numIter
     let finalLoss = loss model
     (toList . Just . Torch.Typed.Tensor.toDevice @'( 'D.CPU, 0)) (isclose 1e-04 1e-04 False (cat @0 . hmap' ToDependent . flattenParameters $ model) zeros) `shouldBe` [True, True]
@@ -400,12 +400,12 @@ spec' device = describe ("for " <> show device) $ do
       D.Device { D.deviceType = D.CPU, D.deviceIndex = 0 } ->
         hfoldrM @IO GDRosenbrockSpec () (hattach cpu   standardFloatingPointDTypes)
       D.Device { D.deviceType = D.CUDA, D.deviceIndex = 0 } ->
-        hfoldrM @IO GDRosenbrockSpec () (hattach cuda0 allFloatingPointDTypes)
+        hfoldrM @IO GDRosenbrockSpec () (hattach cuda0 standardFloatingPointDTypes)
     it "Ackley" $ case device of
       D.Device { D.deviceType = D.CPU, D.deviceIndex = 0 } ->
         hfoldrM @IO GDAckleySpec () (hattach cpu   standardFloatingPointDTypes)
       D.Device { D.deviceType = D.CUDA, D.deviceIndex = 0 } ->
-        hfoldrM @IO GDAckleySpec () (hattach cuda0 allFloatingPointDTypes)
+        hfoldrM @IO GDAckleySpec () (hattach cuda0 standardFloatingPointDTypes)
   describe "GDM" $ do
     it "convex quadratic" $ case device of
       D.Device { D.deviceType = D.CPU, D.deviceIndex = 0 } ->
@@ -416,12 +416,12 @@ spec' device = describe ("for " <> show device) $ do
       D.Device { D.deviceType = D.CPU, D.deviceIndex = 0 } ->
         hfoldrM @IO GDMRosenbrockSpec () (hattach cpu   standardFloatingPointDTypes)
       D.Device { D.deviceType = D.CUDA, D.deviceIndex = 0 } ->
-        hfoldrM @IO GDMRosenbrockSpec () (hattach cuda0 allFloatingPointDTypes)
+        hfoldrM @IO GDMRosenbrockSpec () (hattach cuda0 standardFloatingPointDTypes)
     it "Ackley" $ case device of
       D.Device { D.deviceType = D.CPU, D.deviceIndex = 0 } ->
         hfoldrM @IO GDMAckleySpec () (hattach cpu   standardFloatingPointDTypes)
       D.Device { D.deviceType = D.CUDA, D.deviceIndex = 0 } ->
-        hfoldrM @IO GDMAckleySpec () (hattach cuda0 allFloatingPointDTypes)
+        hfoldrM @IO GDMAckleySpec () (hattach cuda0 standardFloatingPointDTypes)
   describe "Adam" $ do
     it "convex quadratic" $ case device of
       D.Device { D.deviceType = D.CPU, D.deviceIndex = 0 } ->
@@ -432,9 +432,9 @@ spec' device = describe ("for " <> show device) $ do
       D.Device { D.deviceType = D.CPU, D.deviceIndex = 0 } ->
         hfoldrM @IO AdamRosenbrockSpec () (hattach cpu   standardFloatingPointDTypes)
       D.Device { D.deviceType = D.CUDA, D.deviceIndex = 0 } ->
-        hfoldrM @IO AdamRosenbrockSpec () (hattach cuda0 allFloatingPointDTypes)
+        hfoldrM @IO AdamRosenbrockSpec () (hattach cuda0 standardFloatingPointDTypes)
     it "Ackley" $ case device of
       D.Device { D.deviceType = D.CPU, D.deviceIndex = 0 } ->
         hfoldrM @IO AdamAckleySpec () (hattach cpu   standardFloatingPointDTypes)
       D.Device { D.deviceType = D.CUDA, D.deviceIndex = 0 } ->
-        hfoldrM @IO AdamAckleySpec () (hattach cuda0 allFloatingPointDTypes)
+        hfoldrM @IO AdamAckleySpec () (hattach cuda0 standardFloatingPointDTypes)

--- a/hasktorch/test/Torch/Typed/OptimSpec.hs
+++ b/hasktorch/test/Torch/Typed/OptimSpec.hs
@@ -242,7 +242,7 @@ instance
   apply GDConvQuadSpec _ _ = do
     ATen.manual_seed_L 123
     initModel <- A.sample (ConvQuadSpec @features @'D.Float @'( 'D.CPU, 0))
-    let initModel'   = Torch.Typed.Device.toDevice @'( 'D.CPU, 0) @device . Torch.Typed.DType.toDType @'D.Float @dtype $ initModel
+    let initModel'   = Torch.Typed.Device.toDevice @device @'( 'D.CPU, 0) . Torch.Typed.DType.toDType @dtype @'D.Float $ initModel
         initOptim    = mkGD
         a            = eyeSquare @features @dtype @device
         b            = zeros @'[features] @dtype @device
@@ -254,7 +254,7 @@ instance
   apply GDMConvQuadSpec _ _ = do
     ATen.manual_seed_L 123
     initModel <- A.sample (ConvQuadSpec @features @'D.Float @'( 'D.CPU, 0))
-    let initModel'   = Torch.Typed.Device.toDevice @'( 'D.CPU, 0) @device . Torch.Typed.DType.toDType @'D.Float @dtype $ initModel
+    let initModel'   = Torch.Typed.Device.toDevice @device @'( 'D.CPU, 0) . Torch.Typed.DType.toDType @dtype @'D.Float $ initModel
         initOptim    = mkGDM 0.9 (flattenParameters initModel')
         a            = eyeSquare @features @dtype @device
         b            = zeros @'[features] @dtype @device
@@ -266,7 +266,7 @@ instance
   apply AdamConvQuadSpec _ _ = do
     ATen.manual_seed_L 123
     initModel <- A.sample (ConvQuadSpec @features @'D.Float @'( 'D.CPU, 0))
-    let initModel'   = Torch.Typed.Device.toDevice @'( 'D.CPU, 0) @device . Torch.Typed.DType.toDType @'D.Float @dtype $ initModel
+    let initModel'   = Torch.Typed.Device.toDevice @device @'( 'D.CPU, 0) . Torch.Typed.DType.toDType @dtype @'D.Float $ initModel
         initOptim    = mkAdam 0 0.9 0.999 (flattenParameters initModel')
         a            = eyeSquare @features @dtype @device
         b            = zeros @'[features] @dtype @device
@@ -290,7 +290,7 @@ instance
   apply GDRosenbrockSpec _ _ = do
     ATen.manual_seed_L 123
     initModel <- A.sample (RosenbrockSpec @'D.Float @'( 'D.CPU, 0))
-    let initModel'   = Torch.Typed.Device.toDevice @'( 'D.CPU, 0) @device . Torch.Typed.DType.toDType @'D.Float @dtype $ initModel
+    let initModel'   = Torch.Typed.Device.toDevice @device @'( 'D.CPU, 0) . Torch.Typed.DType.toDType @dtype @'D.Float $ initModel
         initOptim    = mkGD
         a :: Float   = 1.0
         b :: Float   = 100.0
@@ -303,7 +303,7 @@ instance
   apply GDMRosenbrockSpec _ _ = do
     ATen.manual_seed_L 123
     initModel <- A.sample (RosenbrockSpec @'D.Float @'( 'D.CPU, 0))
-    let initModel'   = Torch.Typed.Device.toDevice @'( 'D.CPU, 0) @device . Torch.Typed.DType.toDType @'D.Float @dtype $ initModel
+    let initModel'   = Torch.Typed.Device.toDevice @device @'( 'D.CPU, 0) . Torch.Typed.DType.toDType @dtype @'D.Float $ initModel
         initOptim    = mkGDM 0.9 (flattenParameters initModel')
         a :: Float   = 1.0
         b :: Float   = 100.0
@@ -316,7 +316,7 @@ instance
   apply AdamRosenbrockSpec _ _ = do
     ATen.manual_seed_L 123
     initModel <- A.sample (RosenbrockSpec @'D.Float @'( 'D.CPU, 0))
-    let initModel'   = Torch.Typed.Device.toDevice @'( 'D.CPU, 0) @device . Torch.Typed.DType.toDType @'D.Float @dtype $ initModel
+    let initModel'   = Torch.Typed.Device.toDevice @device @'( 'D.CPU, 0) . Torch.Typed.DType.toDType @dtype @'D.Float $ initModel
         initOptim    = mkAdam 0 0.9 0.999 (flattenParameters initModel')
         a :: Float   = 1.0
         b :: Float   = 100.0
@@ -343,7 +343,7 @@ instance
   apply GDAckleySpec _ _ = do
     ATen.manual_seed_L 123
     initModel <- A.sample (AckleySpec @2 @'D.Float @'( 'D.CPU, 0))
-    let initModel'   = Torch.Typed.Device.toDevice @'( 'D.CPU, 0) @device . Torch.Typed.DType.toDType @'D.Float @dtype $ initModel
+    let initModel'   = Torch.Typed.Device.toDevice @device @'( 'D.CPU, 0) . Torch.Typed.DType.toDType @dtype @'D.Float $ initModel
         initOptim    = mkGD
         a :: Float   = 20.0
         b :: Float   = 0.2
@@ -358,7 +358,7 @@ instance
   apply GDMAckleySpec _ _ = do
     ATen.manual_seed_L 123
     initModel <- A.sample (AckleySpec @2 @'D.Float @'( 'D.CPU, 0))
-    let initModel'   = Torch.Typed.Device.toDevice @'( 'D.CPU, 0) @device . Torch.Typed.DType.toDType @'D.Float @dtype $ initModel
+    let initModel'   = Torch.Typed.Device.toDevice @device @'( 'D.CPU, 0) . Torch.Typed.DType.toDType @dtype @'D.Float $ initModel
         initOptim    = mkGDM 0.9 (flattenParameters initModel')
         a :: Float   = 20.0
         b :: Float   = 0.2
@@ -373,7 +373,7 @@ instance
   apply AdamAckleySpec _ _ = do
     ATen.manual_seed_L 123
     initModel <- A.sample (AckleySpec @2 @'D.Float @'( 'D.CPU, 0))
-    let initModel'   = Torch.Typed.Device.toDevice @'( 'D.CPU, 0) @device . Torch.Typed.DType.toDType @'D.Float @dtype $ initModel
+    let initModel'   = Torch.Typed.Device.toDevice @device @'( 'D.CPU, 0) . Torch.Typed.DType.toDType @dtype @'D.Float $ initModel
         initOptim    = mkAdam 0 0.9 0.999 (flattenParameters initModel')
         a :: Float   = 20.0
         b :: Float   = 0.2

--- a/hasktorch/test/Torch/Typed/TensorSpec.hs
+++ b/hasktorch/test/Torch/Typed/TensorSpec.hs
@@ -178,7 +178,7 @@ instance ( TensorOptions shape dtype  device
  where
   apply ToTypeSpec _ _ = do
     let t = ones @shape @dtype @device
-        t' = toType @dtype' t
+        t' = Torch.Typed.Tensor.toDType @dtype' t
     checkDynamicTensorAttributes t'
 
 data ToDeviceSpec = ToDeviceSpec


### PR DESCRIPTION
~this is wip~
This is ready for review!

I implemented two mechanisms:
One for moving (parts of) model ADTs from one device to different one and another mechanism for changing the data type of (parts of) a model ADT.
These mechanisms have very similar implementations and generalize `toDevice` and `toDType`, respectively.
They work kind of like a lens, and they need a `Generic` instance for the model data type. Furthermore, the model data type must be parameterized over at least one device type or at least one dtype type, respectively. I used type families to walk the type parameters of the model data type until I find the device or dtype I want to change.
This idea came to me after reading the generic-lens paper by Csongor Kiss et al.