### PR TITLE
Allow full domain of offset values in diag* functions

### DIFF
--- a/hasktorch/src/Torch/Functional.hs
+++ b/hasktorch/src/Torch/Functional.hs
@@ -1244,11 +1244,11 @@ diag (Diag index) t = unsafePerformIO $ (cast2 ATen.tensor_diag_l) t index
 -- 
 diagEmbed
   :: Diag -- ^ offset
-  -> Int -- ^ dim1
-  -> Int -- ^ dim2
+  -> Dim -- ^ dim1
+  -> Dim -- ^ dim2
   -> Tensor -- ^ self
   -> Tensor
-diagEmbed (Diag offset) dim1 dim2 t = unsafePerformIO $ (cast4 ATen.diag_embed_tlll) t offset dim1 dim2
+diagEmbed (Diag offset) (Dim dim1) (Dim dim2) t = unsafePerformIO $ (cast4 ATen.diag_embed_tlll) t offset dim1 dim2
 
 -- | If input is a vector (1-D tensor), then returns a 2-D square tensor with the elements of input as the diagonal.
 -- If input is a tensor with more than one dimension, then returns a 2-D tensor with diagonal elements equal to a flattened input.

--- a/hasktorch/src/Torch/Functional.hs
+++ b/hasktorch/src/Torch/Functional.hs
@@ -1266,12 +1266,11 @@ diagflat (Diag offset) t = unsafePerformIO $ (cast2 ATen.diagflat_tl) t offset
 -- Applying diagEmbed to the output of this function with the same arguments yields a diagonal matrix with the diagonal entries of the input. However, diagEmbed has different default dimensions, so those need to be explicitly specified.
 diagonal
   :: Diag -- ^ offset
-  -> Dimname -- ^ outdim
-  -> Dimname -- ^ dim1
-  -> Dimname -- ^ dim2
+  -> Dim -- ^ dim1
+  -> Dim -- ^ dim2
   -> Tensor -- ^ input
   -> Tensor -- ^ output
-diagonal (Diag offset) outdim dim1 dim2 t = unsafePerformIO $ (cast5 ATen.diagonal_tnnnl) t outdim dim1 dim2 offset
+diagonal (Diag offset) (Dim dim1) (Dim dim2) t = unsafePerformIO $ (cast4 ATen.diagonal_tlll) t offset dim1 dim2
 
 
 -- | Returns True if all elements in the tensor are True, False otherwise.

--- a/hasktorch/src/Torch/Functional.hs
+++ b/hasktorch/src/Torch/Functional.hs
@@ -1243,12 +1243,12 @@ diag (Diag index) t = unsafePerformIO $ (cast2 ATen.tensor_diag_l) t index
 
 -- 
 diagEmbed
-  :: Offset -- ^ offset
+  :: Diag -- ^ offset
   -> Int -- ^ dim1
   -> Int -- ^ dim2
   -> Tensor -- ^ self
   -> Tensor
-diagEmbed offset dim1 dim2 t = unsafePerformIO $ (cast4 ATen.diag_embed_tlll) t offset dim1 dim2
+diagEmbed (Diag offset) dim1 dim2 t = unsafePerformIO $ (cast4 ATen.diag_embed_tlll) t offset dim1 dim2
 
 data Offset = OffsetMain | OffsetAbove | OffsetBelow deriving Show
 
@@ -1267,21 +1267,21 @@ instance Castable Offset Int64 where
 --  If offset > 0, it is above the main diagonal.
 --  If offset < 0, it is below the main diagonal.
 diagflat
-    :: Offset -- ^ offset
+    :: Diag -- ^ offset
     -> Tensor -- ^ self
     -> Tensor -- ^ output
-diagflat offset t = unsafePerformIO $ (cast2 ATen.diagflat_tl) t offset
+diagflat (Diag offset) t = unsafePerformIO $ (cast2 ATen.diagflat_tl) t offset
 
 -- | Returns a partial view of input with the its diagonal elements with respect to dim1 and dim2 appended as a dimension at the end of the shape.
 -- Applying diagEmbed to the output of this function with the same arguments yields a diagonal matrix with the diagonal entries of the input. However, diagEmbed has different default dimensions, so those need to be explicitly specified.
 diagonal
-  :: Offset -- ^ offset
+  :: Diag -- ^ offset
   -> Dimname -- ^ outdim
   -> Dimname -- ^ dim1
   -> Dimname -- ^ dim2
   -> Tensor -- ^ input
   -> Tensor -- ^ output
-diagonal offset outdim dim1 dim2 t = unsafePerformIO $ (cast5 ATen.diagonal_tnnnl) t outdim dim1 dim2 offset
+diagonal (Diag offset) outdim dim1 dim2 t = unsafePerformIO $ (cast5 ATen.diagonal_tnnnl) t outdim dim1 dim2 offset
 
 
 -- | Returns True if all elements in the tensor are True, False otherwise.

--- a/hasktorch/src/Torch/Functional.hs
+++ b/hasktorch/src/Torch/Functional.hs
@@ -1250,16 +1250,6 @@ diagEmbed
   -> Tensor
 diagEmbed (Diag offset) dim1 dim2 t = unsafePerformIO $ (cast4 ATen.diag_embed_tlll) t offset dim1 dim2
 
-data Offset = OffsetMain | OffsetAbove | OffsetBelow deriving Show
-
-instance Castable Offset Int64 where
-  cast OffsetMain f = f 0
-  cast OffsetAbove f = f 1
-  cast OffsetBelow f = f (-1)
-  uncast 1 f = f OffsetAbove
-  uncast (-1) f = f OffsetBelow
-  uncast _ f = f OffsetMain
-
 -- | If input is a vector (1-D tensor), then returns a 2-D square tensor with the elements of input as the diagonal.
 -- If input is a tensor with more than one dimension, then returns a 2-D tensor with diagonal elements equal to a flattened input.
 -- The argument offset controls which diagonal to consider:

--- a/hasktorch/test/FunctionalSpec.hs
+++ b/hasktorch/test/FunctionalSpec.hs
@@ -116,6 +116,12 @@ spec = do
     shape (diagflat (Diag 1) t1) `shouldBe` [4, 4]
     let t2 = ones' [2, 2]
     shape (diagflat (Diag 0) t2) `shouldBe` [4, 4]
+  it "diagonal" $ do
+    let t1 = ones' [3, 3]
+    shape (diagonal (Diag 0) (Dim 0) (Dim 1) t1) `shouldBe` [3]
+    shape (diagonal (Diag 1) (Dim 0) (Dim 1) t1) `shouldBe` [2]
+    let t2 = ones' [2, 5, 4, 2]
+    shape (diagonal (Diag (-1)) (Dim 1) (Dim 2) t2) `shouldBe` [2, 2, 4]
   it "expand" $ do
     let t = asTensor [[1], [2], [3 :: Int]]
     shape (expand t False [3, 4]) `shouldBe` [3, 4]

--- a/hasktorch/test/FunctionalSpec.hs
+++ b/hasktorch/test/FunctionalSpec.hs
@@ -108,8 +108,8 @@ spec = do
     shape y `shouldBe` [5, 5]
   it "diagEmbed" $ do
     let t = ones' [2, 3]
-    shape (diagEmbed (Diag 0) (-2) (-1) t) `shouldBe` [2, 3, 3]
-    shape (diagEmbed (Diag 1) 0 2 t) `shouldBe` [4, 2, 4]
+    shape (diagEmbed (Diag 0) (Dim (-2)) (Dim (-1)) t) `shouldBe` [2, 3, 3]
+    shape (diagEmbed (Diag 1) (Dim 0) (Dim 2) t) `shouldBe` [4, 2, 4]
   it "diagflat" $ do
     let t1 = ones' [3]
     shape (diagflat (Diag 0) t1) `shouldBe` [3, 3]

--- a/hasktorch/test/FunctionalSpec.hs
+++ b/hasktorch/test/FunctionalSpec.hs
@@ -106,6 +106,16 @@ spec = do
     let x = ones' [3]
     let y = diag (Diag 2) x
     shape y `shouldBe` [5, 5]
+  it "diagEmbed" $ do
+    let t = ones' [2, 3]
+    shape (diagEmbed (Diag 0) (-2) (-1) t) `shouldBe` [2, 3, 3]
+    shape (diagEmbed (Diag 1) 0 2 t) `shouldBe` [4, 2, 4]
+  it "diagflat" $ do
+    let t1 = ones' [3]
+    shape (diagflat (Diag 0) t1) `shouldBe` [3, 3]
+    shape (diagflat (Diag 1) t1) `shouldBe` [4, 4]
+    let t2 = ones' [2, 2]
+    shape (diagflat (Diag 0) t2) `shouldBe` [4, 4]
   it "expand" $ do
     let t = asTensor [[1], [2], [3 :: Int]]
     shape (expand t False [3, 4]) `shouldBe` [3, 4]


### PR DESCRIPTION
Fixes #416.

I also went ahead and removed the `Offset` type and instance as there weren't any other uses.