### PR TITLE
codegen overloaded functions

### DIFF
--- a/codegen/src/RenderCommon.hs
+++ b/codegen/src/RenderCommon.hs
@@ -248,7 +248,7 @@ parsableToHigherHsType parsable =
     P.CppClass _ _ hstype -> fromString hstype
     Backend -> "Backend"
     Layout -> "Layout"
-    MemoryFormat -> "MemoryFormat"
+    MemoryFormat -> "ATen.MemoryFormat"
     QScheme -> "QScheme"
     ConstQuantizerPtr -> "ConstQuantizerPtr"
     Dimname -> "Dimname"

--- a/hasktorch/src/Torch/Functional.hs
+++ b/hasktorch/src/Torch/Functional.hs
@@ -1,35 +1,48 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 
-module Torch.Functional (
-    module Torch.Functional,
-    addmv, addr, allclose, argmin, baddbmm, bmm, acos, asin, atan, dot, einsum, lstsq, mv, slice
-    , sumWithDimnames
+module Torch.Functional
+    ( module Torch.Functional
+    , Internal.addmv
+    , Internal.addr
+    , Internal.allclose
+    , Internal.argmin
+    , Internal.baddbmm
+    , Internal.bmm
+    , Internal.acos
+    , Internal.asin
+    , Internal.atan
+    , Internal.dot
+    , Internal.einsum
+    , Internal.lstsq
+    , Internal.mv
+    , Internal.slice
+    , Internal.sumWithDimnames
 ) where
 
-import          Prelude                 hiding ( all
-                                                , any
-                                                , sin
-                                                , sinh
-                                                , cos
-                                                , cosh
-                                                , tan
-                                                , tanh
-                                                , asin
-                                                , asinh
-                                                , acos
-                                                , acosh
-                                                , atan
-                                                , atanh
-                                                , max
-                                                , min
-                                                , exp
-                                                , log
-                                                , round
-                                                , isNaN
-                                                , floor
-                                                , ceil
-                                                )
+import Prelude hiding ( all
+                      , any
+                      , sin
+                      , sinh
+                      , cos
+                      , cosh
+                      , tan
+                      , tanh
+                      , asin
+                      , asinh
+                      , acos
+                      , acosh
+                      , atan
+                      , atanh
+                      , max
+                      , min
+                      , exp
+                      , log
+                      , round
+                      , isNaN
+                      , floor
+                      , ceil
+                      )
 
 import System.IO.Unsafe
 import Foreign.ForeignPtr
@@ -49,7 +62,7 @@ import Data.Int
 import Torch.Scalar
 import Torch.Tensor
 import Torch.DType
-import Torch.Functional.Internal hiding (argmax, clamp, cosh, conv1d, linear, softmax)
+-- import Torch.Functional.Internal hiding (argmax, clamp, cosh, conv1d, linear, softmax)
 import Torch.TensorFactories (onesLike, ones')
 
 kOne :: ForeignPtr ATen.Scalar

--- a/hasktorch/src/Torch/Functional/Internal.hs
+++ b/hasktorch/src/Torch/Functional/Internal.hs
@@ -279,8 +279,8 @@ embedding_sparse_backward _grad _indices _num_weights _padding_idx _scale_grad_b
 embedding_bag :: Tensor -> Tensor -> Tensor -> Bool -> Int -> Bool -> Tensor -> (Tensor,Tensor,Tensor,Tensor)
 embedding_bag _weight _indices _offsets _scale_grad_by_freq _mode _sparse _per_sample_weights = unsafePerformIO $ (cast7 ATen.embedding_bag_tttblbt) _weight _indices _offsets _scale_grad_by_freq _mode _sparse _per_sample_weights
 
-empty_like :: Tensor -> Tensor
-empty_like _self = unsafePerformIO $ (cast1 ATen.empty_like_t) _self
+empty_like :: Tensor -> MemoryFormat -> Tensor
+empty_like _self _memory_format = unsafePerformIO $ (cast2 ATen.empty_like_tM) _self _memory_format
 
 erfc :: Tensor -> Tensor
 erfc _self = unsafePerformIO $ (cast1 ATen.erfc_t) _self
@@ -294,8 +294,8 @@ flatten _self _start_dim _end_dim = unsafePerformIO $ (cast3 ATen.flatten_tll) _
 frac :: Tensor -> Tensor
 frac _self = unsafePerformIO $ (cast1 ATen.frac_t) _self
 
-full_like :: Tensor -> Float -> Tensor
-full_like _self _fill_value = unsafePerformIO $ (cast2 ATen.full_like_ts) _self _fill_value
+full_like :: Tensor -> Float -> MemoryFormat -> Tensor
+full_like _self _fill_value _memory_format = unsafePerformIO $ (cast3 ATen.full_like_tsM) _self _fill_value _memory_format
 
 grid_sampler :: Tensor -> Tensor -> Int -> Int -> Bool -> Tensor
 grid_sampler _input _grid _interpolation_mode _padding_mode _align_corners = unsafePerformIO $ (cast5 ATen.grid_sampler_ttllb) _input _grid _interpolation_mode _padding_mode _align_corners
@@ -588,14 +588,14 @@ batch_norm_backward_elemt _grad_out _input _mean _invstd _weight _mean_dy _mean_
 batch_norm_update_stats :: Tensor -> Tensor -> Tensor -> Double -> (Tensor,Tensor)
 batch_norm_update_stats _input _running_mean _running_var _momentum = unsafePerformIO $ (cast4 ATen.batch_norm_update_stats_tttd) _input _running_mean _running_var _momentum
 
-ones_like :: Tensor -> Tensor
-ones_like _self = unsafePerformIO $ (cast1 ATen.ones_like_t) _self
+ones_like :: Tensor -> MemoryFormat -> Tensor
+ones_like _self _memory_format = unsafePerformIO $ (cast2 ATen.ones_like_tM) _self _memory_format
 
 pairwise_distance :: Tensor -> Tensor -> Double -> Double -> Bool -> Tensor
 pairwise_distance _x1 _x2 _p _eps _keepdim = unsafePerformIO $ (cast5 ATen.pairwise_distance_ttddb) _x1 _x2 _p _eps _keepdim
 
-cdist :: Tensor -> Tensor -> Double -> Tensor
-cdist _x1 _x2 _p = unsafePerformIO $ (cast3 ATen.cdist_ttd) _x1 _x2 _p
+cdist :: Tensor -> Tensor -> Double -> Int -> Tensor
+cdist _x1 _x2 _p _compute_mode = unsafePerformIO $ (cast4 ATen.cdist_ttdl) _x1 _x2 _p _compute_mode
 
 pdist :: Tensor -> Double -> Tensor
 pdist _self _p = unsafePerformIO $ (cast2 ATen.pdist_td) _self _p
@@ -612,11 +612,11 @@ pinverse _self _rcond = unsafePerformIO $ (cast2 ATen.pinverse_td) _self _rcond
 poisson_nll_loss :: Tensor -> Tensor -> Bool -> Bool -> Double -> Int -> Tensor
 poisson_nll_loss _input _target _log_input _full _eps _reduction = unsafePerformIO $ (cast6 ATen.poisson_nll_loss_ttbbdl) _input _target _log_input _full _eps _reduction
 
-rand_like :: Tensor -> Tensor
-rand_like _self = unsafePerformIO $ (cast1 ATen.rand_like_t) _self
+rand_like :: Tensor -> MemoryFormat -> Tensor
+rand_like _self _memory_format = unsafePerformIO $ (cast2 ATen.rand_like_tM) _self _memory_format
 
-randn_like :: Tensor -> Tensor
-randn_like _self = unsafePerformIO $ (cast1 ATen.randn_like_t) _self
+randn_like :: Tensor -> MemoryFormat -> Tensor
+randn_like _self _memory_format = unsafePerformIO $ (cast2 ATen.randn_like_tM) _self _memory_format
 
 reciprocal :: Tensor -> Tensor
 reciprocal _self = unsafePerformIO $ (cast1 ATen.reciprocal_t) _self
@@ -768,14 +768,14 @@ where' _condition _self _other = unsafePerformIO $ (cast3 ATen.where_ttt) _condi
 norm_except_dim :: Tensor -> Int -> Int -> Tensor
 norm_except_dim _v _pow _dim = unsafePerformIO $ (cast3 ATen.norm_except_dim_tll) _v _pow _dim
 
-zeros_like :: Tensor -> Tensor
-zeros_like _self = unsafePerformIO $ (cast1 ATen.zeros_like_t) _self
+zeros_like :: Tensor -> MemoryFormat -> Tensor
+zeros_like _self _memory_format = unsafePerformIO $ (cast2 ATen.zeros_like_tM) _self _memory_format
 
 native_norm :: Tensor -> Float -> Tensor
 native_norm _self _p = unsafePerformIO $ (cast2 ATen.native_norm_ts) _self _p
 
-clone :: Tensor -> Tensor
-clone _self = unsafePerformIO $ (cast1 ATen.clone_t) _self
+clone :: Tensor -> MemoryFormat -> Tensor
+clone _self _memory_format = unsafePerformIO $ (cast2 ATen.clone_tM) _self _memory_format
 
 addmm :: Tensor -> Tensor -> Tensor -> Float -> Float -> Tensor
 addmm _self _mat1 _mat2 _beta _alpha = unsafePerformIO $ (cast5 ATen.addmm_tttss) _self _mat1 _mat2 _beta _alpha
@@ -1328,3 +1328,4 @@ im2col_backward _grad_output _input_size _kernel_size _dilation _padding _stride
 
 isfinite :: Tensor -> Tensor
 isfinite _self = unsafePerformIO $ (cast1 ATen.isfinite_t) _self
+

--- a/hasktorch/src/Torch/Functional/Internal.hs
+++ b/hasktorch/src/Torch/Functional/Internal.hs
@@ -45,6 +45,9 @@ alpha_dropout _input _p _train = unsafePerformIO $ (cast3 ATen.alpha_dropout_tdb
 feature_alpha_dropout :: Tensor -> Double -> Bool -> Tensor
 feature_alpha_dropout _input _p _train = unsafePerformIO $ (cast3 ATen.feature_alpha_dropout_tdb) _input _p _train
 
+abs :: Tensor -> Tensor
+abs _self = unsafePerformIO $ (cast1 ATen.abs_t) _self
+
 angle :: Tensor -> Tensor
 angle _self = unsafePerformIO $ (cast1 ATen.angle_t) _self
 
@@ -69,6 +72,12 @@ adaptive_avg_pool1d _self _output_size = unsafePerformIO $ (cast2 ATen.adaptive_
 adaptive_max_pool1d :: Tensor -> Int -> (Tensor,Tensor)
 adaptive_max_pool1d _self _output_size = unsafePerformIO $ (cast2 ATen.adaptive_max_pool1d_tl) _self _output_size
 
+add :: Tensor -> Tensor -> Float -> Tensor
+add _self _other _alpha = unsafePerformIO $ (cast3 ATen.add_tts) _self _other _alpha
+
+addScalar :: Tensor -> Float -> Float -> Tensor
+addScalar _self _other _alpha = unsafePerformIO $ (cast3 ATen.add_tss) _self _other _alpha
+
 addmv :: Tensor -> Tensor -> Tensor -> Float -> Float -> Tensor
 addmv _self _mat _vec _beta _alpha = unsafePerformIO $ (cast5 ATen.addmv_tttss) _self _mat _vec _beta _alpha
 
@@ -81,11 +90,17 @@ affine_grid_generator _theta _size _align_corners = unsafePerformIO $ (cast3 ATe
 affine_grid_generator_backward :: Tensor -> [Int] -> Bool -> Tensor
 affine_grid_generator_backward _grad _size _align_corners = unsafePerformIO $ (cast3 ATen.affine_grid_generator_backward_tlb) _grad _size _align_corners
 
+all :: Tensor -> Int -> Bool -> Tensor
+all _self _dim _keepdim = unsafePerformIO $ (cast3 ATen.all_tlb) _self _dim _keepdim
+
 allWithDimname :: Tensor -> Dimname -> Bool -> Tensor
 allWithDimname _self _dim _keepdim = unsafePerformIO $ (cast3 ATen.all_tnb) _self _dim _keepdim
 
 allclose :: Tensor -> Tensor -> Double -> Double -> Bool -> Bool
 allclose _self _other _rtol _atol _equal_nan = unsafePerformIO $ (cast5 ATen.allclose_ttddb) _self _other _rtol _atol _equal_nan
+
+any :: Tensor -> Int -> Bool -> Tensor
+any _self _dim _keepdim = unsafePerformIO $ (cast3 ATen.any_tlb) _self _dim _keepdim
 
 anyWithDimname :: Tensor -> Dimname -> Bool -> Tensor
 anyWithDimname _self _dim _keepdim = unsafePerformIO $ (cast3 ATen.any_tnb) _self _dim _keepdim
@@ -138,8 +153,14 @@ bmm _self _mat2 = unsafePerformIO $ (cast2 ATen.bmm_tt) _self _mat2
 broadcast_tensors :: [Tensor] -> [Tensor]
 broadcast_tensors _tensors = unsafePerformIO $ (cast1 ATen.broadcast_tensors_l) _tensors
 
+cat :: [Tensor] -> Int -> Tensor
+cat _tensors _dim = unsafePerformIO $ (cast2 ATen.cat_ll) _tensors _dim
+
 catWithDimname :: [Tensor] -> Dimname -> Tensor
 catWithDimname _tensors _dim = unsafePerformIO $ (cast2 ATen.cat_ln) _tensors _dim
+
+ceil :: Tensor -> Tensor
+ceil _self = unsafePerformIO $ (cast1 ATen.ceil_t) _self
 
 chain_matmul :: [Tensor] -> Tensor
 chain_matmul _matrices = unsafePerformIO $ (cast1 ATen.chain_matmul_l) _matrices
@@ -174,6 +195,9 @@ convolution_backward_overrideable _grad_output _input _weight _stride _padding _
 conv1d :: Tensor -> Tensor -> Tensor -> Int -> Int -> Int -> Int -> Tensor
 conv1d _input _weight _bias _stride _padding _dilation _groups = unsafePerformIO $ (cast7 ATen.conv1d_tttllll) _input _weight _bias _stride _padding _dilation _groups
 
+conv2d :: Tensor -> Tensor -> Tensor -> (Int,Int) -> (Int,Int) -> (Int,Int) -> Int -> Tensor
+conv2d _input _weight _bias _stride _padding _dilation _groups = unsafePerformIO $ (cast7 ATen.conv2d_tttllll) _input _weight _bias _stride _padding _dilation _groups
+
 conv3d :: Tensor -> Tensor -> Tensor -> (Int,Int,Int) -> (Int,Int,Int) -> (Int,Int,Int) -> Int -> Tensor
 conv3d _input _weight _bias _stride _padding _dilation _groups = unsafePerformIO $ (cast7 ATen.conv3d_tttllll) _input _weight _bias _stride _padding _dilation _groups
 
@@ -185,6 +209,15 @@ conv_tbc_backward _self _input _weight _bias _pad = unsafePerformIO $ (cast5 ATe
 
 conv_transpose1d :: Tensor -> Tensor -> Tensor -> Int -> Int -> Int -> Int -> Int -> Tensor
 conv_transpose1d _input _weight _bias _stride _padding _output_padding _groups _dilation = unsafePerformIO $ (cast8 ATen.conv_transpose1d_tttlllll) _input _weight _bias _stride _padding _output_padding _groups _dilation
+
+conv_transpose2d :: Tensor -> Tensor -> Tensor -> (Int,Int) -> (Int,Int) -> (Int,Int) -> Int -> (Int,Int) -> Tensor
+conv_transpose2d _input _weight _bias _stride _padding _output_padding _groups _dilation = unsafePerformIO $ (cast8 ATen.conv_transpose2d_tttlllll) _input _weight _bias _stride _padding _output_padding _groups _dilation
+
+conv_transpose3d :: Tensor -> Tensor -> Tensor -> (Int,Int,Int) -> (Int,Int,Int) -> (Int,Int,Int) -> Int -> (Int,Int,Int) -> Tensor
+conv_transpose3d _input _weight _bias _stride _padding _output_padding _groups _dilation = unsafePerformIO $ (cast8 ATen.conv_transpose3d_tttlllll) _input _weight _bias _stride _padding _output_padding _groups _dilation
+
+cos :: Tensor -> Tensor
+cos _self = unsafePerformIO $ (cast1 ATen.cos_t) _self
 
 cosh :: Tensor -> Tensor
 cosh _self = unsafePerformIO $ (cast1 ATen.cosh_t) _self
@@ -240,11 +273,23 @@ cudnn_grid_sampler _self _grid = unsafePerformIO $ (cast2 ATen.cudnn_grid_sample
 cudnn_grid_sampler_backward :: Tensor -> Tensor -> Tensor -> (Tensor,Tensor)
 cudnn_grid_sampler_backward _self _grid _grad_output = unsafePerformIO $ (cast3 ATen.cudnn_grid_sampler_backward_ttt) _self _grid _grad_output
 
-cumsum :: Tensor -> Dimname -> DType -> Tensor
-cumsum _self _dim _dtype = unsafePerformIO $ (cast3 ATen.cumsum_tns) _self _dim _dtype
+cumsum :: Tensor -> Int -> DType -> Tensor
+cumsum _self _dim _dtype = unsafePerformIO $ (cast3 ATen.cumsum_tls) _self _dim _dtype
 
-cumprod :: Tensor -> Dimname -> DType -> Tensor
-cumprod _self _dim _dtype = unsafePerformIO $ (cast3 ATen.cumprod_tns) _self _dim _dtype
+cumsumWithDimname :: Tensor -> Dimname -> DType -> Tensor
+cumsumWithDimname _self _dim _dtype = unsafePerformIO $ (cast3 ATen.cumsum_tns) _self _dim _dtype
+
+cumprod :: Tensor -> Int -> DType -> Tensor
+cumprod _self _dim _dtype = unsafePerformIO $ (cast3 ATen.cumprod_tls) _self _dim _dtype
+
+cumprodWithDimname :: Tensor -> Dimname -> DType -> Tensor
+cumprodWithDimname _self _dim _dtype = unsafePerformIO $ (cast3 ATen.cumprod_tns) _self _dim _dtype
+
+ctcLoss' :: Tensor -> Tensor -> [Int] -> [Int] -> Int -> Int -> Bool -> Tensor
+ctcLoss' _log_probs _targets _input_lengths _target_lengths _blank _reduction _zero_infinity = unsafePerformIO $ (cast7 ATen.ctc_loss_ttllllb) _log_probs _targets _input_lengths _target_lengths _blank _reduction _zero_infinity
+
+ctcLoss :: Tensor -> Tensor -> Tensor -> Tensor -> Int -> Int -> Bool -> Tensor
+ctcLoss _log_probs _targets _input_lengths _target_lengths _blank _reduction _zero_infinity = unsafePerformIO $ (cast7 ATen.ctc_loss_ttttllb) _log_probs _targets _input_lengths _target_lengths _blank _reduction _zero_infinity
 
 det :: Tensor -> Tensor
 det _self = unsafePerformIO $ (cast1 ATen.det_t) _self
@@ -257,6 +302,12 @@ diagflat _self _offset = unsafePerformIO $ (cast2 ATen.diagflat_tl) _self _offse
 
 diagonal :: Tensor -> Int -> Int -> Int -> Tensor
 diagonal _self _offset _dim1 _dim2 = unsafePerformIO $ (cast4 ATen.diagonal_tlll) _self _offset _dim1 _dim2
+
+div :: Tensor -> Tensor -> Tensor
+div _self _other = unsafePerformIO $ (cast2 ATen.div_tt) _self _other
+
+divScalar :: Tensor -> Float -> Tensor
+divScalar _self _other = unsafePerformIO $ (cast2 ATen.div_ts) _self _other
 
 dot :: Tensor -> Tensor -> Tensor
 dot _self _tensor = unsafePerformIO $ (cast2 ATen.dot_tt) _self _tensor
@@ -279,11 +330,17 @@ embedding_sparse_backward _grad _indices _num_weights _padding_idx _scale_grad_b
 embedding_bag :: Tensor -> Tensor -> Tensor -> Bool -> Int -> Bool -> Tensor -> (Tensor,Tensor,Tensor,Tensor)
 embedding_bag _weight _indices _offsets _scale_grad_by_freq _mode _sparse _per_sample_weights = unsafePerformIO $ (cast7 ATen.embedding_bag_tttblbt) _weight _indices _offsets _scale_grad_by_freq _mode _sparse _per_sample_weights
 
-empty_like :: Tensor -> MemoryFormat -> Tensor
-empty_like _self _memory_format = unsafePerformIO $ (cast2 ATen.empty_like_tM) _self _memory_format
+empty_like_tM :: Tensor -> MemoryFormat -> Tensor
+empty_like_tM _self _memory_format = unsafePerformIO $ (cast2 ATen.empty_like_tM) _self _memory_format
+
+erf :: Tensor -> Tensor
+erf _self = unsafePerformIO $ (cast1 ATen.erf_t) _self
 
 erfc :: Tensor -> Tensor
 erfc _self = unsafePerformIO $ (cast1 ATen.erfc_t) _self
+
+exp :: Tensor -> Tensor
+exp _self = unsafePerformIO $ (cast1 ATen.exp_t) _self
 
 expm1 :: Tensor -> Tensor
 expm1 _self = unsafePerformIO $ (cast1 ATen.expm1_t) _self
@@ -291,11 +348,23 @@ expm1 _self = unsafePerformIO $ (cast1 ATen.expm1_t) _self
 flatten :: Tensor -> Int -> Int -> Tensor
 flatten _self _start_dim _end_dim = unsafePerformIO $ (cast3 ATen.flatten_tll) _self _start_dim _end_dim
 
+flattenTo :: Tensor -> Int -> Int -> Dimname -> Tensor
+flattenTo _self _start_dim _end_dim _out_dim = unsafePerformIO $ (cast4 ATen.flatten_tlln) _self _start_dim _end_dim _out_dim
+
+flattenToWithDimname :: Tensor -> Dimname -> Dimname -> Dimname -> Tensor
+flattenToWithDimname _self _start_dim _end_dim _out_dim = unsafePerformIO $ (cast4 ATen.flatten_tnnn) _self _start_dim _end_dim _out_dim
+
+flattenToWithDimnames :: Tensor -> [Dimname] -> Dimname -> Tensor
+flattenToWithDimnames _self _dims _out_dim = unsafePerformIO $ (cast3 ATen.flatten_tNn) _self _dims _out_dim
+
+floor :: Tensor -> Tensor
+floor _self = unsafePerformIO $ (cast1 ATen.floor_t) _self
+
 frac :: Tensor -> Tensor
 frac _self = unsafePerformIO $ (cast1 ATen.frac_t) _self
 
-full_like :: Tensor -> Float -> MemoryFormat -> Tensor
-full_like _self _fill_value _memory_format = unsafePerformIO $ (cast3 ATen.full_like_tsM) _self _fill_value _memory_format
+full_like_tsM :: Tensor -> Float -> MemoryFormat -> Tensor
+full_like_tsM _self _fill_value _memory_format = unsafePerformIO $ (cast3 ATen.full_like_tsM) _self _fill_value _memory_format
 
 grid_sampler :: Tensor -> Tensor -> Int -> Int -> Bool -> Tensor
 grid_sampler _input _grid _interpolation_mode _padding_mode _align_corners = unsafePerformIO $ (cast5 ATen.grid_sampler_ttllb) _input _grid _interpolation_mode _padding_mode _align_corners
@@ -347,6 +416,9 @@ index_put _self _indices _values _accumulate = unsafePerformIO $ (cast4 ATen.ind
 
 instance_norm :: Tensor -> Tensor -> Tensor -> Tensor -> Tensor -> Bool -> Double -> Double -> Bool -> Tensor
 instance_norm _input _weight _bias _running_mean _running_var _use_input_stats _momentum _eps _cudnn_enabled = unsafePerformIO $ (cast9 ATen.instance_norm_tttttbddb) _input _weight _bias _running_mean _running_var _use_input_stats _momentum _eps _cudnn_enabled
+
+inverse :: Tensor -> Tensor
+inverse _self = unsafePerformIO $ (cast1 ATen.inverse_t) _self
 
 isclose :: Tensor -> Tensor -> Double -> Double -> Bool -> Tensor
 isclose _self _other _rtol _atol _equal_nan = unsafePerformIO $ (cast5 ATen.isclose_ttddb) _self _other _rtol _atol _equal_nan
@@ -417,11 +489,29 @@ fbgemm_linear_fp16_weight_fp32_activation _input _packed_weight _bias = unsafePe
 fbgemm_linear_fp16_weight :: Tensor -> Tensor -> Tensor -> Tensor
 fbgemm_linear_fp16_weight _input _packed_weight _bias = unsafePerformIO $ (cast3 ATen.fbgemm_linear_fp16_weight_ttt) _input _packed_weight _bias
 
+quantizeFbgemm' :: Tensor -> Tensor
+quantizeFbgemm' _input = unsafePerformIO $ (cast1 ATen.fbgemm_pack_quantized_matrix_t) _input
+
+quantizeFbgemm :: Tensor -> Int -> Int -> Tensor
+quantizeFbgemm _input _K _N = unsafePerformIO $ (cast3 ATen.fbgemm_pack_quantized_matrix_tll) _input _K _N
+
 log :: Tensor -> Tensor
 log _self = unsafePerformIO $ (cast1 ATen.log_t) _self
 
+log10 :: Tensor -> Tensor
+log10 _self = unsafePerformIO $ (cast1 ATen.log10_t) _self
+
+log1p :: Tensor -> Tensor
+log1p _self = unsafePerformIO $ (cast1 ATen.log1p_t) _self
+
+log2 :: Tensor -> Tensor
+log2 _self = unsafePerformIO $ (cast1 ATen.log2_t) _self
+
 logdet :: Tensor -> Tensor
 logdet _self = unsafePerformIO $ (cast1 ATen.logdet_t) _self
+
+log_softmax :: Tensor -> Int -> DType -> Tensor
+log_softmax _self _dim _dtype = unsafePerformIO $ (cast3 ATen.log_softmax_tls) _self _dim _dtype
 
 logSoftmaxWithDimname :: Tensor -> Dimname -> DType -> Tensor
 logSoftmaxWithDimname _self _dim _dtype = unsafePerformIO $ (cast3 ATen.log_softmax_tns) _self _dim _dtype
@@ -435,8 +525,20 @@ logsumexpWithDimnameList _self _dim _keepdim = unsafePerformIO $ (cast3 ATen.log
 margin_ranking_loss :: Tensor -> Tensor -> Tensor -> Double -> Int -> Tensor
 margin_ranking_loss _input1 _input2 _target _margin _reduction = unsafePerformIO $ (cast5 ATen.margin_ranking_loss_tttdl) _input1 _input2 _target _margin _reduction
 
+matmul :: Tensor -> Tensor -> Tensor
+matmul _self _other = unsafePerformIO $ (cast2 ATen.matmul_tt) _self _other
+
+matrixRank :: Tensor -> Double -> Bool -> Tensor
+matrixRank _self _tol _symmetric = unsafePerformIO $ (cast3 ATen.matrix_rank_tdb) _self _tol _symmetric
+
+matrixRank' :: Tensor -> Bool -> Tensor
+matrixRank' _self _symmetric = unsafePerformIO $ (cast2 ATen.matrix_rank_tb) _self _symmetric
+
 matrix_power :: Tensor -> Int -> Tensor
 matrix_power _self _n = unsafePerformIO $ (cast2 ATen.matrix_power_tl) _self _n
+
+maxDim :: Tensor -> Int -> Bool -> (Tensor,Tensor)
+maxDim _self _dim _keepdim = unsafePerformIO $ (cast3 ATen.max_tlb) _self _dim _keepdim
 
 maxValues :: Tensor -> Int -> Bool -> Tensor
 maxValues _self _dim _keepdim = unsafePerformIO $ (cast3 ATen.max_values_tlb) _self _dim _keepdim
@@ -465,11 +567,23 @@ quantized_max_pool2d _self _kernel_size _stride _padding _dilation _ceil_mode = 
 max_pool3d :: Tensor -> (Int,Int,Int) -> (Int,Int,Int) -> (Int,Int,Int) -> (Int,Int,Int) -> Bool -> Tensor
 max_pool3d _self _kernel_size _stride _padding _dilation _ceil_mode = unsafePerformIO $ (cast6 ATen.max_pool3d_tllllb) _self _kernel_size _stride _padding _dilation _ceil_mode
 
+meanAll :: Tensor -> DType -> Tensor
+meanAll _self _dtype = unsafePerformIO $ (cast2 ATen.mean_ts) _self _dtype
+
+meanDim :: Tensor -> Int -> Bool -> DType -> Tensor
+meanDim _self _dim _keepdim _dtype = unsafePerformIO $ (cast4 ATen.mean_tlbs) _self _dim _keepdim _dtype
+
 meanWithDimnames :: Tensor -> [Dimname] -> Bool -> DType -> Tensor
 meanWithDimnames _self _dim _keepdim _dtype = unsafePerformIO $ (cast4 ATen.mean_tNbs) _self _dim _keepdim _dtype
 
+medianDim :: Tensor -> Int -> Bool -> (Tensor,Tensor)
+medianDim _self _dim _keepdim = unsafePerformIO $ (cast3 ATen.median_tlb) _self _dim _keepdim
+
 medianWithDimname :: Tensor -> Dimname -> Bool -> (Tensor,Tensor)
 medianWithDimname _self _dim _keepdim = unsafePerformIO $ (cast3 ATen.median_tnb) _self _dim _keepdim
+
+minDim :: Tensor -> Int -> Bool -> (Tensor,Tensor)
+minDim _self _dim _keepdim = unsafePerformIO $ (cast3 ATen.min_tlb) _self _dim _keepdim
 
 minValues :: Tensor -> Int -> Bool -> Tensor
 minValues _self _dim _keepdim = unsafePerformIO $ (cast3 ATen.min_values_tlb) _self _dim _keepdim
@@ -552,6 +666,12 @@ mode _self _dim _keepdim = unsafePerformIO $ (cast3 ATen.mode_tlb) _self _dim _k
 modeWithDimname :: Tensor -> Dimname -> Bool -> (Tensor,Tensor)
 modeWithDimname _self _dim _keepdim = unsafePerformIO $ (cast3 ATen.mode_tnb) _self _dim _keepdim
 
+mul :: Tensor -> Tensor -> Tensor
+mul _self _other = unsafePerformIO $ (cast2 ATen.mul_tt) _self _other
+
+mulScalar :: Tensor -> Float -> Tensor
+mulScalar _self _other = unsafePerformIO $ (cast2 ATen.mul_ts) _self _other
+
 mv :: Tensor -> Tensor -> Tensor
 mv _self _vec = unsafePerformIO $ (cast2 ATen.mv_tt) _self _vec
 
@@ -588,8 +708,8 @@ batch_norm_backward_elemt _grad_out _input _mean _invstd _weight _mean_dy _mean_
 batch_norm_update_stats :: Tensor -> Tensor -> Tensor -> Double -> (Tensor,Tensor)
 batch_norm_update_stats _input _running_mean _running_var _momentum = unsafePerformIO $ (cast4 ATen.batch_norm_update_stats_tttd) _input _running_mean _running_var _momentum
 
-ones_like :: Tensor -> MemoryFormat -> Tensor
-ones_like _self _memory_format = unsafePerformIO $ (cast2 ATen.ones_like_tM) _self _memory_format
+ones_like_tM :: Tensor -> MemoryFormat -> Tensor
+ones_like_tM _self _memory_format = unsafePerformIO $ (cast2 ATen.ones_like_tM) _self _memory_format
 
 pairwise_distance :: Tensor -> Tensor -> Double -> Double -> Bool -> Tensor
 pairwise_distance _x1 _x2 _p _eps _keepdim = unsafePerformIO $ (cast5 ATen.pairwise_distance_ttddb) _x1 _x2 _p _eps _keepdim
@@ -612,11 +732,17 @@ pinverse _self _rcond = unsafePerformIO $ (cast2 ATen.pinverse_td) _self _rcond
 poisson_nll_loss :: Tensor -> Tensor -> Bool -> Bool -> Double -> Int -> Tensor
 poisson_nll_loss _input _target _log_input _full _eps _reduction = unsafePerformIO $ (cast6 ATen.poisson_nll_loss_ttbbdl) _input _target _log_input _full _eps _reduction
 
-rand_like :: Tensor -> MemoryFormat -> Tensor
-rand_like _self _memory_format = unsafePerformIO $ (cast2 ATen.rand_like_tM) _self _memory_format
+rand_like_tM :: Tensor -> MemoryFormat -> Tensor
+rand_like_tM _self _memory_format = unsafePerformIO $ (cast2 ATen.rand_like_tM) _self _memory_format
 
-randn_like :: Tensor -> MemoryFormat -> Tensor
-randn_like _self _memory_format = unsafePerformIO $ (cast2 ATen.randn_like_tM) _self _memory_format
+randintLike' :: Tensor -> Int -> MemoryFormat -> Tensor
+randintLike' _self _high _memory_format = unsafePerformIO $ (cast3 ATen.randint_like_tlM) _self _high _memory_format
+
+randintLike :: Tensor -> Int -> Int -> MemoryFormat -> Tensor
+randintLike _self _low _high _memory_format = unsafePerformIO $ (cast4 ATen.randint_like_tllM) _self _low _high _memory_format
+
+randn_like_tM :: Tensor -> MemoryFormat -> Tensor
+randn_like_tM _self _memory_format = unsafePerformIO $ (cast2 ATen.randn_like_tM) _self _memory_format
 
 reciprocal :: Tensor -> Tensor
 reciprocal _self = unsafePerformIO $ (cast1 ATen.reciprocal_t) _self
@@ -624,8 +750,23 @@ reciprocal _self = unsafePerformIO $ (cast1 ATen.reciprocal_t) _self
 neg :: Tensor -> Tensor
 neg _self = unsafePerformIO $ (cast1 ATen.neg_t) _self
 
+repeatInterleaveRange :: Tensor -> Tensor
+repeatInterleaveRange _repeats = unsafePerformIO $ (cast1 ATen.repeat_interleave_t) _repeats
+
+repeatInterleave :: Tensor -> Tensor -> Int -> Tensor
+repeatInterleave _self _repeats _dim = unsafePerformIO $ (cast3 ATen.repeat_interleave_ttl) _self _repeats _dim
+
+repeatInterleaveScalar :: Tensor -> Int -> Int -> Tensor
+repeatInterleaveScalar _self _repeats _dim = unsafePerformIO $ (cast3 ATen.repeat_interleave_tll) _self _repeats _dim
+
+reshape :: Tensor -> [Int] -> Tensor
+reshape _self _shape = unsafePerformIO $ (cast2 ATen.reshape_tl) _self _shape
+
 round :: Tensor -> Tensor
 round _self = unsafePerformIO $ (cast1 ATen.round_t) _self
+
+relu :: Tensor -> Tensor
+relu _self = unsafePerformIO $ (cast1 ATen.relu_t) _self
 
 prelu :: Tensor -> Tensor -> Tensor
 prelu _self _weight = unsafePerformIO $ (cast2 ATen.prelu_tt) _self _weight
@@ -651,8 +792,26 @@ rsqrt _self = unsafePerformIO $ (cast1 ATen.rsqrt_t) _self
 selectWithDimname :: Tensor -> Dimname -> Int -> Tensor
 selectWithDimname _self _dim _index = unsafePerformIO $ (cast3 ATen.select_tnl) _self _dim _index
 
+select :: Tensor -> Int -> Int -> Tensor
+select _self _dim _index = unsafePerformIO $ (cast3 ATen.select_tll) _self _dim _index
+
+selu :: Tensor -> Tensor
+selu _self = unsafePerformIO $ (cast1 ATen.selu_t) _self
+
 celu :: Tensor -> Float -> Tensor
 celu _self _alpha = unsafePerformIO $ (cast2 ATen.celu_ts) _self _alpha
+
+sigmoid :: Tensor -> Tensor
+sigmoid _self = unsafePerformIO $ (cast1 ATen.sigmoid_t) _self
+
+sin :: Tensor -> Tensor
+sin _self = unsafePerformIO $ (cast1 ATen.sin_t) _self
+
+sinh :: Tensor -> Tensor
+sinh _self = unsafePerformIO $ (cast1 ATen.sinh_t) _self
+
+size :: Tensor -> Int -> Int
+size _self _dim = unsafePerformIO $ (cast2 ATen.size_tl) _self _dim
 
 sizeWithDimname :: Tensor -> Dimname -> Int
 sizeWithDimname _self _dim = unsafePerformIO $ (cast2 ATen.size_tn) _self _dim
@@ -678,6 +837,12 @@ split _self _split_size _dim = unsafePerformIO $ (cast3 ATen.split_tll) _self _s
 split_with_sizes :: Tensor -> [Int] -> Int -> [Tensor]
 split_with_sizes _self _split_sizes _dim = unsafePerformIO $ (cast3 ATen.split_with_sizes_tll) _self _split_sizes _dim
 
+squeezeAll :: Tensor -> Tensor
+squeezeAll _self = unsafePerformIO $ (cast1 ATen.squeeze_t) _self
+
+squeezeDim :: Tensor -> Int -> Tensor
+squeezeDim _self _dim = unsafePerformIO $ (cast2 ATen.squeeze_tl) _self _dim
+
 squeezeWithDimname :: Tensor -> Dimname -> Tensor
 squeezeWithDimname _self _dim = unsafePerformIO $ (cast2 ATen.squeeze_tn) _self _dim
 
@@ -696,14 +861,41 @@ stride _self _dim = unsafePerformIO $ (cast2 ATen.stride_tl) _self _dim
 strideWithDimname :: Tensor -> Dimname -> Int
 strideWithDimname _self _dim = unsafePerformIO $ (cast2 ATen.stride_tn) _self _dim
 
+sumAll :: Tensor -> DType -> Tensor
+sumAll _self _dtype = unsafePerformIO $ (cast2 ATen.sum_ts) _self _dtype
+
+sumDim :: Tensor -> Int -> Bool -> DType -> Tensor
+sumDim _self _dim _keepdim _dtype = unsafePerformIO $ (cast4 ATen.sum_tlbs) _self _dim _keepdim _dtype
+
 sumWithDimnames :: Tensor -> [Dimname] -> Bool -> DType -> Tensor
 sumWithDimnames _self _dim _keepdim _dtype = unsafePerformIO $ (cast4 ATen.sum_tNbs) _self _dim _keepdim _dtype
+
+sqrt :: Tensor -> Tensor
+sqrt _self = unsafePerformIO $ (cast1 ATen.sqrt_t) _self
+
+stdAll :: Tensor -> Bool -> Tensor
+stdAll _self _unbiased = unsafePerformIO $ (cast2 ATen.std_tb) _self _unbiased
+
+stdDim :: Tensor -> Int -> Bool -> Bool -> Tensor
+stdDim _self _dim _unbiased _keepdim = unsafePerformIO $ (cast4 ATen.std_tlbb) _self _dim _unbiased _keepdim
+
+stdMeanAll :: Tensor -> Bool -> (Tensor,Tensor)
+stdMeanAll _self _unbiased = unsafePerformIO $ (cast2 ATen.std_mean_tb) _self _unbiased
+
+stdMeanDim :: Tensor -> Int -> Bool -> Bool -> (Tensor,Tensor)
+stdMeanDim _self _dim _unbiased _keepdim = unsafePerformIO $ (cast4 ATen.std_mean_tlbb) _self _dim _unbiased _keepdim
 
 stdMeanWithDimnames :: Tensor -> [Dimname] -> Bool -> Bool -> (Tensor,Tensor)
 stdMeanWithDimnames _self _dim _unbiased _keepdim = unsafePerformIO $ (cast4 ATen.std_mean_tNbb) _self _dim _unbiased _keepdim
 
 stdWithDimnames :: Tensor -> [Dimname] -> Bool -> Bool -> Tensor
 stdWithDimnames _self _dim _unbiased _keepdim = unsafePerformIO $ (cast4 ATen.std_tNbb) _self _dim _unbiased _keepdim
+
+prodAll :: Tensor -> DType -> Tensor
+prodAll _self _dtype = unsafePerformIO $ (cast2 ATen.prod_ts) _self _dtype
+
+prodDim :: Tensor -> Int -> Bool -> DType -> Tensor
+prodDim _self _dim _keepdim _dtype = unsafePerformIO $ (cast4 ATen.prod_tlbs) _self _dim _keepdim _dtype
 
 prodWithDimnames :: Tensor -> Dimname -> Bool -> DType -> Tensor
 prodWithDimnames _self _dim _keepdim _dtype = unsafePerformIO $ (cast4 ATen.prod_tnbs) _self _dim _keepdim _dtype
@@ -714,6 +906,9 @@ t _self = unsafePerformIO $ (cast1 ATen.t_t) _self
 tan :: Tensor -> Tensor
 tan _self = unsafePerformIO $ (cast1 ATen.tan_t) _self
 
+tanh :: Tensor -> Tensor
+tanh _self = unsafePerformIO $ (cast1 ATen.tanh_t) _self
+
 tensordot :: Tensor -> Tensor -> [Int] -> [Int] -> Tensor
 tensordot _self _other _dims_self _dims_other = unsafePerformIO $ (cast4 ATen.tensordot_ttll) _self _other _dims_self _dims_other
 
@@ -722,6 +917,9 @@ threshold _self _threshold _value = unsafePerformIO $ (cast3 ATen.threshold_tss)
 
 threshold_backward :: Tensor -> Tensor -> Float -> Tensor
 threshold_backward _grad_output _self _threshold = unsafePerformIO $ (cast3 ATen.threshold_backward_tts) _grad_output _self _threshold
+
+transpose :: Tensor -> Int -> Int -> Tensor
+transpose _self _dim0 _dim1 = unsafePerformIO $ (cast3 ATen.transpose_tll) _self _dim0 _dim1
 
 transposeWithDimname :: Tensor -> Dimname -> Dimname -> Tensor
 transposeWithDimname _self _dim0 _dim1 = unsafePerformIO $ (cast3 ATen.transpose_tnn) _self _dim0 _dim1
@@ -737,6 +935,12 @@ roll _self _shifts _dims = unsafePerformIO $ (cast3 ATen.roll_tll) _self _shifts
 
 rot90 :: Tensor -> Int -> [Int] -> Tensor
 rot90 _self _k _dims = unsafePerformIO $ (cast3 ATen.rot90_tll) _self _k _dims
+
+trapz :: Tensor -> Tensor -> Int -> Tensor
+trapz _y _x _dim = unsafePerformIO $ (cast3 ATen.trapz_ttl) _y _x _dim
+
+trapzScalar :: Tensor -> Double -> Int -> Tensor
+trapzScalar _y _dx _dim = unsafePerformIO $ (cast3 ATen.trapz_tdl) _y _dx _dim
 
 triplet_margin_loss :: Tensor -> Tensor -> Tensor -> Double -> Double -> Double -> Bool -> Int -> Tensor
 triplet_margin_loss _anchor _positive _negative _margin _p _eps _swap _reduction = unsafePerformIO $ (cast8 ATen.triplet_margin_loss_tttdddbl) _anchor _positive _negative _margin _p _eps _swap _reduction
@@ -756,8 +960,20 @@ unique_dim_consecutive _self _dim _return_inverse _return_counts = unsafePerform
 unsqueeze :: Tensor -> Int -> Tensor
 unsqueeze _self _dim = unsafePerformIO $ (cast2 ATen.unsqueeze_tl) _self _dim
 
+var :: Tensor -> Bool -> Tensor
+var _self _unbiased = unsafePerformIO $ (cast2 ATen.var_tb) _self _unbiased
+
+varDim :: Tensor -> Int -> Bool -> Bool -> Tensor
+varDim _self _dim _unbiased _keepdim = unsafePerformIO $ (cast4 ATen.var_tlbb) _self _dim _unbiased _keepdim
+
 varWithDimnames :: Tensor -> [Dimname] -> Bool -> Bool -> Tensor
 varWithDimnames _self _dim _unbiased _keepdim = unsafePerformIO $ (cast4 ATen.var_tNbb) _self _dim _unbiased _keepdim
+
+varMean :: Tensor -> Bool -> (Tensor,Tensor)
+varMean _self _unbiased = unsafePerformIO $ (cast2 ATen.var_mean_tb) _self _unbiased
+
+varMeanDim :: Tensor -> Int -> Bool -> Bool -> (Tensor,Tensor)
+varMeanDim _self _dim _unbiased _keepdim = unsafePerformIO $ (cast4 ATen.var_mean_tlbb) _self _dim _unbiased _keepdim
 
 varMeanWithDimnames :: Tensor -> [Dimname] -> Bool -> Bool -> (Tensor,Tensor)
 varMeanWithDimnames _self _dim _unbiased _keepdim = unsafePerformIO $ (cast4 ATen.var_mean_tNbb) _self _dim _unbiased _keepdim
@@ -765,17 +981,65 @@ varMeanWithDimnames _self _dim _unbiased _keepdim = unsafePerformIO $ (cast4 ATe
 where' :: Tensor -> Tensor -> Tensor -> Tensor
 where' _condition _self _other = unsafePerformIO $ (cast3 ATen.where_ttt) _condition _self _other
 
+isNonZero :: Tensor -> [Tensor]
+isNonZero _condition = unsafePerformIO $ (cast1 ATen.where_t) _condition
+
 norm_except_dim :: Tensor -> Int -> Int -> Tensor
 norm_except_dim _v _pow _dim = unsafePerformIO $ (cast3 ATen.norm_except_dim_tll) _v _pow _dim
 
-zeros_like :: Tensor -> MemoryFormat -> Tensor
-zeros_like _self _memory_format = unsafePerformIO $ (cast2 ATen.zeros_like_tM) _self _memory_format
+zeros_like_tM :: Tensor -> MemoryFormat -> Tensor
+zeros_like_tM _self _memory_format = unsafePerformIO $ (cast2 ATen.zeros_like_tM) _self _memory_format
 
 native_norm :: Tensor -> Float -> Tensor
 native_norm _self _p = unsafePerformIO $ (cast2 ATen.native_norm_ts) _self _p
 
+normCastAll :: Tensor -> Float -> DType -> Tensor
+normCastAll _self _p _dtype = unsafePerformIO $ (cast3 ATen.norm_tss) _self _p _dtype
+
+normAll :: Tensor -> Float -> Tensor
+normAll _self _p = unsafePerformIO $ (cast2 ATen.norm_ts) _self _p
+
+normCastDim :: Tensor -> Float -> Int -> Bool -> DType -> Tensor
+normCastDim _self _p _dim _keepdim _dtype = unsafePerformIO $ (cast5 ATen.norm_tslbs) _self _p _dim _keepdim _dtype
+
+normDim :: Tensor -> Float -> Int -> Bool -> Tensor
+normDim _self _p _dim _keepdim = unsafePerformIO $ (cast4 ATen.norm_tslb) _self _p _dim _keepdim
+
+norm_tsNbs :: Tensor -> Float -> [Dimname] -> Bool -> DType -> Tensor
+norm_tsNbs _self _p _dim _keepdim _dtype = unsafePerformIO $ (cast5 ATen.norm_tsNbs) _self _p _dim _keepdim _dtype
+
+norm_tsNb :: Tensor -> Float -> [Dimname] -> Bool -> Tensor
+norm_tsNb _self _p _dim _keepdim = unsafePerformIO $ (cast4 ATen.norm_tsNb) _self _p _dim _keepdim
+
+frobeniusNormAll :: Tensor -> Tensor
+frobeniusNormAll _self = unsafePerformIO $ (cast1 ATen.frobenius_norm_t) _self
+
+frobeniusNormDim :: Tensor -> Int -> Bool -> Tensor
+frobeniusNormDim _self _dim _keepdim = unsafePerformIO $ (cast3 ATen.frobenius_norm_tlb) _self _dim _keepdim
+
+nuclearNormAll :: Tensor -> Bool -> Tensor
+nuclearNormAll _self _keepdim = unsafePerformIO $ (cast2 ATen.nuclear_norm_tb) _self _keepdim
+
+nuclearNormDim :: Tensor -> (Int,Int) -> Bool -> Tensor
+nuclearNormDim _self _dim _keepdim = unsafePerformIO $ (cast3 ATen.nuclear_norm_tlb) _self _dim _keepdim
+
 clone :: Tensor -> MemoryFormat -> Tensor
 clone _self _memory_format = unsafePerformIO $ (cast2 ATen.clone_tM) _self _memory_format
+
+powScalar :: Tensor -> Float -> Tensor
+powScalar _self _exponent = unsafePerformIO $ (cast2 ATen.pow_ts) _self _exponent
+
+sub :: Tensor -> Tensor -> Float -> Tensor
+sub _self _other _alpha = unsafePerformIO $ (cast3 ATen.sub_tts) _self _other _alpha
+
+subScalar :: Tensor -> Float -> Float -> Tensor
+subScalar _self _other _alpha = unsafePerformIO $ (cast3 ATen.sub_tss) _self _other _alpha
+
+rsub :: Tensor -> Tensor -> Float -> Tensor
+rsub _self _other _alpha = unsafePerformIO $ (cast3 ATen.rsub_tts) _self _other _alpha
+
+rsubScalar :: Tensor -> Float -> Float -> Tensor
+rsubScalar _self _other _alpha = unsafePerformIO $ (cast3 ATen.rsub_tss) _self _other _alpha
 
 addmm :: Tensor -> Tensor -> Tensor -> Float -> Float -> Tensor
 addmm _self _mat1 _mat2 _beta _alpha = unsafePerformIO $ (cast5 ATen.addmm_tttss) _self _mat1 _mat2 _beta _alpha
@@ -846,11 +1110,47 @@ cartesian_prod _tensors = unsafePerformIO $ (cast1 ATen.cartesian_prod_l) _tenso
 combinations :: Tensor -> Int -> Bool -> Tensor
 combinations _self _r _with_replacement = unsafePerformIO $ (cast3 ATen.combinations_tlb) _self _r _with_replacement
 
+resultType :: Tensor -> Tensor -> DType
+resultType _tensor _other = unsafePerformIO $ (cast2 ATen.result_type_tt) _tensor _other
+
+resultTypeScalar :: Tensor -> Float -> DType
+resultTypeScalar _tensor _other = unsafePerformIO $ (cast2 ATen.result_type_ts) _tensor _other
+
+resultTypeScalar' :: Float -> Tensor -> DType
+resultTypeScalar' _scalar _tensor = unsafePerformIO $ (cast2 ATen.result_type_st) _scalar _tensor
+
+resultTypeScalars :: Float -> Float -> DType
+resultTypeScalars _scalar1 _scalar2 = unsafePerformIO $ (cast2 ATen.result_type_ss) _scalar1 _scalar2
+
 can_cast :: DType -> DType -> Bool
 can_cast _from _to = unsafePerformIO $ (cast2 ATen.can_cast_ss) _from _to
 
 promote_types :: DType -> DType -> DType
 promote_types _type1 _type2 = unsafePerformIO $ (cast2 ATen.promote_types_ss) _type1 _type2
+
+lstm :: Tensor -> [Tensor] -> [Tensor] -> Bool -> Int -> Double -> Bool -> Bool -> Bool -> (Tensor,Tensor,Tensor)
+lstm _input _hx _params _has_biases _num_layers _dropout _train _bidirectional _batch_first = unsafePerformIO $ (cast9 ATen.lstm_tllbldbbb) _input _hx _params _has_biases _num_layers _dropout _train _bidirectional _batch_first
+
+lstm' :: Tensor -> Tensor -> [Tensor] -> [Tensor] -> Bool -> Int -> Double -> Bool -> Bool -> (Tensor,Tensor,Tensor)
+lstm' _data _batch_sizes _hx _params _has_biases _num_layers _dropout _train _bidirectional = unsafePerformIO $ (cast9 ATen.lstm_ttllbldbb) _data _batch_sizes _hx _params _has_biases _num_layers _dropout _train _bidirectional
+
+gru :: Tensor -> Tensor -> [Tensor] -> Bool -> Int -> Double -> Bool -> Bool -> Bool -> (Tensor,Tensor)
+gru _input _hx _params _has_biases _num_layers _dropout _train _bidirectional _batch_first = unsafePerformIO $ (cast9 ATen.gru_ttlbldbbb) _input _hx _params _has_biases _num_layers _dropout _train _bidirectional _batch_first
+
+gru' :: Tensor -> Tensor -> Tensor -> [Tensor] -> Bool -> Int -> Double -> Bool -> Bool -> (Tensor,Tensor)
+gru' _data _batch_sizes _hx _params _has_biases _num_layers _dropout _train _bidirectional = unsafePerformIO $ (cast9 ATen.gru_tttlbldbb) _data _batch_sizes _hx _params _has_biases _num_layers _dropout _train _bidirectional
+
+rnnTanh :: Tensor -> Tensor -> [Tensor] -> Bool -> Int -> Double -> Bool -> Bool -> Bool -> (Tensor,Tensor)
+rnnTanh _input _hx _params _has_biases _num_layers _dropout _train _bidirectional _batch_first = unsafePerformIO $ (cast9 ATen.rnn_tanh_ttlbldbbb) _input _hx _params _has_biases _num_layers _dropout _train _bidirectional _batch_first
+
+rnnTanh' :: Tensor -> Tensor -> Tensor -> [Tensor] -> Bool -> Int -> Double -> Bool -> Bool -> (Tensor,Tensor)
+rnnTanh' _data _batch_sizes _hx _params _has_biases _num_layers _dropout _train _bidirectional = unsafePerformIO $ (cast9 ATen.rnn_tanh_tttlbldbb) _data _batch_sizes _hx _params _has_biases _num_layers _dropout _train _bidirectional
+
+rnnRelu :: Tensor -> Tensor -> [Tensor] -> Bool -> Int -> Double -> Bool -> Bool -> Bool -> (Tensor,Tensor)
+rnnRelu _input _hx _params _has_biases _num_layers _dropout _train _bidirectional _batch_first = unsafePerformIO $ (cast9 ATen.rnn_relu_ttlbldbbb) _input _hx _params _has_biases _num_layers _dropout _train _bidirectional _batch_first
+
+rnnRelu' :: Tensor -> Tensor -> Tensor -> [Tensor] -> Bool -> Int -> Double -> Bool -> Bool -> (Tensor,Tensor)
+rnnRelu' _data _batch_sizes _hx _params _has_biases _num_layers _dropout _train _bidirectional = unsafePerformIO $ (cast9 ATen.rnn_relu_tttlbldbb) _data _batch_sizes _hx _params _has_biases _num_layers _dropout _train _bidirectional
 
 lstm_cell :: Tensor -> [Tensor] -> Tensor -> Tensor -> Tensor -> Tensor -> (Tensor,Tensor)
 lstm_cell _input _hx _w_ih _w_hh _b_ih _b_hh = unsafePerformIO $ (cast6 ATen.lstm_cell_tltttt) _input _hx _w_ih _w_hh _b_ih _b_hh
@@ -864,6 +1164,18 @@ rnn_tanh_cell _input _hx _w_ih _w_hh _b_ih _b_hh = unsafePerformIO $ (cast6 ATen
 rnn_relu_cell :: Tensor -> Tensor -> Tensor -> Tensor -> Tensor -> Tensor -> Tensor
 rnn_relu_cell _input _hx _w_ih _w_hh _b_ih _b_hh = unsafePerformIO $ (cast6 ATen.rnn_relu_cell_tttttt) _input _hx _w_ih _w_hh _b_ih _b_hh
 
+quantizedLstm :: Tensor -> [Tensor] -> [Tensor] -> Bool -> Int -> Double -> Bool -> Bool -> Bool -> DType -> Bool -> (Tensor,Tensor,Tensor)
+quantizedLstm _input _hx _params _has_biases _num_layers _dropout _train _bidirectional _batch_first _dtype _use_dynamic = unsafePerformIO $ (cast11 ATen.quantized_lstm_tllbldbbbsb) _input _hx _params _has_biases _num_layers _dropout _train _bidirectional _batch_first _dtype _use_dynamic
+
+quantizedLstm' :: Tensor -> Tensor -> [Tensor] -> [Tensor] -> Bool -> Int -> Double -> Bool -> Bool -> DType -> Bool -> (Tensor,Tensor,Tensor)
+quantizedLstm' _data _batch_sizes _hx _params _has_biases _num_layers _dropout _train _bidirectional _dtype _use_dynamic = unsafePerformIO $ (cast11 ATen.quantized_lstm_ttllbldbbsb) _data _batch_sizes _hx _params _has_biases _num_layers _dropout _train _bidirectional _dtype _use_dynamic
+
+quantizedGru :: Tensor -> Tensor -> [Tensor] -> Bool -> Int -> Double -> Bool -> Bool -> Bool -> (Tensor,Tensor)
+quantizedGru _input _hx _params _has_biases _num_layers _dropout _train _bidirectional _batch_first = unsafePerformIO $ (cast9 ATen.quantized_gru_ttlbldbbb) _input _hx _params _has_biases _num_layers _dropout _train _bidirectional _batch_first
+
+quantizedGru' :: Tensor -> Tensor -> Tensor -> [Tensor] -> Bool -> Int -> Double -> Bool -> Bool -> (Tensor,Tensor)
+quantizedGru' _data _batch_sizes _hx _params _has_biases _num_layers _dropout _train _bidirectional = unsafePerformIO $ (cast9 ATen.quantized_gru_tttlbldbb) _data _batch_sizes _hx _params _has_biases _num_layers _dropout _train _bidirectional
+
 quantized_lstm_cell :: Tensor -> [Tensor] -> Tensor -> Tensor -> Tensor -> Tensor -> Tensor -> Tensor -> Tensor -> Tensor -> Float -> Float -> Float -> Float -> (Tensor,Tensor)
 quantized_lstm_cell _input _hx _w_ih _w_hh _b_ih _b_hh _packed_ih _packed_hh _col_offsets_ih _col_offsets_hh _scale_ih _scale_hh _zero_point_ih _zero_point_hh = unsafePerformIO $ (cast14 ATen.quantized_lstm_cell_tlttttttttssss) _input _hx _w_ih _w_hh _b_ih _b_hh _packed_ih _packed_hh _col_offsets_ih _col_offsets_hh _scale_ih _scale_hh _zero_point_ih _zero_point_hh
 
@@ -876,6 +1188,12 @@ quantized_rnn_relu_cell _input _hx _w_ih _w_hh _b_ih _b_hh _packed_ih _packed_hh
 quantized_rnn_tanh_cell :: Tensor -> Tensor -> Tensor -> Tensor -> Tensor -> Tensor -> Tensor -> Tensor -> Tensor -> Tensor -> Float -> Float -> Float -> Float -> Tensor
 quantized_rnn_tanh_cell _input _hx _w_ih _w_hh _b_ih _b_hh _packed_ih _packed_hh _col_offsets_ih _col_offsets_hh _scale_ih _scale_hh _zero_point_ih _zero_point_hh = unsafePerformIO $ (cast14 ATen.quantized_rnn_tanh_cell_ttttttttttssss) _input _hx _w_ih _w_hh _b_ih _b_hh _packed_ih _packed_hh _col_offsets_ih _col_offsets_hh _scale_ih _scale_hh _zero_point_ih _zero_point_hh
 
+maskedFillScalar :: Tensor -> Tensor -> Float -> Tensor
+maskedFillScalar _self _mask _value = unsafePerformIO $ (cast3 ATen.masked_fill_tts) _self _mask _value
+
+maskedFill :: Tensor -> Tensor -> Tensor -> Tensor
+maskedFill _self _mask _value = unsafePerformIO $ (cast3 ATen.masked_fill_ttt) _self _mask _value
+
 masked_scatter :: Tensor -> Tensor -> Tensor -> Tensor
 masked_scatter _self _mask _source = unsafePerformIO $ (cast3 ATen.masked_scatter_ttt) _self _mask _source
 
@@ -885,14 +1203,47 @@ indexAdd _self _dim _index _source = unsafePerformIO $ (cast4 ATen.index_add_tlt
 indexAddWithDimname :: Tensor -> Dimname -> Tensor -> Tensor -> Tensor
 indexAddWithDimname _self _dim _index _source = unsafePerformIO $ (cast4 ATen.index_add_tntt) _self _dim _index _source
 
+indexFillScalar :: Tensor -> Int -> Tensor -> Float -> Tensor
+indexFillScalar _self _dim _index _value = unsafePerformIO $ (cast4 ATen.index_fill_tlts) _self _dim _index _value
+
+indexFill :: Tensor -> Int -> Tensor -> Tensor -> Tensor
+indexFill _self _dim _index _value = unsafePerformIO $ (cast4 ATen.index_fill_tltt) _self _dim _index _value
+
+indexFillScalarWithDimname :: Tensor -> Dimname -> Tensor -> Float -> Tensor
+indexFillScalarWithDimname _self _dim _index _value = unsafePerformIO $ (cast4 ATen.index_fill_tnts) _self _dim _index _value
+
+indexFillWithDimname :: Tensor -> Dimname -> Tensor -> Tensor -> Tensor
+indexFillWithDimname _self _dim _index _value = unsafePerformIO $ (cast4 ATen.index_fill_tntt) _self _dim _index _value
+
+scatter :: Tensor -> Int -> Tensor -> Tensor -> Tensor
+scatter _self _dim _index _src = unsafePerformIO $ (cast4 ATen.scatter_tltt) _self _dim _index _src
+
+scatterScalar :: Tensor -> Int -> Tensor -> Float -> Tensor
+scatterScalar _self _dim _index _value = unsafePerformIO $ (cast4 ATen.scatter_tlts) _self _dim _index _value
+
+scatterWithDimname :: Tensor -> Dimname -> Tensor -> Tensor -> Tensor
+scatterWithDimname _self _dim _index _src = unsafePerformIO $ (cast4 ATen.scatter_tntt) _self _dim _index _src
+
+scatterScalarWithDimname :: Tensor -> Dimname -> Tensor -> Float -> Tensor
+scatterScalarWithDimname _self _dim _index _value = unsafePerformIO $ (cast4 ATen.scatter_tnts) _self _dim _index _value
+
 scatterAdd :: Tensor -> Int -> Tensor -> Tensor -> Tensor
 scatterAdd _self _dim _index _src = unsafePerformIO $ (cast4 ATen.scatter_add_tltt) _self _dim _index _src
 
 scatterAddWithDimname :: Tensor -> Dimname -> Tensor -> Tensor -> Tensor
 scatterAddWithDimname _self _dim _index _src = unsafePerformIO $ (cast4 ATen.scatter_add_tntt) _self _dim _index _src
 
+bitwiseXorScalar :: Tensor -> Float -> Tensor
+bitwiseXorScalar _self _other = unsafePerformIO $ (cast2 ATen.bitwise_xor_ts) _self _other
+
+bitwiseXor :: Tensor -> Tensor -> Tensor
+bitwiseXor _self _other = unsafePerformIO $ (cast2 ATen.bitwise_xor_tt) _self _other
+
 addbmm :: Tensor -> Tensor -> Tensor -> Float -> Float -> Tensor
 addbmm _self _batch1 _batch2 _beta _alpha = unsafePerformIO $ (cast5 ATen.addbmm_tttss) _self _batch1 _batch2 _beta _alpha
+
+diag :: Tensor -> Int -> Tensor
+diag _self _diagonal = unsafePerformIO $ (cast2 ATen.diag_tl) _self _diagonal
 
 cross :: Tensor -> Tensor -> Int -> Tensor
 cross _self _other _dim = unsafePerformIO $ (cast3 ATen.cross_ttl) _self _other _dim
@@ -905,6 +1256,42 @@ tril _self _diagonal = unsafePerformIO $ (cast2 ATen.tril_tl) _self _diagonal
 
 trace :: Tensor -> Tensor
 trace _self = unsafePerformIO $ (cast1 ATen.trace_t) _self
+
+neScalar :: Tensor -> Float -> Tensor
+neScalar _self _other = unsafePerformIO $ (cast2 ATen.ne_ts) _self _other
+
+ne :: Tensor -> Tensor -> Tensor
+ne _self _other = unsafePerformIO $ (cast2 ATen.ne_tt) _self _other
+
+eqScalar :: Tensor -> Float -> Tensor
+eqScalar _self _other = unsafePerformIO $ (cast2 ATen.eq_ts) _self _other
+
+eq :: Tensor -> Tensor -> Tensor
+eq _self _other = unsafePerformIO $ (cast2 ATen.eq_tt) _self _other
+
+geScalar :: Tensor -> Float -> Tensor
+geScalar _self _other = unsafePerformIO $ (cast2 ATen.ge_ts) _self _other
+
+ge :: Tensor -> Tensor -> Tensor
+ge _self _other = unsafePerformIO $ (cast2 ATen.ge_tt) _self _other
+
+leScalar :: Tensor -> Float -> Tensor
+leScalar _self _other = unsafePerformIO $ (cast2 ATen.le_ts) _self _other
+
+le :: Tensor -> Tensor -> Tensor
+le _self _other = unsafePerformIO $ (cast2 ATen.le_tt) _self _other
+
+gtScalar :: Tensor -> Float -> Tensor
+gtScalar _self _other = unsafePerformIO $ (cast2 ATen.gt_ts) _self _other
+
+gt :: Tensor -> Tensor -> Tensor
+gt _self _other = unsafePerformIO $ (cast2 ATen.gt_tt) _self _other
+
+ltScalar :: Tensor -> Float -> Tensor
+ltScalar _self _other = unsafePerformIO $ (cast2 ATen.lt_ts) _self _other
+
+lt :: Tensor -> Tensor -> Tensor
+lt _self _other = unsafePerformIO $ (cast2 ATen.lt_tt) _self _other
 
 take :: Tensor -> Tensor -> Tensor
 take _self _index = unsafePerformIO $ (cast2 ATen.take_tt) _self _index
@@ -942,8 +1329,35 @@ lstsq _self _A = unsafePerformIO $ (cast2 ATen.lstsq_tt) _self _A
 triangular_solve :: Tensor -> Tensor -> Bool -> Bool -> Bool -> (Tensor,Tensor)
 triangular_solve _self _A _upper _transpose _unitriangular = unsafePerformIO $ (cast5 ATen.triangular_solve_ttbbb) _self _A _upper _transpose _unitriangular
 
+symeig :: Tensor -> Bool -> Bool -> (Tensor,Tensor)
+symeig _self _eigenvectors _upper = unsafePerformIO $ (cast3 ATen.symeig_tbb) _self _eigenvectors _upper
+
+eig :: Tensor -> Bool -> (Tensor,Tensor)
+eig _self _eigenvectors = unsafePerformIO $ (cast2 ATen.eig_tb) _self _eigenvectors
+
+svd :: Tensor -> Bool -> Bool -> (Tensor,Tensor,Tensor)
+svd _self _some _compute_uv = unsafePerformIO $ (cast3 ATen.svd_tbb) _self _some _compute_uv
+
+cholesky :: Tensor -> Bool -> Tensor
+cholesky _self _upper = unsafePerformIO $ (cast2 ATen.cholesky_tb) _self _upper
+
+cholesky_solve :: Tensor -> Tensor -> Bool -> Tensor
+cholesky_solve _self _input2 _upper = unsafePerformIO $ (cast3 ATen.cholesky_solve_ttb) _self _input2 _upper
+
+solve :: Tensor -> Tensor -> (Tensor,Tensor)
+solve _self _A = unsafePerformIO $ (cast2 ATen.solve_tt) _self _A
+
+cholesky_inverse :: Tensor -> Bool -> Tensor
+cholesky_inverse _self _upper = unsafePerformIO $ (cast2 ATen.cholesky_inverse_tb) _self _upper
+
 qr :: Tensor -> Bool -> (Tensor,Tensor)
 qr _self _some = unsafePerformIO $ (cast2 ATen.qr_tb) _self _some
+
+geqrf :: Tensor -> (Tensor,Tensor)
+geqrf _self = unsafePerformIO $ (cast1 ATen.geqrf_t) _self
+
+orgqr :: Tensor -> Tensor -> Tensor
+orgqr _self _input2 = unsafePerformIO $ (cast2 ATen.orgqr_tt) _self _input2
 
 ormqr :: Tensor -> Tensor -> Tensor -> Bool -> Bool -> Tensor
 ormqr _self _input2 _input3 _left _transpose = unsafePerformIO $ (cast5 ATen.ormqr_tttbb) _self _input2 _input3 _left _transpose
@@ -963,17 +1377,44 @@ polygamma _n _self = unsafePerformIO $ (cast2 ATen.polygamma_lt) _n _self
 erfinv :: Tensor -> Tensor
 erfinv _self = unsafePerformIO $ (cast1 ATen.erfinv_t) _self
 
+sign :: Tensor -> Tensor
+sign _self = unsafePerformIO $ (cast1 ATen.sign_t) _self
+
 dist :: Tensor -> Tensor -> Float -> Tensor
 dist _self _other _p = unsafePerformIO $ (cast3 ATen.dist_tts) _self _other _p
 
 atan2 :: Tensor -> Tensor -> Tensor
 atan2 _self _other = unsafePerformIO $ (cast2 ATen.atan2_tt) _self _other
 
+lerpScalar :: Tensor -> Tensor -> Float -> Tensor
+lerpScalar _self _end _weight = unsafePerformIO $ (cast3 ATen.lerp_tts) _self _end _weight
+
+lerp :: Tensor -> Tensor -> Tensor -> Tensor
+lerp _self _end _weight = unsafePerformIO $ (cast3 ATen.lerp_ttt) _self _end _weight
+
 histc :: Tensor -> Int -> Float -> Float -> Tensor
 histc _self _bins _min _max = unsafePerformIO $ (cast4 ATen.histc_tlss) _self _bins _min _max
 
+fmodScalar :: Tensor -> Float -> Tensor
+fmodScalar _self _other = unsafePerformIO $ (cast2 ATen.fmod_ts) _self _other
+
+fmod :: Tensor -> Tensor -> Tensor
+fmod _self _other = unsafePerformIO $ (cast2 ATen.fmod_tt) _self _other
+
+remainderScalar :: Tensor -> Float -> Tensor
+remainderScalar _self _other = unsafePerformIO $ (cast2 ATen.remainder_ts) _self _other
+
+remainder :: Tensor -> Tensor -> Tensor
+remainder _self _other = unsafePerformIO $ (cast2 ATen.remainder_tt) _self _other
+
+min :: Tensor -> Tensor -> Tensor
+min _self _other = unsafePerformIO $ (cast2 ATen.min_tt) _self _other
+
 minAll :: Tensor -> Tensor
 minAll _self = unsafePerformIO $ (cast1 ATen.min_t) _self
+
+max :: Tensor -> Tensor -> Tensor
+max _self _other = unsafePerformIO $ (cast2 ATen.max_tt) _self _other
 
 maxAll :: Tensor -> Tensor
 maxAll _self = unsafePerformIO $ (cast1 ATen.max_t) _self
@@ -996,11 +1437,23 @@ argsortWithDimname _self _dim _descending = unsafePerformIO $ (cast3 ATen.argsor
 topk :: Tensor -> Int -> Int -> Bool -> Bool -> (Tensor,Tensor)
 topk _self _k _dim _largest _sorted = unsafePerformIO $ (cast5 ATen.topk_tllbb) _self _k _dim _largest _sorted
 
+all :: Tensor -> Tensor
+all _self = unsafePerformIO $ (cast1 ATen.all_t) _self
+
+any :: Tensor -> Tensor
+any _self = unsafePerformIO $ (cast1 ATen.any_t) _self
+
 renorm :: Tensor -> Float -> Int -> Float -> Tensor
 renorm _self _p _dim _maxnorm = unsafePerformIO $ (cast4 ATen.renorm_tsls) _self _p _dim _maxnorm
 
 equal :: Tensor -> Tensor -> Bool
 equal _self _other = unsafePerformIO $ (cast2 ATen.equal_tt) _self _other
+
+pow :: Tensor -> Tensor -> Tensor
+pow _self _exponent = unsafePerformIO $ (cast2 ATen.pow_tt) _self _exponent
+
+powScalar' :: Float -> Tensor -> Tensor
+powScalar' _self _exponent = unsafePerformIO $ (cast2 ATen.pow_st) _self _exponent
 
 alias :: Tensor -> Tensor
 alias _self = unsafePerformIO $ (cast1 ATen.alias_t) _self
@@ -1010,6 +1463,9 @@ binary_cross_entropy _self _target _weight _reduction = unsafePerformIO $ (cast4
 
 binary_cross_entropy_backward :: Tensor -> Tensor -> Tensor -> Tensor -> Int -> Tensor
 binary_cross_entropy_backward _grad_output _self _target _weight _reduction = unsafePerformIO $ (cast5 ATen.binary_cross_entropy_backward_ttttl) _grad_output _self _target _weight _reduction
+
+mse_loss :: Tensor -> Tensor -> Int -> Tensor
+mse_loss _self _target _reduction = unsafePerformIO $ (cast3 ATen.mse_loss_ttl) _self _target _reduction
 
 mse_loss_backward :: Tensor -> Tensor -> Tensor -> Int -> Tensor
 mse_loss_backward _grad_output _self _target _reduction = unsafePerformIO $ (cast4 ATen.mse_loss_backward_tttl) _grad_output _self _target _reduction

--- a/hasktorch/src/Torch/Functional/Internal.hs
+++ b/hasktorch/src/Torch/Functional/Internal.hs
@@ -90,8 +90,8 @@ affine_grid_generator _theta _size _align_corners = unsafePerformIO $ (cast3 ATe
 affine_grid_generator_backward :: Tensor -> [Int] -> Bool -> Tensor
 affine_grid_generator_backward _grad _size _align_corners = unsafePerformIO $ (cast3 ATen.affine_grid_generator_backward_tlb) _grad _size _align_corners
 
-all :: Tensor -> Int -> Bool -> Tensor
-all _self _dim _keepdim = unsafePerformIO $ (cast3 ATen.all_tlb) _self _dim _keepdim
+allDim :: Tensor -> Int -> Bool -> Tensor
+allDim _self _dim _keepdim = unsafePerformIO $ (cast3 ATen.all_tlb) _self _dim _keepdim
 
 allWithDimname :: Tensor -> Dimname -> Bool -> Tensor
 allWithDimname _self _dim _keepdim = unsafePerformIO $ (cast3 ATen.all_tnb) _self _dim _keepdim
@@ -99,8 +99,8 @@ allWithDimname _self _dim _keepdim = unsafePerformIO $ (cast3 ATen.all_tnb) _sel
 allclose :: Tensor -> Tensor -> Double -> Double -> Bool -> Bool
 allclose _self _other _rtol _atol _equal_nan = unsafePerformIO $ (cast5 ATen.allclose_ttddb) _self _other _rtol _atol _equal_nan
 
-any :: Tensor -> Int -> Bool -> Tensor
-any _self _dim _keepdim = unsafePerformIO $ (cast3 ATen.any_tlb) _self _dim _keepdim
+anyDim :: Tensor -> Int -> Bool -> Tensor
+anyDim _self _dim _keepdim = unsafePerformIO $ (cast3 ATen.any_tlb) _self _dim _keepdim
 
 anyWithDimname :: Tensor -> Dimname -> Bool -> Tensor
 anyWithDimname _self _dim _keepdim = unsafePerformIO $ (cast3 ATen.any_tnb) _self _dim _keepdim

--- a/hasktorch/src/Torch/Functional/Internal.hs
+++ b/hasktorch/src/Torch/Functional/Internal.hs
@@ -330,8 +330,8 @@ embedding_sparse_backward _grad _indices _num_weights _padding_idx _scale_grad_b
 embedding_bag :: Tensor -> Tensor -> Tensor -> Bool -> Int -> Bool -> Tensor -> (Tensor,Tensor,Tensor,Tensor)
 embedding_bag _weight _indices _offsets _scale_grad_by_freq _mode _sparse _per_sample_weights = unsafePerformIO $ (cast7 ATen.embedding_bag_tttblbt) _weight _indices _offsets _scale_grad_by_freq _mode _sparse _per_sample_weights
 
-empty_like_tM :: Tensor -> ATen.MemoryFormat -> Tensor
-empty_like_tM _self _memory_format = unsafePerformIO $ (cast2 ATen.empty_like_tM) _self _memory_format
+emptyLikeWithMemoryFormat :: Tensor -> ATen.MemoryFormat -> Tensor
+emptyLikeWithMemoryFormat _self _memory_format = unsafePerformIO $ (cast2 ATen.empty_like_tM) _self _memory_format
 
 erf :: Tensor -> Tensor
 erf _self = unsafePerformIO $ (cast1 ATen.erf_t) _self
@@ -363,8 +363,8 @@ floor _self = unsafePerformIO $ (cast1 ATen.floor_t) _self
 frac :: Tensor -> Tensor
 frac _self = unsafePerformIO $ (cast1 ATen.frac_t) _self
 
-full_like_tsM :: Tensor -> Float -> ATen.MemoryFormat -> Tensor
-full_like_tsM _self _fill_value _memory_format = unsafePerformIO $ (cast3 ATen.full_like_tsM) _self _fill_value _memory_format
+fullLikeWithMemoryFormat :: Tensor -> Float -> ATen.MemoryFormat -> Tensor
+fullLikeWithMemoryFormat _self _fill_value _memory_format = unsafePerformIO $ (cast3 ATen.full_like_tsM) _self _fill_value _memory_format
 
 grid_sampler :: Tensor -> Tensor -> Int -> Int -> Bool -> Tensor
 grid_sampler _input _grid _interpolation_mode _padding_mode _align_corners = unsafePerformIO $ (cast5 ATen.grid_sampler_ttllb) _input _grid _interpolation_mode _padding_mode _align_corners
@@ -510,8 +510,8 @@ log2 _self = unsafePerformIO $ (cast1 ATen.log2_t) _self
 logdet :: Tensor -> Tensor
 logdet _self = unsafePerformIO $ (cast1 ATen.logdet_t) _self
 
-log_softmax :: Tensor -> Int -> DType -> Tensor
-log_softmax _self _dim _dtype = unsafePerformIO $ (cast3 ATen.log_softmax_tls) _self _dim _dtype
+logSoftmax :: Tensor -> Int -> DType -> Tensor
+logSoftmax _self _dim _dtype = unsafePerformIO $ (cast3 ATen.log_softmax_tls) _self _dim _dtype
 
 logSoftmaxWithDimname :: Tensor -> Dimname -> DType -> Tensor
 logSoftmaxWithDimname _self _dim _dtype = unsafePerformIO $ (cast3 ATen.log_softmax_tns) _self _dim _dtype
@@ -708,8 +708,8 @@ batch_norm_backward_elemt _grad_out _input _mean _invstd _weight _mean_dy _mean_
 batch_norm_update_stats :: Tensor -> Tensor -> Tensor -> Double -> (Tensor,Tensor)
 batch_norm_update_stats _input _running_mean _running_var _momentum = unsafePerformIO $ (cast4 ATen.batch_norm_update_stats_tttd) _input _running_mean _running_var _momentum
 
-ones_like_tM :: Tensor -> ATen.MemoryFormat -> Tensor
-ones_like_tM _self _memory_format = unsafePerformIO $ (cast2 ATen.ones_like_tM) _self _memory_format
+onesLikeWithMemoryFormat :: Tensor -> ATen.MemoryFormat -> Tensor
+onesLikeWithMemoryFormat _self _memory_format = unsafePerformIO $ (cast2 ATen.ones_like_tM) _self _memory_format
 
 pairwise_distance :: Tensor -> Tensor -> Double -> Double -> Bool -> Tensor
 pairwise_distance _x1 _x2 _p _eps _keepdim = unsafePerformIO $ (cast5 ATen.pairwise_distance_ttddb) _x1 _x2 _p _eps _keepdim
@@ -732,8 +732,8 @@ pinverse _self _rcond = unsafePerformIO $ (cast2 ATen.pinverse_td) _self _rcond
 poisson_nll_loss :: Tensor -> Tensor -> Bool -> Bool -> Double -> Int -> Tensor
 poisson_nll_loss _input _target _log_input _full _eps _reduction = unsafePerformIO $ (cast6 ATen.poisson_nll_loss_ttbbdl) _input _target _log_input _full _eps _reduction
 
-rand_like_tM :: Tensor -> ATen.MemoryFormat -> Tensor
-rand_like_tM _self _memory_format = unsafePerformIO $ (cast2 ATen.rand_like_tM) _self _memory_format
+randLikeWithMemoryFormat :: Tensor -> ATen.MemoryFormat -> Tensor
+randLikeWithMemoryFormat _self _memory_format = unsafePerformIO $ (cast2 ATen.rand_like_tM) _self _memory_format
 
 randintLike' :: Tensor -> Int -> ATen.MemoryFormat -> Tensor
 randintLike' _self _high _memory_format = unsafePerformIO $ (cast3 ATen.randint_like_tlM) _self _high _memory_format
@@ -741,8 +741,8 @@ randintLike' _self _high _memory_format = unsafePerformIO $ (cast3 ATen.randint_
 randintLike :: Tensor -> Int -> Int -> ATen.MemoryFormat -> Tensor
 randintLike _self _low _high _memory_format = unsafePerformIO $ (cast4 ATen.randint_like_tllM) _self _low _high _memory_format
 
-randn_like_tM :: Tensor -> ATen.MemoryFormat -> Tensor
-randn_like_tM _self _memory_format = unsafePerformIO $ (cast2 ATen.randn_like_tM) _self _memory_format
+randnLikeWithMemoryFormat :: Tensor -> ATen.MemoryFormat -> Tensor
+randnLikeWithMemoryFormat _self _memory_format = unsafePerformIO $ (cast2 ATen.randn_like_tM) _self _memory_format
 
 reciprocal :: Tensor -> Tensor
 reciprocal _self = unsafePerformIO $ (cast1 ATen.reciprocal_t) _self
@@ -987,8 +987,8 @@ isNonZero _condition = unsafePerformIO $ (cast1 ATen.where_t) _condition
 norm_except_dim :: Tensor -> Int -> Int -> Tensor
 norm_except_dim _v _pow _dim = unsafePerformIO $ (cast3 ATen.norm_except_dim_tll) _v _pow _dim
 
-zeros_like_tM :: Tensor -> ATen.MemoryFormat -> Tensor
-zeros_like_tM _self _memory_format = unsafePerformIO $ (cast2 ATen.zeros_like_tM) _self _memory_format
+zerosLikeWithMemoryFormat :: Tensor -> ATen.MemoryFormat -> Tensor
+zerosLikeWithMemoryFormat _self _memory_format = unsafePerformIO $ (cast2 ATen.zeros_like_tM) _self _memory_format
 
 native_norm :: Tensor -> Float -> Tensor
 native_norm _self _p = unsafePerformIO $ (cast2 ATen.native_norm_ts) _self _p

--- a/hasktorch/src/Torch/Functional/Internal.hs
+++ b/hasktorch/src/Torch/Functional/Internal.hs
@@ -330,7 +330,7 @@ embedding_sparse_backward _grad _indices _num_weights _padding_idx _scale_grad_b
 embedding_bag :: Tensor -> Tensor -> Tensor -> Bool -> Int -> Bool -> Tensor -> (Tensor,Tensor,Tensor,Tensor)
 embedding_bag _weight _indices _offsets _scale_grad_by_freq _mode _sparse _per_sample_weights = unsafePerformIO $ (cast7 ATen.embedding_bag_tttblbt) _weight _indices _offsets _scale_grad_by_freq _mode _sparse _per_sample_weights
 
-empty_like_tM :: Tensor -> MemoryFormat -> Tensor
+empty_like_tM :: Tensor -> ATen.MemoryFormat -> Tensor
 empty_like_tM _self _memory_format = unsafePerformIO $ (cast2 ATen.empty_like_tM) _self _memory_format
 
 erf :: Tensor -> Tensor
@@ -363,7 +363,7 @@ floor _self = unsafePerformIO $ (cast1 ATen.floor_t) _self
 frac :: Tensor -> Tensor
 frac _self = unsafePerformIO $ (cast1 ATen.frac_t) _self
 
-full_like_tsM :: Tensor -> Float -> MemoryFormat -> Tensor
+full_like_tsM :: Tensor -> Float -> ATen.MemoryFormat -> Tensor
 full_like_tsM _self _fill_value _memory_format = unsafePerformIO $ (cast3 ATen.full_like_tsM) _self _fill_value _memory_format
 
 grid_sampler :: Tensor -> Tensor -> Int -> Int -> Bool -> Tensor
@@ -708,7 +708,7 @@ batch_norm_backward_elemt _grad_out _input _mean _invstd _weight _mean_dy _mean_
 batch_norm_update_stats :: Tensor -> Tensor -> Tensor -> Double -> (Tensor,Tensor)
 batch_norm_update_stats _input _running_mean _running_var _momentum = unsafePerformIO $ (cast4 ATen.batch_norm_update_stats_tttd) _input _running_mean _running_var _momentum
 
-ones_like_tM :: Tensor -> MemoryFormat -> Tensor
+ones_like_tM :: Tensor -> ATen.MemoryFormat -> Tensor
 ones_like_tM _self _memory_format = unsafePerformIO $ (cast2 ATen.ones_like_tM) _self _memory_format
 
 pairwise_distance :: Tensor -> Tensor -> Double -> Double -> Bool -> Tensor
@@ -732,16 +732,16 @@ pinverse _self _rcond = unsafePerformIO $ (cast2 ATen.pinverse_td) _self _rcond
 poisson_nll_loss :: Tensor -> Tensor -> Bool -> Bool -> Double -> Int -> Tensor
 poisson_nll_loss _input _target _log_input _full _eps _reduction = unsafePerformIO $ (cast6 ATen.poisson_nll_loss_ttbbdl) _input _target _log_input _full _eps _reduction
 
-rand_like_tM :: Tensor -> MemoryFormat -> Tensor
+rand_like_tM :: Tensor -> ATen.MemoryFormat -> Tensor
 rand_like_tM _self _memory_format = unsafePerformIO $ (cast2 ATen.rand_like_tM) _self _memory_format
 
-randintLike' :: Tensor -> Int -> MemoryFormat -> Tensor
+randintLike' :: Tensor -> Int -> ATen.MemoryFormat -> Tensor
 randintLike' _self _high _memory_format = unsafePerformIO $ (cast3 ATen.randint_like_tlM) _self _high _memory_format
 
-randintLike :: Tensor -> Int -> Int -> MemoryFormat -> Tensor
+randintLike :: Tensor -> Int -> Int -> ATen.MemoryFormat -> Tensor
 randintLike _self _low _high _memory_format = unsafePerformIO $ (cast4 ATen.randint_like_tllM) _self _low _high _memory_format
 
-randn_like_tM :: Tensor -> MemoryFormat -> Tensor
+randn_like_tM :: Tensor -> ATen.MemoryFormat -> Tensor
 randn_like_tM _self _memory_format = unsafePerformIO $ (cast2 ATen.randn_like_tM) _self _memory_format
 
 reciprocal :: Tensor -> Tensor
@@ -987,7 +987,7 @@ isNonZero _condition = unsafePerformIO $ (cast1 ATen.where_t) _condition
 norm_except_dim :: Tensor -> Int -> Int -> Tensor
 norm_except_dim _v _pow _dim = unsafePerformIO $ (cast3 ATen.norm_except_dim_tll) _v _pow _dim
 
-zeros_like_tM :: Tensor -> MemoryFormat -> Tensor
+zeros_like_tM :: Tensor -> ATen.MemoryFormat -> Tensor
 zeros_like_tM _self _memory_format = unsafePerformIO $ (cast2 ATen.zeros_like_tM) _self _memory_format
 
 native_norm :: Tensor -> Float -> Tensor
@@ -1023,7 +1023,7 @@ nuclearNormAll _self _keepdim = unsafePerformIO $ (cast2 ATen.nuclear_norm_tb) _
 nuclearNormDim :: Tensor -> (Int,Int) -> Bool -> Tensor
 nuclearNormDim _self _dim _keepdim = unsafePerformIO $ (cast3 ATen.nuclear_norm_tlb) _self _dim _keepdim
 
-clone :: Tensor -> MemoryFormat -> Tensor
+clone :: Tensor -> ATen.MemoryFormat -> Tensor
 clone _self _memory_format = unsafePerformIO $ (cast2 ATen.clone_tM) _self _memory_format
 
 powScalar :: Tensor -> Float -> Tensor

--- a/spec/bindings.yaml
+++ b/spec/bindings.yaml
@@ -1,185 +1,150 @@
 # This file controls functions in hasktorch/src/Torch/Functional/Internal.hs.
 # The functions are pure-functions not using IO-monad.
-- rename: {src: where_ttt, dst: where'}
-- rename: {src: min_t, dst: minAll}
-- rename: {src: max_t, dst: maxAll}
-- rename: {src: median_t, dst: medianAll}
-
-# detach needs IO-monad to create new-tensor.
-- remove: {src: detach_t}
-
-# remove already registered functions
-- remove: {src: transpose_tll}
-- remove: {src: select_tll}
-- remove: {src: reshape_tl}
-- remove: {src: erf_t}
-- remove: {src: floor_t}
-- remove: {src: cos_t}
-- remove: {src: exp_t}
-- remove: {src: sin_t}
-- remove: {src: sinh_t}
-- remove: {src: sqrt_t}
-- remove: {src: tanh_t}
-- remove: {src: abs_t}
-- remove: {src: log1p_t}
-- remove: {src: ceil_t}
-- remove: {src: conv2d_tttllll}
-- remove: {src: diag_tl}
-- remove: {src: gels_tt}
-- remove: {src: log10_t}
-- remove: {src: log2_t}
-- remove: {src: matmul_tt}
-- remove: {src: mse_loss_ttl}
-- remove: {src: relu_t}
-- remove: {src: selu_t}
-- remove: {src: sigmoid_t}
-- remove: {src: size_tl}
-- remove: {src: all_t}
-- remove: {src: any_t}
-- remove: {src: qr_t}
-- remove: {src: geqrf_t}
-- remove: {src: orgqr_tt}
-- remove: {src: sign_t}
-- remove: {src: inverse_t}
-- remove: {src: cholesky_tb}
-- remove: {src: cholesky_inverse_tb}
-- remove: {src: cholesky_solve_ttb}
-- remove: {src: eig_tb}
-- remove: {src: solve_tt}
-- remove: {src: svd_tbb}
-- remove: {src: symeig_tbb}
-
-# remove overloaded functions
-- remove: {src: add_tts}
-- remove: {src: add_tss}
-- remove: {src: all_tlb}
-- remove: {src: any_tlb}
-- remove: {src: cumsum_tls}
-- remove: {src: cumsum_tl}
-- remove: {src: cumprod_tls}
-- remove: {src: cumprod_tl}
-- remove: {src: ctc_loss_ttllllb}
-- remove: {src: ctc_loss_ttttllb}
-- remove: {src: div_tt}
-- remove: {src: div_ts}
-- remove: {src: log_softmax_tls}
-- remove: {src: log_softmax_tl}
-- remove: {src: matrix_rank_tdb}
-- remove: {src: matrix_rank_tb}
-- remove: {src: max_tlb}
-- remove: {src: mean_ts}
-- remove: {src: mean_t}
-- remove: {src: mean_tlbs}
-- remove: {src: mean_tlb}
-- remove: {src: mean_tls}
-- remove: {src: median_tlb}
-- remove: {src: min_tlb}
-- remove: {src: mul_tt}
-- remove: {src: mul_ts}
-- remove: {src: randint_like_tl}
-- remove: {src: randint_like_tll}
-- remove: {src: repeat_interleave_t}
-- remove: {src: repeat_interleave_ttl}
-- remove: {src: repeat_interleave_tll}
-- remove: {src: softmax_tl}
-- remove: {src: squeeze_t}
-- remove: {src: squeeze_tl}
-- remove: {src: sum_t}
-- remove: {src: sum_ts}
-- remove: {src: sum_tlbs}
-- remove: {src: sum_tlb}
-- remove: {src: sum_tls}
-- remove: {src: std_tb}
-- remove: {src: std_tlbb}
-- remove: {src: prod_ts}
-- remove: {src: prod_t}
-- remove: {src: prod_tlbs}
-- remove: {src: prod_tlb}
-- remove: {src: prod_tls}
-- remove: {src: var_tb}
-- remove: {src: var_tlbb}
-- remove: {src: norm_tss}
-- remove: {src: norm_ts}
-- remove: {src: norm_tslbs}
-- remove: {src: norm_tslb}
-- remove: {src: frobenius_norm_t}
-- remove: {src: frobenius_norm_tlb}
-- remove: {src: pow_ts}
-- remove: {src: sub_tts}
-- remove: {src: sub_tss}
-- remove: {src: rsub_tts}
-- remove: {src: rsub_tss}
-- remove: {src: lstm_tllbldbbb}
-- remove: {src: lstm_ttllbldbb}
-- remove: {src: gru_ttlbldbbb}
-- remove: {src: gru_tttlbldbb}
-- remove: {src: rnn_tanh_ttlbldbbb}
-- remove: {src: rnn_tanh_tttlbldbb}
-- remove: {src: rnn_relu_ttlbldbbb}
-- remove: {src: rnn_relu_tttlbldbb}
-- remove: {src: masked_fill_tts}
-- remove: {src: masked_fill_ttt}
-- remove: {src: index_fill_tlts}
-- remove: {src: index_fill_tltt}
-- remove: {src: scatter_tltt}
-- remove: {src: scatter_tlts}
-- remove: {src: ne_ts}
-- remove: {src: ne_tt}
-- remove: {src: eq_ts}
-- remove: {src: eq_tt}
-- remove: {src: ge_ts}
-- remove: {src: ge_tt}
-- remove: {src: le_ts}
-- remove: {src: le_tt}
-- remove: {src: gt_ts}
-- remove: {src: gt_tt}
-- remove: {src: lt_ts}
-- remove: {src: lt_tt}
-- remove: {src: lerp_tts}
-- remove: {src: lerp_ttt}
-- remove: {src: fmod_ts}
-- remove: {src: fmod_tt}
-- remove: {src: remainder_ts}
-- remove: {src: remainder_tt}
-- remove: {src: min_tt}
-- remove: {src: max_tt}
-- remove: {src: pow_tt}
-- remove: {src: pow_st}
-- remove: {src: conv_transpose2d_tttlllll}
-- remove: {src: conv_transpose3d_tttlllll}
-- remove: {src: std_mean_tb}
-- remove: {src: std_mean_tlbb}
-- remove: {src: trapz_ttl}
-- remove: {src: trapz_tdl}
-- remove: {src: var_mean_tb}
-- remove: {src: var_mean_tlbb}
-- remove: {src: nuclear_norm_tb}
-- remove: {src: nuclear_norm_tlb}
-- remove: {src: quantized_gru_ttlbldbbb}
-- remove: {src: quantized_gru_tttlbldbb}
-- remove: {src: conv_transpose2d_ttltllll}
-- remove: {src: conv_transpose3d_ttltllll}
-- remove: {src: randint_like_tlM}
-- remove: {src: randint_like_tllM}
-- remove: {src: quantized_lstm_tllbldbbbsb}
-- remove: {src: quantized_lstm_ttllbldbbsb}
-- remove: {src: bitwise_xor_ts}
-- remove: {src: bitwise_xor_tt}
-
-# functions for named tensor
+- rename: {src: all_tlb, dst: all}
+- rename: {src: all_tnb, dst: allWithDimname}
+- rename: {src: any_tlb, dst: any}
+- rename: {src: any_tnb, dst: anyWithDimname}
 - rename: {src: cat_ll, dst: cat}
 - rename: {src: cat_ln, dst: catWithDimname}
-- rename: {src: all_tnb, dst: allWithDimname}
-- rename: {src: any_tnb, dst: anyWithDimname}
+- rename: {src: cumsum_tls, dst: cumsum}
+- rename: {src: cumsum_tns, dst: cumsumWithDimname}
+- rename: {src: cumprod_tls, dst: cumprod}
+- rename: {src: cumprod_tns, dst: cumprodWithDimname}
+- rename: {src: div_tt, dst: div}
+- rename: {src: div_ts, dst: divScalar}
+- rename: {src: log_softmax_tls, dst: log_softmax}
+- rename: {src: max_t, dst: maxAll}
+- rename: {src: max_tlb, dst: maxDim}
 - rename: {src: max_tnb, dst: maxWithDimname}
-- rename: {src: min_tnb, dst: minWithDimname}
+- rename: {src: mean_ts, dst: meanAll}
+- rename: {src: mean_tlbs, dst: meanDim}
 - rename: {src: mean_tNbs, dst: meanWithDimnames}
+- rename: {src: median_t, dst: medianAll}
+- rename: {src: median_tlb, dst: medianDim}
 - rename: {src: median_tnb, dst: medianWithDimname}
-- rename: {src: select_tnl, dst: selectWithDimname}
-- rename: {src: size_tn, dst: sizeWithDimname}
-- rename: {src: transpose_tnn, dst: transposeWithDimname}
+- rename: {src: min_t, dst: minAll}
+- rename: {src: min_tlb, dst: minDim}
+- rename: {src: min_tnb, dst: minWithDimname}
+- rename: {src: mul_tt, dst: mul}
+- rename: {src: mul_ts, dst: mulScalar}
+- rename: {src: norm_ts, dst: normAll}
+- rename: {src: norm_tslb, dst: normDim}
+- rename: {src: norm_tsnb, dst: normWithDimname}
+- rename: {src: norm_tss, dst: normCastAll}
+- rename: {src: norm_tslbs, dst: normCastDim}
+- rename: {src: norm_tsnbs, dst: normCastWithDimname}
+- rename: {src: frobenius_norm_t, dst: frobeniusNormAll}
+- rename: {src: frobenius_norm_tlb, dst: frobeniusNormDim}
+- rename: {src: nuclear_norm_tb, dst: nuclearNormAll}
+- rename: {src: nuclear_norm_tlb, dst: nuclearNormDim}
+- rename: {src: pow_ts, dst: powScalar}
+- rename: {src: sub_tts, dst: sub}
+- rename: {src: sub_tss, dst: subScalar}
+- rename: {src: rsub_tts, dst: rsub}
+- rename: {src: rsub_tss, dst: rsubScalar}
+- rename: {src: prod_ts, dst: prodAll}
+- rename: {src: prod_tlbs, dst: prodDim}
+- rename: {src: prod_tnbs, dst: prodWithDimnames}
+- rename: {src: std_tb, dst: stdAll}
+- rename: {src: std_tlbb, dst: stdDim}
+- rename: {src: std_tNbb, dst: stdWithDimnames}
+- rename: {src: std_mean_tb, dst: stdMeanAll}
+- rename: {src: std_mean_tlbb, dst: stdMeanDim}
+- rename: {src: std_mean_tNbb, dst: stdMeanWithDimnames}
+- rename: {src: squeeze_t, dst: squeezeAll}
+- rename: {src: squeeze_tl, dst: squeezeDim}
+- rename: {src: squeeze_tn, dst: squeezeWithDimname}
+- rename: {src: sum_ts, dst: sumAll}
+- rename: {src: sum_tlbs, dst: sumDim}
+- rename: {src: sum_tNbs, dst: sumWithDimnames}
+- rename: {src: trapz_ttl, dst: trapz}
+- rename: {src: trapz_tdl, dst: trapzScalar}
+- rename: {src: var_tb, dst: var}
+- rename: {src: var_tlbb, dst: varDim}
+- rename: {src: var_tNbb, dst: varWithDimnames}
+- rename: {src: var_mean_tb, dst: varMean}
+- rename: {src: var_mean_tlbb, dst: varMeanDim}
+- rename: {src: var_mean_tNbb, dst: varMeanWithDimnames}
+- rename: {src: where_ttt, dst: where'}
+- rename: {src: where_t, dst: isNonZero}
+- rename: {src: lstm_tllbldbbb, dst: lstm}
+- rename: {src: lstm_ttllbldbb, dst: lstm'}
+- rename: {src: gru_ttlbldbbb, dst: gru}
+- rename: {src: gru_tttlbldbb, dst: gru'}
+- rename: {src: rnn_tanh_ttlbldbbb, dst: rnnTanh}
+- rename: {src: rnn_tanh_tttlbldbb, dst: rnnTanh'}
+- rename: {src: rnn_relu_ttlbldbbb, dst: rnnRelu}
+- rename: {src: rnn_relu_tttlbldbb, dst: rnnRelu'}
+- rename: {src: quantized_lstm_tllbldbbbsb, dst: quantizedLstm}
+- rename: {src: quantized_lstm_ttllbldbbsb, dst: quantizedLstm'}
+- rename: {src: quantized_gru_ttlbldbbb, dst: quantizedGru}
+- rename: {src: quantized_gru_tttlbldbb, dst: quantizedGru'}
+- rename: {src: masked_fill_ttt, dst: maskedFill}
+- rename: {src: masked_fill_tts, dst: maskedFillScalar}
+- rename: {src: index_fill_tltt, dst: indexFill}
+- rename: {src: index_fill_tlts, dst: indexFillScalar}
+- rename: {src: index_fill_tntt, dst: indexFillWithDimname}
+- rename: {src: index_fill_tnts, dst: indexFillScalarWithDimname}
+- rename: {src: scatter_tltt, dst: scatter}
+- rename: {src: scatter_tlts, dst: scatterScalar}
+- rename: {src: scatter_tntt, dst: scatterWithDimname}
+- rename: {src: scatter_tnts, dst: scatterScalarWithDimname}
+- rename: {src: scatter_add_tltt, dst: scatterAdd}
+- rename: {src: scatter_add_tntt, dst: scatterAddWithDimname}
+- rename: {src: index_add_tltt, dst: indexAdd}
+- rename: {src: index_add_tntt, dst: indexAddWithDimname}
+- rename: {src: mode_tlb, dst: mode}
+- rename: {src: mode_tnb, dst: modeWithDimname}
+- rename: {src: stride_tl, dst: stride}
+- rename: {src: stride_tn, dst: strideWithDimname}
+- rename: {src: unbind_tl, dst: unbind}
+- rename: {src: unbind_tn, dst: unbindWithDimname}
+- rename: {src: index_select_tlt, dst: indexSelect}
+- rename: {src: index_select_tnt, dst: indexSelectWithDimname}
+- rename: {src: gather_tltb, dst: gather}
+- rename: {src: gather_tntb, dst: gatherWithDimname}
+- rename: {src: argsort_tlb, dst: argsort}
+- rename: {src: argsort_tnb, dst: argsortWithDimname}
+- rename: {src: softmax_tls, dst: softmax}
+- rename: {src: softmax_tns, dst: softmaxWithDimname}
+- rename: {src: bitwise_xor_tt, dst: bitwiseXor}
+- rename: {src: bitwise_xor_ts, dst: bitwiseXorScalar}
+- rename: {src: ne_ts, dst: neScalar}
+- rename: {src: ne_tt, dst: ne}
+- rename: {src: eq_ts, dst: eqScalar}
+- rename: {src: eq_tt, dst: eq}
+- rename: {src: ge_ts, dst: geScalar}
+- rename: {src: ge_tt, dst: ge}
+- rename: {src: le_ts, dst: leScalar}
+- rename: {src: le_tt, dst: le}
+- rename: {src: gt_ts, dst: gtScalar}
+- rename: {src: gt_tt, dst: gt}
+- rename: {src: lt_ts, dst: ltScalar}
+- rename: {src: lt_tt, dst: lt}
+- rename: {src: lerp_tts, dst: lerpScalar}
+- rename: {src: lerp_ttt, dst: lerp}
+- rename: {src: fmod_ts, dst: fmodScalar}
+- rename: {src: fmod_tt, dst: fmod}
+- rename: {src: remainder_ts, dst: remainderScalar}
+- rename: {src: remainder_tt, dst: remainder}
+- rename: {src: min_tt, dst: min}
+- rename: {src: max_tt, dst: max}
+- rename: {src: pow_tt, dst: pow}
+- rename: {src: pow_st, dst: powScalar'}
+- rename: {src: repeat_interleave_ttl, dst: repeatInterleave}
+- rename: {src: repeat_interleave_tll, dst: repeatInterleaveScalar}
+- rename: {src: repeat_interleave_t, dst: repeatInterleaveRange}
+- rename: {src: matrix_rank_tdb, dst: matrixRank}
+- rename: {src: matrix_rank_tb, dst: matrixRank'}
+- rename: {src: add_tts, dst: add}
+- rename: {src: add_tss, dst: addScalar}
+- rename: {src: ctc_loss_ttttllb, dst: ctcLoss}
+- rename: {src: ctc_loss_ttllllb, dst: ctcLoss'}
 - rename: {src: flatten_tll, dst: flatten}
 - rename: {src: flatten_tnn, dst: flattenWithDimname}
+- rename: {src: flatten_tlln, dst: flattenTo}
+- rename: {src: flatten_tnnn, dst: flattenToWithDimname}
+- rename: {src: flatten_tNn, dst: flattenToWithDimnames}
 - rename: {src: sort_tlb, dst: sort}
 - rename: {src: sort_tnb, dst: sortWithDimname}
 - rename: {src: max_values_tlb, dst: maxValues}
@@ -196,50 +161,58 @@
 - rename: {src: logsumexp_tlb, dst: logsumexp}
 - rename: {src: logsumexp_tnb, dst: logsumexpWithDimname}
 - rename: {src: logsumexp_tNb, dst: logsumexpWithDimnameList}
-- rename: {src: mode_tlb, dst: mode}
-- rename: {src: mode_tnb, dst: modeWithDimname}
-- rename: {src: stride_tl, dst: stride}
-- rename: {src: stride_tn, dst: strideWithDimname}
-- rename: {src: unbind_tl, dst: unbind}
-- rename: {src: unbind_tn, dst: unbindWithDimname}
-- rename: {src: scatter_add_tltt, dst: scatterAdd}
-- rename: {src: scatter_add_tntt, dst: scatterAddWithDimname}
-- rename: {src: index_add_tltt, dst: indexAdd}
-- rename: {src: index_add_tntt, dst: indexAddWithDimname}
-- rename: {src: index_select_tlt, dst: indexSelect}
-- rename: {src: index_select_tnt, dst: indexSelectWithDimname}
-- rename: {src: gather_tltb, dst: gather}
-- rename: {src: gather_tntb, dst: gatherWithDimname}
-- rename: {src: argsort_tlb, dst: argsort}
-- rename: {src: argsort_tnb, dst: argsortWithDimname}
-- rename: {src: squeeze_tn, dst: squeezeWithDimname}
-- rename: {src: sum_tNbs, dst: sumWithDimnames}
-- rename: {src: std_mean_tNbb, dst: stdMeanWithDimnames}
-- rename: {src: std_tNbb, dst: stdWithDimnames}
-- rename: {src: prod_tnbs, dst: prodWithDimnames}
-- rename: {src: var_tNbb, dst: varWithDimnames}
-- rename: {src: var_mean_tNbb, dst: varMeanWithDimnames}
-- rename: {src: softmax_tls, dst: softmax}
-- rename: {src: softmax_tns, dst: softmaxWithDimname}
-  
-# remove overloaded functions of libtorch-1.3 except for the above list
-- remove: {src: where_t}
-- remove: {src: cat_ll}
-- remove: {src: flatten_tlln}
-- remove: {src: flatten_tnnn}
-- remove: {src: flatten_tnn}
-- remove: {src: flatten_tNn}
-- remove: {src: fbgemm_pack_quantized_matrix_t}
-- remove: {src: fbgemm_pack_quantized_matrix_tll}
-- remove: {src: norm_tsnbs}
-- remove: {src: norm_tsnb}
-- remove: {src: norm_tsNbs}
-- remove: {src: norm_tsNb}
-- remove: {src: result_type_tt}
-- remove: {src: result_type_ts}
-- remove: {src: result_type_st}
-- remove: {src: result_type_ss}
-- remove: {src: index_fill_tnts}
-- remove: {src: index_fill_tntt}
-- remove: {src: scatter_tntt}
-- remove: {src: scatter_tnts}
+- rename: {src: transpose_tll, dst: transpose}
+- rename: {src: transpose_tnn, dst: transposeWithDimname}
+- rename: {src: select_tll, dst: select}
+- rename: {src: select_tnl, dst: selectWithDimname}
+- rename: {src: reshape_tl, dst: reshape}
+- rename: {src: erf_t, dst: erf}
+- rename: {src: floor_t, dst: floor}
+- rename: {src: cos_t, dst: cos}
+- rename: {src: exp_t, dst: exp}
+- rename: {src: sin_t, dst: sin}
+- rename: {src: sinh_t, dst: sinh}
+- rename: {src: sqrt_t, dst: sqrt}
+- rename: {src: tanh_t, dst: tanh}
+- rename: {src: abs_t, dst: abs}
+- rename: {src: log1p_t, dst: log1p}
+- rename: {src: ceil_t, dst: ceil}
+- rename: {src: conv2d_tttllll, dst: conv2d}
+- rename: {src: diag_tl, dst: diag}
+- rename: {src: gels_tt, dst: gels}
+- rename: {src: log10_t, dst: log10}
+- rename: {src: log2_t, dst: log2}
+- rename: {src: matmul_tt, dst: matmul}
+- rename: {src: mse_loss_ttl, dst: mse_loss}
+- rename: {src: relu_t, dst: relu}
+- rename: {src: selu_t, dst: selu}
+- rename: {src: sigmoid_t, dst: sigmoid}
+- rename: {src: size_tl, dst: size}
+- rename: {src: size_tn, dst: sizeWithDimname}
+- rename: {src: all_t, dst: all}
+- rename: {src: any_t, dst: any}
+- rename: {src: qr_t, dst: qr}
+- rename: {src: geqrf_t, dst: geqrf}
+- rename: {src: orgqr_tt, dst: orgqr}
+- rename: {src: sign_t, dst: sign}
+- rename: {src: inverse_t, dst: inverse}
+- rename: {src: cholesky_tb, dst: cholesky}
+- rename: {src: cholesky_inverse_tb, dst: cholesky_inverse}
+- rename: {src: cholesky_solve_ttb, dst: cholesky_solve}
+- rename: {src: eig_tb, dst: eig}
+- rename: {src: solve_tt, dst: solve}
+- rename: {src: svd_tbb, dst: svd}
+- rename: {src: symeig_tbb, dst: symeig}
+- rename: {src: fbgemm_pack_quantized_matrix_tll, dst: quantizeFbgemm}
+- rename: {src: fbgemm_pack_quantized_matrix_t, dst: quantizeFbgemm'}
+- rename: {src: result_type_tt, dst: resultType}
+- rename: {src: result_type_ts, dst: resultTypeScalar}
+- rename: {src: result_type_st, dst: resultTypeScalar'}
+- rename: {src: result_type_ss, dst: resultTypeScalars}
+- rename: {src: randint_like_tllM, dst: randintLike}
+- rename: {src: randint_like_tlM, dst: randintLike'}
+# - rename: {src: , dst: }
+
+# detach needs IO-monad to create new-tensor.
+- remove: {src: detach_t}
+

--- a/spec/bindings.yaml
+++ b/spec/bindings.yaml
@@ -12,7 +12,7 @@
 - rename: {src: cumprod_tns, dst: cumprodWithDimname}
 - rename: {src: div_tt, dst: div}
 - rename: {src: div_ts, dst: divScalar}
-- rename: {src: log_softmax_tls, dst: log_softmax}
+- rename: {src: log_softmax_tls, dst: logSoftmax}
 - rename: {src: max_t, dst: maxAll}
 - rename: {src: max_tlb, dst: maxDim}
 - rename: {src: max_tnb, dst: maxWithDimname}
@@ -183,7 +183,7 @@
 - rename: {src: log10_t, dst: log10}
 - rename: {src: log2_t, dst: log2}
 - rename: {src: matmul_tt, dst: matmul}
-- rename: {src: mse_loss_ttl, dst: mse_loss}
+- rename: {src: mse_loss_ttl, dst: mseLoss}
 - rename: {src: relu_t, dst: relu}
 - rename: {src: selu_t, dst: selu}
 - rename: {src: sigmoid_t, dst: sigmoid}
@@ -197,8 +197,8 @@
 - rename: {src: sign_t, dst: sign}
 - rename: {src: inverse_t, dst: inverse}
 - rename: {src: cholesky_tb, dst: cholesky}
-- rename: {src: cholesky_inverse_tb, dst: cholesky_inverse}
-- rename: {src: cholesky_solve_ttb, dst: cholesky_solve}
+- rename: {src: cholesky_inverse_tb, dst: choleskyInverse}
+- rename: {src: cholesky_solve_ttb, dst: choleskySolve}
 - rename: {src: eig_tb, dst: eig}
 - rename: {src: solve_tt, dst: solve}
 - rename: {src: svd_tbb, dst: svd}
@@ -211,6 +211,12 @@
 - rename: {src: result_type_ss, dst: resultTypeScalars}
 - rename: {src: randint_like_tllM, dst: randintLike}
 - rename: {src: randint_like_tlM, dst: randintLike'}
+- rename: {src: empty_like_tM, dst: emptyLikeWithMemoryFormat}
+- rename: {src: full_like_tsM, dst: fullLikeWithMemoryFormat}
+- rename: {src: ones_like_tM, dst: onesLikeWithMemoryFormat}
+- rename: {src: rand_like_tM, dst: randLikeWithMemoryFormat}
+- rename: {src: randn_like_tM, dst: randnLikeWithMemoryFormat}
+- rename: {src: zeros_like_tM, dst: zerosLikeWithMemoryFormat}
 # - rename: {src: , dst: }
 
 # detach needs IO-monad to create new-tensor.

--- a/spec/bindings.yaml
+++ b/spec/bindings.yaml
@@ -1,8 +1,8 @@
 # This file controls functions in hasktorch/src/Torch/Functional/Internal.hs.
 # The functions are pure-functions not using IO-monad.
-- rename: {src: all_tlb, dst: all}
+- rename: {src: all_tlb, dst: allDim}
 - rename: {src: all_tnb, dst: allWithDimname}
-- rename: {src: any_tlb, dst: any}
+- rename: {src: any_tlb, dst: anyDim}
 - rename: {src: any_tnb, dst: anyWithDimname}
 - rename: {src: cat_ll, dst: cat}
 - rename: {src: cat_ln, dst: catWithDimname}


### PR DESCRIPTION
This PR adjusts the codegen behavior for the `Functional.Internal` module to include overloaded functions under their masked names.
I've since gone over the extra functions generated this way, and made an attempt to rename them to something semi-intelligible.