### PR TITLE
rename all' / any' to allDim / anyDim

### DIFF
--- a/hasktorch/src/Torch/Functional.hs
+++ b/hasktorch/src/Torch/Functional.hs
@@ -888,21 +888,21 @@ any t = toInt (unsafePerformIO $ (cast1 ATen.any_t) t) == 1
 
 -- | Returns True if all elements in each row of the tensor in the given dimension dim are True, False otherwise.
 -- If keepdim is True, the output tensor is of the same size as input except in the dimension dim where it is of size 1. Otherwise, dim is squeezed, resulting in the output tensor having 1 fewer dimension than input.  
-all' 
+allDim 
  :: Tensor -- ^ input
  -> Int -- ^ dimension
  -> Bool -- ^ boolean corresponding to keepdim
  -> Tensor -- ^ output
-all' t dim keepdim = unsafePerformIO $ (cast3 ATen.all_tlb) t dim keepdim
+allDim t dim keepdim = unsafePerformIO $ (cast3 ATen.all_tlb) t dim keepdim
 
 -- | Returns True if any elements in each row of the tensor in the given dimension dim are True, False otherwise.
 -- If keepdim is True, the output tensor is of the same size as input except in the dimension dim where it is of size 1. Otherwise, dim is squeezed, resulting in the output tensor having 1 fewer dimension than input.
-any' 
+anyDim 
  :: Tensor -- ^ input 
  -> Int -- ^ dimension 
  -> Bool -- ^ boolean corresponding to keepdim
  -> Tensor -- output
-any' t dim keepdim = unsafePerformIO $ (cast3 ATen.any_tlb) t dim keepdim
+anyDim t dim keepdim = unsafePerformIO $ (cast3 ATen.any_tlb) t dim keepdim
 
 -- | Permute the dimensions of this tensor.
 permute 

--- a/hasktorch/src/Torch/Typed/Functional.hs
+++ b/hasktorch/src/Torch/Typed/Functional.hs
@@ -1123,23 +1123,23 @@ type family ConditionalDropDimension (shape :: [Nat]) (dim :: Nat) (keepOrDropDi
   ConditionalDropDimension (x : xs) 0 DropDim       = xs
   ConditionalDropDimension (x : xs) i keepOrDropDim = x ': ConditionalDropDimension xs (i - 1) keepOrDropDim
 
--- | all'
+-- | allDim
 -- See https://pytorch.org/docs/stable/tensors.html#torch.BoolTensor.all.
 --
 -- >>> t = fromJust [[True, True], [True, False], [True, True], [True, True]] :: CPUTensor 'D.Bool '[4, 2]
 --
--- >>> dtype &&& shape &&& (\t' -> D.asValue (toDynamic t') :: [Bool]) $ all' @1 @DropDim t
+-- >>> dtype &&& shape &&& (\t' -> D.asValue (toDynamic t') :: [Bool]) $ allDim @1 @DropDim t
 -- (Bool,([4],[True,False,True,True]))
 --
--- >>> dtype &&& shape &&& (\t' -> D.asValue (toDynamic t') :: [[Bool]]) $ all' @1 @KeepDim t
+-- >>> dtype &&& shape &&& (\t' -> D.asValue (toDynamic t') :: [[Bool]]) $ allDim @1 @KeepDim t
 -- (Bool,([4,1],[[True],[False],[True],[True]]))
 --
--- >>> dtype &&& shape &&& (\t' -> D.asValue (toDynamic t') :: [Bool]) $ all' @0 @DropDim t
+-- >>> dtype &&& shape &&& (\t' -> D.asValue (toDynamic t') :: [Bool]) $ allDim @0 @DropDim t
 -- (Bool,([2],[True,False]))
 --
--- >>> dtype &&& shape &&& (\t' -> D.asValue (toDynamic t') :: [[Bool]]) $ all' @0 @KeepDim t
+-- >>> dtype &&& shape &&& (\t' -> D.asValue (toDynamic t') :: [[Bool]]) $ allDim @0 @KeepDim t
 -- (Bool,([1,2],[[True,False]]))
-all'
+allDim
   :: forall dim keepOrDropDim shape' shape device
    . ( KnownNat dim
      , KnownKeepOrDropDim keepOrDropDim
@@ -1147,26 +1147,26 @@ all'
      )
   => Tensor device 'D.Bool shape -- ^ input
   -> Tensor device 'D.Bool shape' -- ^ output
-all' input = unsafePerformIO
+allDim input = unsafePerformIO
   $ ATen.cast3 ATen.Managed.all_tlb input (natValI @dim) (keepOrDropDimVal @keepOrDropDim)
 
--- | any'
+-- | anyDim
 -- See https://pytorch.org/docs/stable/tensors.html#torch.BoolTensor.any.
 --
 -- >>> t = fromJust [[True, True], [True, False], [True, True], [True, True]] :: CPUTensor 'D.Bool '[4, 2]
 --
--- >>> dtype &&& shape &&& (\t' -> D.asValue (toDynamic t') :: [Bool]) $ any' @1 @DropDim t
+-- >>> dtype &&& shape &&& (\t' -> D.asValue (toDynamic t') :: [Bool]) $ anyDim @1 @DropDim t
 -- (Bool,([4],[True,True,True,True]))
 --
--- >>> dtype &&& shape &&& (\t' -> D.asValue (toDynamic t') :: [[Bool]]) $ any' @1 @KeepDim t
+-- >>> dtype &&& shape &&& (\t' -> D.asValue (toDynamic t') :: [[Bool]]) $ anyDim @1 @KeepDim t
 -- (Bool,([4,1],[[True],[True],[True],[True]]))
 --
--- >>> dtype &&& shape &&& (\t' -> D.asValue (toDynamic t') :: [Bool]) $ any' @0 @DropDim t
+-- >>> dtype &&& shape &&& (\t' -> D.asValue (toDynamic t') :: [Bool]) $ anyDim @0 @DropDim t
 -- (Bool,([2],[True,True]))
 --
--- >>> dtype &&& shape &&& (\t' -> D.asValue (toDynamic t') :: [[Bool]]) $ any' @0 @KeepDim t
+-- >>> dtype &&& shape &&& (\t' -> D.asValue (toDynamic t') :: [[Bool]]) $ anyDim @0 @KeepDim t
 -- (Bool,([1,2],[[True,True]]))
-any'
+anyDim
   :: forall dim keepOrDropDim shape' shape device
    . ( KnownNat dim
      , KnownKeepOrDropDim keepOrDropDim
@@ -1174,7 +1174,7 @@ any'
      )
   => Tensor device 'D.Bool shape -- ^ input
   -> Tensor device 'D.Bool shape' -- ^ output
-any' input = unsafePerformIO $ ATen.cast3 ATen.Managed.any_tlb input (natValI @dim) (keepOrDropDimVal @keepOrDropDim)
+anyDim input = unsafePerformIO $ ATen.cast3 ATen.Managed.any_tlb input (natValI @dim) (keepOrDropDimVal @keepOrDropDim)
 
 -- | dropout
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?

--- a/hasktorch/test/Torch/Typed/FunctionalSpec.hs
+++ b/hasktorch/test/Torch/Typed/FunctionalSpec.hs
@@ -637,11 +637,11 @@ instance
   ) => Apply' AnyPrimeAllPrimeSpec (((Proxy dim, Proxy keepOrDropDim), (Proxy device, Proxy shape)), IO ()) (IO ()) where
   apply' AnyPrimeSpec (_, agg) = agg >> do
     let t = ones @shape @'D.Bool @device
-        t' = any' @dim @keepOrDropDim t
+        t' = anyDim @dim @keepOrDropDim t
     checkDynamicTensorAttributes t'
   apply' AllPrimeSpec (_, agg) = agg >> do
     let t = ones @shape @'D.Bool @device
-        t' = all' @dim @keepOrDropDim t
+        t' = allDim @dim @keepOrDropDim t
     checkDynamicTensorAttributes t'
 
 data LstmCellSpec = LstmCellSpec
@@ -943,8 +943,8 @@ spec' device =
                 hfoldrM @IO anyPrimeAllPrimeSpec () (hproduct
                                                       (hproduct anyPrimeAllPrimeDims keepOrDropDims)
                                                       (hattach cuda0 anyPrimeAllPrimeShapes))
-        it "all'" $ dispatch AllPrimeSpec
-        it "any'" $ dispatch AnyPrimeSpec
+        it "allDim" $ dispatch AllPrimeSpec
+        it "anyDim" $ dispatch AnyPrimeSpec
 
     describe "pooling" $
       it "maxPool2d" $ do


### PR DESCRIPTION
names `all'` / `any'` feel sorta inconsistent with `*Dim` names used for sum/min/max/median/mean... I feel the latter are more clear.