### PR TITLE
Move HasForward to Torch.NN

### DIFF
--- a/examples/distill/Distill.hs
+++ b/examples/distill/Distill.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE FlexibleContexts #-}
 
 module Distill where
 
@@ -30,7 +31,7 @@ data Optimizer o => OptimSpec o = OptimSpec {
 }
 
 -- | Train the teacher model
-train :: (Dataset d, Optimizer o, Parameterized p) => OptimSpec o -> d -> p -> IO p
+train :: (Dataset d, Optimizer o, Parameterized p, HasForward p Tensor Tensor) => OptimSpec o -> d -> p -> IO p
 train OptimSpec{..} dataset init = do
     trained <- foldLoop init numIters $
         \state iter -> do

--- a/examples/distill/Main.hs
+++ b/examples/distill/Main.hs
@@ -41,7 +41,9 @@ mlpTemp temperature MLP{..} input =
   where
     logSoftmaxTemp t z = (z/t) - log (sumDim (Dim 1) KeepDim Float (exp (z/t)))
 
-instance Parameterized MLP where
+instance Parameterized MLP
+
+instance HasForward MLP Tensor Tensor where
     forward = mlpTemp 1.0
 
 instance Randomizable MLPSpec MLP where

--- a/hasktorch/src/Torch/NN.hs
+++ b/hasktorch/src/Torch/NN.hs
@@ -44,9 +44,10 @@ class Parameterized f where
   default replaceOwnParameters :: (Generic f, Parameterized' (Rep f)) => f -> ParamStream f
   replaceOwnParameters f = to <$> replaceOwnParameters' (from f)
 
-  forward :: f -> Tensor -> Tensor
-  default forward :: f -> Tensor -> Tensor
-  forward t = undefined
+class HasForward f a b | f a -> b where
+  forward :: f -> a -> b
+  forwardStoch :: f -> a -> IO b
+  forwardStoch = (pure .) . forward
 
 instance Parameterized Parameter where
   flattenParameters = pure

--- a/hasktorch/src/Torch/Typed/NN.hs
+++ b/hasktorch/src/Torch/Typed/NN.hs
@@ -20,7 +20,10 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# OPTIONS_GHC -Wno-partial-type-signatures #-}
 
-module Torch.Typed.NN where
+module Torch.Typed.NN
+    ( module Torch.Typed.NN
+    , Torch.NN.HasForward(..)
+) where
 
 import           Control.Monad.State.Strict
 import           Torch.HList
@@ -32,6 +35,7 @@ import           GHC.Generics
 import           System.IO.Unsafe
 
 import qualified Torch.NN                      as A
+import           Torch.NN (HasForward(..))
 import qualified Torch.Autograd                as A
 import qualified Torch.Tensor                  as A
 import qualified Torch.DType                   as D
@@ -42,11 +46,6 @@ import           Torch.Typed.Functional
 import           Torch.Typed.Tensor
 import           Torch.Typed.Parameter
 import           Torch.Typed.Device
-
-class HasForward f a b | f a -> b where
-  forward :: f -> a -> b
-  forwardStoch :: f -> a -> IO b
-  forwardStoch = (pure .) . forward
 
 ----------------------------------------------
 -- Linear Layer


### PR DESCRIPTION
Move HasForward into Torch.NN for untype API.
This PR is useful to allow not Tensor's type for input-argument e.g.`Parameterized a => a -> [Tensor] -> Tensor`.