### PR TITLE
Add slice-operators

### DIFF
--- a/hasktorch/src/Torch/Functional.hs
+++ b/hasktorch/src/Torch/Functional.hs
@@ -21,7 +21,6 @@ module Torch.Functional
     , Internal.logdet
     , Internal.lstsq
     , Internal.mv
-    , Internal.slice
     , Internal.sumWithDimnames
 ) where
 

--- a/hasktorch/src/Torch/Tensor.hs
+++ b/hasktorch/src/Torch/Tensor.hs
@@ -273,6 +273,16 @@ newtype RawTensorIndex = RawTensorIndex (ForeignPtr ATen.TensorIndex)
     ATen.tensorIndexList_push_back vec i
   ATen.index t vec >>= (return . Unsafe)
 
+(@=) :: TensorIndex a => Tensor -> (a,Tensor) -> Tensor
+(Unsafe t') @= (idx,(Unsafe v)) = unsafePerformIO $ do
+  let idxs = pushIndex [] idx
+  t <- ATen.clone_t t'
+  vec <- ATen.newTensorIndexList
+  forM_ idxs $ \(RawTensorIndex i) -> do
+    ATen.tensorIndexList_push_back vec i
+  ATen.index_put_ t vec v
+  return $ Unsafe t
+
 data None = None
   deriving (Show, Eq)
 

--- a/hasktorch/src/Torch/Tensor.hs
+++ b/hasktorch/src/Torch/Tensor.hs
@@ -262,9 +262,16 @@ toCUDA t = unsafePerformIO $ (cast1 ATen.tensor_cuda) t
 -- `1:3:2`                 | `Slice (1, 3, 2)`
 -- `torch.tensor([1, 2])`) | `asTensor([1, 2 ::Int])`
 
+newtype RawTensorIndexList = RawTensorIndexList (ForeignPtr (ATen.StdVector ATen.TensorIndex))
+newtype RawTensorIndex = RawTensorIndex (ForeignPtr ATen.TensorIndex)
 
 (@@) :: TensorIndex a => Tensor -> a -> Tensor
-t @@ idx = fst $ indexWith (t, 0) idx
+(Unsafe t) @@ idx = unsafePerformIO $ do
+  let idxs = pushIndex [] idx
+  vec <- ATen.newTensorIndexList
+  forM_ idxs $ \(RawTensorIndex i) -> do
+    ATen.tensorIndexList_push_back vec i
+  ATen.index t vec >>= (return . Unsafe)
 
 data None = None
   deriving (Show, Eq)
@@ -275,113 +282,104 @@ data Ellipsis = Ellipsis
 data Slice a = Slice a
   deriving (Show, Eq)
 
-newtype RawTensorIndexList = RawTensorIndexList (ForeignPtr (ATen.StdVector ATen.TensorIndex))
-newtype RawTensorIndex = RawTensorIndex (ForeignPtr ATen.TensorIndex)
-
 instance Castable RawTensorIndex (ForeignPtr ATen.TensorIndex) where
   cast (RawTensorIndex obj) f = f obj
   uncast obj f = f $ RawTensorIndex obj
 
 class TensorIndex a where
-  indexWith :: (Tensor, Int) -> a -> (Tensor, Int)
   pushIndex :: [RawTensorIndex] -> a -> [RawTensorIndex]
-  pushIndex = undefined
 
-
--- ToDo:
---   1, offset may have a bug.
---   2, Implement Ellipsis and Boolean
-
+instance {-# OVERLAPS #-} TensorIndex None where
+  pushIndex vec _ = unsafePerformIO $ do
+    idx <- ATen.newTensorIndexWithNone
+    return ((RawTensorIndex idx):vec)
+    
+instance {-# OVERLAPS #-} TensorIndex Ellipsis where
+  pushIndex vec _ = unsafePerformIO $ do
+    idx <- ATen.newTensorIndexWithEllipsis
+    return ((RawTensorIndex idx):vec)
+    
+instance {-# OVERLAPS #-} TensorIndex Bool where
+  pushIndex vec b = unsafePerformIO $ do
+    idx <- ATen.newTensorIndexWithBool (if b then 1 else 0)
+    return ((RawTensorIndex idx):vec)
+    
 instance {-# OVERLAPS #-} (Integral a) => TensorIndex (Slice (a,a)) where
-  indexWith (t, offset) (Slice (start,end)) = (slice t offset (fromIntegral start) (fromIntegral end) 1, offset+1)
   pushIndex vec (Slice (start,end)) = unsafePerformIO $ do
     idx <- ATen.newTensorIndexWithSlice (fromIntegral start :: CInt) (fromIntegral end ::CInt) 1
     return ((RawTensorIndex idx):vec)
     
 instance {-# OVERLAPS #-} (Integral a) => TensorIndex (Slice (a,a,a)) where
-  indexWith (t, offset) (Slice (start,end,step)) = (slice t offset (fromIntegral start) (fromIntegral end) (fromIntegral step), offset+1)
   pushIndex vec (Slice (start,end,step)) = unsafePerformIO $ do
     idx <- ATen.newTensorIndexWithSlice (fromIntegral start :: CInt) (fromIntegral end ::CInt) (fromIntegral step ::CInt)
     return ((RawTensorIndex idx):vec)
 
 instance {-# OVERLAPS #-} (Integral a) => TensorIndex (Slice (None,None,a)) where
-  indexWith (t, offset) (Slice (_,_,step)) = (slice t offset 0 (fromIntegral (maxBound :: Int)) (fromIntegral step), offset+1)
   pushIndex vec (Slice (_,_,step)) = unsafePerformIO $ do
     idx <- ATen.newTensorIndexWithSlice 0 (maxBound ::CInt) (fromIntegral step ::CInt)
     return ((RawTensorIndex idx):vec)
 
 instance {-# OVERLAPS #-} (Integral a) => TensorIndex (Slice a) where
-  indexWith (t, offset) (Slice start) = (slice t offset (fromIntegral start) (fromIntegral (maxBound :: Int)) 1, offset+1)
   pushIndex vec (Slice start) = unsafePerformIO $ do
     idx <- ATen.newTensorIndexWithSlice (fromIntegral start :: CInt) (maxBound ::CInt) 1
     return ((RawTensorIndex idx):vec)
 
 instance {-# OVERLAPS #-} (Integral a) => TensorIndex (Slice (a,None)) where
-  indexWith (t, offset) (Slice (start,_)) = (slice t offset (fromIntegral start) (fromIntegral (maxBound :: Int)) 1, offset+1)
   pushIndex vec (Slice (start,_)) = unsafePerformIO $ do
     idx <- ATen.newTensorIndexWithSlice (fromIntegral start :: CInt) (maxBound ::CInt) 1
     return ((RawTensorIndex idx):vec)
 
 instance {-# OVERLAPS #-} (Integral a) => TensorIndex (Slice (a,None,a)) where
-  indexWith (t, offset) (Slice (start,_,step)) = (slice t offset (fromIntegral start) (fromIntegral (maxBound :: Int)) (fromIntegral step), offset+1)
   pushIndex vec (Slice (start,_,step)) = unsafePerformIO $ do
     idx <- ATen.newTensorIndexWithSlice (fromIntegral start :: CInt) (maxBound ::CInt) (fromIntegral step :: CInt)
     return ((RawTensorIndex idx):vec)
 
 instance {-# OVERLAPS #-} (Integral a) => TensorIndex (Slice (None,a,a)) where
-  indexWith (t, offset) (Slice (_,end,step)) = (slice t offset 0 (fromIntegral end) (fromIntegral step), offset+1)
   pushIndex vec (Slice (_,end,step)) = unsafePerformIO $ do
     idx <- ATen.newTensorIndexWithSlice 0 (fromIntegral end :: CInt) (fromIntegral step :: CInt)
     return ((RawTensorIndex idx):vec)
 
 instance {-# OVERLAPS #-} (Integral a) => TensorIndex (Slice (None,a)) where
-  indexWith (t, offset) (Slice (_,end)) = (slice t offset 0 (fromIntegral end) 1, offset+1)
   pushIndex vec (Slice (_,end)) = unsafePerformIO $ do
     idx <- ATen.newTensorIndexWithSlice 0 (fromIntegral end :: CInt) 1
     return ((RawTensorIndex idx):vec)
 
 instance {-# OVERLAPS #-} TensorIndex (Slice ()) where
-  indexWith (t, offset) _ = (t, offset + 1)
   pushIndex vec (Slice ()) = unsafePerformIO $ do
     idx <- ATen.newTensorIndexWithSlice 0 (maxBound :: CInt) 1
     return ((RawTensorIndex idx):vec)
 
 instance TensorIndex Int where
-  indexWith (t, offset) idx = (select t offset idx, offset)
   pushIndex vec v = unsafePerformIO $ do
     idx <- ATen.newTensorIndexWithInt (fromIntegral v::CInt)
     return ((RawTensorIndex idx):vec)
 
 instance TensorIndex Integer where
-  indexWith (t, offset) idx = (select t offset (fromIntegral idx), offset)
   pushIndex vec v = unsafePerformIO $ do
     idx <- ATen.newTensorIndexWithInt (fromIntegral v::CInt)
     return ((RawTensorIndex idx):vec)
 
 instance TensorIndex Tensor where
-  indexWith (t, offset) idx = (indexSelect t offset idx, offset)
   pushIndex vec v = unsafePerformIO $ do
     idx <- cast1 ATen.newTensorIndexWithTensor v
     return (idx:vec)
 
 instance TensorIndex () where
-  indexWith (t, offset) _ = (t, offset + 1)
   pushIndex vec _ = unsafePerformIO $ do
     idx <- ATen.newTensorIndexWithSlice 0 (maxBound :: CInt) 1
     return ((RawTensorIndex idx):vec)
 
 instance (TensorIndex a, TensorIndex b) => TensorIndex (a,b) where
-  indexWith toff (a, b) = indexWith (indexWith toff a) b
-  pushIndex vec (a,b) = (flip pushIndex b) . (flip pushIndex a) $ vec
+  pushIndex vec (a,b) = (flip pushIndex a) . (flip pushIndex b) $ vec
   
-
 instance (TensorIndex a, TensorIndex b, TensorIndex c) => TensorIndex (a,b,c) where
-  indexWith toff (a, b, c) = indexWith (indexWith (indexWith toff a) b) c
-  pushIndex vec (a,b,c) = (flip pushIndex c) . (flip pushIndex b) . (flip pushIndex a) $ vec
+  pushIndex vec (a,b,c) = (flip pushIndex a) . (flip pushIndex b) . (flip pushIndex c) $ vec
 
 instance (TensorIndex a, TensorIndex b, TensorIndex c, TensorIndex d) => TensorIndex (a,b,c,d) where
-  indexWith toff (a, b, c, d) = indexWith (indexWith (indexWith (indexWith toff a) b) c) d
-  pushIndex vec (a,b,c,d) = (flip pushIndex d) . (flip pushIndex c) . (flip pushIndex b) . (flip pushIndex a) $ vec
+  pushIndex vec (a,b,c,d) = (flip pushIndex a) . (flip pushIndex b) . (flip pushIndex c) . (flip pushIndex d) $ vec
+
+instance (TensorIndex a, TensorIndex b, TensorIndex c, TensorIndex d, TensorIndex e) => TensorIndex (a,b,c,d,e) where
+  pushIndex vec (a,b,c,d,e) = (flip pushIndex a) . (flip pushIndex b) . (flip pushIndex c) . (flip pushIndex d) . (flip pushIndex e) $ vec
 
 --------------------------------------------------------------------------------
 -- Scalar <-> Tensor promotion

--- a/hasktorch/src/Torch/Tensor.hs
+++ b/hasktorch/src/Torch/Tensor.hs
@@ -198,6 +198,16 @@ slice
   -> Tensor
 slice _self _dim _start _end _step = unsafePerformIO $ (cast5 ATen.slice_tllll) _self _dim _start _end _step
 
+isContiguous
+  :: Tensor
+  -> Bool
+isContiguous t = unsafePerformIO $ (cast1 ATen.tensor_is_contiguous) t
+
+contiguous
+  :: Tensor
+  -> Tensor
+contiguous t = unsafePerformIO $ (cast1 ATen.tensor_contiguous) t
+
 -- | Returns a tensor with the same data and number of elements as input, but with the specified shape.
 reshape 
  :: [Int] 
@@ -392,7 +402,8 @@ instance {-# OVERLAPPING #-}TensorLike a => TensorLike [a] where
 
   asTensor v = asTensor' v defaultOpts
 
-  asValue t = unsafePerformIO $ do
+  asValue t' = unsafePerformIO $ do
+    let t = if isContiguous t' then t' else contiguous t'
     if _dtype @a == dtype t
     then do
       withTensor t $ \ptr -> do

--- a/hasktorch/src/Torch/Tensor.hs
+++ b/hasktorch/src/Torch/Tensor.hs
@@ -285,20 +285,50 @@ class TensorIndex a where
 instance TensorIndex (Slice (Integer,Integer)) where
   indexWith (t, offset) (Slice (start,end)) = (slice t offset (fromIntegral start) (fromIntegral end) 1, offset+1)
 
+instance TensorIndex (Slice (Int,Int)) where
+  indexWith (t, offset) (Slice (start,end)) = (slice t offset start end 1, offset+1)
+
 instance TensorIndex (Slice (Integer,Integer,Integer)) where
   indexWith (t, offset) (Slice (start,end,step)) = (slice t offset (fromIntegral start) (fromIntegral end) (fromIntegral step), offset+1)
+
+instance TensorIndex (Slice (Int,Int,Int)) where
+  indexWith (t, offset) (Slice (start,end,step)) = (slice t offset start end step, offset+1)
 
 instance TensorIndex (Slice (None,None,Integer)) where
   indexWith (t, offset) (Slice (_,_,step)) = (slice t offset 0 (fromIntegral (maxBound :: Int)) (fromIntegral step), offset+1)
 
+instance TensorIndex (Slice (None,None,Int)) where
+  indexWith (t, offset) (Slice (_,_,step)) = (slice t offset 0 (maxBound :: Int) step, offset+1)
+
 instance TensorIndex (Slice Integer) where
   indexWith (t, offset) (Slice start) = (slice t offset (fromIntegral start) (fromIntegral (maxBound :: Int)) 1, offset+1)
+
+instance TensorIndex (Slice Int) where
+  indexWith (t, offset) (Slice start) = (slice t offset start (maxBound :: Int) 1, offset+1)
 
 instance TensorIndex (Slice (Integer,None)) where
   indexWith (t, offset) (Slice (start,_)) = (slice t offset (fromIntegral start) (fromIntegral (maxBound :: Int)) 1, offset+1)
 
+instance TensorIndex (Slice (Int,None,Int)) where
+  indexWith (t, offset) (Slice (start,_,step)) = (slice t offset start (maxBound :: Int) step, offset+1)
+
+instance TensorIndex (Slice (Integer,None,Integer)) where
+  indexWith (t, offset) (Slice (start,_,step)) = (slice t offset (fromIntegral start) (fromIntegral (maxBound :: Int)) (fromIntegral step), offset+1)
+
+instance TensorIndex (Slice (None,Int,Int)) where
+  indexWith (t, offset) (Slice (_,end,step)) = (slice t offset 0 end step, offset+1)
+
+instance TensorIndex (Slice (None,Integer,Integer)) where
+  indexWith (t, offset) (Slice (_,end,step)) = (slice t offset 0 (fromIntegral end) (fromIntegral step), offset+1)
+
+instance TensorIndex (Slice (Int,None)) where
+  indexWith (t, offset) (Slice (start,_)) = (slice t offset start (maxBound :: Int) 1, offset+1)
+
 instance TensorIndex (Slice (None,Integer)) where
   indexWith (t, offset) (Slice (_,end)) = (slice t offset 0 (fromIntegral end) 1, offset+1)
+
+instance TensorIndex (Slice (None,Int)) where
+  indexWith (t, offset) (Slice (_,end)) = (slice t offset 0 end 1, offset+1)
 
 instance TensorIndex (Slice ()) where
   indexWith (t, offset) _ = (t, offset + 1)

--- a/hasktorch/test/TensorSpec.hs
+++ b/hasktorch/test/TensorSpec.hs
@@ -16,138 +16,159 @@ import Data.Int
 
 spec :: Spec
 spec = do
-  it "TensorLike Bool" $ property $
-    \x -> asValue (asTensor x) `shouldBe` (x :: Bool)
-  it "TensorLike Word8" $ property $
-    \x -> asValue (asTensor x) `shouldBe` (x :: Word8)
-  it "TensorLike Int8" $ property $
-    \x -> asValue (asTensor x) `shouldBe` (x :: Int8)
-  it "TensorLike Int16" $ property $
-    \x -> asValue (asTensor x) `shouldBe` (x :: Int16)
-  it "TensorLike Int32" $ property $
-    \x -> asValue (asTensor x) `shouldBe` (x :: Int32)
-  it "TensorLike Int" $ property $
-    \x -> asValue (asTensor x) `shouldBe` (x :: Int)
-  it "TensorLike Int64" $ property $
-    \x -> asValue (asTensor x) `shouldBe` (x :: Int64)
-  it "TensorLike Float" $ property $
-    \x -> asValue (asTensor x) `shouldBe` (x :: Float)
-  it "TensorLike Double" $ property $
-    \x -> asValue (asTensor x) `shouldBe` (x :: Double)
+  describe "TensorLike" $ do
+    it "TensorLike Bool" $ property $
+      \x -> asValue (asTensor x) `shouldBe` (x :: Bool)
+    it "TensorLike Word8" $ property $
+      \x -> asValue (asTensor x) `shouldBe` (x :: Word8)
+    it "TensorLike Int8" $ property $
+      \x -> asValue (asTensor x) `shouldBe` (x :: Int8)
+    it "TensorLike Int16" $ property $
+      \x -> asValue (asTensor x) `shouldBe` (x :: Int16)
+    it "TensorLike Int32" $ property $
+      \x -> asValue (asTensor x) `shouldBe` (x :: Int32)
+    it "TensorLike Int" $ property $
+      \x -> asValue (asTensor x) `shouldBe` (x :: Int)
+    it "TensorLike Int64" $ property $
+      \x -> asValue (asTensor x) `shouldBe` (x :: Int64)
+    it "TensorLike Float" $ property $
+      \x -> asValue (asTensor x) `shouldBe` (x :: Float)
+    it "TensorLike Double" $ property $
+      \x -> asValue (asTensor x) `shouldBe` (x :: Double)
+  
+    it "Compare internal expression of c++ with Storable expression of haskell" $ do
+      show (asTensor [True,False,True,False]) `shouldBe`
+        "Tensor Bool [4] [ 1,  0,  1,  0]"
+      show (asTensor ([1,0,1,0]::[Word8])) `shouldBe`
+        "Tensor UInt8 [4] [ 1,  0,  1,  0]"
+      show (asTensor ([1,0,1,0]::[Int8])) `shouldBe`
+        "Tensor Int8 [4] [ 1,  0,  1,  0]"
+      show (asTensor ([1,0,1,0]::[Int16])) `shouldBe`
+        "Tensor Int16 [4] [ 1,  0,  1,  0]"
+      show (asTensor ([1,0,1,0]::[Int32])) `shouldBe`
+        "Tensor Int32 [4] [ 1,  0,  1,  0]"
+      show (asTensor ([1,0,1,0]::[Int])) `shouldBe`
+        "Tensor Int64 [4] [ 1,  0,  1,  0]"
+      show (asTensor ([1,0,1,0]::[Int64])) `shouldBe`
+        "Tensor Int64 [4] [ 1,  0,  1,  0]"
+      show (asTensor ([1,0,1,0]::[Float])) `shouldBe`
+        "Tensor Float [4] [ 1.0000   ,  0.0000,  1.0000   ,  0.0000]"
+      show (asTensor ([1,0,1,0]::[Double])) `shouldBe`
+        "Tensor Double [4] [ 1.0000   ,  0.0000,  1.0000   ,  0.0000]"
+  
+    it "TensorLike [Bool]" $ property $
+      \(NonEmpty (x :: [Bool])) -> do
+        asValue (asTensor x) `shouldBe` x
+        toDouble (select (asTensor x) 0 0) `shouldBe` (if (head x) then 1 else 0)
+        shape (asTensor x) `shouldBe` [length x]
+        let xx = replicate 5 x
+        asValue (asTensor xx) `shouldBe` xx
+        let xxx = replicate 3 xx
+        asValue (asTensor xxx) `shouldBe` xxx
+    it "TensorLike [Word8]" $ property $
+      \(NonEmpty (x :: [Word8])) -> do
+        asValue (asTensor x) `shouldBe` x
+        toDouble (select (asTensor x) 0 0) `shouldBe` fromIntegral (head x)
+        shape (asTensor x) `shouldBe` [length x]
+        let xx = replicate 5 x
+        asValue (asTensor xx) `shouldBe` xx
+        let xxx = replicate 3 xx
+        asValue (asTensor xxx) `shouldBe` xxx
+    it "TensorLike [Int8]" $ property $
+      \(NonEmpty (x :: [Int8])) -> do
+        asValue (asTensor x) `shouldBe` x
+        toDouble (select (asTensor x) 0 0) `shouldBe` fromIntegral (head x)
+        shape (asTensor x) `shouldBe` [length x]
+        let xx = replicate 5 x
+        asValue (asTensor xx) `shouldBe` xx
+        let xxx = replicate 3 xx
+        asValue (asTensor xxx) `shouldBe` xxx
+    it "TensorLike [Int16]" $ property $
+      \(NonEmpty (x :: [Int16])) -> do
+        asValue (asTensor x) `shouldBe` x
+        toDouble (select (asTensor x) 0 0) `shouldBe` fromIntegral (head x)
+        shape (asTensor x) `shouldBe` [length x]
+        let xx = replicate 5 x
+        asValue (asTensor xx) `shouldBe` xx
+        let xxx = replicate 3 xx
+        asValue (asTensor xxx) `shouldBe` xxx
+    it "TensorLike [Int32]" $ property $
+      \(NonEmpty (x :: [Int32])) -> do
+        asValue (asTensor x) `shouldBe` x
+        toDouble (select (asTensor x) 0 0) `shouldBe` fromIntegral (head x)
+        shape (asTensor x) `shouldBe` [length x]
+        let xx = replicate 5 x
+        asValue (asTensor xx) `shouldBe` xx
+        let xxx = replicate 3 xx
+        asValue (asTensor xxx) `shouldBe` xxx
+    it "TensorLike [Int]" $ property $
+      \(NonEmpty (x :: [Int])) -> do
+        asValue (asTensor x) `shouldBe` x
+        toDouble (select (asTensor x) 0 0) `shouldBe` fromIntegral (head x)
+        shape (asTensor x) `shouldBe` [length x]
+        let xx = replicate 5 x
+        asValue (asTensor xx) `shouldBe` xx
+        let xxx = replicate 3 xx
+        asValue (asTensor xxx) `shouldBe` xxx
+    it "TensorLike [Int64]" $ property $
+      \(NonEmpty (x :: [Int64])) -> do
+        asValue (asTensor x) `shouldBe` x
+        toDouble (select (asTensor x) 0 0) `shouldBe` fromIntegral (head x)
+        shape (asTensor x) `shouldBe` [length x]
+        let xx = replicate 5 x
+        asValue (asTensor xx) `shouldBe` xx
+        let xxx = replicate 3 xx
+        asValue (asTensor xxx) `shouldBe` xxx
+    it "TensorLike [Float]" $ property $
+      \(NonEmpty (x :: [Float])) -> do
+        asValue (asTensor x) `shouldBe` x
+        toDouble (select (asTensor x) 0 0) `shouldBe` realToFrac (head x)
+        shape (asTensor x) `shouldBe` [length x]
+        let xx = replicate 5 x
+        asValue (asTensor xx) `shouldBe` xx
+        let xxx = replicate 3 xx
+        asValue (asTensor xxx) `shouldBe` xxx
+    it "TensorLike [Double]" $ property $
+      \(NonEmpty (x :: [Double])) -> do
+        asValue (asTensor x) `shouldBe` x
+        toDouble (select (asTensor x) 0 0) `shouldBe` realToFrac (head x)
+        shape (asTensor x) `shouldBe` [length x]
+        let xx = replicate 5 x
+        asValue (asTensor xx) `shouldBe` xx
+        let xxx = replicate 3 xx
+        asValue (asTensor xxx) `shouldBe` xxx
+  
+    it "invalid cast of TensorLike a" $ do
+      let x = asTensor (10 :: Int)
+      (dtype x) `shouldBe` Int64
+      (print (asValue x :: Double)) `shouldThrow` anyException
+    it "invalid cast of TensorLike [a]" $ do
+      let x = asTensor ([0..10] :: [Int])
+      (print (asValue x :: [Double])) `shouldThrow` anyException
+  
+    it "lists having different length" $ do
+      (print (asTensor ([[1],[1,2]] :: [[Double]]))) `shouldThrow` anyException
+    it "cast of Tensor" $ do
+      let x = asTensor ([0..10] :: [Int])
+      (dtype (toType Float x)) `shouldBe` Float
 
-  it "Compare internal expression of c++ with Storable expression of haskell" $ do
-    show (asTensor [True,False,True,False]) `shouldBe`
-      "Tensor Bool [4] [ 1,  0,  1,  0]"
-    show (asTensor ([1,0,1,0]::[Word8])) `shouldBe`
-      "Tensor UInt8 [4] [ 1,  0,  1,  0]"
-    show (asTensor ([1,0,1,0]::[Int8])) `shouldBe`
-      "Tensor Int8 [4] [ 1,  0,  1,  0]"
-    show (asTensor ([1,0,1,0]::[Int16])) `shouldBe`
-      "Tensor Int16 [4] [ 1,  0,  1,  0]"
-    show (asTensor ([1,0,1,0]::[Int32])) `shouldBe`
-      "Tensor Int32 [4] [ 1,  0,  1,  0]"
-    show (asTensor ([1,0,1,0]::[Int])) `shouldBe`
-      "Tensor Int64 [4] [ 1,  0,  1,  0]"
-    show (asTensor ([1,0,1,0]::[Int64])) `shouldBe`
-      "Tensor Int64 [4] [ 1,  0,  1,  0]"
-    show (asTensor ([1,0,1,0]::[Float])) `shouldBe`
-      "Tensor Float [4] [ 1.0000   ,  0.0000,  1.0000   ,  0.0000]"
-    show (asTensor ([1,0,1,0]::[Double])) `shouldBe`
-      "Tensor Double [4] [ 1.0000   ,  0.0000,  1.0000   ,  0.0000]"
-
-  it "TensorLike [Bool]" $ property $
-    \(NonEmpty (x :: [Bool])) -> do
-      asValue (asTensor x) `shouldBe` x
-      toDouble (select (asTensor x) 0 0) `shouldBe` (if (head x) then 1 else 0)
-      shape (asTensor x) `shouldBe` [length x]
-      let xx = replicate 5 x
-      asValue (asTensor xx) `shouldBe` xx
-      let xxx = replicate 3 xx
-      asValue (asTensor xxx) `shouldBe` xxx
-  it "TensorLike [Word8]" $ property $
-    \(NonEmpty (x :: [Word8])) -> do
-      asValue (asTensor x) `shouldBe` x
-      toDouble (select (asTensor x) 0 0) `shouldBe` fromIntegral (head x)
-      shape (asTensor x) `shouldBe` [length x]
-      let xx = replicate 5 x
-      asValue (asTensor xx) `shouldBe` xx
-      let xxx = replicate 3 xx
-      asValue (asTensor xxx) `shouldBe` xxx
-  it "TensorLike [Int8]" $ property $
-    \(NonEmpty (x :: [Int8])) -> do
-      asValue (asTensor x) `shouldBe` x
-      toDouble (select (asTensor x) 0 0) `shouldBe` fromIntegral (head x)
-      shape (asTensor x) `shouldBe` [length x]
-      let xx = replicate 5 x
-      asValue (asTensor xx) `shouldBe` xx
-      let xxx = replicate 3 xx
-      asValue (asTensor xxx) `shouldBe` xxx
-  it "TensorLike [Int16]" $ property $
-    \(NonEmpty (x :: [Int16])) -> do
-      asValue (asTensor x) `shouldBe` x
-      toDouble (select (asTensor x) 0 0) `shouldBe` fromIntegral (head x)
-      shape (asTensor x) `shouldBe` [length x]
-      let xx = replicate 5 x
-      asValue (asTensor xx) `shouldBe` xx
-      let xxx = replicate 3 xx
-      asValue (asTensor xxx) `shouldBe` xxx
-  it "TensorLike [Int32]" $ property $
-    \(NonEmpty (x :: [Int32])) -> do
-      asValue (asTensor x) `shouldBe` x
-      toDouble (select (asTensor x) 0 0) `shouldBe` fromIntegral (head x)
-      shape (asTensor x) `shouldBe` [length x]
-      let xx = replicate 5 x
-      asValue (asTensor xx) `shouldBe` xx
-      let xxx = replicate 3 xx
-      asValue (asTensor xxx) `shouldBe` xxx
-  it "TensorLike [Int]" $ property $
-    \(NonEmpty (x :: [Int])) -> do
-      asValue (asTensor x) `shouldBe` x
-      toDouble (select (asTensor x) 0 0) `shouldBe` fromIntegral (head x)
-      shape (asTensor x) `shouldBe` [length x]
-      let xx = replicate 5 x
-      asValue (asTensor xx) `shouldBe` xx
-      let xxx = replicate 3 xx
-      asValue (asTensor xxx) `shouldBe` xxx
-  it "TensorLike [Int64]" $ property $
-    \(NonEmpty (x :: [Int64])) -> do
-      asValue (asTensor x) `shouldBe` x
-      toDouble (select (asTensor x) 0 0) `shouldBe` fromIntegral (head x)
-      shape (asTensor x) `shouldBe` [length x]
-      let xx = replicate 5 x
-      asValue (asTensor xx) `shouldBe` xx
-      let xxx = replicate 3 xx
-      asValue (asTensor xxx) `shouldBe` xxx
-  it "TensorLike [Float]" $ property $
-    \(NonEmpty (x :: [Float])) -> do
-      asValue (asTensor x) `shouldBe` x
-      toDouble (select (asTensor x) 0 0) `shouldBe` realToFrac (head x)
-      shape (asTensor x) `shouldBe` [length x]
-      let xx = replicate 5 x
-      asValue (asTensor xx) `shouldBe` xx
-      let xxx = replicate 3 xx
-      asValue (asTensor xxx) `shouldBe` xxx
-  it "TensorLike [Double]" $ property $
-    \(NonEmpty (x :: [Double])) -> do
-      asValue (asTensor x) `shouldBe` x
-      toDouble (select (asTensor x) 0 0) `shouldBe` realToFrac (head x)
-      shape (asTensor x) `shouldBe` [length x]
-      let xx = replicate 5 x
-      asValue (asTensor xx) `shouldBe` xx
-      let xxx = replicate 3 xx
-      asValue (asTensor xxx) `shouldBe` xxx
-
-  it "invalid cast of TensorLike a" $ do
-    let x = asTensor (10 :: Int)
-    (dtype x) `shouldBe` Int64
-    (print (asValue x :: Double)) `shouldThrow` anyException
-  it "invalid cast of TensorLike [a]" $ do
-    let x = asTensor ([0..10] :: [Int])
-    (print (asValue x :: [Double])) `shouldThrow` anyException
-
-  it "lists having different length" $ do
-    (print (asTensor ([[1],[1,2]] :: [[Double]]))) `shouldThrow` anyException
-  it "cast of Tensor" $ do
-    let x = asTensor ([0..10] :: [Int])
-    (dtype (toType Float x)) `shouldBe` Float
-
+  describe "indexing" $ do
+    it "pick up a value" $ do
+      let x = asTensor ([[[0,1,2],[3,4,5]],[[6,7,8],[9,10,11]]] :: [[[Int]]])
+      show (x @@ (1::Int,0::Int,2::Int)) `shouldBe` "Tensor Int64 []  8"
+    it "pick up a bottom tensor" $ do
+      let x = asTensor ([[[0,1,2],[3,4,5]],[[6,7,8],[9,10,11]]] :: [[[Int]]])
+      show (x @@ (1::Int,0::Int)) `shouldBe` "Tensor Int64 [3] [ 6,  7,  8]"
+    it "make a slice of bottom values" $ do
+      let x = asTensor ([[[0,1,2],[3,4,5]],[[6,7,8],[9,10,11]]] :: [[[Int]]])
+      show (x @@ ((),(),1::Int)) `shouldBe` "Tensor Int64 [2,2] [[ 1,  4],\n                    [ 7,  10]]"
+    it "make a slice via muliple slices" $ do
+      let x = asTensor ([[[0,1,2],[3,4,5]],[[6,7,8],[9,10,11]]] :: [[[Int]]])
+          r = x @@ ((),(Slice (1::Integer,None)))
+      show r `shouldBe` "Tensor Int64 [2,1,3] "
+      (asValue r :: [[[Int]]]) `shouldBe` [[[3,4,5]],[[9,10,11]]]
+    it "make a slice via muliple slices" $ do
+      let x = asTensor ([[[0,1,2],[3,4,5]],[[6,7,8],[9,10,11]]] :: [[[Int]]])
+          r = x @@ ((),(Slice (1::Integer,None)),(Slice (0::Integer,1::Integer)))
+      show r `shouldBe` "Tensor Int64 [2,1,1] "
+      (asValue r :: [[[Int]]]) `shouldBe` [[[3]],[[9]]]

--- a/hasktorch/test/TensorSpec.hs
+++ b/hasktorch/test/TensorSpec.hs
@@ -168,6 +168,10 @@ spec = do
       let x = asTensor ([[[0,1,2],[3,4,5]],[[6,7,8],[9,10,11]]] :: [[[Int]]])
           r = x @@ ((),(),1)
       (dtype &&& shape &&& asValue) r `shouldBe` (Int64, ([2,2], [[1 :: Int, 4], [7, 10]]))
+    it "ellipsis" $ do
+      let x = asTensor ([[[0,1,2],[3,4,5]],[[6,7,8],[9,10,11]]] :: [[[Int]]])
+          r = x @@ (Ellipsis,1)
+      (dtype &&& shape &&& asValue) r `shouldBe` (Int64, ([2,2], [[1 :: Int, 4], [7, 10]]))
     it "make a slice via muliple slices" $ do
       let x = asTensor ([[[0,1,2],[3,4,5]],[[6,7,8],[9,10,11]]] :: [[[Int]]])
           r = x @@ ((),(Slice (1,None)))

--- a/hasktorch/test/TensorSpec.hs
+++ b/hasktorch/test/TensorSpec.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE ExtendedDefaultRules #-}
+
 
 module TensorSpec (spec) where
 
@@ -155,20 +157,20 @@ spec = do
   describe "indexing" $ do
     it "pick up a value" $ do
       let x = asTensor ([[[0,1,2],[3,4,5]],[[6,7,8],[9,10,11]]] :: [[[Int]]])
-      show (x @@ (1::Int,0::Int,2::Int)) `shouldBe` "Tensor Int64 []  8"
+      show (x @@ (1,0,2)) `shouldBe` "Tensor Int64 []  8"
     it "pick up a bottom tensor" $ do
       let x = asTensor ([[[0,1,2],[3,4,5]],[[6,7,8],[9,10,11]]] :: [[[Int]]])
-      show (x @@ (1::Int,0::Int)) `shouldBe` "Tensor Int64 [3] [ 6,  7,  8]"
+      show (x @@ (1,0)) `shouldBe` "Tensor Int64 [3] [ 6,  7,  8]"
     it "make a slice of bottom values" $ do
       let x = asTensor ([[[0,1,2],[3,4,5]],[[6,7,8],[9,10,11]]] :: [[[Int]]])
-      show (x @@ ((),(),1::Int)) `shouldBe` "Tensor Int64 [2,2] [[ 1,  4],\n                    [ 7,  10]]"
+      show (x @@ ((),(),1)) `shouldBe` "Tensor Int64 [2,2] [[ 1,  4],\n                    [ 7,  10]]"
     it "make a slice via muliple slices" $ do
       let x = asTensor ([[[0,1,2],[3,4,5]],[[6,7,8],[9,10,11]]] :: [[[Int]]])
-          r = x @@ ((),(Slice (1::Integer,None)))
+          r = x @@ ((),(Slice (1,None)))
       show r `shouldBe` "Tensor Int64 [2,1,3] "
       (asValue r :: [[[Int]]]) `shouldBe` [[[3,4,5]],[[9,10,11]]]
     it "make a slice via muliple slices" $ do
       let x = asTensor ([[[0,1,2],[3,4,5]],[[6,7,8],[9,10,11]]] :: [[[Int]]])
-          r = x @@ ((),(Slice (1::Integer,None)),(Slice (0::Integer,1::Integer)))
+          r = x @@ ((),(Slice (1,None)),(Slice (0,1)))
       show r `shouldBe` "Tensor Int64 [2,1,1] "
       (asValue r :: [[[Int]]]) `shouldBe` [[[3]],[[9]]]

--- a/hasktorch/test/TensorSpec.hs
+++ b/hasktorch/test/TensorSpec.hs
@@ -7,6 +7,7 @@ module TensorSpec (spec) where
 import Test.Hspec
 import Test.QuickCheck
 import Control.Exception.Safe
+import Control.Arrow                  ( (&&&) )
 
 import Torch.Tensor
 import Torch.DType
@@ -157,20 +158,21 @@ spec = do
   describe "indexing" $ do
     it "pick up a value" $ do
       let x = asTensor ([[[0,1,2],[3,4,5]],[[6,7,8],[9,10,11]]] :: [[[Int]]])
-      show (x @@ (1,0,2)) `shouldBe` "Tensor Int64 []  8"
+          r = x @@ (1,0,2)
+      (dtype &&& shape &&& asValue) r `shouldBe` (Int64, ([], 8 :: Int))
     it "pick up a bottom tensor" $ do
       let x = asTensor ([[[0,1,2],[3,4,5]],[[6,7,8],[9,10,11]]] :: [[[Int]]])
-      show (x @@ (1,0)) `shouldBe` "Tensor Int64 [3] [ 6,  7,  8]"
+          r = x @@ (1,0)
+      (dtype &&& shape &&& asValue) r `shouldBe` (Int64, ([3], [6 :: Int, 7, 8]))
     it "make a slice of bottom values" $ do
       let x = asTensor ([[[0,1,2],[3,4,5]],[[6,7,8],[9,10,11]]] :: [[[Int]]])
-      show (x @@ ((),(),1)) `shouldBe` "Tensor Int64 [2,2] [[ 1,  4],\n                    [ 7,  10]]"
+          r = x @@ ((),(),1)
+      (dtype &&& shape &&& asValue) r `shouldBe` (Int64, ([2,2], [[1 :: Int, 4], [7, 10]]))
     it "make a slice via muliple slices" $ do
       let x = asTensor ([[[0,1,2],[3,4,5]],[[6,7,8],[9,10,11]]] :: [[[Int]]])
           r = x @@ ((),(Slice (1,None)))
-      show r `shouldBe` "Tensor Int64 [2,1,3] "
-      (asValue r :: [[[Int]]]) `shouldBe` [[[3,4,5]],[[9,10,11]]]
+      (dtype &&& shape &&& asValue) r `shouldBe` (Int64, ([2,1,3], [[[3::Int,4,5]],[[9,10,11]]]))
     it "make a slice via muliple slices" $ do
       let x = asTensor ([[[0,1,2],[3,4,5]],[[6,7,8],[9,10,11]]] :: [[[Int]]])
           r = x @@ ((),(Slice (1,None)),(Slice (0,1)))
-      show r `shouldBe` "Tensor Int64 [2,1,1] "
-      (asValue r :: [[[Int]]]) `shouldBe` [[[3]],[[9]]]
+      (dtype &&& shape &&& asValue) r `shouldBe` (Int64, ([2,1,1], [[[3::Int]],[[9]]]))

--- a/libtorch-ffi/csrc/hasktorch_finializer.cpp
+++ b/libtorch-ffi/csrc/hasktorch_finializer.cpp
@@ -8,6 +8,14 @@ void delete_tensorlist(std::vector<at::Tensor>* tensors){
   delete tensors;
 }
 
+void delete_tensorindex(at::indexing::TensorIndex* idx){
+  delete idx;
+}
+
+void delete_tensorindexlist(std::vector<at::indexing::TensorIndex>* idxs){
+  delete idxs;
+}
+
 void delete_c10dict(c10::Dict<at::IValue,at::IValue>* object){
   delete object;
 }

--- a/libtorch-ffi/csrc/hasktorch_finializer.h
+++ b/libtorch-ffi/csrc/hasktorch_finializer.h
@@ -10,6 +10,10 @@ extern "C" {
 
   void delete_tensorlist(std::vector<at::Tensor>* tensors);
 
+  void delete_tensorindex(at::indexing::TensorIndex* idx);
+
+  void delete_tensorindexlist(std::vector<at::indexing::TensorIndex>* idxs);
+
   void delete_c10dict(c10::Dict<at::IValue,at::IValue>* object);
 
   void delete_c10listivalue(c10::List<at::IValue>* object);

--- a/libtorch-ffi/libtorch-ffi.cabal
+++ b/libtorch-ffi/libtorch-ffi.cabal
@@ -37,6 +37,7 @@ library
                     , Torch.Internal.Unmanaged.Type.Tensor
                     , Torch.Internal.Unmanaged.Type.TensorList
                     , Torch.Internal.Unmanaged.Type.TensorOptions
+                    , Torch.Internal.Unmanaged.Type.TensorIndex
                     , Torch.Internal.Unmanaged.Type.StdString
                     , Torch.Internal.Unmanaged.Type.StdArray
                     , Torch.Internal.Unmanaged.Type.Context
@@ -60,6 +61,7 @@ library
                     , Torch.Internal.Managed.Type.Storage
                     , Torch.Internal.Managed.Type.Tensor
                     , Torch.Internal.Managed.Type.TensorList
+                    , Torch.Internal.Managed.Type.TensorIndex
                     , Torch.Internal.Managed.Type.TensorOptions
                     , Torch.Internal.Managed.Type.StdString
                     , Torch.Internal.Managed.Type.StdArray

--- a/libtorch-ffi/src/Torch/Internal/Managed/Type/TensorIndex.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Type/TensorIndex.hs
@@ -1,0 +1,70 @@
+
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE FlexibleInstances #-}
+
+module Torch.Internal.Managed.Type.TensorIndex where
+
+
+import Foreign.C.String
+import Foreign.C.Types
+import Foreign
+import Torch.Internal.Type
+import Torch.Internal.Class
+import Torch.Internal.Cast
+import Torch.Internal.Unmanaged.Type.Generator
+import Torch.Internal.Unmanaged.Type.IntArray
+import Torch.Internal.Unmanaged.Type.Scalar
+import Torch.Internal.Unmanaged.Type.Storage
+import Torch.Internal.Unmanaged.Type.Tensor
+import Torch.Internal.Unmanaged.Type.TensorList
+import Torch.Internal.Unmanaged.Type.TensorOptions
+import Torch.Internal.Unmanaged.Type.Tuple
+import Torch.Internal.Unmanaged.Type.StdString
+import Torch.Internal.Unmanaged.Type.Dimname
+import Torch.Internal.Unmanaged.Type.DimnameList
+import Torch.Internal.Unmanaged.Type.IValue
+
+import qualified Torch.Internal.Unmanaged.Type.TensorIndex as Unmanaged
+
+
+newTensorIndexList :: IO (ForeignPtr (StdVector TensorIndex))
+newTensorIndexList = cast0 Unmanaged.newTensorIndexList
+
+newTensorIndexWithInt :: CInt -> IO (ForeignPtr TensorIndex)
+newTensorIndexWithInt = cast1 Unmanaged.newTensorIndexWithInt
+
+newTensorIndexWithBool :: CBool -> IO (ForeignPtr TensorIndex)
+newTensorIndexWithBool = cast1 Unmanaged.newTensorIndexWithBool
+
+newTensorIndexWithSlice :: CInt -> CInt -> CInt -> IO (ForeignPtr TensorIndex)
+newTensorIndexWithSlice = cast3 Unmanaged.newTensorIndexWithSlice
+
+newTensorIndexWithTensor :: ForeignPtr Tensor -> IO (ForeignPtr TensorIndex)
+newTensorIndexWithTensor = cast1 Unmanaged.newTensorIndexWithTensor
+
+newTensorIndexWithEllipsis :: IO (ForeignPtr TensorIndex)
+newTensorIndexWithEllipsis = cast0 Unmanaged.newTensorIndexWithEllipsis
+
+newTensorIndexWithNone :: IO (ForeignPtr TensorIndex)
+newTensorIndexWithNone = cast0 Unmanaged.newTensorIndexWithNone
+
+tensorIndexList_empty :: ForeignPtr (StdVector TensorIndex) -> IO (CBool)
+tensorIndexList_empty = cast1 Unmanaged.tensorIndexList_empty
+
+tensorIndexList_size :: ForeignPtr (StdVector TensorIndex) -> IO (CSize)
+tensorIndexList_size = cast1 Unmanaged.tensorIndexList_size
+
+tensorIndexList_push_back :: ForeignPtr (StdVector TensorIndex) -> ForeignPtr TensorIndex -> IO ()
+tensorIndexList_push_back = cast2 Unmanaged.tensorIndexList_push_back
+
+index :: ForeignPtr Tensor -> ForeignPtr (StdVector TensorIndex) -> IO (ForeignPtr Tensor)
+index = cast2 Unmanaged.index
+
+index_put_ :: ForeignPtr Tensor -> ForeignPtr (StdVector TensorIndex) -> ForeignPtr Tensor -> IO (ForeignPtr Tensor)
+index_put_ = cast3 Unmanaged.index_put_

--- a/libtorch-ffi/src/Torch/Internal/Managed/Type/TensorIndex.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Type/TensorIndex.hs
@@ -17,18 +17,7 @@ import Foreign
 import Torch.Internal.Type
 import Torch.Internal.Class
 import Torch.Internal.Cast
-import Torch.Internal.Unmanaged.Type.Generator
-import Torch.Internal.Unmanaged.Type.IntArray
-import Torch.Internal.Unmanaged.Type.Scalar
-import Torch.Internal.Unmanaged.Type.Storage
 import Torch.Internal.Unmanaged.Type.Tensor
-import Torch.Internal.Unmanaged.Type.TensorList
-import Torch.Internal.Unmanaged.Type.TensorOptions
-import Torch.Internal.Unmanaged.Type.Tuple
-import Torch.Internal.Unmanaged.Type.StdString
-import Torch.Internal.Unmanaged.Type.Dimname
-import Torch.Internal.Unmanaged.Type.DimnameList
-import Torch.Internal.Unmanaged.Type.IValue
 
 import qualified Torch.Internal.Unmanaged.Type.TensorIndex as Unmanaged
 

--- a/libtorch-ffi/src/Torch/Internal/Type.hs
+++ b/libtorch-ffi/src/Torch/Internal/Type.hs
@@ -42,6 +42,8 @@ data Tensor
 -- std::vector<at::Tensor>
 type TensorList = StdVector Tensor
 
+data TensorIndex
+
 data Scalar
 data TensorOptions
 
@@ -125,4 +127,5 @@ typeTable = Map.fromList [
       , (C.TypeName "torch::jit::Graph", [t|JitGraph|])
       , (C.TypeName "torch::jit::Node", [t|JitNode|])
       , (C.TypeName "torch::jit::Value", [t|JitValue|])
+      , (C.TypeName "at::indexing::TensorIndex", [t|TensorIndex|])
     ]

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/TensorIndex.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/TensorIndex.hs
@@ -1,0 +1,76 @@
+
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE FlexibleInstances #-}
+
+module Torch.Internal.Unmanaged.Type.TensorIndex where
+
+
+import qualified Language.C.Inline.Cpp as C
+import qualified Language.C.Inline.Cpp.Exceptions as C
+import qualified Language.C.Inline.Context as C
+import qualified Language.C.Types as C
+import qualified Data.Map as Map
+import Foreign.C.String
+import Foreign.C.Types
+import Foreign
+import Torch.Internal.Type
+import Torch.Internal.Class
+
+C.context $ C.cppCtx <> mempty { C.ctxTypesTable = typeTable }
+
+C.include "<ATen/ATen.h>"
+C.include "<vector>"
+
+newTensorIndexList :: IO (Ptr (StdVector TensorIndex))
+newTensorIndexList = [C.throwBlock| std::vector<at::indexing::TensorIndex>* { return new std::vector<at::indexing::TensorIndex>(); }|]
+
+newTensorIndexWithInt :: CInt -> IO (Ptr TensorIndex)
+newTensorIndexWithInt value = [C.throwBlock| at::indexing::TensorIndex* { return new at::indexing::TensorIndex($(int value)); }|]
+
+newTensorIndexWithBool :: CBool -> IO (Ptr TensorIndex)
+newTensorIndexWithBool value = [C.throwBlock| at::indexing::TensorIndex* { return new at::indexing::TensorIndex((bool)$(bool value)); }|]
+
+newTensorIndexWithSlice :: CInt -> CInt -> CInt -> IO (Ptr TensorIndex)
+newTensorIndexWithSlice start stop step = [C.throwBlock| at::indexing::TensorIndex* { return new at::indexing::TensorIndex(at::indexing::Slice($(int start),$(int stop),$(int step))); }|]
+
+newTensorIndexWithTensor :: Ptr Tensor -> IO (Ptr TensorIndex)
+newTensorIndexWithTensor value = [C.throwBlock| at::indexing::TensorIndex* { return new at::indexing::TensorIndex(*$(at::Tensor* value)); }|]
+
+newTensorIndexWithEllipsis :: IO (Ptr TensorIndex)
+newTensorIndexWithEllipsis = [C.throwBlock| at::indexing::TensorIndex* { return new at::indexing::TensorIndex("..."); }|]
+
+newTensorIndexWithNone :: IO (Ptr TensorIndex)
+newTensorIndexWithNone = [C.throwBlock| at::indexing::TensorIndex* { return new at::indexing::TensorIndex(at::indexing::None); }|]
+
+foreign import ccall unsafe "hasktorch_finalizer.h &delete_tensorindex"
+  c_delete_tensorindex :: FunPtr ( Ptr TensorIndex -> IO ())
+
+foreign import ccall unsafe "hasktorch_finalizer.h &delete_tensorindexlist"
+  c_delete_tensorindexlist :: FunPtr ( Ptr (StdVector TensorIndex) -> IO ())
+
+instance CppObject TensorIndex where
+  fromPtr ptr = newForeignPtr c_delete_tensorindex ptr
+
+instance CppObject (StdVector TensorIndex) where
+  fromPtr ptr = newForeignPtr c_delete_tensorindexlist ptr
+
+tensorIndexList_empty :: Ptr (StdVector TensorIndex) -> IO (CBool)
+tensorIndexList_empty _obj = [C.throwBlock| bool { return (*$(std::vector<at::indexing::TensorIndex>* _obj)).empty(); }|]
+
+tensorIndexList_size :: Ptr (StdVector TensorIndex) -> IO (CSize)
+tensorIndexList_size _obj = [C.throwBlock| size_t { return (*$(std::vector<at::indexing::TensorIndex>* _obj)).size(); }|]
+
+tensorIndexList_push_back :: Ptr (StdVector TensorIndex) -> Ptr TensorIndex -> IO ()
+tensorIndexList_push_back _obj _v = [C.throwBlock| void {  (*$(std::vector<at::indexing::TensorIndex>* _obj)).push_back(*$(at::indexing::TensorIndex* _v)); }|]
+
+index :: Ptr Tensor -> Ptr (StdVector TensorIndex) -> IO (Ptr Tensor)
+index _obj idx = [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).index(*$(std::vector<at::indexing::TensorIndex>* idx))); } |]
+
+index_put_ :: Ptr Tensor -> Ptr (StdVector TensorIndex) -> Ptr Tensor -> IO (Ptr Tensor)
+index_put_ _obj idx value = [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).index_put_(*$(std::vector<at::indexing::TensorIndex>* idx),*$(at::Tensor * value))); } |]


### PR DESCRIPTION
This PR adds slice-operators.
It is made in the same way as C++ syntax.

Pytorch(Python) | Pytorch(C++)| This PR
-- | -- | -- 
None | None | None
Ellipsis | Ellipsis | Ellipsis
... | "..." | Ellipsis
123 | 123 | 123
True | true | True
False | false | False
: or :: | Slice() or Slice(None, None) or Slice(None, None, None) | ()
1: or 1:: | Slice(1, None) or Slice(1, None, None) | Slice 1
:3 or :3: | Slice(None, 3) or Slice(None, 3, None) | Slice (None,3)
::2 | Slice(None, None, 2) | Slice (None,None,2)
1:3 | Slice(1, 3) | Slice (1,3)
1::2 | Slice(1, None, 2) | Slice (1,None,2)
:3:2 | Slice(None, 3, 2) | Slice (None,3,2)
1:3:2 | Slice(1, 3, 2) | Slice (1,3,2)
torch.tensor([1, 2]) | torch::tensor({1, 2}) | asTensor([1,2])
