### PR TITLE
nix: inline mkl derivation to make it build on a mac

### DIFF
--- a/nix/mkl.nix
+++ b/nix/mkl.nix
@@ -1,0 +1,110 @@
+{ stdenvNoCC, fetchurl, rpmextract, undmg, darwin }:
+/*
+  For details on using mkl as a blas provider for python packages such as numpy,
+  numexpr, scipy, etc., see the Python section of the NixPkgs manual.
+*/
+stdenvNoCC.mkDerivation rec {
+  name = "mkl-${version}";
+  version = "${date}.${rel}";
+  date = "2019.3";
+  rel = "199";
+
+  src = if stdenvNoCC.isDarwin
+    then
+      (fetchurl {
+        url = "http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15235/m_mkl_${version}.dmg";
+        sha256 = "14b3ciz7995sqcd6jz7hc8g2x4zwvqxmgxgni46vrlb7n523l62f";
+      })
+    else
+      (fetchurl {
+        url = "http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15275/l_mkl_${version}.tgz";
+        sha256 = "13rb2v2872jmvzcqm4fqsvhry0j2r5cn4lqql4wpqbl1yia2pph6";
+      });
+
+  nativeBuildInputs = if stdenvNoCC.isDarwin
+    then
+      [ undmg
+        darwin.cctools
+      ]
+    else
+      [ rpmextract ];
+
+  buildPhase = if stdenvNoCC.isDarwin then ''
+      for f in Contents/Resources/pkg/*.tgz; do
+          tar xzvf $f
+      done
+  '' else ''
+    rpmextract rpm/intel-mkl-common-c-${date}-${rel}-${date}-${rel}.noarch.rpm
+    rpmextract rpm/intel-mkl-core-${date}-${rel}-${date}-${rel}.x86_64.rpm
+    rpmextract rpm/intel-mkl-core-rt-${date}-${rel}-${date}-${rel}.x86_64.rpm
+    rpmextract rpm/intel-openmp-19.0.3-${rel}-19.0.3-${rel}.x86_64.rpm
+  '';
+
+  installPhase = ''
+    for f in $(find . -name 'mkl*.pc') ; do
+      bn=$(basename $f)
+      substituteInPlace $f \
+        --replace "prefix=<INSTALLDIR>/mkl" "prefix=$out" \
+        --replace "lib/intel64_lin" "lib"
+    done
+
+    for f in $(find opt/intel -name 'mkl*iomp.pc') ; do
+      substituteInPlace $f \
+        --replace "../compiler/lib" "lib"
+    done
+  '' +
+    (if stdenvNoCC.isDarwin then ''
+      mkdir -p $out/lib
+
+      cp -r compilers_and_libraries_${version}/mac/mkl/include $out/
+
+      cp -r compilers_and_libraries_${version}/licensing/mkl/en/license.txt $out/lib/
+      cp -r compilers_and_libraries_${version}/mac/compiler/lib/* $out/lib/
+      cp -r compilers_and_libraries_${version}/mac/mkl/lib/* $out/lib/
+      cp -r compilers_and_libraries_${version}/mac/tbb/lib/* $out/lib/
+
+      mkdir -p $out/lib/pkgconfig
+      cp -r compilers_and_libraries_${version}/mac/mkl/bin/pkgconfig/* $out/lib/pkgconfig
+  '' else ''
+      mkdir -p $out/lib
+
+      cp -r opt/intel/compilers_and_libraries_${version}/linux/mkl/include $out/
+
+      cp -r opt/intel/compilers_and_libraries_${version}/linux/compiler/lib/intel64_lin/* $out/lib/
+      cp -r opt/intel/compilers_and_libraries_${version}/linux/mkl/lib/intel64_lin/* $out/lib/
+      cp license.txt $out/lib/
+
+      mkdir -p $out/lib/pkgconfig
+      cp -r opt/intel/compilers_and_libraries_${version}/linux/mkl/bin/pkgconfig/* $out/lib/pkgconfig
+  '');
+
+  # fixDarwinDylibName fails for libmkl_cdft_core.dylib because the
+  # larger updated load commands do not fit. Use install_name_tool
+  # explicitly and ignore the error.
+  postFixup = stdenvNoCC.lib.optionalString stdenvNoCC.isDarwin ''
+      for f in $out/lib/*.dylib; do
+          install_name_tool -id $out/lib/$(basename $f) $f || true
+      done
+      install_name_tool -change @rpath/libiomp5.dylib $out/lib/libiomp5.dylib $out/lib/libmkl_intel_thread.dylib
+      install_name_tool -change @rpath/libtbb.dylib $out/lib/libtbb.dylib $out/lib/libmkl_tbb_thread.dylib
+      install_name_tool -change @rpath/libtbbmalloc.dylib $out/lib/libtbbmalloc.dylib $out/lib/libtbbmalloc_proxy.dylib
+  '';
+
+  # Per license agreement, do not modify the binary
+  dontStrip = true;
+  dontPatchELF = true;
+
+  meta = with stdenvNoCC.lib; {
+    description = "Intel Math Kernel Library";
+    longDescription = ''
+      Intel Math Kernel Library (Intel MKL) optimizes code with minimal effort
+      for future generations of Intel processors. It is compatible with your
+      choice of compilers, languages, operating systems, and linking and
+      threading models.
+    '';
+    homepage = https://software.intel.com/en-us/mkl;
+    license = licenses.issl;
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
+    maintainers = [ maintainers.bhipple ];
+  };
+}

--- a/nix/shared.nix
+++ b/nix/shared.nix
@@ -17,6 +17,10 @@ let
       libtorch_cudatoolkit_10_2
     ;
 
+    mkl = if pkgs.stdenv.hostPlatform.system == "x86_64-darwin"
+          then pkgsOld.callPackage ./mkl.nix {} # https://github.com/matthewbauer/undmg/issues/4
+          else pkgsOld.mkl;
+
     haskell = pkgsOld.haskell // {
       packages = pkgsOld.haskell.packages // {
         "${compiler}" = pkgsOld.haskell.packages."${compiler}".override (old: {
@@ -59,7 +63,7 @@ let
                         )
                         (old: {
                               preConfigure = (old.preConfigure or "") + optionalString (!isDarwin) ''
-                                export LD_PRELOAD=${pkgs.mkl}/lib/libmkl_rt.so
+                                export LD_PRELOAD=${pkgsNew.mkl}/lib/libmkl_rt.so
                               '';
                             }
                         );


### PR DESCRIPTION
The original derivation had the correct version number but fails with the following:

```
parallel_studio_xe_2019.3.043/uninstall.app/Contents/Resources/qt.conf
installing
substituteStream(): WARNING: pattern 'lib/intel64_lin' doesn't match anything in file './compilers_and_libraries_2019.3.199/mac/mkl/bin/pkgconfig/mkl-static-lp64-seq.pc'
substituteStream(): WARNING: pattern 'lib/intel64_lin' doesn't match anything in file './compilers_and_libraries_2019.3.199/mac/mkl/bin/pkgconfig/mkl-static-ilp64-iomp.pc'
substituteStream(): WARNING: pattern 'lib/intel64_lin' doesn't match anything in file './compilers_and_libraries_2019.3.199/mac/mkl/bin/pkgconfig/mkl-dynamic-ilp64-iomp.pc'
substituteStream(): WARNING: pattern 'lib/intel64_lin' doesn't match anything in file './compilers_and_libraries_2019.3.199/mac/mkl/bin/pkgconfig/mkl-static-ilp64-seq.pc'
substituteStream(): WARNING: pattern 'lib/intel64_lin' doesn't match anything in file './compilers_and_libraries_2019.3.199/mac/mkl/bin/pkgconfig/mkl-dynamic-lp64-iomp.pc'
substituteStream(): WARNING: pattern 'lib/intel64_lin' doesn't match anything in file './compilers_and_libraries_2019.3.199/mac/mkl/bin/pkgconfig/mkl-dynamic-ilp64-seq.pc'
substituteStream(): WARNING: pattern 'lib/intel64_lin' doesn't match anything in file './compilers_and_libraries_2019.3.199/mac/mkl/bin/pkgconfig/mkl-dynamic-lp64-seq.pc'
substituteStream(): WARNING: pattern 'lib/intel64_lin' doesn't match anything in file './compilers_and_libraries_2019.3.199/mac/mkl/bin/pkgconfig/mkl-static-lp64-iomp.pc'
find: 'opt/intel': No such file or directory
cp: missing destination file operand after '/nix/store/zaivbvrwpxb2zxq7piwibjvpipg753s2-mkl-2019.3.199/lib/'
Try 'cp --help' for more information.
builder for '/nix/store/gws187rk7zcyglc60zzdjypzndkcp98f-mkl-2019.3.199.drv' failed with exit code 1
error: build of '/nix/store/gws187rk7zcyglc60zzdjypzndkcp98f-mkl-2019.3.199.drv' failed
```