### PR TITLE
Fix static-xor-mlp example

### DIFF
--- a/hasktorch/test/Torch/Typed/AuxSpec.hs
+++ b/hasktorch/test/Torch/Typed/AuxSpec.hs
@@ -95,6 +95,7 @@ cpu = Proxy @'( 'D.CPU, 0)
 cuda0 :: _
 cuda0 = Proxy @'( 'D.CUDA, 0)
 
+availableDevices :: [D.Device]
 availableDevices =
   let hasCuda = unsafePerformIO $ cast0 ATen.hasCUDA
   in  [D.Device { D.deviceType = D.CPU, D.deviceIndex = 0 }]


### PR DESCRIPTION
the static-xor-mlp example was broken. I fixed it.

- [x] add type alias for device, move device to cuda by default
- [x] add workaround for wrong runtime device for haskell literal: `0.5 :: Tensor '( 'D.CUDA, 0) 'D.Float '[]` does currently not lead to a cuda tensor at runtime.
- [x] resolve autodiff issue with mseLoss arguments being swapped
