### PR TITLE
Add typed GRUCell with tests

### DIFF
--- a/hasktorch/hasktorch.cabal
+++ b/hasktorch/hasktorch.cabal
@@ -101,6 +101,8 @@ test-suite spec
                     , Torch.Typed.NNSpec
                     , Torch.Typed.NN.Recurrent.LSTMSpec
                     , Torch.Typed.NN.Recurrent.GRUSpec
+                    , Torch.Typed.NN.Recurrent.Cell.LSTMSpec
+                    , Torch.Typed.NN.Recurrent.Cell.GRUSpec
                     , Torch.Typed.NN.TransformerSpec
                     , Torch.Typed.VisionSpec
                     , SerializeSpec

--- a/hasktorch/hasktorch.cabal
+++ b/hasktorch/hasktorch.cabal
@@ -32,6 +32,7 @@ library
                     , Torch.Typed.NN
                     , Torch.Typed.NN.DataParallel
                     , Torch.Typed.NN.Recurrent.Cell.LSTM
+                    , Torch.Typed.NN.Recurrent.Cell.GRU
                     , Torch.Typed.NN.Recurrent.LSTM
                     , Torch.Typed.NN.Recurrent.GRU
                     , Torch.Typed.NN.Transformer

--- a/hasktorch/src/Torch/Typed/Functional.hs
+++ b/hasktorch/src/Torch/Typed/Functional.hs
@@ -3632,8 +3632,22 @@ gru tensorParameters dropoutProb dropoutOn hc input = unsafePerformIO $ ATen.cas
   numLayers :: I.Int64
   numLayers  = fromIntegral $ natValI @numLayers
 
--- gru_cell :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape
--- gru_cell _input _hx _w_ih _w_hh _b_ih _b_hh = unsafePerformIO $ (ATen.cast6 ATen.Managed.gru_cell_tttttt) _input _hx _w_ih _w_hh _b_ih _b_hh
+-- | gruCell
+--
+-- >>> dtype &&& shape $ gruCell (ones :: CPUTensor 'D.Float '[9,2]) (ones :: CPUTensor 'D.Float '[9,3]) (ones :: CPUTensor 'D.Float '[9]) (ones :: CPUTensor 'D.Float '[9]) (ones :: CPUTensor 'D.Float '[2,3]) (ones :: CPUTensor 'D.Float '[2,2])
+-- (Float,[2,3])
+gruCell
+  :: forall inputSize hiddenSize batchSize dtype device
+   . Tensor device dtype '[3 * hiddenSize, inputSize]
+  -> Tensor device dtype '[3 * hiddenSize, hiddenSize]
+  -> Tensor device dtype '[3 * hiddenSize]
+  -> Tensor device dtype '[3 * hiddenSize]
+  -> Tensor device dtype '[batchSize, hiddenSize]
+  -> Tensor device dtype '[batchSize, inputSize]
+  -> Tensor device dtype '[batchSize, hiddenSize]
+gruCell wi wh bi bh hx input =
+  unsafePerformIO
+    $ ATen.cast6 ATen.Managed.gru_cell_tttttt input hx wi wh bi bh
 
 -- rnn_tanh_cell :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape
 -- rnn_tanh_cell _input _hx _w_ih _w_hh _b_ih _b_hh = unsafePerformIO $ (ATen.cast6 ATen.Managed.rnn_tanh_cell_tttttt) _input _hx _w_ih _w_hh _b_ih _b_hh

--- a/hasktorch/src/Torch/Typed/NN/Recurrent/Cell/GRU.hs
+++ b/hasktorch/src/Torch/Typed/NN/Recurrent/Cell/GRU.hs
@@ -1,0 +1,121 @@
+{-# LANGUAGE AllowAmbiguousTypes     #-}
+{-# LANGUAGE DataKinds               #-}
+{-# LANGUAGE DeriveGeneric           #-}
+{-# LANGUAGE FlexibleContexts        #-}
+{-# LANGUAGE FlexibleInstances       #-}
+{-# LANGUAGE MultiParamTypeClasses   #-}
+{-# LANGUAGE NoStarIsType            #-}
+{-# LANGUAGE OverloadedLists         #-}
+{-# LANGUAGE PolyKinds               #-}
+{-# LANGUAGE RankNTypes              #-}
+{-# LANGUAGE RecordWildCards         #-}
+{-# LANGUAGE ScopedTypeVariables     #-}
+{-# LANGUAGE TypeFamilies            #-}
+{-# LANGUAGE TypeOperators           #-}
+{-# LANGUAGE UndecidableInstances    #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
+{-# OPTIONS_GHC -fplugin GHC.TypeLits.Normalise #-}
+{-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver #-}
+{-# OPTIONS_GHC -fplugin GHC.TypeLits.Extra.Solver #-}
+{-# OPTIONS_GHC -fconstraint-solver-iterations=0 #-}
+
+module Torch.Typed.NN.Recurrent.Cell.GRU where
+
+import           Data.List                      ( foldl'
+                                                , scanl'
+                                                )
+import           GHC.Generics
+import           GHC.TypeLits
+import qualified Torch.Device                  as D
+import qualified Torch.DType                   as D
+import qualified Torch.NN                      as A
+import           Torch.Typed.Tensor
+import           Torch.Typed.Parameter
+import           Torch.Typed.Factories
+import           Torch.Typed.Functional      hiding ( linear )
+import           Torch.Typed.NN
+
+-- | A specification for a gated recurrent unit (GRU) cell.
+--
+data GRUCellSpec (inputDim :: Nat) (hiddenDim :: Nat)
+                  (dtype :: D.DType)
+                  (device :: (D.DeviceType, Nat))
+  = GRUCellSpec -- ^ Weights and biases are drawn from the standard normal distibution (having mean 0 and variance 1)
+  deriving (Show, Eq, Ord, Generic, Enum, Bounded)
+
+-- | A gated recurrent unit (GRU) cell.
+--
+data GRUCell (inputDim :: Nat) (hiddenDim :: Nat)
+              (dtype :: D.DType)
+              (device :: (D.DeviceType, Nat))
+  =  GRUCell { gruCell_w_ih :: Parameter device dtype '[3 * hiddenDim, inputDim] -- ^ input-to-hidden weights
+              , gruCell_w_hh :: Parameter device dtype '[3 * hiddenDim, hiddenDim] -- ^ hidden-to-hidden weights
+              , gruCell_b_ih :: Parameter device dtype '[3 * hiddenDim] -- ^ input-to-hidden bias
+              , gruCell_b_hh :: Parameter device dtype '[3 * hiddenDim] -- ^ hidden-to-hidden bias
+              }
+  deriving Generic
+
+instance ( KnownDevice device
+         , KnownDType dtype
+         , KnownNat inputDim
+         , KnownNat hiddenDim
+         , RandDTypeIsValid device dtype
+         )
+  => A.Randomizable
+       (GRUCellSpec inputDim hiddenDim dtype device)
+       (GRUCell     inputDim hiddenDim dtype device)
+ where
+  sample GRUCellSpec =
+    GRUCell
+      <$> (makeIndependent =<< randn)
+      <*> (makeIndependent =<< randn)
+      <*> (makeIndependent =<< randn)
+      <*> (makeIndependent =<< randn)
+
+-- | A single recurrent step of a `GRUCell`
+--
+forwardStep
+  :: forall inputDim hiddenDim batchSize dtype device
+   . ( KnownDType dtype
+     , KnownNat inputDim
+     , KnownNat hiddenDim
+     , KnownNat batchSize
+     )
+  => GRUCell inputDim hiddenDim dtype device -- ^ The cell
+  -> Tensor device dtype '[batchSize, hiddenDim]-- ^ The current Hidden state
+  -> Tensor device dtype '[batchSize, inputDim]-- ^ The input
+  -> Tensor device dtype '[batchSize, hiddenDim]-- ^ The subsequent Hidden state
+forwardStep GRUCell {..} = gruCell   (toDependent gruCell_w_ih)
+                                     (toDependent gruCell_w_hh)
+                                     (toDependent gruCell_b_ih)
+                                     (toDependent gruCell_b_hh)
+
+-- | foldl' for lists of tensors unsing a `GRUCell`
+--
+forward
+  :: forall inputDim hiddenDim batchSize dtype device
+   . ( KnownDType dtype
+     , KnownNat inputDim
+     , KnownNat hiddenDim
+     , KnownNat batchSize
+     )
+  => GRUCell inputDim hiddenDim dtype device
+  -> Tensor device dtype '[batchSize, hiddenDim] -- ^ The initial Hidden state
+  -> [Tensor device dtype '[batchSize, inputDim]] -- ^ The list of inputs
+  -> Tensor device dtype '[batchSize, hiddenDim] -- ^ The final Hidden state
+forward cell = foldl' (forwardStep cell)
+
+-- | scanl' for lists of tensors unsing a `GRUCell`
+--
+forwardScan
+  :: forall inputDim hiddenDim batchSize dtype device
+   . ( KnownDType dtype
+     , KnownNat inputDim
+     , KnownNat hiddenDim
+     , KnownNat batchSize
+     )
+  => GRUCell inputDim hiddenDim dtype device
+  -> Tensor device dtype '[batchSize, hiddenDim] -- ^ The initial Hidden state
+  -> [Tensor device dtype '[batchSize, inputDim]] -- ^ The list of inputs
+  -> [Tensor device dtype '[batchSize, hiddenDim]] -- ^ All subsequent Hidden states
+forwardScan cell = scanl' (forwardStep cell)

--- a/hasktorch/test/Torch/Typed/FunctionalSpec.hs
+++ b/hasktorch/test/Torch/Typed/FunctionalSpec.hs
@@ -650,14 +650,8 @@ instance
   ( TensorOptions '[4 * hiddenSize, inputSize] dtype device
   , TensorOptions '[4 * hiddenSize, hiddenSize] dtype device
   , TensorOptions '[4 * hiddenSize] dtype device
-  , TensorOptions '[4 * hiddenSize] dtype device
-  , ( TensorOptions '[batchSize, hiddenSize] dtype device
-    , TensorOptions '[batchSize, hiddenSize] dtype device
-    )
+  , TensorOptions '[batchSize, hiddenSize] dtype device
   , TensorOptions '[batchSize, inputSize] dtype device
-  , ( TensorOptions '[batchSize, hiddenSize] dtype device
-    , TensorOptions '[batchSize, hiddenSize] dtype device
-    )
   , KnownNat inputSize, KnownNat hiddenSize, KnownNat batchSize
   ) => Apply' LstmCellSpec ((Proxy device, (Proxy dtype, (Proxy hiddenSize, Proxy inputSize, Proxy batchSize))), IO ()) (IO ()) where
   apply' LstmCellSpec (_, agg) = agg >> do
@@ -678,10 +672,8 @@ instance
   ( TensorOptions '[3 * hiddenSize, inputSize] dtype device
   , TensorOptions '[3 * hiddenSize, hiddenSize] dtype device
   , TensorOptions '[3 * hiddenSize] dtype device
-  , TensorOptions '[3 * hiddenSize] dtype device
   , TensorOptions '[batchSize, hiddenSize] dtype device
   , TensorOptions '[batchSize, inputSize] dtype device
-  , TensorOptions '[batchSize, hiddenSize] dtype device
   , KnownNat inputSize, KnownNat hiddenSize, KnownNat batchSize
   ) => Apply' GruCellSpec ((Proxy device, (Proxy dtype, (Proxy hiddenSize, Proxy inputSize, Proxy batchSize))), IO ()) (IO ()) where
   apply' GruCellSpec (_, agg) = agg >> do

--- a/hasktorch/test/Torch/Typed/NN/Recurrent/Cell/GRUSpec.hs
+++ b/hasktorch/test/Torch/Typed/NN/Recurrent/Cell/GRUSpec.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE DataKinds #-}
+
+module Torch.Typed.NN.Recurrent.Cell.GRUSpec
+  ( Torch.Typed.NN.Recurrent.Cell.GRUSpec.spec
+  )
+where
+
+import           Test.Hspec
+
+import           Torch.HList
+import qualified Torch.NN                      as A
+import qualified Torch.DType                   as D
+import qualified Torch.Device                  as D
+import           Torch.Typed.Factories
+import           Torch.Typed.Functional
+import           Torch.Typed.Parameter
+import           Torch.Typed.NN
+import           Torch.Typed.NN.Recurrent.Cell.GRU
+
+spec :: Spec
+spec = return ()
+
+testGRUCell
+  :: IO
+       (HList
+          '[Parameter '( 'D.CPU, 0) 'D.Float '[21, 5],
+            Parameter '( 'D.CPU, 0) 'D.Float '[21, 7],
+            Parameter '( 'D.CPU, 0) 'D.Float '[21],
+            Parameter '( 'D.CPU, 0) 'D.Float '[21]])
+
+testGRUCell = do
+  let spec = GRUCellSpec  @5 @7 @'D.Float @'( 'D.CPU, 0)
+  model <- A.sample spec
+  pure . flattenParameters $ model

--- a/hasktorch/test/Torch/Typed/NN/Recurrent/Cell/GRUSpec.hs
+++ b/hasktorch/test/Torch/Typed/NN/Recurrent/Cell/GRUSpec.hs
@@ -13,9 +13,7 @@ import qualified Torch.NN                      as A
 import qualified Torch.DType                   as D
 import qualified Torch.Device                  as D
 import           Torch.Typed.Factories
-import           Torch.Typed.Functional
 import           Torch.Typed.Parameter
-import           Torch.Typed.NN
 import           Torch.Typed.NN.Recurrent.Cell.GRU
 
 spec :: Spec

--- a/hasktorch/test/Torch/Typed/NN/Recurrent/Cell/LSTMSpec.hs
+++ b/hasktorch/test/Torch/Typed/NN/Recurrent/Cell/LSTMSpec.hs
@@ -13,9 +13,7 @@ import qualified Torch.NN                      as A
 import qualified Torch.DType                   as D
 import qualified Torch.Device                  as D
 import           Torch.Typed.Factories
-import           Torch.Typed.Functional
 import           Torch.Typed.Parameter
-import           Torch.Typed.NN
 import           Torch.Typed.NN.Recurrent.Cell.LSTM
 
 spec :: Spec

--- a/hasktorch/test/Torch/Typed/NN/Recurrent/Cell/LSTMSpec.hs
+++ b/hasktorch/test/Torch/Typed/NN/Recurrent/Cell/LSTMSpec.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE DataKinds #-}
+
+module Torch.Typed.NN.Recurrent.Cell.LSTMSpec
+  ( Torch.Typed.NN.Recurrent.Cell.LSTMSpec.spec
+  )
+where
+
+import           Test.Hspec
+
+import           Torch.HList
+import qualified Torch.NN                      as A
+import qualified Torch.DType                   as D
+import qualified Torch.Device                  as D
+import           Torch.Typed.Factories
+import           Torch.Typed.Functional
+import           Torch.Typed.Parameter
+import           Torch.Typed.NN
+import           Torch.Typed.NN.Recurrent.Cell.LSTM
+
+spec :: Spec
+spec = return ()
+
+testLSTMCell
+  :: IO
+       (HList
+          '[Parameter '( 'D.CPU, 0) 'D.Float '[28, 5],
+            Parameter '( 'D.CPU, 0) 'D.Float '[28, 7],
+            Parameter '( 'D.CPU, 0) 'D.Float '[28],
+            Parameter '( 'D.CPU, 0) 'D.Float '[28]])
+
+testLSTMCell = do
+  let spec = LSTMCellSpec  @5 @7 @'D.Float @'( 'D.CPU, 0)
+  model <- A.sample spec
+  pure . flattenParameters $ model


### PR DESCRIPTION
This PR implements refined type of gruCell in Torch.Typed.Functional,
 GRUCell in Torch.Typed.NN.Recurrent.Cell.GRU,
and adds tests for LSTMCell and GRUCell in Torch.Typed.NN.Recurrent.Cell