### PR TITLE
add topk typed implementation

### DIFF
--- a/hasktorch/src/Torch/Typed/Aux.hs
+++ b/hasktorch/src/Torch/Typed/Aux.hs
@@ -149,10 +149,9 @@ type family ReplaceDim (dim :: Nat) (shape :: [Nat]) (n :: Nat) :: Maybe [Nat] w
   ReplaceDim dim (h ': t) n = AppendToMaybe h (ReplaceDim (dim - 1) t n)
   ReplaceDim _   _        _ = Nothing
 
-type family FromJust (ma :: Maybe k) :: k where 
-  FromJust Nothing = TypeError (Text "FromJust on Nothing!")
-  FromJust (Just a ) = a
-
+type family If c t e where
+  If 'True  t e = t
+  If 'False t e = e
 --------------------------------------------------------------------------------
 -- Operations
 --------------------------------------------------------------------------------

--- a/hasktorch/src/Torch/Typed/Aux.hs
+++ b/hasktorch/src/Torch/Typed/Aux.hs
@@ -149,6 +149,10 @@ type family ReplaceDim (dim :: Nat) (shape :: [Nat]) (n :: Nat) :: Maybe [Nat] w
   ReplaceDim dim (h ': t) n = AppendToMaybe h (ReplaceDim (dim - 1) t n)
   ReplaceDim _   _        _ = Nothing
 
+type family FromJust (ma :: Maybe k) :: k where 
+  FromJust Nothing = TypeError (Text "FromJust on Nothing!")
+  FromJust (Just a ) = a
+
 --------------------------------------------------------------------------------
 -- Operations
 --------------------------------------------------------------------------------

--- a/hasktorch/src/Torch/Typed/Functional.hs
+++ b/hasktorch/src/Torch/Typed/Functional.hs
@@ -3915,6 +3915,11 @@ type TopK k shape dim = TopKCheck k shape dim (ExtractDim dim shape) (ReplaceDim
 
 type TopKIdx k = If (k <=? 0) 0 1
 
+type family TopKDeviceAndDTypeCheck dtype (device :: (D.DeviceType, Nat)) :: Constraint where 
+  TopKDeviceAndDTypeCheck D.Bool _           = (TypeError (Text "topk is not defined for Bool tensors."))
+  TopKDeviceAndDTypeCheck D.Half '(D.CPU, _) = (TypeError (Text "topk is not defined for Half types on CPU."))
+  TopKDeviceAndDTypeCheck _ _ = ()
+
 
 -- | Returns the k largest (if largest is `True`) elements of the given input tensor along a given dimension.
 --
@@ -3929,7 +3934,7 @@ type TopKIdx k = If (k <=? 0) 0 1
 --
 topk 
   :: forall k dim shape dtype device 
-   . (KnownNat k, KnownNat dim, All KnownNat shape) 
+   . (KnownNat k, KnownNat dim, All KnownNat shape, TopKDeviceAndDTypeCheck dtype device) 
    => Tensor device dtype shape 
    -> Bool -- ^ if we're returning the top k largest (or, if False, the top k smallest)
    -> Bool -- ^ if the resulting k elements are themselves sorted

--- a/hasktorch/src/Torch/Typed/Functional.hs
+++ b/hasktorch/src/Torch/Typed/Functional.hs
@@ -3921,11 +3921,11 @@ type family TopKDeviceAndDTypeCheck dtype (device :: (D.DeviceType, Nat)) :: Con
 
 -- | Returns the k largest (if largest is `True`) elements of the given input tensor along a given dimension.
 --
--- >>> topk @3 @1 (ones :: CPUTensor 'D.Float '[2,3]) True True
+-- >>> topk @3 @1 True True (ones :: CPUTensor 'D.Float '[2,3])
 -- (Tensor Float [2,3] [[ 1.0000   ,  1.0000   ,  1.0000   ],
 --                     [ 1.0000   ,  1.0000   ,  1.0000   ]],Tensor Int64 [2,3] [[ 0,  1,  2],
 --                     [ 0,  1,  2]])
--- >>> topk @0 @1 (ones :: CPUTensor 'D.Float '[2,3]) True True
+-- >>> topk @0 @1 True True (ones :: CPUTensor 'D.Float '[2,3])
 -- (Tensor Float [2,0] [[],
 --                     []],Tensor Int64 [2,0] [[],
 --                     []])

--- a/hasktorch/src/Torch/Typed/Functional.hs
+++ b/hasktorch/src/Torch/Typed/Functional.hs
@@ -3908,10 +3908,12 @@ median' input = unsafePerformIO $ ATen.cast3 ATen.Managed.median_tlb
 type family TopKCheck (k :: Nat) (shape :: [Nat]) (dim :: Nat) (satd :: Maybe Nat) (result :: Maybe a) :: a where
   TopKCheck _ shape dim _ Nothing       = DimOutOfBound shape dim
   TopKCheck _ shape dim Nothing _       = DimOutOfBound shape dim
-  TopKCheck k shape dim (Just v) (Just result) = If ( k <=? v ) result (TypeError (Text "k must be less than or equal to the number of elements in the requested dimention and greater than or equal to 1"))
+  TopKCheck k shape dim (Just v) (Just result) = If ( k <=? v ) result (TypeError (Text "k must be less than or equal to the number of elements in the requested dimension."))
 
 
 type TopK k shape dim = TopKCheck k shape dim (ExtractDim dim shape) (ReplaceDim dim shape k)
+
+type TopKIdx k = If (k <=? 0) 0 1
 
 
 -- | Returns the k largest (if largest is `True`) elements of the given input tensor along a given dimension.
@@ -3920,13 +3922,18 @@ type TopK k shape dim = TopKCheck k shape dim (ExtractDim dim shape) (ReplaceDim
 -- (Tensor Float [2,3] [[ 1.0000   ,  1.0000   ,  1.0000   ],
 --                     [ 1.0000   ,  1.0000   ,  1.0000   ]],Tensor Int64 [2,3] [[ 0,  1,  2],
 --                     [ 0,  1,  2]])
+-- >>> topk @0 @1 (ones :: CPUTensor 'D.Float '[2,3]) True True
+-- (Tensor Float [2,0] [[],
+--                  []],Tensor Int64 [2,0] [[],
+--                  []])
+--
 topk 
   :: forall k dim shape dtype device 
    . (KnownNat k, KnownNat dim, All KnownNat shape) 
    => Tensor device dtype shape 
    -> Bool -- ^ if we're returning the top k largest (or, if False, the top k smallest)
    -> Bool -- ^ if the resulting k elements are themselves sorted
-   -> (Tensor device dtype (TopK k shape dim), Tensor device dtype (TopK 1 shape dim))
+   -> (Tensor device dtype (TopK k shape dim), Tensor device dtype (TopK (TopKIdx k) shape dim))
 topk _input _largest _sorted = unsafePerformIO $ (ATen.cast5 ATen.Managed.topk_tllbb) _input _k _dim _largest _sorted
   where 
   _k = natValI @k

--- a/hasktorch/src/Torch/Typed/Functional.hs
+++ b/hasktorch/src/Torch/Typed/Functional.hs
@@ -3905,8 +3905,24 @@ median' input = unsafePerformIO $ ATen.cast3 ATen.Managed.median_tlb
 -- argsort :: Tensor device dtype shape -> Int -> Bool -> Tensor device dtype shape
 -- argsort _input _dim _descending = unsafePerformIO $ (ATen.cast3 ATen.Managed.argsort_tlb) _input _dim _descending
 
--- topk :: Tensor device dtype shape -> Int -> Int -> Bool -> Bool -> (Tensor device dtype shape,Tensor device dtype shape)
--- topk _input _k _dim _largest _sorted = unsafePerformIO $ (ATen.cast5 ATen.Managed.topk_tllbb) _input _k _dim _largest _sorted
+
+-- | Returns the k largest (if largest is `True`) elements of the given input tensor along a given dimension.
+--
+-- >>> topk @3 @1 (ones :: CPUTensor 'D.Float '[2,3]) True True
+-- (Tensor Float [2,3] [[ 1.0000   ,  1.0000   ,  1.0000   ],
+--                     [ 1.0000   ,  1.0000   ,  1.0000   ]],Tensor Int64 [2,3] [[ 0,  1,  2],
+--                     [ 0,  1,  2]])
+topk 
+  :: forall k dim shape dtype device 
+   . (KnownNat k, KnownNat dim, All KnownNat shape, DimOutOfBoundCheck shape dim, FromJust (ExtractDim dim shape) >= k) 
+   => Tensor device dtype shape 
+   -> Bool -- ^ if we're returning the top k largest (or top k smallest)
+   -> Bool -- ^ if the resulting k elements are themselves sorted
+   -> (Tensor device dtype (FromJust (ReplaceDim dim shape k)), Tensor device dtype (FromJust (ReplaceDim dim shape 1)))
+topk _input _largest _sorted = unsafePerformIO $ (ATen.cast5 ATen.Managed.topk_tllbb) _input _k _dim _largest _sorted
+  where 
+  _k = natValI @k
+  _dim = natValI @dim
 
 -- renorm :: Tensor device dtype shape -> Float -> Int -> Float -> Tensor device dtype shape
 -- renorm _input _p _dim _maxnorm = unsafePerformIO $ (ATen.cast4 ATen.Managed.renorm_tsls) _input _p _dim _maxnorm

--- a/hasktorch/src/Torch/Typed/Functional.hs
+++ b/hasktorch/src/Torch/Typed/Functional.hs
@@ -3936,7 +3936,7 @@ topk
    => Bool -- ^ if we're returning the top k largest (or, if False, the top k smallest)
    -> Bool -- ^ if the resulting k elements are themselves sorted
    -> Tensor device dtype shape 
-   -> (Tensor device dtype (TopK k shape dim), Tensor device dtype (TopK k shape dim))
+   -> (Tensor device dtype (TopK k shape dim), Tensor device 'D.Int64 (TopK k shape dim))
 topk _largest _sorted _input = unsafePerformIO $ (ATen.cast5 ATen.Managed.topk_tllbb) _input _k _dim _largest _sorted
   where 
   _k = natValI @k

--- a/hasktorch/src/Torch/Typed/Functional.hs
+++ b/hasktorch/src/Torch/Typed/Functional.hs
@@ -3924,8 +3924,8 @@ type TopKIdx k = If (k <=? 0) 0 1
 --                     [ 0,  1,  2]])
 -- >>> topk @0 @1 (ones :: CPUTensor 'D.Float '[2,3]) True True
 -- (Tensor Float [2,0] [[],
---                  []],Tensor Int64 [2,0] [[],
---                  []])
+--                     []],Tensor Int64 [2,0] [[],
+--                     []])
 --
 topk 
   :: forall k dim shape dtype device 

--- a/hasktorch/test/Torch/Typed/FunctionalSpec.hs
+++ b/hasktorch/test/Torch/Typed/FunctionalSpec.hs
@@ -883,4 +883,9 @@ spec' device =
         let c = maxPool2d @'(1,1) @'(1,1) @'(0,0) (ones :: CPUTensor 'D.Float '[1,3,4,5])
         checkDynamicTensorAttributes c
 
+    describe "sorting" $ 
+      it "topk" $ do 
+        let c = topk @3 @1 True True (ones :: CPUTensor 'D.Float '[2,3])
+        checkDynamicTensorAttributes c
+
     describe "binary native ops" $ return ()

--- a/hasktorch/test/Torch/Typed/FunctionalSpec.hs
+++ b/hasktorch/test/Torch/Typed/FunctionalSpec.hs
@@ -885,7 +885,8 @@ spec' device =
 
     describe "sorting" $ 
       it "topk" $ do 
-        let c = topk @3 @1 True True (ones :: CPUTensor 'D.Float '[2,3])
+        let (c,c') = topk @3 @1 True True (ones :: CPUTensor 'D.Float '[2,3])
         checkDynamicTensorAttributes c
+        checkDynamicTensorAttributes c'
 
     describe "binary native ops" $ return ()


### PR DESCRIPTION
Assuming doctests don't balk at the test, this should be functional.   I needed a `FromJust` type family to work with the existing families which is maybe more principled than writing a dedicated type family at the cost of exposing unnecessary logic. 