### PR TITLE
warn about IndependentTensor vs makeIndependent

### DIFF
--- a/hasktorch/src/Torch/Autograd.hs
+++ b/hasktorch/src/Torch/Autograd.hs
@@ -15,6 +15,8 @@ import Torch.Internal.Cast
 
 import Torch.Tensor
 
+-- | Note: to create an `IndependentTensor` use `makeIndependent`;
+-- | otherwise, Torch will complain the parameter does not require a gradient.
 newtype IndependentTensor = IndependentTensor { toDependent :: Tensor }
     deriving (Show)
 


### PR DESCRIPTION
I wanted to add this warning based on an error I ran into:
`CppStdException "Exception: One of the differentiated Tensors does not require grad; type: std::runtime_error"`
