### PR TITLE
Add write-ghc-environment-files=always for doctest

### DIFF
--- a/.github/workflows/cabal-linux.yml
+++ b/.github/workflows/cabal-linux.yml
@@ -27,11 +27,11 @@ jobs:
         ./setup-cabal.sh
         cabal v2-update
         cabal v2-install hspec-discover
-        cabal v2-build all --jobs=2 --write-ghc-environment-files=always
+        cabal v2-build all --jobs=2
     - name: Test
       run: |
         export PATH=/opt/ghc/bin:$PATH
         source setenv
-        cabal v2-test all --jobs=2 --write-ghc-environment-files=always
+        cabal v2-test all --jobs=2
         cabal v2-exec codegen-exe
         cabal exec xor-mlp

--- a/cabal.project
+++ b/cabal.project
@@ -7,6 +7,7 @@ packages:
     experimental/*.cabal
 
 tests: true
+write-ghc-environment-files: always
 
 documentation: false
 


### PR DESCRIPTION
In CI of github-actions, we use write-ghc-environment-files=always for doctest.
When we test packages on local environment, we sometimes forget to add the option and test fails.
This pr adds write-ghc-environment-files=always to cabal.project not to forget the option.


