### PR TITLE
Making import list explicit in regression example

### DIFF
--- a/examples/regression/Main.hs
+++ b/examples/regression/Main.hs
@@ -5,13 +5,20 @@
 module Main where
 
 import Control.Monad (foldM, when)
-
-import Torch.Tensor
+import Torch.Autograd (grad, makeIndependent, toDependent)
 import Torch.DType (DType (Float))
-import Torch.TensorFactories (ones', rand', randn')
-import Torch.Functional
-import Torch.Autograd
+import Torch.Functional (squeezeAll, matmul, mse_loss)
 import Torch.NN
+  ( Linear (Linear, bias, weight),
+    LinearSpec (LinearSpec, in_features, out_features),
+    flattenParameters,
+    linear,
+    replaceParameters,
+    sample,
+    sgd,
+  )
+import Torch.Tensor (Tensor, asTensor)
+import Torch.TensorFactories (ones', rand', randn')
 
 batch_size = 64
 num_iters = 2000


### PR DESCRIPTION
This is a small PR that makes the import list explicit in the regression example. As a newcomer to hasktorch, it has been useful for me to better track functions and data types. I thought it might also be useful for other newcomers.

I followed the import style guide instruction from here:
https://github.com/tweag/guides/blob/master/style/Haskell.md