### PR TITLE
get-deps: install python dependency pyyaml

### DIFF
--- a/deps/get-deps.sh
+++ b/deps/get-deps.sh
@@ -117,6 +117,12 @@ if [[ ! -d build ]]; then
 mkdir build
 fi
 
+PIP=pip
+if ! (pip --version | grep "python 2") ;then
+    PIP=pip3
+fi
+$PIP install --user pyyaml
+
 PYTHON=python
 if ! (python --version | grep "Python 2") ;then
     PYTHON=python3


### PR DESCRIPTION
We so far called [`$PYTHON aten/src/ATen/gen.py`](https://github.com/hasktorch/hasktorch/blob/master/deps/get-deps.sh#L127), which depends on `pyyaml`.
If that wasn't preinstalled, the script failed.
