### PR TITLE
Added function definitions for untyped api to reduce parity

### DIFF
--- a/hasktorch/src/Torch/Functional.hs
+++ b/hasktorch/src/Torch/Functional.hs
@@ -1028,3 +1028,10 @@ triu
   -> Tensor -- ^ input
   -> Tensor -- ^ output
 triu diagonal input = unsafePerformIO $ (cast2 ATen.triu_tl) input diagonal
+
+-- | tril
+tril
+  :: Int -- ^ diagonal
+  -> Tensor -- ^ input
+  -> Tensor -- ^ output
+tril diagonal input = unsafePerformIO $ (cast2 ATen.tril_tl) input diagonal

--- a/hasktorch/src/Torch/Functional.hs
+++ b/hasktorch/src/Torch/Functional.hs
@@ -1035,3 +1035,10 @@ tril
   -> Tensor -- ^ input
   -> Tensor -- ^ output
 tril diagonal input = unsafePerformIO $ (cast2 ATen.tril_tl) input diagonal
+
+-- | unsqueeze
+unsqueeze
+  :: Dim  -- ^ dim
+  -> Tensor -- ^ input
+  -> Tensor -- ^ output
+unsqueeze (Dim d) input = unsafePerformIO $ (cast2 ATen.unsqueeze_tl) input d

--- a/hasktorch/src/Torch/Functional.hs
+++ b/hasktorch/src/Torch/Functional.hs
@@ -1002,3 +1002,12 @@ stack
   -> [Tensor] -- ^ input
   -> Tensor -- ^ output
 stack (Dim d) tensors = unsafePerformIO $ (cast2 ATen.stack_ll) tensors d
+
+-- | sumDim
+sumDim
+  :: Dim -- ^ dim to sum along
+  -> KeepDim -- ^ whether the output tensor has dim retained or not
+  -> DType -- ^ datatype
+  -> Tensor -- ^ input
+  -> Tensor -- ^ output
+sumDim (Dim d) k dtype input = unsafePerformIO $ (cast4 ATen.sum_tlbs) input d (keepdim k) dtype

--- a/hasktorch/src/Torch/Functional.hs
+++ b/hasktorch/src/Torch/Functional.hs
@@ -996,14 +996,17 @@ softShrink
   -> Tensor -- ^ output
 softShrink lambda input = unsafePerformIO $ (cast2 ATen.softshrink_ts) input lambda
 
--- | stack
+-- | Concatenates sequence of tensors along a new dimension.
+-- All tensors need to be of the same size.
 stack
   :: Dim -- ^ dim
   -> [Tensor] -- ^ input
   -> Tensor -- ^ output
 stack (Dim d) tensors = unsafePerformIO $ (cast2 ATen.stack_ll) tensors d
 
--- | sumDim
+-- | Returns the sum of each row of the input tensor in the given dimension dim.
+-- If keepdim is True, the output tensor is of the same size as input except in the dimension(s) dim where it is of size 1. 
+-- Otherwise, dim is squeezed, resulting in the output tensor having 1 (or len(dim)) fewer dimension(s).
 sumDim
   :: Dim -- ^ dim to sum along
   -> KeepDim -- ^ whether the output tensor has dim retained or not
@@ -1012,7 +1015,10 @@ sumDim
   -> Tensor -- ^ output
 sumDim (Dim d) k dtype input = unsafePerformIO $ (cast4 ATen.sum_tlbs) input d (keepdim k) dtype
 
--- | topK
+-- | Returns the k largest elements of the given input tensor along a given dimension.
+-- If largest is False then the k smallest elements are returned.
+-- The boolean option sorted if True, will make sure that the returned k elements are themselves sorted
+-- A tuple of (values, indices) is returned, where the indices are the indices of the elements in the original input tensor.  
 topK 
   :: Int -- ^ k
   -> Dim -- ^ dim to find topK along
@@ -1022,21 +1028,31 @@ topK
   -> (Tensor,Tensor) -- ^ output
 topK k (Dim d) largest sorted input = unsafePerformIO $ (cast5 ATen.topk_tllbb) input k d largest sorted
 
--- | triu
+-- | Returns the upper triangular part of a matrix (2-D tensor) or batch of matrices input, the other elements of the result tensor out are set to 0.
+-- The upper triangular part of the matrix is defined as the elements on and above the diagonal.
+-- The argument diagonal controls which diagonal to consider. If diagonal = 0, all elements on and above the main diagonal are retained. 
+-- A positive value excludes just as many diagonals above the main diagonal, and similarly a negative value includes just as many diagonals below the main diagonal. 
+-- The main diagonal are the set of indices \((i,i)\) for \(i\) \(\in [0,\min(d_1,d_2)-1]\) where \(d_1\) and \(d_2 \) are the dimensions of the matrix.
 triu
   :: Int -- ^ diagonal
   -> Tensor -- ^ input
   -> Tensor -- ^ output
 triu diagonal input = unsafePerformIO $ (cast2 ATen.triu_tl) input diagonal
 
--- | tril
+-- | Returns the lower triangular part of the matrix (2-D tensor) or batch of matrices input, the other elements of the result tensor out are set to 0.
+-- The lower triangular part of the matrix is defined as the elements on and below the diagonal.
+-- The argument diagonal controls which diagonal to consider. If diagonal = 0, all elements on and below the main diagonal are retained. 
+-- A positive value includes just as many diagonals above the main diagonal, and similarly a negative value excludes just as many diagonals below the main diagonal. 
+-- The main diagonals are the set of indices \((i,i)\) for \(i\) \(\in [0,\min(d_1,d_2)-1]\) where \(d_1\) and \(d_2 \) are the dimensions of the matrix.
 tril
   :: Int -- ^ diagonal
   -> Tensor -- ^ input
   -> Tensor -- ^ output
 tril diagonal input = unsafePerformIO $ (cast2 ATen.tril_tl) input diagonal
 
--- | unsqueeze
+-- | Returns a new tensor with a dimension of size one inserted at the specified position.
+-- The returned tensor shares the same underlying data with this tensor.
+-- A dim value within the range [(dim input) - 1, (dim input) + 1) can be used. Negative dim will correspond to unsqueeze applied at dim = dim + (dim input) + 1
 unsqueeze
   :: Dim  -- ^ dim
   -> Tensor -- ^ input

--- a/hasktorch/src/Torch/Functional.hs
+++ b/hasktorch/src/Torch/Functional.hs
@@ -1011,3 +1011,13 @@ sumDim
   -> Tensor -- ^ input
   -> Tensor -- ^ output
 sumDim (Dim d) k dtype input = unsafePerformIO $ (cast4 ATen.sum_tlbs) input d (keepdim k) dtype
+
+-- | topK
+topK 
+  :: Int -- ^ k
+  -> Dim -- ^ dim to find topK along
+  -> Bool -- ^ largest
+  -> Bool -- ^ sorted
+  -> Tensor -- ^ input
+  -> (Tensor,Tensor) -- ^ output
+topK k (Dim d) largest sorted input = unsafePerformIO $ (cast5 ATen.topk_tllbb) input k d largest sorted

--- a/hasktorch/src/Torch/Functional.hs
+++ b/hasktorch/src/Torch/Functional.hs
@@ -995,3 +995,10 @@ softShrink
   -> Tensor -- ^ input
   -> Tensor -- ^ output
 softShrink lambda input = unsafePerformIO $ (cast2 ATen.softshrink_ts) input lambda
+
+-- | stack
+stack
+  :: Dim -- ^ dim
+  -> [Tensor] -- ^ input
+  -> Tensor -- ^ output
+stack (Dim d) tensors = unsafePerformIO $ (cast2 ATen.stack_ll) tensors d

--- a/hasktorch/src/Torch/Functional.hs
+++ b/hasktorch/src/Torch/Functional.hs
@@ -1021,3 +1021,10 @@ topK
   -> Tensor -- ^ input
   -> (Tensor,Tensor) -- ^ output
 topK k (Dim d) largest sorted input = unsafePerformIO $ (cast5 ATen.topk_tllbb) input k d largest sorted
+
+-- | triu
+triu
+  :: Int -- ^ diagonal
+  -> Tensor -- ^ input
+  -> Tensor -- ^ output
+triu diagonal input = unsafePerformIO $ (cast2 ATen.triu_tl) input diagonal

--- a/hasktorch/test/FunctionalSpec.hs
+++ b/hasktorch/test/FunctionalSpec.hs
@@ -167,6 +167,10 @@ spec = do
   it "sumDim" $ do
     let x = asTensor([[1,2,3],[4,5,6],[7,8,9],[10,11,12]]::[[Float]])
         output = sumDim (Dim 0) KeepDim Float x
-    (toDouble $ select output 1 1) `shouldBe` (26.0)  
+    (toDouble $ select output 1 1) `shouldBe` (26.0)
+  it "topK" $ do
+    let x = asTensor([1,2,3] :: [Float])
+        output = fst $ topK 2 (Dim 0) True True x 
+    (toDouble $ select output 0 0) `shouldBe` (3.0)    
 
 

--- a/hasktorch/test/FunctionalSpec.hs
+++ b/hasktorch/test/FunctionalSpec.hs
@@ -174,6 +174,9 @@ spec = do
     (toDouble $ select output 0 0) `shouldBe` (3.0)
   it "triu" $ do
     let x = asTensor([[1,2,3],[4,5,6],[7,8,9],[10,11,12]]::[[Float]])
-    (toDouble $ sumAll $ triu 0 x) `shouldBe` (26.0)      
+    (toDouble $ sumAll $ triu 0 x) `shouldBe` (26.0)
+  it "tril" $ do
+    let x = asTensor([[1,2,3],[4,5,6],[7,8,9],[10,11,12]]::[[Float]])
+    (toDouble $ sumAll $ tril 0 x) `shouldBe` (67.0)      
 
 

--- a/hasktorch/test/FunctionalSpec.hs
+++ b/hasktorch/test/FunctionalSpec.hs
@@ -159,5 +159,10 @@ spec = do
     let input = 3 * ones' [3]
         output = softShrink 1 input
     (toDouble $ select output 0 0) `shouldBe` (2.0)
+  it "stack" $ do
+    let x = ones' [4,3]
+        y = ones' [4,3]
+        output = stack (Dim 1) [x,y]
+    (shape output) `shouldBe` ([4,2,3]) 
 
 

--- a/hasktorch/test/FunctionalSpec.hs
+++ b/hasktorch/test/FunctionalSpec.hs
@@ -177,6 +177,10 @@ spec = do
     (toDouble $ sumAll $ triu 0 x) `shouldBe` (26.0)
   it "tril" $ do
     let x = asTensor([[1,2,3],[4,5,6],[7,8,9],[10,11,12]]::[[Float]])
-    (toDouble $ sumAll $ tril 0 x) `shouldBe` (67.0)      
+    (toDouble $ sumAll $ tril 0 x) `shouldBe` (67.0)
+  it "unsqueeze" $ do
+    let x = asTensor([[1,2,3],[4,5,6],[7,8,9],[10,11,12]]::[[Float]])
+        output = unsqueeze (Dim 0) x
+    (shape output) `shouldBe` ([1,4,3])      
 
 

--- a/hasktorch/test/FunctionalSpec.hs
+++ b/hasktorch/test/FunctionalSpec.hs
@@ -164,5 +164,9 @@ spec = do
         y = ones' [4,3]
         output = stack (Dim 1) [x,y]
     (shape output) `shouldBe` ([4,2,3]) 
+  it "sumDim" $ do
+    let x = asTensor([[1,2,3],[4,5,6],[7,8,9],[10,11,12]]::[[Float]])
+        output = sumDim (Dim 0) KeepDim Float x
+    (toDouble $ select output 1 1) `shouldBe` (26.0)  
 
 

--- a/hasktorch/test/FunctionalSpec.hs
+++ b/hasktorch/test/FunctionalSpec.hs
@@ -171,6 +171,9 @@ spec = do
   it "topK" $ do
     let x = asTensor([1,2,3] :: [Float])
         output = fst $ topK 2 (Dim 0) True True x 
-    (toDouble $ select output 0 0) `shouldBe` (3.0)    
+    (toDouble $ select output 0 0) `shouldBe` (3.0)
+  it "triu" $ do
+    let x = asTensor([[1,2,3],[4,5,6],[7,8,9],[10,11,12]]::[[Float]])
+    (toDouble $ sumAll $ triu 0 x) `shouldBe` (26.0)      
 
 


### PR DESCRIPTION
Extension of #337 to address #328 . Includes stack, sumDim, topK, triu, tril, unSqueeze functions along with tests in untyped api.