### PR TITLE
Add typed mean ops (wip)

### DIFF
--- a/hasktorch/src/Torch/Typed/Functional.hs
+++ b/hasktorch/src/Torch/Typed/Functional.hs
@@ -228,6 +228,19 @@ median
   -> Tensor device dtype '[] -- ^ output
 median input = unsafePerformIO $ ATen.cast1 ATen.Managed.median_t input
 
+-- | mean
+--
+-- >>> dtype &&& shape $ mean (ones :: CPUTensor 'D.Float '[2,2])
+-- (Float,[])
+mean
+  :: forall shape dtype device
+  . ( AggregationDTypeIsValid device dtype
+    , AllDimsPositive shape
+    )
+  => Tensor device dtype shape -- ^ input
+  -> Tensor device dtype '[] -- ^ output
+mean input = unsafePerformIO $ ATen.cast1 ATen.Managed.mean_t input
+
 -- | addScalar
 -- TODO: what dtypes is this defined for?
 -- TODO: what scalar types is this defined for?
@@ -3895,6 +3908,48 @@ median'
      , Tensor device 'D.Int64 (ConditionalDropDimension shape dim keepOrDropDim)
      )
 median' input = unsafePerformIO $ ATen.cast3 ATen.Managed.median_tlb
+                                        input
+                                        (natValI @dim)
+                                        (keepOrDropDimVal @keepOrDropDim)
+
+-- | meanAll
+--
+-- >>> dtype &&& shape $ meanAll (ones :: CPUTensor 'D.Float '[2,2])
+-- (Float,[])
+meanAll
+  :: forall shape dtype device
+   . Tensor device dtype shape -- ^ input
+  -> Tensor device dtype '[] -- ^ output
+meanAll input = unsafePerformIO $ ATen.cast1 ATen.Managed.mean_t input
+
+-- | meanDim
+--
+-- >>> t = ones :: CPUTensor 'D.Float '[3,4,5]
+-- >>> dtype &&& shape $ meanDim @0 t
+-- (Float,[4,5])
+-- >>> dtype &&& shape $ meanDim @1 t
+-- (Float,[3,5])
+-- >>> dtype &&& shape $ meanDim @2 t
+-- (Float,[3,4])
+meanDim
+  :: forall d shape dtype device
+   . (KnownNat d)
+  => Tensor device dtype shape -- ^ input
+  -> Tensor device dtype    (DropValue shape d) -- ^ output
+meanDim input = unsafePerformIO $ ATen.cast2 ATen.Managed.mean_tl input (natValI @d)
+
+-- | mean
+-- See https://pytorch.org/docs/stable/torch.html#torch.mean.
+--
+-- >>> t = fromJust [[5, 1], [3, 2], [4, 1], [2, 7]] :: CPUTensor 'D.Float '[4, 2]
+-- >>> mean' @0 @KeepDim t
+-- Tensor Float [1,2] [[ 3.5000   ,  2.7500   ]]
+mean'
+  :: forall dim keepOrDropDim shape dtype device
+   . (KnownNat dim, KnownKeepOrDropDim keepOrDropDim)
+  => Tensor device dtype shape
+  -> Tensor device dtype (ConditionalDropDimension shape dim keepOrDropDim)
+mean' input = unsafePerformIO $ ATen.cast3 ATen.Managed.mean_tlb
                                         input
                                         (natValI @dim)
                                         (keepOrDropDimVal @keepOrDropDim)

--- a/hasktorch/test/Torch/Typed/FunctionalSpec.hs
+++ b/hasktorch/test/Torch/Typed/FunctionalSpec.hs
@@ -314,6 +314,7 @@ data AggregationSpec =
     MinSpec
   | MaxSpec
   | MedianSpec
+  | MeanSpec
 
 instance
   ( TensorOptions shape dtype device
@@ -331,6 +332,10 @@ instance
         t' = min t
     checkDynamicTensorAttributes t'
   apply' MedianSpec (_, agg) = agg >> do
+    let t = ones @shape @dtype @device
+        t' = min t
+    checkDynamicTensorAttributes t'
+  apply' MeanSpec (_, agg) = agg >> do
     let t = ones @shape @dtype @device
         t' = min t
     checkDynamicTensorAttributes t'
@@ -761,6 +766,7 @@ spec' device =
       it "min"    $ dispatch MinSpec
       it "max"    $ dispatch MaxSpec
       it "median" $ dispatch MedianSpec
+      it "mean"   $ dispatch MeanSpec
 
     describe "shape ops" $ do
       it "squeezeAll" $ case device of


### PR DESCRIPTION
this is my wip attempt at adding typed mean ops,
pretty much just copied over from their median variants.
this is currently still yielding errors:

```haskell
> /meltan/downloads/repos/hasktorch/hasktorch/src/Torch/Typed/Functional.hs:3941:35: error:
>     • Could not deduce (ATen.CppTuple2 (ForeignPtr ATen.Tensor))
>         arising from a use of ‘ATen.cast2’
>       from the context: KnownNat d
>         bound by the type signature for:
>                    meanDim :: forall (d :: Nat) (shape :: [Nat]) (dtype :: D.DType) (device :: (D.DeviceType,
>                                                                                                 Nat)).
>                               KnownNat d =>
>                               Tensor device dtype shape
>                               -> (Tensor device dtype (DropValue shape d),
>                                   Tensor device 'D.Int64 (DropValue shape d))
>         at src/Torch/Typed/Functional.hs:(3934,1)-(3940,6)
>     • In the second argument of ‘($)’, namely
>         ‘ATen.cast2 ATen.Managed.mean_tl input (natValI @d)’
>       In the expression:
>         unsafePerformIO
>           $ ATen.cast2 ATen.Managed.mean_tl input (natValI @d)
>       In an equation for ‘meanDim’:
>           meanDim input
>             = unsafePerformIO
>                 $ ATen.cast2 ATen.Managed.mean_tl input (natValI @d)
>      |
> 3941 | meanDim input = unsafePerformIO $ ATen.cast2 ATen.Managed.mean_tl input (natValI @d)
>      |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 
> /meltan/downloads/repos/hasktorch/hasktorch/src/Torch/Typed/Functional.hs:3956:33: error:
>     • Could not deduce (ATen.CppTuple2 (ForeignPtr ATen.Tensor))
>         arising from a use of ‘ATen.cast3’
>       from the context: (KnownNat dim, KnownKeepOrDropDim keepOrDropDim)
>         bound by the type signature for:
>                    mean' :: forall (dim :: Nat) (keepOrDropDim :: KeepOrDropDim) (shape :: [Nat]) (dtype :: D.DType) (device :: (D.DeviceType,
>                                                                                                                                  Nat)).
>                             (KnownNat dim, KnownKeepOrDropDim keepOrDropDim) =>
>                             Tensor device dtype shape
>                             -> (Tensor
>                                   device dtype (ConditionalDropDimension shape dim keepOrDropDim),
>                                 Tensor
>                                   device
>                                   'D.Int64
>                                   (ConditionalDropDimension shape dim keepOrDropDim))
>         at src/Torch/Typed/Functional.hs:(3949,1)-(3955,6)
>     • In the second argument of ‘($)’, namely
>         ‘ATen.cast3
>            ATen.Managed.mean_tlb
>            input
>            (natValI @dim)
>            (keepOrDropDimVal @keepOrDropDim)’
>       In the expression:
>         unsafePerformIO
>           $ ATen.cast3
>               ATen.Managed.mean_tlb
>               input
>               (natValI @dim)
>               (keepOrDropDimVal @keepOrDropDim)
>       In an equation for ‘mean'’:
>           mean' input
>             = unsafePerformIO
>                 $ ATen.cast3
>                     ATen.Managed.mean_tlb
>                     input
>                     (natValI @dim)
>                     (keepOrDropDimVal @keepOrDropDim)
>      |
> 3956 | mean' input = unsafePerformIO $ ATen.cast3 ATen.Managed.mean_tlb
>      |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^...
```
