### PR TITLE
Add typed diag

### DIFF
--- a/hasktorch/src/Torch/Typed/Functional.hs
+++ b/hasktorch/src/Torch/Typed/Functional.hs
@@ -1191,8 +1191,31 @@ transpose2D
   -> Tensor device dtype '[j, i] -- ^ output
 transpose2D = transpose @0 @1
 
--- diag :: Tensor device dtype shape -> Int -> Tensor device dtype shape
--- diag t index = unsafePerformIO $ (ATen.cast2 ATen.Managed.tensor_diag_l) t index
+-- | diag with positive index (above the main diagonal)
+--
+-- >>> dtype &&& shape $ upperDiag @0 (ones :: CPUTensor 'D.Float '[3,2])
+-- (Float,[2])
+-- >>> dtype &&& shape $ upperDiag @1 (ones :: CPUTensor 'D.Float '[3,2])
+-- (Float,[1])
+upperDiag
+  :: forall (index :: Nat) (i :: Nat) (j :: Nat) device dtype
+   . KnownNat index
+  => Tensor device dtype '[i, j] -- ^ input
+  -> Tensor device dtype '[Min i j - index] -- ^ output
+upperDiag t = unsafePerformIO $ ATen.cast2 ATen.Managed.tensor_diag_l t (natValI @index)
+
+-- | diag with negative index (below the main diagonal)
+--
+-- >>> dtype &&& shape $ lowerDiag @0 (ones :: CPUTensor 'D.Float '[3,2])
+-- (Float,[2])
+-- >>> dtype &&& shape $ lowerDiag @1 (ones :: CPUTensor 'D.Float '[3,2])
+-- (Float,[2])
+lowerDiag
+  :: forall (index :: Nat) (i :: Nat) (j :: Nat) device dtype
+   . KnownNat index
+  => Tensor device dtype '[i, j] -- ^ input
+  -> Tensor device dtype '[Min i j - index] -- ^ output
+lowerDiag t = unsafePerformIO $ ATen.cast2 ATen.Managed.tensor_diag_l t (- natValI @index)
 
 -- | all
 -- See https://pytorch.org/docs/stable/tensors.html#torch.BoolTensor.all.

--- a/hasktorch/src/Torch/Typed/Functional.hs
+++ b/hasktorch/src/Torch/Typed/Functional.hs
@@ -1194,7 +1194,7 @@ transpose2D = transpose @0 @1
 type family DiagShape (index :: Nat) (shape :: [Nat]) :: [Nat] where
   DiagShape i '[n] = '[n + i, n + i] -- 1d -> 2d case
   DiagShape i '[m, n] = '[Min m n - i] -- 2d -> 1d case
-  DiagShape _ _ =  TypeError (Text "The input must be matrix or vector.")
+  DiagShape _ _ =  TypeError (Text "The input must be a matrix or a vector.")
 
 -- | diag
 --

--- a/hasktorch/src/Torch/Typed/Functional.hs
+++ b/hasktorch/src/Torch/Typed/Functional.hs
@@ -1191,31 +1191,24 @@ transpose2D
   -> Tensor device dtype '[j, i] -- ^ output
 transpose2D = transpose @0 @1
 
--- | diag with positive index (above the main diagonal)
+-- | diag
 --
--- >>> dtype &&& shape $ upperDiag @0 (ones :: CPUTensor 'D.Float '[3,2])
+-- >>> dtype &&& shape $ diag @0 Upper (ones :: CPUTensor 'D.Float '[3,2])
 -- (Float,[2])
--- >>> dtype &&& shape $ upperDiag @1 (ones :: CPUTensor 'D.Float '[3,2])
+-- >>> dtype &&& shape $ diag @1 Upper (ones :: CPUTensor 'D.Float '[3,2])
 -- (Float,[1])
-upperDiag
+-- >>> dtype &&& shape $ diag @1 Lower (ones :: CPUTensor 'D.Float '[3,2])
+-- (Float,[2])
+diag
   :: forall (index :: Nat) (i :: Nat) (j :: Nat) device dtype
    . KnownNat index
-  => Tensor device dtype '[i, j] -- ^ input
+  => Tri -- ^ upper or lower
+  -> Tensor device dtype '[i, j] -- ^ input
   -> Tensor device dtype '[Min i j - index] -- ^ output
-upperDiag t = unsafePerformIO $ ATen.cast2 ATen.Managed.tensor_diag_l t (natValI @index)
-
--- | diag with negative index (below the main diagonal)
---
--- >>> dtype &&& shape $ lowerDiag @0 (ones :: CPUTensor 'D.Float '[3,2])
--- (Float,[2])
--- >>> dtype &&& shape $ lowerDiag @1 (ones :: CPUTensor 'D.Float '[3,2])
--- (Float,[2])
-lowerDiag
-  :: forall (index :: Nat) (i :: Nat) (j :: Nat) device dtype
-   . KnownNat index
-  => Tensor device dtype '[i, j] -- ^ input
-  -> Tensor device dtype '[Min i j - index] -- ^ output
-lowerDiag t = unsafePerformIO $ ATen.cast2 ATen.Managed.tensor_diag_l t (- natValI @index)
+diag tri t = unsafePerformIO $ ATen.cast2 ATen.Managed.tensor_diag_l t
+  $ case tri of
+    Upper -> natValI @index
+    Lower -> - natValI @index
 
 -- | all
 -- See https://pytorch.org/docs/stable/tensors.html#torch.BoolTensor.all.

--- a/hasktorch/src/Torch/Typed/Functional.hs
+++ b/hasktorch/src/Torch/Typed/Functional.hs
@@ -1194,7 +1194,7 @@ transpose2D = transpose @0 @1
 type family DiagShape (index :: Nat) (shape :: [Nat]) :: [Nat] where
   DiagShape i '[n] = '[n + i, n + i] -- 1d -> 2d case
   DiagShape i '[m, n] = '[Min m n - i] -- 2d -> 1d case
-  DiagShape _ _ =  TypeError (Text "The input must be a matrix or a vector.")
+  DiagShape _ shape =  TypeError (Text "The input must be a matrix or a vector, but it has " :<>: ListLength shape  :<>: " dimensions.")
 
 -- | diag
 --

--- a/hasktorch/src/Torch/Typed/Functional.hs
+++ b/hasktorch/src/Torch/Typed/Functional.hs
@@ -1202,8 +1202,32 @@ instance KnownTri Lower where
 
 type family DiagShape (tri :: Tri) (index :: Nat) (shape :: [Nat]) :: [Nat] where
   DiagShape _ i '[n] = '[n + i, n + i]
-  DiagShape 'Upper i '[m, n] = '[Min m (n - i)]
-  DiagShape 'Lower i '[m, n] = '[Min (m - i) n]
+  DiagShape 'Upper i '[m, n] =
+    If
+      (i <=? n)
+      '[Min m (n - i)]
+      ( TypeError
+          ( Text "For a matrix with shape "
+              :<>: ShowType '[m, n]
+              :<>: Text ", the maximum index for an upper diagonal is "
+              :<>: ShowType n
+              :<>: Text ", but asked for index "
+              :<>: ShowType i
+          )
+      )
+  DiagShape 'Lower i '[m, n] =
+    If
+      (i <=? m)
+      '[Min (m - i) n]
+      ( TypeError
+          ( Text "For a matrix with shape "
+              :<>: ShowType '[m, n]
+              :<>: Text ", the maximum index for a lower diagonal is "
+              :<>: ShowType m
+              :<>: Text ", but asked for index "
+              :<>: ShowType i
+          )
+      )
   DiagShape _ _ shape =
     TypeError
       ( Text "The input must be a matrix or a vector, but it has "

--- a/hasktorch/src/Torch/Typed/Functional.hs
+++ b/hasktorch/src/Torch/Typed/Functional.hs
@@ -1194,7 +1194,12 @@ transpose2D = transpose @0 @1
 type family DiagShape (index :: Nat) (shape :: [Nat]) :: [Nat] where
   DiagShape i '[n] = '[n + i, n + i] -- 1d -> 2d case
   DiagShape i '[m, n] = '[Min m n - i] -- 2d -> 1d case
-  DiagShape _ shape =  TypeError (Text "The input must be a matrix or a vector, but it has " :<>: ListLength shape  :<>: " dimensions.")
+  DiagShape _ shape =
+    TypeError
+      ( Text "The input must be a matrix or a vector, but it has "
+          :<>: ShowType (ListLength shape)
+          :<>: Text " dimensions."
+      )
 
 -- | diag
 --

--- a/hasktorch/src/Torch/Typed/Functional.hs
+++ b/hasktorch/src/Torch/Typed/Functional.hs
@@ -1194,6 +1194,7 @@ transpose2D = transpose @0 @1
 type family DiagShape (index :: Nat) (shape :: [Nat]) :: [Nat] where
   DiagShape i '[n] = '[n + i, n + i] -- 1d -> 2d case
   DiagShape i '[m, n] = '[Min m n - i] -- 2d -> 1d case
+  DiagShape _ _ =  TypeError (Text "The input must be matrix or vector.")
 
 -- | diag
 --

--- a/hasktorch/src/Torch/Typed/Functional.hs
+++ b/hasktorch/src/Torch/Typed/Functional.hs
@@ -1247,6 +1247,7 @@ diag
   :: forall (tri :: Tri) (index :: Nat) (shape :: [Nat]) (shape' :: [Nat]) device dtype
    . ( KnownTri tri
      , KnownNat index
+     , StandardDTypeValidation device dtype
      , shape' ~ DiagShape tri index shape
      )
   => Tensor device dtype shape -- ^ input

--- a/hasktorch/test/Torch/Typed/FunctionalSpec.hs
+++ b/hasktorch/test/Torch/Typed/FunctionalSpec.hs
@@ -732,6 +732,7 @@ instance
   , shape' ~ DiagShape tri index shape
   , KnownTri tri
   , KnownNat index
+  , StandardDTypeValidation device dtype
   ) => Apply' DiagSpec (((Proxy tri, Proxy index), (Proxy device, (Proxy dtype, Proxy shape))), IO ()) (IO ()) where
   apply' DiagSpec (_, agg) = agg >> do
     let t = ones @shape @dtype @device
@@ -1043,9 +1044,9 @@ spec' device =
             hfoldrM @IO DiagSpec () (hproduct (hproduct tris indexes)  (hattach cpu   (hproduct standardDTypes vectorShapes)))
             hfoldrM @IO DiagSpec () (hproduct (hproduct tris indexes') (hattach cpu   (hproduct standardDTypes emptyShapes)))
           Device { deviceType = CUDA, deviceIndex = 0 } -> do
-            hfoldrM @IO DiagSpec () (hproduct (hproduct tris indexes)  (hattach cuda0 (hproduct allDTypes standardShapes)))
-            hfoldrM @IO DiagSpec () (hproduct (hproduct tris indexes)  (hattach cuda0 (hproduct allDTypes vectorShapes)))
-            hfoldrM @IO DiagSpec () (hproduct (hproduct tris indexes') (hattach cuda0 (hproduct allDTypes emptyShapes)))
+            hfoldrM @IO DiagSpec () (hproduct (hproduct tris indexes)  (hattach cuda0 (hproduct standardDTypes standardShapes)))
+            hfoldrM @IO DiagSpec () (hproduct (hproduct tris indexes)  (hattach cuda0 (hproduct standardDTypes vectorShapes)))
+            hfoldrM @IO DiagSpec () (hproduct (hproduct tris indexes') (hattach cuda0 (hproduct standardDTypes emptyShapes)))
 
     describe "loss functions" $ do
       let dispatch lossSpec = case device of

--- a/hasktorch/test/Torch/Typed/FunctionalSpec.hs
+++ b/hasktorch/test/Torch/Typed/FunctionalSpec.hs
@@ -1032,20 +1032,20 @@ spec' device =
           hfoldrM @IO Transpose2DSpec () (hattach cuda0 (hproduct allDTypes (Proxy @'[2, 3] :. HNil)))
       it "diag" $ do
         let
-          shapes1 = Proxy @'[0] :. Proxy @'[1] :. Proxy @'[3] :. HNil
-          shapes2 = Proxy @'[2, 3] :. HNil
-          shapes2' = Proxy @'[0, 0] :. Proxy @'[0, 1]  :. Proxy @'[1, 0] :. HNil -- only offset 0 has upper and lower defined
+          vectorShapes = Proxy @'[0] :. Proxy @'[1] :. Proxy @'[2] :. HNil
+          emptyShapes = Proxy @'[0, 0] :. Proxy @'[0, 1]  :. Proxy @'[1, 0] :. HNil
           tris = Proxy @'Upper :. Proxy @'Lower :. HNil
-          offsets = Proxy @0 :. Proxy @1 :. Proxy @2 :. HNil
+          indexes = Proxy @0 :. Proxy @1 :. HNil
+          indexes' = Proxy @0 :. HNil
         case device of
           Device { deviceType = CPU,  deviceIndex = 0 } -> do
-            hfoldrM @IO DiagSpec () (hproduct (hproduct tris offsets) (hattach cpu   (hproduct allDTypes shapes1)))
-            hfoldrM @IO DiagSpec () (hproduct (hproduct tris offsets) (hattach cpu   (hproduct allDTypes shapes2)))
-            hfoldrM @IO DiagSpec () (hproduct (hproduct tris (Proxy @0 :. HNil)) (hattach cpu   (hproduct allDTypes shapes2')))
+            hfoldrM @IO DiagSpec () (hproduct (hproduct tris indexes)  (hattach cpu   (hproduct allDTypes standardShapes)))
+            hfoldrM @IO DiagSpec () (hproduct (hproduct tris indexes)  (hattach cpu   (hproduct allDTypes vectorShapes)))
+            hfoldrM @IO DiagSpec () (hproduct (hproduct tris indexes') (hattach cpu   (hproduct allDTypes emptyShapes)))
           Device { deviceType = CUDA, deviceIndex = 0 } -> do
-            hfoldrM @IO DiagSpec () (hproduct (hproduct tris offsets) (hattach cuda0 (hproduct allDTypes shapes1)))
-            hfoldrM @IO DiagSpec () (hproduct (hproduct tris offsets) (hattach cuda0 (hproduct allDTypes shapes2)))
-            hfoldrM @IO DiagSpec () (hproduct (hproduct tris (Proxy @0 :. HNil)) (hattach cuda0 (hproduct allDTypes shapes2')))
+            hfoldrM @IO DiagSpec () (hproduct (hproduct tris indexes)  (hattach cuda0 (hproduct allDTypes standardShapes)))
+            hfoldrM @IO DiagSpec () (hproduct (hproduct tris indexes)  (hattach cuda0 (hproduct allDTypes vectorShapes)))
+            hfoldrM @IO DiagSpec () (hproduct (hproduct tris indexes') (hattach cuda0 (hproduct allDTypes emptyShapes)))
 
     describe "loss functions" $ do
       let dispatch lossSpec = case device of

--- a/hasktorch/test/Torch/Typed/FunctionalSpec.hs
+++ b/hasktorch/test/Torch/Typed/FunctionalSpec.hs
@@ -729,10 +729,10 @@ data DiagSpec = DiagSpec
 instance
   ( TensorOptions shape dtype device
   , TensorOptions shape' dtype device
-  , shape' ~ DiagShape tri index shape
   , KnownTri tri
   , KnownNat index
   , StandardDTypeValidation device dtype
+  , shape' ~ DiagShape tri index shape
   ) => Apply' DiagSpec (((Proxy tri, Proxy index), (Proxy device, (Proxy dtype, Proxy shape))), IO ()) (IO ()) where
   apply' DiagSpec (_, agg) = agg >> do
     let t = ones @shape @dtype @device

--- a/hasktorch/test/Torch/Typed/FunctionalSpec.hs
+++ b/hasktorch/test/Torch/Typed/FunctionalSpec.hs
@@ -1039,9 +1039,9 @@ spec' device =
           indexes' = Proxy @0 :. HNil
         case device of
           Device { deviceType = CPU,  deviceIndex = 0 } -> do
-            hfoldrM @IO DiagSpec () (hproduct (hproduct tris indexes)  (hattach cpu   (hproduct allDTypes standardShapes)))
-            hfoldrM @IO DiagSpec () (hproduct (hproduct tris indexes)  (hattach cpu   (hproduct allDTypes vectorShapes)))
-            hfoldrM @IO DiagSpec () (hproduct (hproduct tris indexes') (hattach cpu   (hproduct allDTypes emptyShapes)))
+            hfoldrM @IO DiagSpec () (hproduct (hproduct tris indexes)  (hattach cpu   (hproduct standardDTypes standardShapes)))
+            hfoldrM @IO DiagSpec () (hproduct (hproduct tris indexes)  (hattach cpu   (hproduct standardDTypes vectorShapes)))
+            hfoldrM @IO DiagSpec () (hproduct (hproduct tris indexes') (hattach cpu   (hproduct standardDTypes emptyShapes)))
           Device { deviceType = CUDA, deviceIndex = 0 } -> do
             hfoldrM @IO DiagSpec () (hproduct (hproduct tris indexes)  (hattach cuda0 (hproduct allDTypes standardShapes)))
             hfoldrM @IO DiagSpec () (hproduct (hproduct tris indexes)  (hattach cuda0 (hproduct allDTypes vectorShapes)))

--- a/hasktorch/test/Torch/Typed/FunctionalSpec.hs
+++ b/hasktorch/test/Torch/Typed/FunctionalSpec.hs
@@ -1044,9 +1044,9 @@ spec' device =
             hfoldrM @IO DiagSpec () (hproduct (hproduct tris indexes)  (hattach cpu   (hproduct standardDTypes vectorShapes)))
             hfoldrM @IO DiagSpec () (hproduct (hproduct tris indexes') (hattach cpu   (hproduct standardDTypes emptyShapes)))
           Device { deviceType = CUDA, deviceIndex = 0 } -> do
-            hfoldrM @IO DiagSpec () (hproduct (hproduct tris indexes)  (hattach cuda0 (hproduct standardDTypes standardShapes)))
-            hfoldrM @IO DiagSpec () (hproduct (hproduct tris indexes)  (hattach cuda0 (hproduct standardDTypes vectorShapes)))
-            hfoldrM @IO DiagSpec () (hproduct (hproduct tris indexes') (hattach cuda0 (hproduct standardDTypes emptyShapes)))
+            hfoldrM @IO DiagSpec () (hproduct (hproduct tris indexes)  (hattach cuda0 (hproduct (withHalf standardDTypes) standardShapes)))
+            hfoldrM @IO DiagSpec () (hproduct (hproduct tris indexes)  (hattach cuda0 (hproduct (withHalf standardDTypes) vectorShapes)))
+            hfoldrM @IO DiagSpec () (hproduct (hproduct tris indexes') (hattach cuda0 (hproduct (withHalf standardDTypes) emptyShapes)))
 
     describe "loss functions" $ do
       let dispatch lossSpec = case device of


### PR DESCRIPTION
#233 

- [x] diag

**EDIT**: this PR just adds `diag` to `Torch.Typed.Functional`. The comments below the line are resolved.

TODO
- [x] Fix invalid dtype, device combos exposed by tests

----
(outdated)

So far I've only attempted `diag`. I approached this by splitting into 2 branches (`upperDiag` and `lowerDiag`), which return diagonals above and below the main diagonal, respectively (this is so the index can be a natural).

I also considered implementing this as a single function with a `Bool` type parameter, i.e. something like

``` haskell
diag
  :: forall (index :: Nat) (upper :: Bool) (i :: Nat) (j :: Nat) device dtype
   . (KnownNat index, KnownBool upper)
  => Tensor device dtype '[i, j] -- ^ input
  -> Tensor device dtype '[Min i j - index] -- ^ output
diag t = unsafePerformIO $ ATen.cast2 ATen.Managed.tensor_diag_l t index
  where
    absIndex = natValI @index
    index = if boolVal (Proxy @upper) then absIndex else -absIndex
```

but splitting into 2 branches seemed simpler, although I'm happy to revisit this.


