### PR TITLE
GHC 8.10: nix

### DIFF
--- a/nix/shared.nix
+++ b/nix/shared.nix
@@ -1,4 +1,4 @@
-{ compiler ? "ghc883" }:
+{ compiler ? "ghc8101" }:
 
 let
   libtorch_src = pkgs:


### PR DESCRIPTION
edit: `nix-linux` CI error:
```
Configuring language-haskell-extract-0.2.4...
...
Setup: Encountered missing or private dependencies:
template-haskell <2.16
```

hm. wth?

cc @junjihashimoto, @tscholak
