### PR TITLE
Fix cuda's branch

### DIFF
--- a/libtorch-ffi/libtorch-ffi.cabal
+++ b/libtorch-ffi/libtorch-ffi.cabal
@@ -94,23 +94,16 @@ library
                     , sysinfo
                     , async
                     , libtorch-ffi-helper
+ extra-libraries:     c10
+                    , torch
+                    , torch_cpu
  if os(darwin)
   extra-libraries:     c++
-                     , c10
-                     , torch
-                     , torch_cpu
  else
-   if flag(cuda)
-     extra-libraries:     stdc++
-                        , c10
-                        , torch
-                        , torch_cpu
-                        , torch_cuda
-   else
-     extra-libraries:     stdc++
-                        , c10
-                        , torch
-                        , torch_cpu
+  extra-libraries:     stdc++
+
+ if flag(cuda)
+  extra-libraries:     torch_cuda
 
  extra-ghci-libraries: stdc++
  if os(darwin)

--- a/nix/shared.nix
+++ b/nix/shared.nix
@@ -33,26 +33,21 @@ let
                   haskellPackagesNew: haskellPackagesOld: {
                     "libtorch-ffi_${postfix}" =
                         appendConfigureFlag
-                          (overrideCabal
-                            (haskellPackagesOld.callCabal2nix
-                              "libtorch-ffi"
-                              ../libtorch-ffi
-                              { c10 = pkgsNew."libtorch_${postfix}"
-                              ; torch = pkgsNew."libtorch_${postfix}"
-                              ; torch_cpu = pkgsNew."libtorch_${postfix}"
-                              ; ${if postfix == "cpu" then null else "torch_cuda"} = pkgsNew."libtorch_${postfix}"
-                              ; }
-                            )
-                            (old: {
-                                preConfigure = (old.preConfigure or "") + optionalString isDarwin ''
-                                  sed -i -e 's/-optc-std=c++11 -optc-xc++/-optc-xc++/g' ../libtorch-ffi/libtorch-ffi.cabal;
-                                '';
-                                configureFlags =
-                                  (if postfix == "cpu" then [] else [ "-fcuda" ])++
-                                  (if isDarwin then [ "-fgcc" ] else [])
-                                  ;
-                              }
-                            )
+                          (haskellPackagesOld.callCabal2nixWithOptions
+                            "libtorch-ffi"
+                            ../libtorch-ffi
+                            (if postfix == "cpu" then
+                              (if isDarwin then
+                                 "-fgcc"
+                               else
+                                 "")
+                             else
+                               "-fcuda")
+                            { c10 = pkgsNew."libtorch_${postfix}"
+                            ; torch = pkgsNew."libtorch_${postfix}"
+                            ; torch_cpu = pkgsNew."libtorch_${postfix}"
+                            ; ${if postfix == "cpu" then null else "torch_cuda"} = pkgsNew."libtorch_${postfix}"
+                            ; }
                           )
                         "--extra-include-dirs=${pkgsNew."libtorch_${postfix}"}/include/torch/csrc/api/include";
                     "hasktorch_${postfix}" =


### PR DESCRIPTION
The build of nix with cuda does not work (https://github.com/hasktorch/hasktorch/runs/611457740) , 
because torch_cuda's option is ignored on haskellPackagesOld.callCabal2nix.
callCabal2nixWithOptions can add  not ignored the flag of cabal.