### PR TITLE
Enable doctests to build by default again.

### DIFF
--- a/hasktorch/hasktorch.cabal
+++ b/hasktorch/hasktorch.cabal
@@ -13,7 +13,8 @@ cabal-version:       >=1.10
 
 Flag disable-doctest
  Description: Disable doctest. ToDo: This flag is to avoid relocation-error of ghci for macos.
-   Default:       os(darwin)
+ Default:     False
+ Manual:      True
 
 library
  exposed-modules:     Torch
@@ -133,7 +134,7 @@ test-suite spec
                     , inline-c-cpp
 
 test-suite doctests
-  if flag(disable-doctest)
+  if os(darwin) || flag(disable-doctest)
     Buildable: False
   else
     Buildable: True

--- a/hasktorch/src/Torch/Typed/Functional.hs
+++ b/hasktorch/src/Torch/Typed/Functional.hs
@@ -85,6 +85,9 @@ import           Torch.Typed.Aux
 import           Torch.Typed.Factories
 import           Torch.Typed.Tensor
 
+-- $setup
+--
+-- >>> :set -XOverloadedLists
 
 type family SumDType (dtype :: D.DType) :: D.DType where
   SumDType D.Bool = D.Int64

--- a/hasktorch/test/doctests.hs
+++ b/hasktorch/test/doctests.hs
@@ -4,12 +4,10 @@ import Test.DocTest
 
 main :: IO ()
 main = doctest
-  [ "-XOverloadedStrings"
-  , "-XOverloadedLists"
-  , "-XDataKinds"
+  [ "-XDataKinds"
   , "-XScopedTypeVariables"
-  , "-XTypeFamilies"
   , "-XTypeApplications"
+  , "-XTypeFamilies"
   , "-fplugin GHC.TypeLits.Normalise"
   , "-fplugin GHC.TypeLits.KnownNat.Solver"
   , "-fplugin GHC.TypeLits.Extra.Solver"


### PR DESCRIPTION
This PR makes sure the doctests for `hasktorch` build by default.

This also fixes up a small problem with the doctests.

This PR also makes sure that the doctests are run in CI.  Currently, `master` does not appear to be actually running the doctests.