### PR TITLE
Torch.Functional param order: subject-last

### DIFF
--- a/examples/gaussian-process/Main.hs
+++ b/examples/gaussian-process/Main.hs
@@ -26,7 +26,7 @@ kernel1d_rbf :: Double -> Double -> Tensor -> Tensor -> Tensor
 kernel1d_rbf sigma length t t' = (sigma'^2) * exp eterm
     where
         sigma' = asTensor sigma
-        eterm = mulScalar (- (pow (t - t') (2 :: Int))) (1 / (2 * length^2) )
+        eterm = mulScalar (1 / (2 * length^2) ) (- (pow (t - t') (2 :: Int)))
 
 -- | derive a covariance matrix from the kernel for points on the axis
 makeCovmatrix :: [Float] -> [Float] -> CovMatrix

--- a/examples/gaussian-process/Main.hs
+++ b/examples/gaussian-process/Main.hs
@@ -26,7 +26,7 @@ kernel1d_rbf :: Double -> Double -> Tensor -> Tensor -> Tensor
 kernel1d_rbf sigma length t t' = (sigma'^2) * exp eterm
     where
         sigma' = asTensor sigma
-        eterm = mulScalar (1 / (2 * length^2) ) (- (pow (t - t') (2 :: Int)))
+        eterm = mulScalar (1 / (2 * length^2) ) (- (pow (2 :: Int) (t - t')))
 
 -- | derive a covariance matrix from the kernel for points on the axis
 makeCovmatrix :: [Float] -> [Float] -> CovMatrix
@@ -41,7 +41,7 @@ mvnCholesky (CovMatrix cov) axisDim n = do
     samples <- randnIO' [axisDim, n]
     pure $ matmul l samples
     where 
-      l = cholesky Upper cov
+      l = cholesky cov Upper
 
 -- | Compute posterior mean and covariance parameters based on observed data y
 condition 

--- a/examples/gaussian-process/Main.hs
+++ b/examples/gaussian-process/Main.hs
@@ -41,7 +41,7 @@ mvnCholesky (CovMatrix cov) axisDim n = do
     samples <- randnIO' [axisDim, n]
     pure $ matmul l samples
     where 
-      l = cholesky cov Upper
+      l = cholesky Upper cov
 
 -- | Compute posterior mean and covariance parameters based on observed data y
 condition 

--- a/examples/load-torchscript/Main.hs
+++ b/examples/load-torchscript/Main.hs
@@ -37,7 +37,7 @@ main = prettyException $ do
   case (mimg,mode) of
     (Left err,_) -> print err
     (Right img',"resnet")-> do
-      let img'' = (D.toType D.Float $ hwc2chw img') `D.divScalar` (255.0::Float)
+      let img'' = D.divScalar (255.0::Float) $ D.toType D.Float $ hwc2chw img'
           img = IVTensor $ img''
           [[r,g,b]] = D.asValue img'' :: [[[[Float]]]]
       print $ take 10 (head r)
@@ -46,7 +46,7 @@ main = prettyException $ do
         IVTensor v' -> print $ D.argmax (D.Dim 1) D.RemoveDim v'
         _ -> print "Return value is not tensor."
     (Right img',"maskrcnn")-> do
-      let img'' = (D.toType D.Float $ hwc2chw img') `D.divScalar` (255.0::Float)
+      let img'' = D.divScalar (255.0::Float) $ D.toType D.Float $ hwc2chw img'
           [[r,g,b]] = D.asValue img'' :: [[[[Float]]]]
       print $ take 10 (head r)
       let img = IVTensorList [D.squeezeAll $ img'']

--- a/examples/matrix-factorization/SparseRatingMatrix.hs
+++ b/examples/matrix-factorization/SparseRatingMatrix.hs
@@ -54,7 +54,7 @@ lossMF (MatrixFact u v) (RatingBatch items users ratings) = loss
     u''' = reshape [batch_size, 1, -1] u''
     v''' = reshape [batch_size, -1, 1] v''
     uv_ui = toDType (Double :: DType) $ bmm u''' v'''
-    loss = mseLoss uv_ui ratings_tensor
+    loss = mseLoss ratings_tensor uv_ui
 
 n_users = 500
 

--- a/examples/minimal-text-example/Hello.hs
+++ b/examples/minimal-text-example/Hello.hs
@@ -31,7 +31,7 @@ run :: (RecurrentCell a, Parameterized a)
     -> IO (a)
 run input_tensor init_hidden expected_output model i = do
     let output = finalState model input_tensor init_hidden
-        loss = mseLoss output expected_output
+        loss = mseLoss expected_output output
     when (i `mod` 100 == 0) $ do
         print loss
     (newParam, _) <- runStep model GD loss 0.05
@@ -70,7 +70,7 @@ getIndex result = case index of
     Nothing -> -1
     Just x  -> x
     where
-        losses = map toDouble (map (mseLoss result) letters)
+        losses = map toDouble (map (flip mseLoss result) letters)
         min_loss = Prelude.minimum losses
         index = elemIndex min_loss losses
 

--- a/examples/mnist-mlp/Main.hs
+++ b/examples/mnist-mlp/Main.hs
@@ -56,7 +56,7 @@ train trainData = do
             let idx = take batchSize (drop (iter * batchSize) idxList)
             input <- V.getImages' batchSize dataDim trainData idx
             let label = V.getLabels' batchSize trainData idx
-                loss = nllLoss' (mlp state input) label
+                loss = nllLoss' label $ mlp state input
             when (iter `mod` 50 == 0) $ do
                 putStrLn $ "Iteration: " ++ show iter ++ " | Loss: " ++ show loss
             (newParam, _) <- runStep state optimizer loss 1e-3

--- a/examples/optimizers/TestFunctions.hs
+++ b/examples/optimizers/TestFunctions.hs
@@ -29,7 +29,7 @@ instance Parameterized ConvQuad
 
 convexQuadratic :: Tensor -> Tensor -> Tensor -> Tensor
 convexQuadratic a b w =
-    mulScalar (dot w (mv a w)) (0.5 :: Float) - dot b w
+    mulScalar (0.5 :: Float) (dot w (mv a w)) - dot b w
 
 lossConvQuad :: Tensor -> Tensor -> ConvQuad -> Tensor
 lossConvQuad a b (ConvQuad w) = convexQuadratic a b w'
@@ -59,8 +59,8 @@ instance Parameterized Rosen where
   flattenParameters (Rosen x y) = [x, y]
 
 rosenbrock2d :: Float -> Float -> Tensor -> Tensor -> Tensor
-rosenbrock2d a b x y = square (addScalar ((-1.0) * x ) a) + mulScalar (square (y - x*x)) b
-    where square c = pow c (2 :: Int)
+rosenbrock2d a b x y = square (addScalar a ((-1.0) * x )) + mulScalar b (square (y - x*x))
+    where square c = pow (2 :: Int) c
 
 rosenbrock' :: Tensor -> Tensor -> Tensor
 rosenbrock' = rosenbrock2d 1.0 100.0
@@ -82,8 +82,8 @@ instance Parameterized Ackley
 
 ackley :: Float -> Float -> Float -> Tensor -> Tensor
 ackley a b c x = 
-    mulScalar (exp (-b' * (sqrt $ (sumAll (x * x)) / d))) (-a)
-    - exp (1.0 / d * sumAll (cos (mulScalar x c))) 
+    mulScalar (-a) (exp (-b' * (sqrt $ (sumAll (x * x)) / d)))
+    - exp (1.0 / d * sumAll (cos (mulScalar c x))) 
     + (asTensor $ a + P.exp 1.0)
     where
         b' = asTensor b

--- a/examples/regression/Main.hs
+++ b/examples/regression/Main.hs
@@ -29,7 +29,7 @@ main = do
     (trained, _) <- foldLoop (init, randGen) numIters $ \(state, randGen) i -> do
         let (input, randGen') = randn' [batchSize, numFeatures] randGen
             (y, y') = (groundTruth input, model state input)
-            loss = mseLoss y' y
+            loss = mseLoss y y'
         when (i `mod` 100 == 0) $ do
             putStrLn $ "Iteration: " ++ show i ++ " | Loss: " ++ show loss
         (newParam, _) <- runStep state optimizer loss 5e-3 

--- a/examples/rnn/Main.hs
+++ b/examples/rnn/Main.hs
@@ -29,7 +29,7 @@ run :: (RecurrentCell a, Parameterized a)
     -> IO (a) -- ^ new model state
 run input_tensor init_hidden expected_output model i = do
     let output = finalState model input_tensor init_hidden
-        loss = mseLoss output expected_output
+        loss = mseLoss expected_output output
     print loss 
     (newParam, _) <- runStep model GD loss 5e-2
     pure $ replaceParameters model newParam

--- a/examples/serialization/Main.hs
+++ b/examples/serialization/Main.hs
@@ -49,7 +49,7 @@ main = do
     input <- randnIO' [batch_size, num_features]
     let expected_output = groundTruth input
         output          = model state input
-        loss            = mseLoss output expected_output
+        loss            = mseLoss expected_output output
         flat_parameters = flattenParameters state
         gradients       = grad loss flat_parameters
     if i `mod` 100 == 0 then putStrLn $ "Loss: " ++ show loss else pure ()

--- a/examples/static-xor-mlp/Main.hs
+++ b/examples/static-xor-mlp/Main.hs
@@ -123,7 +123,7 @@ main = do
 
     let expectedOutput = xor input
     let actualOutput   = squeezeAll . Main.forward model $ input
-    let loss           = mseLoss @D.ReduceMean actualOutput expectedOutput
+    let loss           = mseLoss @D.ReduceMean expectedOutput actualOutput
 
     when (i `mod` 2500 == 0) (print loss)
 

--- a/examples/vae/Main.hs
+++ b/examples/vae/Main.hs
@@ -56,7 +56,7 @@ vaeLoss recon_x x mu logvar = reconLoss + kld
   where
     -- reconLoss = binary_cross_entropy_loss recon_x x undefined ReduceSum
     reconLoss = mseLoss recon_x x
-    kld = -0.5 * (sumAll (1 + logvar - pow mu (2 :: Int) - exp logvar))
+    kld = -0.5 * (sumAll (1 + logvar - pow (2 :: Int) mu - exp logvar))
 
 -- | End-to-end function for VAE model
 model :: VAEState -> Tensor -> IO ModelOutput

--- a/examples/vae/Main.hs
+++ b/examples/vae/Main.hs
@@ -87,7 +87,7 @@ mvnCholesky cov n axisDim = do
     samples <- randnIO' [axisDim, n]
     pure $ matmul l samples
     where
-      l = cholesky cov Upper
+      l = cholesky Upper cov
 
 -- | Construct and initialize model parameter state
 makeModel :: Int -> Int -> Int -> IO VAEState

--- a/examples/vae/Main.hs
+++ b/examples/vae/Main.hs
@@ -55,7 +55,7 @@ vaeLoss :: Tensor -> Tensor -> Tensor -> Tensor -> Tensor
 vaeLoss recon_x x mu logvar = reconLoss + kld
   where
     -- reconLoss = binary_cross_entropy_loss recon_x x undefined ReduceSum
-    reconLoss = mseLoss recon_x x
+    reconLoss = mseLoss x recon_x
     kld = -0.5 * (sumAll (1 + logvar - pow (2 :: Int) mu - exp logvar))
 
 -- | End-to-end function for VAE model
@@ -87,7 +87,7 @@ mvnCholesky cov n axisDim = do
     samples <- randnIO' [axisDim, n]
     pure $ matmul l samples
     where
-      l = cholesky Upper cov
+      l = cholesky cov Upper
 
 -- | Construct and initialize model parameter state
 makeModel :: Int -> Int -> Int -> IO VAEState

--- a/examples/xor-mlp/Main.hs
+++ b/examples/xor-mlp/Main.hs
@@ -60,7 +60,7 @@ main = do
     trained <- foldLoop init numIters $ \state i -> do
         input <- randIO' [batchSize, 2] >>= return . (toDType Float) . (gt 0.5)
         let (y, y') = (tensorXOR input, squeezeAll $ model state input)
-            loss = mseLoss y' y
+            loss = mseLoss y y'
         when (i `mod` 100 == 0) $ do
             putStrLn $ "Iteration: " ++ show i ++ " | Loss: " ++ show loss
         (newParam, _) <- runStep state optimizer loss 1e-1

--- a/experimental/dataloader-cifar10/Main.hs
+++ b/experimental/dataloader-cifar10/Main.hs
@@ -61,7 +61,7 @@ train numEpoch trainData = do
             let len = length batch
                 input = toType Float $ reshape [len,1024*3] images
                 label = asTensor $ map (fromEnum.snd.getXY) batch
-                loss = nllLoss' (mlp state input) label
+                loss = nllLoss' label $ mlp state input
                 flatParameters = flattenParameters state
             (newParam, _) <- runStep state GD loss 1e-3
             pure $ (replaceParameters state newParam, (toDouble loss)+sumLoss)

--- a/hasktorch/src/Torch/Functional.hs
+++ b/hasktorch/src/Torch/Functional.hs
@@ -194,34 +194,34 @@ median t = unsafePerformIO $ (cast1 ATen.median_t) t
 -- | Adds each element of the input input with the scalar and returns a new resulting tensor.
 addScalar 
  :: Scalar a 
- => Tensor -- ^ input
- -> a -- ^ summand
+ => a -- ^ summand
+ -> Tensor -- ^ input
  -> Tensor -- ^ output
-addScalar t a = unsafePerformIO $ (cast2 ATen.add_ts) t a
+addScalar a t = unsafePerformIO $ (cast2 ATen.add_ts) t a
 
 -- | Subtracts each element of the input input with the scalar and returns a new resulting tensor.
 subScalar 
  :: Scalar a 
- => Tensor -- ^ input
- -> a -- ^ subtrahend
+ => a -- ^ subtrahend
+ -> Tensor -- ^ input
  -> Tensor -- ^ output
-subScalar t a = unsafePerformIO $ (cast2 ATen.sub_ts) t a
+subScalar a t = unsafePerformIO $ (cast2 ATen.sub_ts) t a
 
 -- | Multiplies each element of the input input with the scalar and returns a new resulting tensor.
 mulScalar 
  :: Scalar a 
- => Tensor -- ^ input
- -> a -- ^ multiplier
+ => a -- ^ multiplier
+ -> Tensor -- ^ input
  -> Tensor -- ^ output
-mulScalar t a = unsafePerformIO $ (cast2 ATen.mul_ts) t a
+mulScalar a t = unsafePerformIO $ (cast2 ATen.mul_ts) t a
 
 -- | Divides each element of the input input with the scalar and returns a new resulting tensor.
 divScalar 
  :: Scalar a 
- => Tensor -- ^ input
- -> a -- ^ divisor
+ => a -- ^ divisor
+ -> Tensor -- ^ input
  -> Tensor -- ^ output
-divScalar t a = unsafePerformIO $ (cast2 ATen.div_ts) t a
+divScalar a t = unsafePerformIO $ (cast2 ATen.div_ts) t a
 
 -- |  Matrix product of two tensors.
 --
@@ -270,10 +270,10 @@ log10 t = unsafePerformIO $ (cast1 ATen.log10_t) t
 -- | Takes the power of each element in input with exponent and returns a tensor with the result.
 pow 
  :: Scalar a 
- => Tensor -- ^ input
- -> a -- ^ exponent
+ => a -- ^ exponent
+ -> Tensor -- ^ input
  -> Tensor -- ^ output
-pow t s = unsafePerformIO $ (cast2 ATen.pow_ts) t s
+pow s t = unsafePerformIO $ (cast2 ATen.pow_ts) t s
 
 -- | Takes the power of each element in input with exponent and returns a tensor with the result.
 -- Exponent is a tensor with the same number of elements as input.
@@ -453,33 +453,33 @@ squeezeAll t = unsafePerformIO $ (cast1 ATen.squeeze_t) t
 
 -- | Function that measures the Binary Cross Entropy between the target and the output.
 binaryCrossEntropyLoss 
- :: Tensor -- ^ input
+ :: Reduction -- ^ Specifies the reduction to apply to the output
  -> Tensor -- ^ target
  -> Tensor -- ^ weight
- -> Reduction -- ^ Specifies the reduction to apply to the output
+ -> Tensor -- ^ input
  -> Tensor -- ^ output
-binaryCrossEntropyLoss t target weight reduction = unsafePerformIO $ (cast4 ATen.binary_cross_entropy_tttl) t target weight reduction
+binaryCrossEntropyLoss reduction target weight t = unsafePerformIO $ (cast4 ATen.binary_cross_entropy_tttl) t target weight reduction
 
 -- | Binary Cross Entropy with weights defaulted to 1.0 & reduction defaulted to ReduceMean
 binaryCrossEntropyLoss' 
- :: Tensor -- ^ input
- -> Tensor -- ^ target
+ :: Tensor -- ^ target
+ -> Tensor -- ^ input
  -> Tensor -- ^ output
-binaryCrossEntropyLoss' t target = unsafePerformIO $ (cast4 ATen.binary_cross_entropy_tttl) t target (onesLike target) ReduceMean
+binaryCrossEntropyLoss' target t = unsafePerformIO $ (cast4 ATen.binary_cross_entropy_tttl) t target (onesLike target) ReduceMean
 
 -- | Creates a criterion that measures the mean squared error (squared L2 norm) between each element in the @input@ and @target@.
 mseLoss 
- :: Tensor -- ^ input
- -> Tensor -- ^ target
+ :: Tensor -- ^ target
+ -> Tensor -- ^ input
  -> Tensor -- ^ output
-mseLoss input output = unsafePerformIO $ (cast3 ATen.mse_loss_ttl) input output ATen.kMean
+mseLoss output input = unsafePerformIO $ (cast3 ATen.mse_loss_ttl) input output ATen.kMean
 
 -- | The negative log likelihood loss.
 nllLoss' 
- :: Tensor -- ^ input
- -> Tensor -- ^ target tensor
+ :: Tensor -- ^ target tensor
+ -> Tensor -- ^ input
  -> Tensor -- ^ output
-nllLoss' t target = unsafePerformIO $ (cast5 ATen.nll_loss_tttll) t target weight ReduceMean (-100 :: Int)
+nllLoss' target t = unsafePerformIO $ (cast5 ATen.nll_loss_tttll) t target weight ReduceMean (-100 :: Int)
     where
         nClass = (shape t) !! 1 -- TODO nicer runtime error if input dimensions don't conform
         weight = ones' [nClass]
@@ -562,44 +562,44 @@ inverse t = unsafePerformIO $ (cast1 ATen.inverse_t) t
 
 -- | This function returns eigenvalues and eigenvectors of a real symmetric matrix input or a batch of real symmetric matrices, represented by a namedtuple (eigenvalues, eigenvectors).
 symeig 
- :: Tensor -- ^ input tensor  
- -> Bool -- ^ bool which controls whether eigenvectors have to be computed
+ :: Bool -- ^ bool which controls whether eigenvectors have to be computed
  -> Tri -- ^ controls whether to consider upper-triangular or lower-triangular region
+ -> Tensor -- ^ input tensor  
  -> (Tensor, Tensor) -- ^ output tensors
-symeig t eigenvectors upper = unsafePerformIO $ (cast3 ATen.symeig_tbb) t eigenvectors boolUpper
+symeig eigenvectors upper t = unsafePerformIO $ (cast3 ATen.symeig_tbb) t eigenvectors boolUpper
   where boolUpper = isUpper upper
 
 -- | Computes the eigenvalues and eigenvectors of a real square matrix
 eig 
- :: Tensor -- ^ input (square matrix) for which the eigen values and eigen vectors are to be computed
- -> Bool -- ^ bool to compute both eigenvalues and eigenvectors; otherwise, only eigenvalues will be computed
+ :: Bool -- ^ bool to compute both eigenvalues and eigenvectors; otherwise, only eigenvalues will be computed
+ -> Tensor -- ^ input (square matrix) for which the eigen values and eigen vectors are to be computed
  -> (Tensor, Tensor) -- ^ output tensors
-eig t eigenvectors = unsafePerformIO $ (cast2 ATen.eig_tb) t eigenvectors
+eig eigenvectors t = unsafePerformIO $ (cast2 ATen.eig_tb) t eigenvectors
 
 -- | This function returns a namedtuple (U, S, V) which is the singular value decomposition of a input real matrix or batches of real matrices input such that input = U * diag(S) * V^T
 svd 
- :: Tensor -- ^ input 
- -> Bool -- ^ controls the shape of returned U and V
+ :: Bool -- ^ controls the shape of returned U and V
  -> Bool -- ^ option whether to compute U and V or not
+ -> Tensor -- ^ input 
  -> (Tensor, Tensor, Tensor) -- ^ output tuple of tensors
-svd t some compute_uv = unsafePerformIO $ (cast3 ATen.svd_tbb) t some compute_uv
+svd some compute_uv t = unsafePerformIO $ (cast3 ATen.svd_tbb) t some compute_uv
 
 -- | Computes the Cholesky decomposition of a symmetric positive-definite matrix AA or for batches of symmetric positive-definite matrices.
 cholesky 
- :: Tensor -- ^ input
- -> Tri -- ^ flag that indicates whether to return a upper or lower triangular matrix.
+ :: Tri -- ^ flag that indicates whether to return a upper or lower triangular matrix.
+ -> Tensor -- ^ input
  -> Tensor -- ^ output
-cholesky t upper = unsafePerformIO $ (cast2 ATen.cholesky_tb) t boolUpper
+cholesky upper t = unsafePerformIO $ (cast2 ATen.cholesky_tb) t boolUpper
   where boolUpper = isUpper upper
 
 
 -- | Solves a linear system of equations with a positive semidefinite matrix to be inverted given its Cholesky factor matrix uu .
 choleskySolve 
- :: Tensor -- ^ input matrix b 
+ :: Tri -- ^ bool whether to consider the Cholesky factor as a lower or upper triangular matrix
+ -> Tensor -- ^ input matrix b 
  -> Tensor -- ^ input matrix u
- -> Tri -- ^ bool whether to consider the Cholesky factor as a lower or upper triangular matrix
  -> Tensor -- ^ output
-choleskySolve t1 t2 upper = unsafePerformIO $ (cast3 ATen.cholesky_solve_ttb) t1 t2 boolUpper
+choleskySolve upper t1 t2 = unsafePerformIO $ (cast3 ATen.cholesky_solve_ttb) t1 t2 boolUpper
   where boolUpper = isUpper upper
 
 
@@ -673,17 +673,17 @@ adaptiveAvgPool1d outputSize input = unsafePerformIO
 
 -- | Applies a 2D adaptive average pooling over an input signal composed of several input planes.
 adaptiveAvgPool2d 
- :: Tensor -- ^ input 
- -> (Int,Int) -- ^ output size (Height * Width)
+ :: (Int,Int) -- ^ output size (Height * Width)
+ -> Tensor -- ^ input 
  -> Tensor -- ^ output
-adaptiveAvgPool2d _self _output_size = unsafePerformIO $ (cast2 ATen.adaptive_avg_pool2d_tl) _self _output_size
+adaptiveAvgPool2d _output_size _self = unsafePerformIO $ (cast2 ATen.adaptive_avg_pool2d_tl) _self _output_size
 
 -- | Applies a 3D adaptive average pooling over an input signal composed of several input planes.
 adaptiveAvgPool3d 
- :: Tensor -- ^ input
- -> (Int,Int,Int) -- ^ output size (Depth * Height * Width)
+ :: (Int,Int,Int) -- ^ output size (Depth * Height * Width)
+ -> Tensor -- ^ input
  -> Tensor -- ^ output
-adaptiveAvgPool3d _self _output_size = unsafePerformIO $ (cast2 ATen.adaptive_avg_pool3d_tl) _self _output_size
+adaptiveAvgPool3d _output_size _self = unsafePerformIO $ (cast2 ATen.adaptive_avg_pool3d_tl) _self _output_size
 
 -- | Computes the bitwise NOT of the given input tensor. The input tensor must be of integral or Boolean types. For bool tensors, it computes the logical NOT.
 bitwiseNot 
@@ -813,14 +813,14 @@ solve b a = unsafePerformIO $ (cast2 ATen.solve_tt) b a
 
 -- | Solves a linear system of equations with a positive semidefinite matrix to be inverted given its Cholesky factor matrix uu .
 choleskyInverse
-    :: Tensor -- ^ input
-    -> Tri -- ^ upper or lower triangle
+    :: Tri -- ^ upper or lower triangle
+    -> Tensor -- ^ input
     -> Tensor -- ^ solution
-choleskyInverse t upper = unsafePerformIO $ (cast2 ATen.cholesky_inverse_tb) t boolUpper
+choleskyInverse upper t = unsafePerformIO $ (cast2 ATen.cholesky_inverse_tb) t boolUpper
   where boolUpper = isUpper upper
 
--- pstrf :: Tensor -> Bool -> Double -> (Tensor, Tensor)
--- pstrf t upper tol = unsafePerformIO $ (cast3 ATen.pstrf_tbs) t upper tol
+-- pstrf :: Bool -> Double -> Tensor -> (Tensor, Tensor)
+-- pstrf upper tol t = unsafePerformIO $ (cast3 ATen.pstrf_tbs) t upper tol
 
 -- qr :: Tensor -> (Tensor, Tensor)
 -- qr t = unsafePerformIO $ (cast1 ATen.qr_t) t
@@ -848,17 +848,17 @@ sign t = unsafePerformIO $ (cast1 ATen.sign_t) t
 
 -- | Returns a tensor that is a transposed version of @input@. The given dimensions @dim0@ and @dim1@ are swapped.
 transpose 
- :: Tensor -- ^ input
- -> Int -- ^ dim1
+ :: Int -- ^ dim1
  -> Int -- ^ dim2
- -> Tensor -- ^ 
-transpose t a b = unsafePerformIO $ (cast3 ATen.transpose_tll) t a b
+ -> Tensor -- ^ input
+ -> Tensor -- ^ output
+transpose a b t = unsafePerformIO $ (cast3 ATen.transpose_tll) t a b
 
 -- | transpose special case for a 2D tensor
 transpose2D 
     :: Tensor -- ^ input
     -> Tensor -- ^ output
-transpose2D t = transpose t 0 1
+transpose2D = transpose 0 1
 
 
 -- | Returns a tensor with the elements of input as the diagonal.
@@ -868,10 +868,10 @@ transpose2D t = transpose t 0 1
 --        If Int < 0, it is below the main diagonal.
 
 diag
-    ::  Tensor -- ^ input
-    ->  Int -- ^ diagonal
+    ::  Int -- ^ diagonal
+    ->  Tensor -- ^ input
     ->  Tensor -- ^ output
-diag t index = unsafePerformIO $ (cast2 ATen.tensor_diag_l) t index
+diag index t = unsafePerformIO $ (cast2 ATen.tensor_diag_l) t index
 
 -- | Returns True if all elements in the tensor are True, False otherwise.
 all
@@ -889,24 +889,24 @@ any t = toInt (unsafePerformIO $ (cast1 ATen.any_t) t) == 1
 -- | Returns True if all elements in each row of the tensor in the given dimension dim are True, False otherwise.
 -- If keepdim is True, the output tensor is of the same size as input except in the dimension dim where it is of size 1. Otherwise, dim is squeezed, resulting in the output tensor having 1 fewer dimension than input.  
 all' 
- :: Tensor -- ^ input
- -> Int -- ^ dimension
+ :: Int -- ^ dimension
  -> Bool -- ^ boolean corresponding to keepdim
+ -> Tensor -- ^ input
  -> Tensor -- ^ output
-all' t dim keepdim = unsafePerformIO $ (cast3 ATen.all_tlb) t dim keepdim
+all' dim keepdim t = unsafePerformIO $ (cast3 ATen.all_tlb) t dim keepdim
 
 -- | Returns True if any elements in each row of the tensor in the given dimension dim are True, False otherwise.
 -- If keepdim is True, the output tensor is of the same size as input except in the dimension dim where it is of size 1. Otherwise, dim is squeezed, resulting in the output tensor having 1 fewer dimension than input.
 any' 
- :: Tensor -- ^ input 
- -> Int -- ^ dimension 
+ :: Int -- ^ dimension 
  -> Bool -- ^ boolean corresponding to keepdim
+ -> Tensor -- ^ input 
  -> Tensor -- output
-any' t dim keepdim = unsafePerformIO $ (cast3 ATen.any_tlb) t dim keepdim
+any' dim keepdim t = unsafePerformIO $ (cast3 ATen.any_tlb) t dim keepdim
 
 -- | Permute the dimensions of this tensor.
 permute 
- :: Tensor -- ^ input
- -> [Int] -- ^ list corresponding to ordering of dimensions to permute with 
+ :: [Int] -- ^ list corresponding to ordering of dimensions to permute with 
+ -> Tensor -- ^ input
  -> Tensor -- output
-permute t dims = unsafePerformIO $ (cast2 ATen.tensor_permute_l) t dims
+permute dims t = unsafePerformIO $ (cast2 ATen.tensor_permute_l) t dims

--- a/hasktorch/src/Torch/Initializers.hs
+++ b/hasktorch/src/Torch/Initializers.hs
@@ -39,7 +39,7 @@ calculateFan shape =
 xavierUniform :: Float -> [Int] -> IO Tensor
 xavierUniform gain shape = do
     init <- randIO' shape
-    pure $ subScalar (mulScalar init (bound * 2.0)) bound
+    pure $ subScalar bound $ mulScalar (bound * 2.0) init
     where
         (fanIn, fanOut) = calculateFan shape
         std = gain * sqrt (2.0 / (fromIntegral fanIn + fromIntegral fanOut))
@@ -49,7 +49,7 @@ xavierUniform gain shape = do
 xavierNormal :: Float -> [Int] -> IO Tensor
 xavierNormal gain shape = do
     init <- randnIO' shape
-    pure $ mulScalar init std
+    pure $ mulScalar std init
     where
         (fanIn, fanOut) = calculateFan shape
         std = gain * sqrt (2.0 / (fromIntegral fanIn + fromIntegral fanOut))
@@ -63,7 +63,7 @@ getter FanOut = snd
 kaimingUniform :: FanMode -> NonLinearity -> [Int] -> IO Tensor
 kaimingUniform mode nonlinearity shape = do
     init <- randIO' shape
-    pure $ subScalar (mulScalar init (bound * 2.0)) bound
+    pure $ subScalar bound $ mulScalar (bound * 2.0) init
     where 
         gain = calculateGain nonlinearity
         fanValue = fromIntegral $ (getter mode) (calculateFan shape)
@@ -74,7 +74,7 @@ kaimingUniform mode nonlinearity shape = do
 kaimingNormal :: FanMode -> NonLinearity -> [Int] -> IO Tensor
 kaimingNormal mode nonlinearity shape = do
     init <- (randnIO' shape)
-    pure $ mulScalar init std
+    pure $ mulScalar std init
     where 
         gain = calculateGain nonlinearity
         fanValue = fromIntegral $ (getter mode) (calculateFan shape)
@@ -86,7 +86,7 @@ kaimingFC :: [Int] -> IO (Tensor, Tensor)
 kaimingFC weightShape = do
     weight <- kaimingUniform' weightShape
     biasInit <- randIO' biasShape
-    let bias = subScalar (mulScalar biasInit (bound * 2.0)) bound
+    let bias = subScalar bound $ mulScalar (bound * 2.0) biasInit
     pure (weight, bias)
     where
         (fanIn, _) = calculateFan weightShape

--- a/hasktorch/src/Torch/Optim.hs
+++ b/hasktorch/src/Torch/Optim.hs
@@ -72,7 +72,7 @@ gdm
 gdm lr (Gradients gradients) parameters (GDM beta momentum) = 
     (fmap fst runStep, GDM beta (fmap snd runStep))
     where
-        step p dp z = let z' = mulScalar z beta + dp in (p - lr * z', z')
+        step p dp z = let z' = mulScalar beta z + dp in (p - lr * z', z')
         runStep = (zipWith3 step) parameters gradients momentum
 
 instance Optimizer GDM where
@@ -101,12 +101,12 @@ adam
 adam lr (Gradients gradients) parameters Adam{..} = (parameters', Adam beta1 beta2 m1' m2' (iter+1))
     where
         -- decaying averages of 1st & 2nd moments
-        f1 m1 dp = mulScalar m1 beta1 + mulScalar dp (1 - beta1)
-        f2 m2 dp = mulScalar m2 beta2 + mulScalar (dp * dp) (1 - beta2)
+        f1 m1 dp = mulScalar beta1 m1 + mulScalar (1 - beta1) dp
+        f2 m2 dp = mulScalar beta2 m2 + mulScalar (1 - beta2) (dp * dp)
         m1' = zipWith f1 m1 gradients
         m2' = zipWith f2 m2 gradients
         -- bias adjustment
-        a beta m = divScalar m (1 - beta^(iter + 1))
+        a beta m = divScalar (1 - beta^(iter + 1)) m
         a1 = fmap (a beta1) m1'
         a2 = fmap (a beta2) m2'
         -- parameter update

--- a/hasktorch/src/Torch/Typed/NN/Recurrent/GRU.hs
+++ b/hasktorch/src/Torch/Typed/NN/Recurrent/GRU.hs
@@ -308,7 +308,7 @@ calculateFan shape
 -- | Xavier Initialization - Uniform
 xavierUniformFIXME :: D.Tensor -> Float -> [Int] -> IO D.Tensor
 xavierUniformFIXME init gain shape = pure
-  $ D.subScalar (D.mulScalar init (bound * 2.0)) bound
+  $ D.subScalar bound $ D.mulScalar (bound * 2.0) init
  where
   (fanIn, fanOut) = calculateFan shape
   std = gain * sqrt (2.0 / (fromIntegral fanIn + fromIntegral fanOut))

--- a/hasktorch/src/Torch/Typed/NN/Recurrent/LSTM.hs
+++ b/hasktorch/src/Torch/Typed/NN/Recurrent/LSTM.hs
@@ -308,7 +308,7 @@ calculateFan shape
 -- | Xavier Initialization - Uniform
 xavierUniformFIXME :: D.Tensor -> Float -> [Int] -> IO D.Tensor
 xavierUniformFIXME init gain shape = pure
-  $ D.subScalar (D.mulScalar init (bound * 2.0)) bound
+  $ D.subScalar bound $ D.mulScalar (bound * 2.0) init
  where
   (fanIn, fanOut) = calculateFan shape
   std = gain * sqrt (2.0 / (fromIntegral fanIn + fromIntegral fanOut))

--- a/hasktorch/src/Torch/Vision.hs
+++ b/hasktorch/src/Torch/Vision.hs
@@ -209,8 +209,8 @@ writePng file tensor = do
 
 -- [batch, height, width, channel] -> [batch, channel, height, width]
 hwc2chw :: D.Tensor -> D.Tensor
-hwc2chw input = D.permute input [0,3,1,2]
+hwc2chw = D.permute [0,3,1,2]
 
 -- [batch, channel, height, width] -> [batch, height, width, channel]
 chw2hwc :: D.Tensor -> D.Tensor
-chw2hwc input = D.permute input [0,2,3,1]
+chw2hwc = D.permute [0,2,3,1]

--- a/hasktorch/test/FunctionalSpec.hs
+++ b/hasktorch/test/FunctionalSpec.hs
@@ -93,7 +93,7 @@ spec = do
     shape qr `shouldBe` [5,3]
   it "diag" $ do
     let x = ones' [3]
-    let y = diag x 2
+    let y = diag 2 x
     shape y `shouldBe` [5, 5]
 
   -- decomposition / solvers
@@ -106,7 +106,7 @@ spec = do
 
   it "cholesky decomposes" $ do
     let x = asTensor ([[4.0, 12.0, -16.0], [12.0, 37.0, -43.0], [-16.0, -43.0, 98.0]] :: [[Double]])
-        c = cholesky x Upper
+        c = cholesky Upper x
         c' = asTensor ([[2.0, 6.0, -8.0], [0.0, 1.0, 5.0], [0.0, 0.0, 3.0]] :: [[Double]])
     all (c ==. c') `shouldBe` True
   it "inverse of an identity matrix is an identity matrix" $ do

--- a/hasktorch/test/OptimSpec.hs
+++ b/hasktorch/test/OptimSpec.hs
@@ -35,7 +35,7 @@ instance Parameterized ConvQuad
 
 convexQuadratic :: Tensor -> Tensor -> Tensor -> Tensor
 convexQuadratic a b w =
-    mulScalar (dot w (mv a w)) (0.5 :: Float) - dot b w
+    mulScalar (0.5 :: Float) (dot (mv a w) w) - dot w b
 
 lossConvQuad :: Tensor -> Tensor -> ConvQuad -> Tensor
 lossConvQuad a b (ConvQuad w) = convexQuadratic a b w'
@@ -65,8 +65,8 @@ instance Parameterized Rosen where
   flattenParameters (Rosen x y) = [x, y]
 
 rosenbrock2d :: Float -> Float -> Tensor -> Tensor -> Tensor
-rosenbrock2d a b x y = square (addScalar ((-1.0) * x ) a) + mulScalar (square (y - x*x)) b
-    where square c = pow c (2 :: Int)
+rosenbrock2d a b x y = square (addScalar a $ (-1.0) * x ) + mulScalar b (square (y - x*x))
+    where square = pow (2 :: Int)
 
 rosenbrock' :: Tensor -> Tensor -> Tensor
 rosenbrock' = rosenbrock2d 1.0 100.0
@@ -88,8 +88,8 @@ instance Parameterized Ackley
 
 ackley :: Float -> Float -> Float -> Tensor -> Tensor
 ackley a b c x = 
-    mulScalar (exp (-b' * (sqrt $ (sumAll (x * x)) / d))) (-a)
-    - exp (1.0 / d * sumAll (cos (mulScalar x c))) 
+    mulScalar (-a) (exp (-b' * (sqrt $ (sumAll (x * x)) / d)))
+    - exp (1.0 / d * sumAll (cos (mulScalar c x))) 
     + (asTensor $ a + P.exp 1.0)
     where
         b' = asTensor b


### PR DESCRIPTION
I think there may be some controversial functions in here -- let's discuss which ones we want what way. :)

For the part-tensor-part-scalar ops at least I think we'd probably want tensor param last.
For the non-associative ones there (subtract, divide), we'd probably need versions with either side (both `a` and `b` for e.g. `a - b`) as the tensor, but in that case we may wanna try and ensure the naming of the tensor-only and both half-tensor ops to somehow align to make sense as well...
I haven't put much thought into that yet.
