### PR TITLE
allow untyped optimization for typed LSTM

### DIFF
--- a/hasktorch/src/Torch/Typed/NN/Recurrent/LSTM.hs
+++ b/hasktorch/src/Torch/Typed/NN/Recurrent/LSTM.hs
@@ -150,6 +150,54 @@ instance
       <*> (makeIndependent =<< pure zeros)
       <*> (makeIndependent =<< pure zeros)
 
+instance A.Parameterized (LSTMLayer inputSize hiddenSize directionality dtype device) where
+  flattenParameters (LSTMUnidirectionalLayer wi wh bi bh) =
+      [ untypeParam wi
+      , untypeParam wh
+      , untypeParam bi
+      , untypeParam bh
+      ]
+  flattenParameters (LSTMBidirectionalLayer wi wh bi bh wi' wh' bi' bh') =
+      [ untypeParam wi
+      , untypeParam wh
+      , untypeParam bi
+      , untypeParam bh
+      , untypeParam wi'
+      , untypeParam wh'
+      , untypeParam bi'
+      , untypeParam bh'
+      ]
+  replaceOwnParameters (LSTMUnidirectionalLayer _wi _wh _bi _bh) = do
+    wi <- A.nextParameter
+    wh <- A.nextParameter
+    bi <- A.nextParameter
+    bh <- A.nextParameter
+    return (LSTMUnidirectionalLayer
+            (UnsafeMkParameter wi)
+            (UnsafeMkParameter wh)
+            (UnsafeMkParameter bi)
+            (UnsafeMkParameter bh)
+            )
+  replaceOwnParameters (LSTMBidirectionalLayer _wi _wh _bi _bh _wi' _wh' _bi' _bh') = do
+    wi <- A.nextParameter
+    wh <- A.nextParameter
+    bi <- A.nextParameter
+    bh <- A.nextParameter
+    wi' <- A.nextParameter
+    wh' <- A.nextParameter
+    bi' <- A.nextParameter
+    bh' <- A.nextParameter
+    return (LSTMBidirectionalLayer
+            (UnsafeMkParameter wi)
+            (UnsafeMkParameter wh)
+            (UnsafeMkParameter bi)
+            (UnsafeMkParameter bh)
+            (UnsafeMkParameter wi')
+            (UnsafeMkParameter wh')
+            (UnsafeMkParameter bi')
+            (UnsafeMkParameter bh')
+            )
+
 data LSTMLayerStackSpec
   (inputSize :: Nat)
   (hiddenSize :: Nat)
@@ -240,6 +288,20 @@ instance {-# OVERLAPPABLE #-}
       <$> (A.sample $ LSTMLayerStackSpec @inputSize @hiddenSize @(numLayers - 1) @directionality @dtype @device)
       <*> (A.sample $ LSTMLayerSpec @(hiddenSize * NumberOfDirections directionality) @hiddenSize @directionality @dtype @device)
 
+instance A.Parameterized (LSTMLayerStack inputSize hiddenSize numLayers directionality dtype device) where
+  flattenParameters (LSTMLayer1 layer) =
+           A.flattenParameters layer
+  flattenParameters (LSTMLayerK stack layer) =
+           A.flattenParameters stack
+        ++ A.flattenParameters layer
+  replaceOwnParameters (LSTMLayer1 layer) = do
+    layer' <- A.replaceOwnParameters layer
+    return $ LSTMLayer1 layer'
+  replaceOwnParameters (LSTMLayerK stack layer) = do
+    stack' <- A.replaceOwnParameters stack
+    layer' <- A.replaceOwnParameters layer
+    return $ LSTMLayerK stack' layer'
+
 newtype LSTMSpec
   (inputSize :: Nat)
   (hiddenSize :: Nat)
@@ -266,6 +328,15 @@ data LSTM
 -- TODO: when we have cannonical initializers do this correctly:
 -- https://github.com/pytorch/pytorch/issues/9221
 -- https://discuss.pytorch.org/t/initializing-rnn-gru-and-lstm-correctly/23605
+
+instance A.Parameterized (LSTM inputSize hiddenSize numLayers directionality dtype device) where
+  flattenParameters LSTM{..} = A.flattenParameters lstm_layer_stack
+  replaceOwnParameters LSTM{..} = do
+    lstm_layer_stack' <- A.replaceOwnParameters lstm_layer_stack
+    return $ LSTM
+                 { lstm_layer_stack = lstm_layer_stack'
+                 , ..
+                 }
 
 -- | Helper to do xavier uniform initializations on weight matrices and
 -- orthagonal initializations for the gates. (When implemented.)
@@ -459,6 +530,28 @@ instance
       <$> A.sample lstmSpec
       <*> (makeIndependent =<< pure c)
       <*> (makeIndependent =<< pure h)
+
+instance A.Parameterized (LSTMWithInit inputSize hiddenSize numLayers directionality initialization dtype device) where
+  flattenParameters LSTMWithConstInit{..} =
+           A.flattenParameters lstmWithConstInit_lstm
+  flattenParameters LSTMWithLearnedInit{..} =
+           A.flattenParameters lstmWithLearnedInit_lstm
+        ++ fmap untypeParam [lstmWithLearnedInit_c, lstmWithLearnedInit_h]
+  replaceOwnParameters LSTMWithConstInit{..} = do
+    lstmWithConstInit_lstm' <- A.replaceOwnParameters lstmWithConstInit_lstm
+    return $ LSTMWithConstInit
+                 { lstmWithConstInit_lstm = lstmWithConstInit_lstm'
+                 , ..
+                 }
+  replaceOwnParameters LSTMWithLearnedInit{..} = do
+    lstmWithLearnedInit_lstm' <- A.replaceOwnParameters lstmWithLearnedInit_lstm
+    lstmWithLearnedInit_c'    <- A.nextParameter
+    lstmWithLearnedInit_h'    <- A.nextParameter
+    return $ LSTMWithLearnedInit
+                 { lstmWithLearnedInit_lstm = lstmWithLearnedInit_lstm'
+                 , lstmWithLearnedInit_c    = UnsafeMkParameter lstmWithLearnedInit_c'
+                 , lstmWithLearnedInit_h    = UnsafeMkParameter lstmWithLearnedInit_h'
+                 }
 
 lstm
   :: forall

--- a/hasktorch/src/Torch/Typed/Parameter.hs
+++ b/hasktorch/src/Torch/Typed/Parameter.hs
@@ -41,6 +41,12 @@ import           Torch.Typed.Tensor
 newtype Parameter (device :: (D.DeviceType, Nat)) (dtype :: D.DType) (shape :: [Nat]) = UnsafeMkParameter A.IndependentTensor
   deriving Show
 
+untypeParam
+  :: forall device dtype shape
+   . Parameter device dtype shape
+  -> A.Parameter
+untypeParam = A.IndependentTensor . toDynamic . toDependent
+
 toDependent
   :: forall shape dtype device
    . Parameter device dtype shape

--- a/hasktorch/src/Torch/Typed/Parameter.hs
+++ b/hasktorch/src/Torch/Typed/Parameter.hs
@@ -45,7 +45,7 @@ untypeParam
   :: forall device dtype shape
    . Parameter device dtype shape
   -> A.Parameter
-untypeParam = A.IndependentTensor . toDynamic . toDependent
+untypeParam (UnsafeMkParameter param) = param
 
 toDependent
   :: forall shape dtype device

--- a/hasktorch/src/Torch/Typed/Parameter.hs
+++ b/hasktorch/src/Torch/Typed/Parameter.hs
@@ -41,10 +41,7 @@ import           Torch.Typed.Tensor
 newtype Parameter (device :: (D.DeviceType, Nat)) (dtype :: D.DType) (shape :: [Nat]) = UnsafeMkParameter A.IndependentTensor
   deriving Show
 
-untypeParam
-  :: forall device dtype shape
-   . Parameter device dtype shape
-  -> A.Parameter
+untypeParam :: Parameter device dtype shape -> A.Parameter
 untypeParam (UnsafeMkParameter param) = param
 
 toDependent


### PR DESCRIPTION
I was making a model that included both parts known statically as well as dynamic ones, meaning typed optimization was out for me.
This means I'd need to fall back to untyped optimization, while I was still using the typed LSTM here as well. As a result, I needed to ensure that supported untyped optimization (i.e. instance `A.Parameterized`). This PR adds that.

I'm open to feedback on the function `untypeParam` -- I was under the impression we didn't have something like it yet, and I wanted to use a name that wouldn't clash with `toDynamic`, wouldn't sound like a noun (`dynamicParameter`), and ideally wouldn't be super long, as this may get repeated a bunch in lists (see `LSTMLayer` instance). So I was a bit on the fence, but I'm open to e.g. `untypeParameter` or other ideas if preferred.
