### PR TITLE
Print current seed before test

### DIFF
--- a/hasktorch/test/Torch/Typed/FunctionalSpec.hs
+++ b/hasktorch/test/Torch/Typed/FunctionalSpec.hs
@@ -68,6 +68,7 @@ import           Torch.Typed.Factories
 import           Torch.Typed.Functional
 import           Torch.Typed.Tensor
 import           Torch.Typed.AuxSpec
+import qualified Torch.Internal.Managed.Type.Context as LibTorch
 
 data UnaryAllDTypesSpec =
     SignSpec
@@ -721,7 +722,13 @@ instance ( TensorOptions shape  'D.Bool device
         t' = all' @dim @keepOrDropDim t
     checkDynamicTensorAttributes t'
 
-spec = foldMap spec' availableDevices
+spec = before_ printSeed $ do
+  foldMap spec' availableDevices
+  where
+    printSeed = do
+      putStr "      seed:"
+      LibTorch.get_manual_seed >>= print
+      
 
 spec' :: D.Device -> Spec
 spec' device =

--- a/libtorch-ffi/src/Torch/Internal/Managed/Type/Context.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Type/Context.hs
@@ -85,3 +85,8 @@ manual_seed_L
   -> IO (())
 manual_seed_L = cast1 Unmanaged.manual_seed_L
 
+get_manual_seed
+  :: IO (Word64)
+get_manual_seed = do
+  g <- getDefaultCPUGenerator
+  generator_current_seed g


### PR DESCRIPTION
When using a certain seed, test fails. 
But we do not know the seed used in the test.
This pr outputs using seed before test to find out the cause of the error.

https://github.com/hasktorch/hasktorch/runs/437503475?check_suite_focus=true