### PR TITLE
Add readImageAsRGB8 to read jpeg-file as RGB8-format

### DIFF
--- a/examples/image-processing/Main.hs
+++ b/examples/image-processing/Main.hs
@@ -59,7 +59,7 @@ lowpass input = conv weight input
                  ]
 
 main = do
-  readImage "input.bmp" >>= \case
+  readImageAsRGB8 "input.bmp" >>= \case
     Right tensor -> do
       writeBitmap "output_sharpness.bmp" $ sharpness tensor
       writeBitmap "output_lowpass.bmp" $ lowpass tensor

--- a/examples/load-torchscript/Main.hs
+++ b/examples/load-torchscript/Main.hs
@@ -33,7 +33,7 @@ main = prettyException $ do
   [mode,modelfile,inputfile] <- opt <$> getArgs
   _ <- dlopen "libtorchvision.so" [RTLD_GLOBAL,RTLD_LAZY]
   model <- load WithoutRequiredGrad modelfile
-  mimg <- readImage inputfile
+  mimg <- readImageAsRGB8 inputfile
   case (mimg,mode) of
     (Left err,_) -> print err
     (Right img',"resnet")-> do


### PR DESCRIPTION
readImage function reads jpeg-file as YCbCr-format.
It is not convenient for some applications.
readImageAsRGB8 function always read a image as RGB8-format.
