### PR TITLE
Move literal number to device's place

### DIFF
--- a/examples/static-xor-mlp/Main.hs
+++ b/examples/static-xor-mlp/Main.hs
@@ -103,7 +103,8 @@ foldLoop x count block = foldM block x ([1 .. count] :: [a])
 
 xor
   :: forall batchSize dtype device
-   . Tensor device dtype '[batchSize, 2]
+   . KnownDevice device
+  => Tensor device dtype '[batchSize, 2]
   -> Tensor device dtype '[batchSize]
 xor t = (1 - (1 - a) * (1 - b)) * (1 - (a * b))
  where
@@ -121,7 +122,7 @@ main = do
   (trained, _) <- foldLoop (initModel, initOptim) numIters $ \(model, optim) i -> do
     input <-
       Torch.Typed.Tensor.toDType @D.Float
-      .   gt (Torch.Typed.Tensor.toDevice @Device (0.5 :: CPUTensor 'D.Float '[]))
+      .   gt (0.5 :: Tensor Device 'D.Float '[])
       <$> rand @'[256, 2] @'D.Float @Device
 
     let actualOutput   = squeezeAll . Main.forward model $ input

--- a/hasktorch/src/Torch/Typed/Optim.hs
+++ b/hasktorch/src/Torch/Typed/Optim.hs
@@ -104,6 +104,7 @@ instance
   , gradient ~ Tensor device dtype shape
   , shape ~ Broadcast '[] shape
   , BasicArithmeticDTypeIsValid device dtype
+  , KnownDevice device
   ) => Apply' (GDStep device dtype) (parameter, gradient) parameter where
   apply' (GDStep learningRate) (parameter, gradient) =
     parameter - mul learningRate gradient
@@ -150,6 +151,7 @@ instance
   , gradient ~ Tensor device dtype shape
   , momentum ~ Tensor device dtype shape
   , shape ~ Broadcast '[] shape
+  , KnownDevice device
   , BasicArithmeticDTypeIsValid device dtype
   ) => Apply' (GDMStep device dtype) (parameter, gradient, momentum) (parameter, momentum) where
   apply' (GDMStep beta learningRate) (parameter, gradient, momentum) =
@@ -214,6 +216,7 @@ newtype AdamMomentum1Update = AdamMomentum1Update Float
 instance
   ( gradient ~ Tensor device dtype shape
   , momentum1 ~ Tensor device dtype shape
+  , KnownDevice device
   ) => Apply' AdamMomentum1Update (momentum1, gradient) momentum1 where
     apply' (AdamMomentum1Update beta1) (momentum1, gradient) =
       mulScalar beta1 momentum1 + mulScalar (1 - beta1) gradient
@@ -225,6 +228,7 @@ instance
   ( gradient ~ Tensor device dtype shape
   , momentum2 ~ Tensor device dtype shape
   , shape ~ Broadcast shape shape
+  , KnownDevice device
   , BasicArithmeticDTypeIsValid device dtype
   ) => Apply' AdamMomentum2Update (momentum2, gradient) momentum2 where
     apply' (AdamMomentum2Update beta2) (momentum2, gradient) =
@@ -246,6 +250,7 @@ instance
   ( parameter ~ Tensor device dtype shape
   , momentum ~ Tensor device dtype shape
   , shape ~ Broadcast '[] shape
+  , KnownDevice device
   , BasicArithmeticDTypeIsValid device dtype
   , StandardFloatingPointDTypeValidation device dtype
   ) => Apply' (AdamParameterUpdate device dtype) (parameter, momentum, momentum) parameter where

--- a/hasktorch/src/Torch/Typed/Tensor.hs
+++ b/hasktorch/src/Torch/Typed/Tensor.hs
@@ -129,13 +129,13 @@ type family ComputeItemType (ty :: Type) (shape :: [Nat]) :: Type where
 
 instance ( D.TensorLike [ComputeItemType (ComputeHaskellType dtype) shape]
          , KnownShape shape)
-  => IsList (Maybe (Tensor '( 'D.CPU, 0) dtype shape))
+  => IsList (Maybe (Tensor device dtype shape))
  where
-  type Item (Maybe (Tensor '( 'D.CPU, 0) dtype shape)) = ComputeItemType (ComputeHaskellType dtype) shape
+  type Item (Maybe (Tensor device dtype shape)) = ComputeItemType (ComputeHaskellType dtype) shape
   fromList xs = do
     shapeXs <- D._deepDims xs
     if shapeVal @shape == shapeXs
-    then return $ UnsafeMkTensor . D.asTensor $ xs
+    then return $ UnsafeMkTensor . D.toDevice (deviceVal @device) . D.asTensor $ xs
     else Nothing
   toList Nothing = []
   toList (Just t) = D.asValue . toDynamic $ t
@@ -147,12 +147,12 @@ instance Num (Tensor device dtype shape) where
   negate t = UnsafeMkTensor $ negate $ toDynamic t
   abs t = UnsafeMkTensor $ abs $ toDynamic t
   signum t = UnsafeMkTensor $ signum $ toDynamic t
-  fromInteger i = UnsafeMkTensor $ D.asTensor @Int $ fromInteger @Int i
+  fromInteger i = UnsafeMkTensor . D.toDevice (deviceVal @device) . D.asTensor @Int $ fromInteger @Int i
 
 instance Fractional (Tensor device dtype shape) where
   a / b = UnsafeMkTensor $ toDynamic a / toDynamic b
   recip t = UnsafeMkTensor $ recip $ toDynamic t
-  fromRational i = UnsafeMkTensor $ D.asTensor @Float $ fromRational @Float i
+  fromRational i = UnsafeMkTensor . D.toDevice (deviceVal @device) . D.asTensor @Float $ fromRational @Float i
 
 instance Show (Tensor device dtype shape) where
     show (UnsafeMkTensor dynamic) = show dynamic

--- a/hasktorch/test/Torch/Typed/AutogradSpec.hs
+++ b/hasktorch/test/Torch/Typed/AutogradSpec.hs
@@ -116,7 +116,7 @@ rastriginLayer' x a n = (mulScalar a . mulScalar n $ ones)
 
 gradientsRastriginLayer'
   :: forall device dtype a shape
-   . (StandardFloatingPointDTypeValidation device dtype, D.Scalar a)
+   . (KnownDevice device, StandardFloatingPointDTypeValidation device dtype, D.Scalar a)
   => Tensor device dtype shape
   -> a
   -> Tensor device dtype shape
@@ -264,7 +264,8 @@ rastrigin model a =
 data GradientsRastriginA a = GradientsRastriginA a
 
 instance
-  ( StandardFloatingPointDTypeValidation device dtype
+  ( KnownDevice device
+  , StandardFloatingPointDTypeValidation device dtype
   , D.Scalar a
   ) => Apply' (GradientsRastriginA a) (Parameter device dtype '[n]) (Tensor device dtype '[n]) where
   apply' (GradientsRastriginA a) parameter = gradientsRastriginLayer' (toDependent parameter) $ a

--- a/hasktorch/test/Torch/Typed/OptimSpec.hs
+++ b/hasktorch/test/Torch/Typed/OptimSpec.hs
@@ -97,7 +97,7 @@ instance
 
 convQuad
   :: forall features dtype device
-   . DotDTypeIsValid device dtype
+   . (KnownDevice device, DotDTypeIsValid device dtype)
   => ConvQuad features dtype device
   -> Tensor device dtype '[features, features]
   -> Tensor device dtype '[features]
@@ -131,7 +131,7 @@ instance
 
 rosenbrock
   :: forall a dtype device
-   . D.Scalar a
+   . (KnownDevice device, D.Scalar a)
   => Rosenbrock dtype device
   -> a
   -> a


### PR DESCRIPTION
When we define cuda's number and use it, it throws following exception.
This PR is to fix the exception.
``` 
0.5 :: Tensor '( 'D.CUDA, 0) 'D.Float '[]
```
```
*** Exception: CppStdException "Exception: the derivative for 'target' is not implemented; type: std::runtime_error"
```
