### PR TITLE
Distillation Example

### DIFF
--- a/examples/distill/Dataset.hs
+++ b/examples/distill/Dataset.hs
@@ -1,0 +1,29 @@
+module Dataset where
+
+import Torch
+import qualified Torch.Typed.Vision as V hiding (getImages')
+import qualified Torch.Vision as V
+
+-- This is a placeholder for this example until we have a more formal data loader abstraction
+--
+class Dataset d where
+    getItem
+        :: d
+        -> Int -- index
+        -> Int -- batchSize
+        -> IO (Tensor, Tensor) -- input, label
+
+data MNIST = MNIST {
+    dataset :: V.MnistData,
+    idxList :: [Int]
+}
+
+instance Dataset MNIST where
+	getItem mnistData index n = do
+		let currIndex = index
+		let idx = take n (drop (currIndex + n) (idxList mnistData))
+		input <- V.getImages' n mnistDataDim (dataset mnistData) idx
+		let label = V.getLabels' n (dataset mnistData) idx
+		pure (input, label)
+
+mnistDataDim = 784

--- a/examples/distill/Distill.hs
+++ b/examples/distill/Distill.hs
@@ -12,12 +12,14 @@ import Prelude hiding (exp, log)
 import Torch
 import Dataset
 
+newtype ModelView = ModelView { view :: Tensor }
+
 data (Parameterized t, Parameterized s) => DistillSpec t s = DistillSpec {
     teacher :: t,
     student :: s,
-    teacherView :: t -> Tensor -> Tensor,
-    studentView :: s -> Tensor -> Tensor,
-    distillLoss :: Tensor -> Tensor -> Tensor
+    teacherView :: t -> Tensor -> ModelView,
+    studentView :: s -> Tensor -> ModelView,
+    distillLoss :: ModelView -> ModelView -> Tensor
 }
 
 data Optimizer o => OptimSpec o = OptimSpec {

--- a/examples/distill/Distill.hs
+++ b/examples/distill/Distill.hs
@@ -1,0 +1,54 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Distill where
+
+import Control.Monad (when)
+import GHC.Generics
+import Prelude hiding (exp, log)
+
+import Torch
+import qualified Torch.Typed.Vision as V hiding (getImages')
+import qualified Torch.Vision as V
+
+-- hard coded placeholder for this example until we have a more generic dataset types
+type Dataset = V.MnistData 
+dataDim = 784 :: Int
+
+data Parameterized p => DistillSpec p = DistillSpec {
+    teacher :: p,
+    student :: p,
+    teacherLens :: p -> Tensor -> Tensor,
+    studentLens :: p -> Tensor -> Tensor,
+    distillLoss :: Tensor -> Tensor -> Tensor
+}
+
+data Optimizer o => OptimSpec o = OptimSpec {
+    optimizer :: o,
+    batchSize :: Int,
+    numIters :: Int
+}
+
+distill
+    :: (Parameterized p, Optimizer o)
+    => DistillSpec p
+    -> OptimSpec o
+    -> Dataset
+    -> IO p 
+distill DistillSpec{..} OptimSpec{..} trainData = do
+    let nImages = V.length trainData
+        idxList = V.randomIndexes nImages
+    trained <- foldLoop student numIters $
+        \state iter -> do
+            let idx = take batchSize (drop (iter * batchSize) idxList)
+            input <- V.getImages' batchSize dataDim trainData idx
+            let tOutput = teacherLens teacher input
+                sOutput = studentLens state input
+                loss = distillLoss tOutput sOutput
+            when (iter `mod` 50 == 0) $ do
+                putStrLn $ "Iteration: " ++ show iter ++ " | Loss: " ++ show loss
+            (newParam, _) <- runStep state optimizer loss 1e-3 -- GD
+            pure $ replaceParameters state newParam
+    pure trained
+

--- a/examples/distill/Distill.hs
+++ b/examples/distill/Distill.hs
@@ -27,7 +27,8 @@ data Parameterized p => DistillSpec p = DistillSpec {
 data Optimizer o => OptimSpec o = OptimSpec {
     optimizer :: o,
     batchSize :: Int,
-    numIters :: Int
+    numIters :: Int,
+    learningRate :: Tensor
 }
 
 distill
@@ -48,7 +49,7 @@ distill DistillSpec{..} OptimSpec{..} trainData = do
                 loss = distillLoss tOutput sOutput
             when (iter `mod` 50 == 0) $ do
                 putStrLn $ "Iteration: " ++ show iter ++ " | Loss: " ++ show loss
-            (newParam, _) <- runStep state optimizer loss 1e-3 -- GD
+            (newParam, _) <- runStep state optimizer loss learningRate
             pure $ replaceParameters state newParam
     pure trained
 

--- a/examples/distill/Distill.hs
+++ b/examples/distill/Distill.hs
@@ -13,7 +13,7 @@ import qualified Torch.Typed.Vision as V hiding (getImages')
 import qualified Torch.Vision as V
 
 -- hard coded placeholder for this example until we have a more generic dataset types
-type Dataset = V.MnistData 
+-- type Dataset = V.MnistData 
 dataDim = 784 :: Int
 
 data Parameterized p => DistillSpec p = DistillSpec {
@@ -31,11 +31,27 @@ data Optimizer o => OptimSpec o = OptimSpec {
     learningRate :: Tensor
 }
 
+class Dataset d where
+    get :: d -> Int -> IO (Tensor, d)
+
+data MNIST = MNIST {
+    trainData :: V.MnistData,
+    testData :: V.MnistData,
+    idxList :: [Int],
+    index :: Int
+} 
+
+instance Dataset MNIST where
+    get MNIST{..} n = do
+        let idx = take n (drop (index + n) idxList)
+        input <- V.getImages' n dataDim trainData idx
+        pure (input, MNIST trainData testData idxList (index + n))
+
 distill
     :: (Parameterized p, Optimizer o)
     => DistillSpec p
     -> OptimSpec o
-    -> Dataset
+    -> V.MnistData
     -> IO p 
 distill DistillSpec{..} OptimSpec{..} trainData = do
     let nImages = V.length trainData
@@ -44,6 +60,26 @@ distill DistillSpec{..} OptimSpec{..} trainData = do
         \state iter -> do
             let idx = take batchSize (drop (iter * batchSize) idxList)
             input <- V.getImages' batchSize dataDim trainData idx
+            let tOutput = teacherLens teacher input
+                sOutput = studentLens state input
+                loss = distillLoss tOutput sOutput
+            when (iter `mod` 50 == 0) $ do
+                putStrLn $ "Iteration: " ++ show iter ++ " | Loss: " ++ show loss
+            (newParam, _) <- runStep state optimizer loss learningRate
+            pure $ replaceParameters state newParam
+    pure trained
+
+
+distill'
+    :: (Parameterized p, Optimizer o, Dataset d)
+    => DistillSpec p
+    -> OptimSpec o
+    -> d
+    -> IO p 
+distill' DistillSpec{..} OptimSpec{..} trainData = do
+    trained <- foldLoop student numIters $
+        \state iter -> do
+            (input, _) <- get trainData batchSize
             let tOutput = teacherLens teacher input
                 sOutput = studentLens state input
                 loss = distillLoss tOutput sOutput

--- a/examples/distill/Main.hs
+++ b/examples/distill/Main.hs
@@ -84,9 +84,9 @@ runDistill mnistData = do
     let distillSpec = DistillSpec {
         teacher = teacher,
         student = initStudent,
-        teacherView = mlpTemp 20.0,
-        studentView = mlpTemp 1.0,
-        distillLoss = \tOutput sOutput -> nllLoss' (maxIndex tOutput) sOutput
+        teacherView = \t inp -> ModelView (mlpTemp 20.0 t inp),
+        studentView = \s inp -> ModelView (mlpTemp 1.0 s inp),
+        distillLoss = \(ModelView tOutput) (ModelView sOutput) -> nllLoss' (maxIndex tOutput) sOutput
     }
     student <- distill distillSpec optimSpec mnistData
     pure (teacher, student)

--- a/examples/distill/Main.hs
+++ b/examples/distill/Main.hs
@@ -60,7 +60,7 @@ train OptimSpec{..} trainData init = do
                 loss = nllLoss' label $ forward state input
             when (iter `mod` 50 == 0) $ do
                 putStrLn $ "Iteration: " ++ show iter ++ " | Loss: " ++ show loss
-            (newParam, _) <- runStep state optimizer loss 1e-3
+            (newParam, _) <- runStep state optimizer loss learningRate
             pure $ replaceParameters state newParam
     pure trained
 
@@ -73,7 +73,8 @@ runDistill trainData = do
     let optimSpec = OptimSpec {
         optimizer = GD,
         batchSize = 256,
-        numIters = 500
+        numIters = 500,
+        learningRate = asTensor 1e-3
     }
     teacher <- train optimSpec trainData initTeacher
     -- Distill student

--- a/examples/distill/Main.hs
+++ b/examples/distill/Main.hs
@@ -1,0 +1,108 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Main where
+
+import Control.Monad (when)
+import GHC.Generics
+import Prelude hiding (exp, log)
+import System.Random (mkStdGen, randoms)
+
+import Torch
+import qualified Torch.Typed.Vision as V hiding (getImages')
+import qualified Torch.Vision as V
+
+dataDim = 784
+batchSize = 256
+numIters = 500
+teacherSpec = MLPSpec dataDim 300 300 10
+studentSpec = MLPSpec dataDim 30 30 10
+
+data MLPSpec = MLPSpec {
+    inputFeatures :: Int,
+    hiddenFeatures0 :: Int,
+    hiddenFeatures1 :: Int,
+    outputFeatures :: Int
+    } deriving (Show, Eq)
+
+data MLP = MLP { 
+    l0 :: Linear,
+    l1 :: Linear,
+    l2 :: Linear
+    } deriving (Generic, Show)
+
+instance Parameterized MLP
+instance Randomizable MLPSpec MLP where
+    sample MLPSpec {..} = MLP 
+        <$> sample (LinearSpec inputFeatures hiddenFeatures0)
+        <*> sample (LinearSpec hiddenFeatures0 hiddenFeatures1)
+        <*> sample (LinearSpec hiddenFeatures1 outputFeatures)
+
+mlpTemp :: Float -> MLP -> Tensor -> Tensor
+mlpTemp temperature MLP{..} input = 
+    logSoftmaxTemp (asTensor temperature)
+    . linear l2
+    . relu
+    . linear l1
+    . relu
+    . linear l0
+    $ input
+    where
+        logSoftmaxTemp t z = (z/t) - log (sumDim (Dim 1) KeepDim Float (exp (z/t)))
+
+mlp = mlpTemp 1.0
+
+train :: V.MnistData -> MLP -> IO MLP
+train trainData init = do
+    let optimizer = GD
+    let nImages = V.length trainData
+        idxList = V.randomIndexes nImages
+    trained <- foldLoop init numIters $
+        \state iter -> do
+            let idx = take batchSize (drop (iter * batchSize) idxList)
+            input <- V.getImages' batchSize dataDim trainData idx
+            let label = V.getLabels' batchSize trainData idx
+                loss = nllLoss' label $ mlp state input
+            when (iter `mod` 50 == 0) $ do
+                putStrLn $ "Iteration: " ++ show iter ++ " | Loss: " ++ show loss
+            (newParam, _) <- runStep state optimizer loss 1e-3 -- GD
+            pure $ replaceParameters state newParam
+    pure trained
+
+maxIndex = Torch.argmax (Dim 1) RemoveDim
+
+distill :: V.MnistData -> MLP -> MLP -> IO MLP
+distill trainData teacher studentInit = do
+    let optimizer = GD
+    let nImages = V.length trainData
+        idxList = V.randomIndexes nImages
+    trained <- foldLoop studentInit numIters $
+        \state iter -> do
+            let idx = take batchSize (drop (iter * batchSize) idxList)
+            input <- V.getImages' batchSize dataDim trainData idx
+            let tOutput = mlpTemp 20.0 teacher input
+                sOutput = mlp state input
+            let label = maxIndex tOutput
+            let loss = nllLoss' label sOutput
+            when (iter `mod` 50 == 0) $ do
+                putStrLn $ "Iteration: " ++ show iter ++ " | Loss: " ++ show loss
+            (newParam, _) <- runStep state optimizer loss 1e-3 -- GD
+            pure $ replaceParameters state newParam
+    pure trained
+
+main = do
+    (trainData, testData) <- V.initMnist "datasets/mnist"
+    initTeacher <- sample teacherSpec
+    initStudent <- sample studentSpec
+    teacher <- train trainData initTeacher
+    student <- distill trainData teacher initStudent
+    mapM (\idx -> do
+        testImg <- V.getImages' 1 784 testData [idx]
+        print $ shape testImg
+        V.dispImage testImg
+        putStrLn $ "Teacher      : " ++ (show . maxIndex $ mlp teacher testImg)
+        putStrLn $ "Student      : " ++ (show . maxIndex $ mlp student testImg)
+        putStrLn $ "Ground Truth : " ++ (show $ V.getLabels' 1 testData [idx])
+        ) [0..10]
+    putStrLn "Done"

--- a/examples/distill/Main.hs
+++ b/examples/distill/Main.hs
@@ -47,7 +47,7 @@ instance Randomizable MLPSpec MLP where
         <*> sample (LinearSpec hiddenFeatures0 hiddenFeatures1)
         <*> sample (LinearSpec hiddenFeatures1 outputFeatures)
 
-train :: Optimizer o => OptimSpec o -> Dataset -> MLP -> IO MLP
+train :: Optimizer o => OptimSpec o -> V.MnistData -> MLP -> IO MLP
 train OptimSpec{..} trainData init = do
     let optimizer = GD
         nImages = V.length trainData
@@ -66,7 +66,7 @@ train OptimSpec{..} trainData init = do
 
 maxIndex = Torch.argmax (Dim 1) RemoveDim
 
-runDistill :: Dataset -> IO (MLP, MLP) 
+runDistill :: V.MnistData -> IO (MLP, MLP) 
 runDistill trainData = do
     -- Train teacher
     initTeacher <- sample teacherSpec
@@ -74,7 +74,7 @@ runDistill trainData = do
         optimizer = GD,
         batchSize = 256,
         numIters = 500,
-        learningRate = asTensor 1e-3
+        learningRate = 1e-3
     }
     teacher <- train optimSpec trainData initTeacher
     -- Distill student
@@ -93,6 +93,7 @@ runDistill trainData = do
     studentSpec = MLPSpec dataDim 30 30 10
 
 main = do
+
     (trainData, testData) <- V.initMnist "datasets/mnist"
     (teacher, student) <- runDistill trainData
     mapM (\idx -> do

--- a/examples/distill/README.md
+++ b/examples/distill/README.md
@@ -10,13 +10,18 @@ Distillation module operations are decoupled from details of this example. In pa
 data (Parameterized t, Parameterized s) => DistillSpec t s = DistillSpec {
     teacher :: t,
     student :: s,
-    teacherView :: t -> Tensor -> Tensor,
-    studentView :: s -> Tensor -> Tensor,
-    distillLoss :: Tensor -> Tensor -> Tensor
-}
+    teacherView :: t -> Tensor -> ModelView,
+    studentView :: s -> Tensor -> ModelView,
+    distillLoss :: ModelView -> ModelView -> Tensor
 ```
 
-A generic offline distillation is then a function of the following signature:
+Here `ModelView` is just a newtype wrapper around a tensor to communicate intent:
+
+```
+newtype ModelView = ModelView { view :: Tensor }
+```
+
+A generic offline distillation is then just a function of the following signature:
 
 ```
 distill
@@ -27,4 +32,13 @@ distill
     -> IO s
 ```
 
+Where `OptimSpec` wraps details of the optimizer to be used:
 
+```
+data Optimizer o => OptimSpec o = OptimSpec {
+    optimizer :: o,
+    batchSize :: Int,
+    numIters :: Int,
+    learningRate :: Tensor
+}
+```

--- a/examples/distill/README.md
+++ b/examples/distill/README.md
@@ -1,0 +1,5 @@
+# Distillation Example
+
+Trains MNIST on a larger neural network, distills to a student network using soft target distribution.
+
+See [Hinton, Vinyals, Dean 2015](https://arxiv.org/abs/1503.02531)

--- a/examples/distill/README.md
+++ b/examples/distill/README.md
@@ -1,5 +1,30 @@
 # Distillation Example
 
-Trains MNIST on a larger neural network, distills to a student network using soft target distribution.
+Trains MNIST on a larger neural network (MLP 2 hidden layers of 300 dimensions each), distills to a student network (MLP 2 hidden layers of 30 dimensions each) using soft target distribution.
 
-See [Hinton, Vinyals, Dean 2015](https://arxiv.org/abs/1503.02531)
+Trains students with soft targets per [Hinton, Vinyals, Dean 2015](https://arxiv.org/abs/1503.02531) with a temperature parameter of 20.
+
+Distillation module operations are decoupled from details of this example. In particular a distillation process is paramaterized as a teacher model, a student model, view functions into both teacher and student (given an input) and a distillation loss that compares the views.
+
+```
+data (Parameterized t, Parameterized s) => DistillSpec t s = DistillSpec {
+    teacher :: t,
+    student :: s,
+    teacherView :: t -> Tensor -> Tensor,
+    studentView :: s -> Tensor -> Tensor,
+    distillLoss :: Tensor -> Tensor -> Tensor
+}
+```
+
+A generic offline distillation is then a function of the following signature:
+
+```
+distill
+    :: (Parameterized t, Parameterized s, Optimizer o, Dataset d)
+    => DistillSpec t s
+    -> OptimSpec o
+    -> d
+    -> IO s
+```
+
+

--- a/examples/examples.cabal
+++ b/examples/examples.cabal
@@ -235,6 +235,7 @@ executable distill
   import:              config
   hs-source-dirs:      distill
   main-is:             Main.hs
+  other-modules:       Distill
   ghc-options:         -fno-warn-partial-type-signatures
   build-depends:       libtorch-ffi
                      , bytestring >= 0.10.8

--- a/examples/examples.cabal
+++ b/examples/examples.cabal
@@ -225,3 +225,14 @@ executable alexNet
  build-depends:        base >= 4.7 && <5
                      , hasktorch
                      , libtorch-ffi
+
+executable distill
+  import:              config
+  hs-source-dirs:      distill
+  main-is:             Main.hs
+  ghc-options:         -fno-warn-partial-type-signatures
+  build-depends:       libtorch-ffi
+                     , bytestring >= 0.10.8
+                     , random >= 1.1
+                     , safe-exceptions
+                     , static-mnist

--- a/examples/examples.cabal
+++ b/examples/examples.cabal
@@ -235,10 +235,11 @@ executable distill
   import:              config
   hs-source-dirs:      distill
   main-is:             Main.hs
-  other-modules:       Distill
+  other-modules:       Distill, Dataset
   ghc-options:         -fno-warn-partial-type-signatures
   build-depends:       libtorch-ffi
                      , bytestring >= 0.10.8
+                     , mtl
                      , random >= 1.1
                      , safe-exceptions
                      , static-mnist

--- a/hasktorch/hasktorch.cabal
+++ b/hasktorch/hasktorch.cabal
@@ -75,6 +75,7 @@ library
                     , ghc-typelits-natnormalise
                     , mtl
                     , safe-exceptions
+                    , random
                     , reflection
                     , singletons
                     , stm

--- a/hasktorch/src/Torch/Functional.hs
+++ b/hasktorch/src/Torch/Functional.hs
@@ -297,6 +297,12 @@ log2
     -> Tensor -- ^ output
 log2 t = unsafePerformIO $ (cast1 ATen.log2_t) t
 
+-- | Returns a new tensor with the natural logarithm of the elements of input.
+log
+  :: Tensor -- ^ input
+  -> Tensor -- ^ output
+log _self = unsafePerformIO $ (cast1 ATen.log_t) _self
+
 -- | Returns a new tensor with the logarithm to the base 10 of the elements of input.
 log10 
     :: Tensor -- ^ input
@@ -529,10 +535,10 @@ binaryCrossEntropyWithLogits reduction target weight pos_weight input = unsafePe
 
 -- | Creates a criterion that measures the mean squared error (squared L2 norm) between each element in the @input@ and @target@.
 mseLoss 
- :: Tensor -- ^ target
+ :: Tensor -- ^ target tensor
  -> Tensor -- ^ input
  -> Tensor -- ^ output
-mseLoss output input = unsafePerformIO $ (cast3 ATen.mse_loss_ttl) input output ATen.kMean
+mseLoss target t = unsafePerformIO $ (cast3 ATen.mse_loss_ttl) t target ATen.kMean
 
 -- | The negative log likelihood loss.
 nllLoss' 

--- a/hasktorch/src/Torch/NN.hs
+++ b/hasktorch/src/Torch/NN.hs
@@ -44,6 +44,10 @@ class Parameterized f where
   default replaceOwnParameters :: (Generic f, Parameterized' (Rep f)) => f -> ParamStream f
   replaceOwnParameters f = to <$> replaceOwnParameters' (from f)
 
+  forward :: f -> Tensor -> Tensor
+  default forward :: f -> Tensor -> Tensor
+  forward t = undefined
+
 instance Parameterized Parameter where
   flattenParameters = pure
   replaceOwnParameters _ = nextParameter

--- a/hasktorch/src/Torch/Vision.hs
+++ b/hasktorch/src/Torch/Vision.hs
@@ -33,6 +33,7 @@ import           Data.Int
 import           Data.Word
 import qualified Codec.Picture                 as I
 import qualified Data.Vector.Storable          as V
+import           System.Random (mkStdGen, randoms)
 
 import qualified Torch.Typed.Vision as I
 import Torch.Functional hiding (take)
@@ -254,3 +255,6 @@ hwc2chw = D.permute [0,3,1,2]
 -- [batch, channel, height, width] -> [batch, height, width, channel]
 chw2hwc :: D.Tensor -> D.Tensor
 chw2hwc = D.permute [0,2,3,1]
+
+randomIndexes :: Int -> [Int]
+randomIndexes size = (`mod` size) <$> randoms seed where seed = mkStdGen 123

--- a/hasktorch/test/ScriptSpec.hs
+++ b/hasktorch/test/ScriptSpec.hs
@@ -9,9 +9,8 @@ import Prelude hiding (abs, exp, floor, log, min, max)
 
 import Test.Hspec
 
-import Torch
+import Torch hiding (forward)
 import Torch.Script
-import Torch.NN
 import Torch.Autograd
 import GHC.Generics
 import Control.Exception.Safe (catch,throwIO)


### PR DESCRIPTION
Description from the README:

Trains MNIST on a larger neural network (MLP 2 hidden layers of 300 dimensions each), distills to a student network (MLP 2 hidden layers of 30 dimensions each) using soft target distribution.

Trains students with soft targets per [Hinton, Vinyals, Dean 2015](https://arxiv.org/abs/1503.02531) with a temperature parameter of 20.

Distillation module operations are decoupled from details of this example. In particular a distillation process is paramaterized as a teacher model, a student model, view functions into both teacher and student (given an input) and a distillation loss that compares the views.

```
data (Parameterized t, Parameterized s) => DistillSpec t s = DistillSpec {
    teacher :: t,
    student :: s,
    teacherView :: t -> Tensor -> ModelView,
    studentView :: s -> Tensor -> ModelView,
    distillLoss :: ModelView -> ModelView -> Tensor
```

Here `ModelView` is just a newtype wrapper around a tensor to communicate intent:

```
newtype ModelView = ModelView { view :: Tensor }
```

A generic offline distillation is then just a function of the following signature:

```
distill
    :: (Parameterized t, Parameterized s, Optimizer o, Dataset d)
    => DistillSpec t s
    -> OptimSpec o
    -> d
    -> IO s
```

Where `OptimSpec` wraps details of the optimizer to be used:

```
data Optimizer o => OptimSpec o = OptimSpec {
    optimizer :: o,
    batchSize :: Int,
    numIters :: Int,
    learningRate :: Tensor
}
```

# Additional changes

- add natural log to Functional
- Add `forward` as a function available for Parameterized. (Open to feedback on this, any reasons not to have this? Right now the default implementation is `undefined`, should it be something else like `error`?)
- Has a placeholder module/typeclass for Dataset that looks something like a PyTorch dataset, with MNIST implementing the interface. Can swap this out once we have a standardized dataloader.