### PR TITLE
Get stack.yaml working again, building with nix

### DIFF
--- a/.github/workflows/stack-nix-linux.yml
+++ b/.github/workflows/stack-nix-linux.yml
@@ -1,0 +1,39 @@
+name: stack-nix-linux
+
+on: [push, pull_request]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: free disk space
+        run: |
+          sudo swapoff -a
+          sudo rm -f /swapfile
+          sudo apt -y purge ghc* cabal-install* php* || true
+          sudo apt autoremove -y || true
+          sudo apt autoclean -y || true
+          docker rmi $(docker image ls -aq)
+          df -h
+      - name: Setup packages
+        run: |
+          sudo apt update -qq
+          sudo apt -y --allow-downgrades --allow-remove-essential --allow-change-held-packages install cmake curl wget unzip git libtinfo-dev python3 python3-yaml
+          (wget -qO- https://get.haskellstack.org/ | sh) || true
+      - uses: cachix/install-nix-action@v8
+      - uses: cachix/cachix-action@v6
+        with:
+          name: hasktorch
+          signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+      - run: nix-env -iA cachix -f https://cachix.org/api/v1/install
+      - run: cachix use iohk
+      - name: Build
+        run: stack --nix build
+      - name: Test
+        run: |
+          stack --nix test codegen
+          stack --nix test libtorch-ffi
+          stack --nix test hasktorch
+          stack --nix exec codegen-exe
+          stack --nix exec xor-mlp

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Starting at the top-level directory of the project, go to the `deps/` (dependenc
 
 ```
 pushd deps           # Change to deps directory and save the current directory.
-./get-deps.sh        # Run the shell script to retrieve the dependency. 
+./get-deps.sh        # Run the shell script to retrieve the dependency.
 popd                 # Go back to the root directory of the project.
 ```
 
@@ -67,6 +67,23 @@ nix-shell ./hasktorch/shell.nix --arg cudaVersion 9 # or 10
 ```
 
 If you are running cabal or stack to develop hasktorch, there is a shell hook to tell you which `extra-lib-dirs` and `extra-include-dirs` fields to include in your stack.yaml or cabal.project.local. This hook will also explain how to create a cabal.project.freeze file.
+
+### Stack with Nix
+
+It is also possible to compile hasktorch with Stack while getting system
+dependencies with Nix.
+
+First, make sure both Stack and Nix are installed, and then optionally enable
+the hasktorch Cachix, as described above.  After that, just run
+`stack --nix build` to build.
+
+As long as you pass the `--nix` flag to Stack, Stack will use Nix to get into
+an environment with all required system dependencies (mostly just `libtorch`)
+before running builds, tests, etc.
+
+Note that if you are running `stack` with Nix, you want to make sure you have
+_not_ run the `deps/get-deps.sh` script.  In particular, the `deps/libtorch/` and
+`deps/mklml/` directories must not exist.
 
 ### Building examples
 

--- a/nix/stack-shell.nix
+++ b/nix/stack-shell.nix
@@ -1,0 +1,33 @@
+
+# This shell file is specifically to be used with Stack.
+#
+# This file allows using Stack's built-in Nix integration.  This means that you
+# can compile hasktorch with Stack by using a command like `stack --nix build`.
+# Stack will use Nix to download and build required system libraries (like GHC
+# and libtorch), and then build Haskell libraries like normal.
+#
+# This approach allows for more reproducibility than using Stack without Nix.
+
+{ withHoogle ? false
+}@args:
+
+let
+  shared = import ../shared.nix {};
+  pkgs = shared.defaultCpu.pkgs;
+in
+
+with pkgs;
+
+haskell.lib.buildStackProject {
+  name = "stack-build-hasktorch";
+  ghc = haskell.compiler.ghc883;
+  extraArgs = [
+    "--extra-include-dirs=${pkgs.torch}/include/torch/csrc/api/include"
+  ];
+  buildInputs = [
+    git # needed so that stack can get extra-deps from github
+    torch
+    zlib
+  ];
+  inherit withHoogle;
+}

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,16 +8,16 @@ packages:
 - examples
 - experimental
 
-extra-include-dirs:
-  - deps/libtorch/include/torch/csrc/api/include
-  - deps/libtorch/include
-
-extra-lib-dirs:
-  - deps/libtorch/lib
-  - deps/mklml/lib
-
 # see https://github.com/commercialhaskell/stack/issues/4073
 # with-gcc: /usr/local/bin/gcc-7
+
+extra-include-dirs:
+- deps/libtorch/include/torch/csrc/api/include
+- deps/libtorch/include
+
+extra-lib-dirs:
+- deps/libtorch/lib
+- deps/mklml/lib
 
 extra-deps:
 # libtorch-ffi
@@ -34,6 +34,5 @@ extra-deps:
 - streaming-attoparsec-1.0.0.1@sha256:fe9b878072423d3f075534fe8af24722d9ded1a1129e9a6ed5b71c4a29681b39,1146
 - streaming-cassava-0.1.0.1@sha256:2d1dfeb09af62009e88311fe92f44d06dafb5cdd38879b437ea6adb3bc40acfe,1739
 
-
 nix:
-  packages: [zlib.dev, zlib.out]
+  shell-file: nix/stack-shell.nix


### PR DESCRIPTION
This PR gets stack.yaml usable again for actually compiling with `stack`.