### PR TITLE
Add new untyped bindings to Functional module

### DIFF
--- a/hasktorch/src/Torch/Functional.hs
+++ b/hasktorch/src/Torch/Functional.hs
@@ -547,36 +547,34 @@ eq a b = unsafePerformIO $ (cast2 ATen.eq_tt) a b
 (==.) = eq
 
 isclose
-  :: Tensor -- ^ self
-  -> Tensor -- ^ other
-  -> Double -- ^ rtol
+  :: Double -- ^ rtol
   -> Double -- ^ atol
   -> Bool -- ^ equal_nan
+  -> Tensor -- ^ self
+  -> Tensor -- ^ other
   -> Tensor
-isclose _self _other _rtol _atol _equal_nan = unsafePerformIO $ (cast5 ATen.isclose_ttddb) _self _other _rtol _atol _equal_nan
+isclose rtol atol equalNan self other = unsafePerformIO $ (cast5 ATen.isclose_ttddb) self other rtol atol equalNan
 
 isnan
   :: Tensor -- ^ self
-  -> Tensor
-isnan _self = unsafePerformIO $ (cast1 ATen.isnan_t) _self
+  -> Tensor -- a new tensor with boolean elements representing if each element is NaN or not.
+isnan t = unsafePerformIO $ (cast1 ATen.isnan_t) t
 
-
-is_nonzero
+isNonzero
   :: Tensor -- ^ self
   -> Bool
-is_nonzero _self = unsafePerformIO $ (cast1 ATen.is_nonzero_t) _self
+isNonzero _self = unsafePerformIO $ (cast1 ATen.is_nonzero_t) _self
 
-is_same_size
+isSameSize
   :: Tensor -- ^ self
   -> Tensor -- ^ other
   -> Bool
-is_same_size _self _other = unsafePerformIO $ (cast2 ATen.is_same_size_tt) _self _other
+isSameSize self other = unsafePerformIO $ (cast2 ATen.is_same_size_tt) self other
 
-is_signed
-  :: Tensor -- ^ self
-  -> Bool
-is_signed _self = unsafePerformIO $ (cast1 ATen.is_signed_t) _self
-
+isSigned
+  :: Tensor -- ^ input
+  -> Bool -- ^ True if the data type of input is a signed type
+isSigned t = unsafePerformIO $ (cast1 ATen.is_signed_t) t
 
 -- | Computes input /= other element-wise.
 -- The second argument can be a number or a tensor whose shape is broadcastable with the first argument.

--- a/hasktorch/test/FunctionalSpec.hs
+++ b/hasktorch/test/FunctionalSpec.hs
@@ -201,4 +201,4 @@ spec = do
     (shape output) `shouldBe` ([1,4,3])      
   it "ctcLoss" $ do
     ctcLoss' ReduceMean [1] [1]  (asTensor ([[[0.1, 0.2, 0.7]]] :: [[[Float]]]))
-        (asTensor ([2] :: [Int])) `shouldBe` (-0.7 :: Float)
+        (asTensor ([2] :: [Int])) `shouldBe` asTensor (-0.7 :: Float)

--- a/hasktorch/test/FunctionalSpec.hs
+++ b/hasktorch/test/FunctionalSpec.hs
@@ -199,4 +199,6 @@ spec = do
     let x = asTensor([[1,2,3],[4,5,6],[7,8,9],[10,11,12]]::[[Float]])
         output = unsqueeze (Dim 0) x
     (shape output) `shouldBe` ([1,4,3])      
-
+  it "ctcLoss" $ do
+    ctcLoss' ReduceMean [1] [1]  (asTensor ([[[0.1, 0.2, 0.7]]] :: [[[Float]]]))
+        (asTensor ([2] :: [Int])) `shouldBe` (-0.7 :: Float)


### PR DESCRIPTION
- Add Eq instance to tensors as `all (eq t1 t2)
- Add loss: klDiv, CTC
- Add logical*: logicalNot, logicalXor, logicalAnd, logicalOr
- Add is*: isclose, isnan, isNonzero, isSameSize, isSigned
- Add diag*: diagEmbed, diagflat, diagonal
- Add erfc, erfinv, logsumexp
- Add *gamma: lgamma, digamma, polygamma, mvlgamma
- whitelist a few trivial ops from Internal
- Start grouping Functional ops into blocks of related concepts (may refactor as separate modules in the future to try improving compilation time)