### PR TITLE
Added datatype for diagonal in untyped api

### DIFF
--- a/hasktorch/src/Torch/Functional.hs
+++ b/hasktorch/src/Torch/Functional.hs
@@ -101,6 +101,8 @@ instance Castable Reduction Int64 where
   uncast 1 f = f ReduceMean
   uncast _ f = f ReduceSum
 
+data Diag = Diag Int
+
 isUpper Upper = True
 isUpper Lower = False
 
@@ -946,10 +948,10 @@ transpose2D = transpose (Dim 0) (Dim 1)
 --        If Int < 0, it is below the main diagonal.
 
 diag
-    ::  Int -- ^ diagonal
+    ::  Diag -- ^ diagonal
     ->  Tensor -- ^ input
     ->  Tensor -- ^ output
-diag index t = unsafePerformIO $ (cast2 ATen.tensor_diag_l) t index
+diag (Diag index) t = unsafePerformIO $ (cast2 ATen.tensor_diag_l) t index
 
 -- | Returns True if all elements in the tensor are True, False otherwise.
 all
@@ -1216,10 +1218,10 @@ topK k (Dim d) largest sorted input = unsafePerformIO $ (cast5 ATen.topk_tllbb) 
 -- A positive value excludes just as many diagonals above the main diagonal, and similarly a negative value includes just as many diagonals below the main diagonal. 
 -- The main diagonal are the set of indices \((i,i)\) for \(i\) \(\in [0,\min(d_1,d_2)-1]\) where \(d_1\) and \(d_2 \) are the dimensions of the matrix.
 triu
-  :: Int -- ^ diagonal
+  :: Diag -- ^ diagonal
   -> Tensor -- ^ input
   -> Tensor -- ^ output
-triu diagonal input = unsafePerformIO $ (cast2 ATen.triu_tl) input diagonal
+triu (Diag diagonal) input = unsafePerformIO $ (cast2 ATen.triu_tl) input diagonal
 
 -- | Returns the lower triangular part of the matrix (2-D tensor) or batch of matrices input, the other elements of the result tensor out are set to 0.
 -- The lower triangular part of the matrix is defined as the elements on and below the diagonal.
@@ -1227,10 +1229,10 @@ triu diagonal input = unsafePerformIO $ (cast2 ATen.triu_tl) input diagonal
 -- A positive value includes just as many diagonals above the main diagonal, and similarly a negative value excludes just as many diagonals below the main diagonal. 
 -- The main diagonals are the set of indices \((i,i)\) for \(i\) \(\in [0,\min(d_1,d_2)-1]\) where \(d_1\) and \(d_2 \) are the dimensions of the matrix.
 tril
-  :: Int -- ^ diagonal
+  :: Diag -- ^ diagonal
   -> Tensor -- ^ input
   -> Tensor -- ^ output
-tril diagonal input = unsafePerformIO $ (cast2 ATen.tril_tl) input diagonal
+tril (Diag diagonal) input = unsafePerformIO $ (cast2 ATen.tril_tl) input diagonal
 
 -- | Returns a new tensor with a dimension of size one inserted at the specified position.
 -- The returned tensor shares the same underlying data with this tensor.

--- a/hasktorch/test/FunctionalSpec.hs
+++ b/hasktorch/test/FunctionalSpec.hs
@@ -94,7 +94,7 @@ spec = do
     shape qr `shouldBe` [5,3]
   it "diag" $ do
     let x = ones' [3]
-    let y = diag 2 x
+    let y = diag (Diag 2) x
     shape y `shouldBe` [5, 5]
   it "expand" $ do
     let t = asTensor [[1], [2], [3 :: Int]]
@@ -181,10 +181,10 @@ spec = do
     (toDouble $ select output 0 0) `shouldBe` (3.0)
   it "triu" $ do
     let x = asTensor([[1,2,3],[4,5,6],[7,8,9],[10,11,12]]::[[Float]])
-    (toDouble $ sumAll $ triu 0 x) `shouldBe` (26.0)
+    (toDouble $ sumAll $ triu (Diag 0) x) `shouldBe` (26.0)
   it "tril" $ do
     let x = asTensor([[1,2,3],[4,5,6],[7,8,9],[10,11,12]]::[[Float]])
-    (toDouble $ sumAll $ tril 0 x) `shouldBe` (67.0)
+    (toDouble $ sumAll $ tril (Diag 0) x) `shouldBe` (67.0)
   it "unsqueeze" $ do
     let x = asTensor([[1,2,3],[4,5,6],[7,8,9],[10,11,12]]::[[Float]])
         output = unsqueeze (Dim 0) x


### PR DESCRIPTION
Would having a datatype for diagonal help? Since more functions crept up with that as a parameter in the last PR (#357 ) i.e. tril and triu in addition to the previously present diag. Thought of this change in reference to #322 . 