### PR TITLE
Typed diagEmbed, diagflat, diagonal

### DIFF
--- a/hasktorch/src/Torch/Typed/Aux.hs
+++ b/hasktorch/src/Torch/Typed/Aux.hs
@@ -114,7 +114,7 @@ type family InsertImpl (n :: Nat) (x :: a) (l :: [a]) :: Maybe [a] where
   InsertImpl n x '[] = Nothing
   InsertImpl n x (h ': t) = AppendToMaybe h (InsertImpl (n - 1) x t)
 
-type family CheckInsert (n :: Nat) (x :: a) (l :: [a]) (result :: Maybe [a]):: [a] where
+type family CheckInsert (n :: Nat) (x :: a) (l :: [a]) (result :: Maybe [a]) :: [a] where
   CheckInsert _ _ _ (Just xs) = xs
   CheckInsert n x l Nothing = DimOutOfBound l n
 

--- a/hasktorch/src/Torch/Typed/Aux.hs
+++ b/hasktorch/src/Torch/Typed/Aux.hs
@@ -99,6 +99,28 @@ type Backwards l n = BackwardsImpl (LastDim l) n
 
                     ----------------------------------------
 
+type family Init (xs :: [a]) :: [a] where
+  Init '[] = TypeError (Text "Init of empty list.")
+  Init (x ': '[]) = '[]
+  Init (x ': xs) = x ': Init xs
+
+type family Last (xs :: [a]) :: a where
+  Last '[] = TypeError (Text "Last of empty list.")
+  Last (x ': '[]) = x
+  Last (x ': xs) = Last xs
+
+type family InsertImpl (n :: Nat) (x :: a) (l :: [a]) :: Maybe [a] where
+  InsertImpl 0 x l = Just (x ': l)
+  InsertImpl n x '[] = Nothing
+  InsertImpl n x (h ': t) = AppendToMaybe h (InsertImpl (n - 1) x t)
+
+type family CheckInsert (n :: Nat) (x :: a) (l :: [a]) (result :: Maybe [a]):: [a] where
+  CheckInsert _ _ _ (Just xs) = xs
+  CheckInsert n x l Nothing = DimOutOfBound l n
+
+type family Insert (n :: Nat) (x :: a) (l :: [a]) :: [a] where
+  Insert n x l = CheckInsert n x l (InsertImpl n x l)
+
 type family RemoveImpl (l :: [a]) (n :: Nat) :: Maybe [a] where
   RemoveImpl (h ': t) 0 = Just t
   RemoveImpl (h ': t) n = AppendToMaybe h (RemoveImpl t (n - 1))

--- a/hasktorch/src/Torch/Typed/Functional.hs
+++ b/hasktorch/src/Torch/Typed/Functional.hs
@@ -2359,12 +2359,9 @@ diagflat tri t = unsafePerformIO $ ATen.cast2 ATen.Managed.diagflat_tl t $
     Upper -> natValI @index
     Lower -> - natValI @index
 
-type family DiagonalShapeImpl' (shape :: [Nat]) (l :: Nat) :: [Nat] where
-  DiagonalShapeImpl' shape l = shape ++ '[l]
-
 type family DiagonalShapeImpl (tri :: Tri) (index :: Nat) (shape :: [Nat]) (dim1 :: Nat) (dim2 :: Nat) :: [Nat] where
   DiagonalShapeImpl tri index shape dim1 dim2 =
-    DiagonalShapeImpl' (Remove (Remove shape dim2) dim1) (DiagSize tri index (Index shape dim1) (Index shape dim2))
+    Remove (Remove shape dim2) dim1 ++ '[DiagSize tri index (Index shape dim1) (Index shape dim2)]
 
 type family DiagonalShape (tri :: Tri) (index :: Nat) (dim1 :: Dim) (dim2 :: Dim) (shape :: [Nat]) :: [Nat] where
   DiagonalShape tri index dim1 dim2 shape = DiagonalShapeImpl tri index shape (UnDim shape dim1) (UnDim shape dim2)

--- a/hasktorch/src/Torch/Typed/Functional.hs
+++ b/hasktorch/src/Torch/Typed/Functional.hs
@@ -2303,15 +2303,16 @@ type family UnDim (shape :: [Nat]) (dim :: Dim) :: Nat where
 type family CmpDim (shape :: [Nat]) (dim :: Dim) (dim' :: Dim) :: Ordering where
   CmpDim shape dim dim' = CmpNat (UnDim shape dim) (UnDim shape dim')
 
-type family DiagEmbedShapeImpl' (shape :: [Nat]) (n :: Nat) (dim1 :: Nat) (dim2 :: Nat) :: [Nat] where
-  DiagEmbedShapeImpl' shape n dim1 dim2 = Insert dim1 n (Insert (dim2 - 1) n (Init shape))
+type family DiagEmbedShapeImpl' (shape :: [Nat]) (dim1 :: Nat) (dim2 :: Nat) (n :: Nat) :: [Nat] where
+  DiagEmbedShapeImpl' shape dim1 dim2 n = Insert dim1 n (Insert (dim2 - 1) n (Init shape))
 
-type family DiagEmbedShapeImpl (dim1 :: Dim) (dim2 :: Dim) (shape :: [Nat]) (n :: Nat) (outdims :: Nat) :: [Nat] where
-  DiagEmbedShapeImpl dim1 dim2 shape n outdims = DiagEmbedShapeImpl' shape n (UnDimImpl dim1 outdims) (UnDimImpl dim2 outdims)
+type family DiagEmbedShapeImpl (index :: Nat) (dim1 :: Dim) (dim2 :: Dim) (shape :: [Nat]) (outdims :: Nat) :: [Nat] where
+  DiagEmbedShapeImpl index dim1 dim2 shape outdims =
+    DiagEmbedShapeImpl' shape (UnDimImpl dim1 outdims) (UnDimImpl dim2 outdims) (Last shape + index)
 
 type family DiagEmbedShape (index :: Nat) (dim1 :: Dim) (dim2 :: Dim) (shape :: [Nat]) :: [Nat] where
   DiagEmbedShape index dim1 dim2 shape =
-    DiagEmbedShapeImpl dim1 dim2 shape (Last shape + index) (ListLength shape + 1)
+    DiagEmbedShapeImpl index dim1 dim2 shape (ListLength shape + 1)
 
 -- diag_embed :: Tensor device dtype shape -> Int -> Int -> Int -> Tensor device dtype shape
 -- diag_embed _input _offset _dim1 _dim2 = unsafePerformIO $ (ATen.cast4 ATen.Managed.diag_embed_tlll) _input _offset _dim1 _dim2

--- a/hasktorch/src/Torch/Typed/Functional.hs
+++ b/hasktorch/src/Torch/Typed/Functional.hs
@@ -1244,7 +1244,7 @@ type family DiagShape (tri :: Tri) (index :: Nat) (shape :: [Nat]) :: [Nat] wher
 -- >>> dtype &&& shape $ diag @'Lower @1 (ones :: CPUTensor 'D.Float '[3,2])
 -- (Float,[2])
 diag
-  :: forall (tri :: Tri) (index :: Nat) (shape :: [Nat]) (shape' :: [Nat]) device dtype
+  :: forall tri index shape shape' device dtype
    . ( KnownTri tri
      , KnownNat index
      , StandardDTypeValidation device dtype

--- a/hasktorch/src/Torch/Typed/Functional.hs
+++ b/hasktorch/src/Torch/Typed/Functional.hs
@@ -2354,16 +2354,11 @@ diagEmbed tri t =
       (dimVal @dim1)
       (dimVal @dim2)
 
--- TODO: elimate or move to 'Torch.Typed.Aux'
-type family NatProd (ns :: [Nat]) :: Nat where
-  NatProd '[] = 1
-  NatProd (n ': ns) = n * NatProd ns
-
 type family DiagflatShapeImpl (d :: Nat) :: [Nat] where
   DiagflatShapeImpl d = '[d, d]
 
 type family DiagflatShape (index :: Nat) (shape :: [Nat]) :: [Nat] where
-  DiagflatShape index shape = DiagflatShapeImpl (NatProd shape + index)
+  DiagflatShape index shape = DiagflatShapeImpl (Numel shape + index)
 
 -- diagflat :: Tensor device dtype shape -> Int -> Tensor device dtype shape
 -- diagflat _input _offset = unsafePerformIO $ (ATen.cast2 ATen.Managed.diagflat_tl) _input _offset

--- a/hasktorch/src/Torch/Typed/Functional.hs
+++ b/hasktorch/src/Torch/Typed/Functional.hs
@@ -2284,17 +2284,17 @@ instance (KnownNat n) => KnownDim (NDim n) where
 
 -- TODO: eliminate or move to 'Torch.Typed.Aux': UnDim, CmpDim, Drop, Take, Last
 -- TODO: maybe generalize 'DimOutOfBound' and use here?
-type family UnDimImpl (dim :: Dim) (last :: Nat) :: Nat where
+type family UnDimImpl (dim :: Dim) (ndims :: Nat) :: Nat where
   UnDimImpl (PDim dim) _  = dim
-  UnDimImpl (NDim dim) last =
+  UnDimImpl (NDim dim) ndims =
     If
-      (dim <=? last)
-      (last - dim)
+      (dim <=? ndims)
+      (ndims - dim)
       (TypeError
         (Text "Out of bound dimension: -"
           :<>: ShowType dim
           :<>: Text " (the tensor is only "
-          :<>: ShowType last
+          :<>: ShowType ndims
           :<>: Text "D)"))
 
 type family UnDim (shape :: [Nat]) (dim :: Dim) :: Nat where

--- a/hasktorch/src/Torch/Typed/Functional.hs
+++ b/hasktorch/src/Torch/Typed/Functional.hs
@@ -1200,8 +1200,8 @@ instance KnownTri Upper where
 instance KnownTri Lower where
   triVal = Lower
 
-type family DiagLength (tri :: Tri) (index :: Nat) (m :: Nat) (n :: Nat) :: Nat where
-  DiagLength 'Upper i m n =
+type family DiagSize (tri :: Tri) (index :: Nat) (m :: Nat) (n :: Nat) :: Nat where
+  DiagSize 'Upper i m n =
     If
       (i <=? n)
       (Min m (n - i))
@@ -1214,7 +1214,7 @@ type family DiagLength (tri :: Tri) (index :: Nat) (m :: Nat) (n :: Nat) :: Nat 
               :<>: ShowType i
           )
       )
-  DiagLength 'Lower i m n =
+  DiagSize 'Lower i m n =
     If
       (i <=? m)
       (Min (m - i) n)
@@ -1230,7 +1230,7 @@ type family DiagLength (tri :: Tri) (index :: Nat) (m :: Nat) (n :: Nat) :: Nat 
 
 type family DiagShape (tri :: Tri) (index :: Nat) (shape :: [Nat]) :: [Nat] where
   DiagShape _ i '[n] = '[n + i, n + i]
-  DiagShape tri i '[m, n] = '[DiagLength tri i m n]
+  DiagShape tri i '[m, n] = '[DiagSize tri i m n]
   DiagShape _ _ shape =
     TypeError
       ( Text "The input must be a matrix or a vector, but it has "
@@ -2364,7 +2364,7 @@ type family DiagonalShapeImpl' (shape :: [Nat]) (l :: Nat) :: [Nat] where
 
 type family DiagonalShapeImpl (tri :: Tri) (index :: Nat) (shape :: [Nat]) (dim1 :: Nat) (dim2 :: Nat) :: [Nat] where
   DiagonalShapeImpl tri index shape dim1 dim2 =
-    DiagonalShapeImpl' (Remove (Remove shape dim2) dim1) (DiagLength tri index (Index shape dim1) (Index shape dim2))
+    DiagonalShapeImpl' (Remove (Remove shape dim2) dim1) (DiagSize tri index (Index shape dim1) (Index shape dim2))
 
 type family DiagonalShape (tri :: Tri) (index :: Nat) (dim1 :: Dim) (dim2 :: Dim) (shape :: [Nat]) :: [Nat] where
   DiagonalShape tri index dim1 dim2 shape = DiagonalShapeImpl tri index shape (UnDim shape dim1) (UnDim shape dim2)

--- a/hasktorch/src/Torch/Typed/Functional.hs
+++ b/hasktorch/src/Torch/Typed/Functional.hs
@@ -2291,7 +2291,7 @@ type family DiagEmbedShape (index :: Nat) (dim1 :: Nat) (dim2 :: Nat) (shape :: 
 
 -- | diagEmbed
 --
--- >>> dtype &&& shape $ diagEmbed @0 @0 @1 Upper (ones :: CPUTensor 'D.Float '[2,3])
+-- >>> dtype &&& shape $ diagEmbed @0 @1 @2 Upper (ones :: CPUTensor 'D.Float '[2,3])
 -- (Float,[2,3,3])
 -- >>> dtype &&& shape $ diagEmbed @1 @0 @2 Upper (ones :: CPUTensor 'D.Float '[2,3])
 -- (Float,[4,2,4])

--- a/hasktorch/src/Torch/Typed/Functional.hs
+++ b/hasktorch/src/Torch/Typed/Functional.hs
@@ -2300,7 +2300,7 @@ type family UnDimImpl (dim :: Dim) (last :: Nat) :: Nat where
 type family UnDim (shape :: [Nat]) (dim :: Dim) :: Nat where
   UnDim shape dim = UnDimImpl dim (ListLength shape)
 
-type family CmpDim (shape :: [Nat]) (dim :: Dim) (dim' :: Dim) where
+type family CmpDim (shape :: [Nat]) (dim :: Dim) (dim' :: Dim) :: Ordering where
   CmpDim shape dim dim' = CmpNat (UnDim shape dim) (UnDim shape dim')
 
 type family Drop (n :: Nat) (xs :: [a]) :: [a] where

--- a/hasktorch/src/Torch/Typed/Functional.hs
+++ b/hasktorch/src/Torch/Typed/Functional.hs
@@ -2330,8 +2330,12 @@ type family DiagEmbedShape (index :: Nat) (dim1 :: Dim) (dim2 :: Dim) (shape :: 
   DiagEmbedShape index dim1 dim2 shape =
     DiagEmbedShapeImpl index dim1 dim2 shape (ListLength shape + 1)
 
--- diag_embed :: Tensor device dtype shape -> Int -> Int -> Int -> Tensor device dtype shape
--- diag_embed _input _offset _dim1 _dim2 = unsafePerformIO $ (ATen.cast4 ATen.Managed.diag_embed_tlll) _input _offset _dim1 _dim2
+-- | diagEmbed
+--
+-- >>> dtype &&& shape $ diagEmbed @0 @('NDim 2) @('NDim 1) Upper (ones :: CPUTensor 'D.Float '[2,3])
+-- (Float,[2,3,3])
+-- >>> dtype &&& shape $ diagEmbed @1 @('PDim 0) @('PDim 2) Upper (ones :: CPUTensor 'D.Float '[2,3])
+-- (Float,[4,2,4])
 diagEmbed
   :: forall index dim1 dim2 shape shape' device dtype
    . ( KnownNat index
@@ -2359,8 +2363,14 @@ type family DiagflatShapeImpl (d :: Nat) :: [Nat] where
 type family DiagflatShape (index :: Nat) (shape :: [Nat]) :: [Nat] where
   DiagflatShape index shape = DiagflatShapeImpl (Numel shape + index)
 
--- diagflat :: Tensor device dtype shape -> Int -> Tensor device dtype shape
--- diagflat _input _offset = unsafePerformIO $ (ATen.cast2 ATen.Managed.diagflat_tl) _input _offset
+-- | diagflat
+--
+-- >>> dtype &&& shape $ diagflat @0 Upper (ones :: CPUTensor 'D.Float '[3])
+-- (Float,[3,3])
+-- >>> dtype &&& shape $ diagflat @1 Upper (ones :: CPUTensor 'D.Float '[3])
+-- (Float,[4,4])
+-- >>> dtype &&& shape $ diagflat @0 Upper (ones :: CPUTensor 'D.Float '[2,2])
+-- (Float,[4,4])
 diagflat
   :: forall index shape shape' device dtype
    . ( KnownNat index
@@ -2395,8 +2405,14 @@ type family DiagonalShapeImpl (tri :: Tri) (index :: Nat) (shape :: [Nat]) (dim1
 type family DiagonalShape (tri :: Tri) (index :: Nat) (dim1 :: Dim) (dim2 :: Dim) (shape :: [Nat]) :: [Nat] where
   DiagonalShape tri index dim1 dim2 shape = DiagonalShapeImpl tri index shape (UnDim shape dim1) (UnDim shape dim2)
 
--- diagonal :: Tensor device dtype shape -> Int -> Int -> Int -> Tensor device dtype shape
--- diagonal _input _offset _dim1 _dim2 = unsafePerformIO $ (ATen.cast4 ATen.Managed.diagonal_tlll) _input _offset _dim1 _dim2
+-- | diagonal
+--
+-- >>> dtype &&& shape $ diagonal @'Upper @0 @('NDim 2) @('NDim 1) (ones :: CPUTensor 'D.Float '[3,3])
+-- (Float,[3])
+-- >>> dtype &&& shape $ diagonal @'Upper @1 @('NDim 2) @('NDim 1) (ones :: CPUTensor 'D.Float '[3,3])
+-- (Float,[2])
+-- >>> dtype &&& shape $ diagonal @'Lower @1 @('PDim 1) @('PDim 2) (ones :: CPUTensor 'D.Float '[2,5,4,2])
+-- (Float,[2,2,4])
 diagonal
   :: forall tri index dim1 dim2 shape shape' device dtype
    . ( KnownTri tri

--- a/hasktorch/src/Torch/Typed/Functional.hs
+++ b/hasktorch/src/Torch/Typed/Functional.hs
@@ -2282,7 +2282,7 @@ instance (KnownNat n) => KnownDim (PDim n) where
 instance (KnownNat n) => KnownDim (NDim n) where
   dimVal = - natValI @n
 
--- TODO: eliminate or move to 'Torch.Typed.Aux': UnDim, CmpDim, Last
+-- TODO: eliminate or move to 'Torch.Typed.Aux': UnDim, CmpDim
 -- TODO: maybe generalize 'DimOutOfBound' and use here?
 type family UnDimImpl (dim :: Dim) (ndims :: Nat) :: Nat where
   UnDimImpl (PDim dim) _  = dim

--- a/hasktorch/src/Torch/Typed/Functional.hs
+++ b/hasktorch/src/Torch/Typed/Functional.hs
@@ -2270,21 +2270,18 @@ det
   -> Tensor device dtype (Det shape) -- ^ output
 det input = unsafePerformIO $ ATen.cast1 ATen.Managed.det_t input
 
-type family DimsDistinctAscendingCheck (shape :: [Nat]) (dim1 :: Nat) (dim2 :: Nat) (cmp :: Ordering) :: Constraint where
-  DimsDistinctAscendingCheck _ _ _ 'LT = ()
-  DimsDistinctAscendingCheck shape dim1 dim2 _ =
+type family DimsDistinctAscendingCheck (dim1 :: Nat) (dim2 :: Nat) (cmp :: Ordering) :: Constraint where
+  DimsDistinctAscendingCheck _ _ 'LT = ()
+  DimsDistinctAscendingCheck dim1 dim2 _ =
     TypeError
     ( Text "Dimensions must be distinct and in ascending order, but got "
         :<>: ShowType dim1
         :<>: Text ", "
         :<>: ShowType dim2
-        :<>: Text " for "
-        :<>: ShowType (ListLength shape)
-        :<>: Text "D tensor."
     )
 
-type family DimsDistinctAscending (shape :: [Nat]) (dim1 :: Nat) (dim2 :: Nat) :: Constraint where
-  DimsDistinctAscending shape dim1 dim2 = DimsDistinctAscendingCheck shape dim1 dim2 (CmpNat dim1 dim2)
+type family DimsDistinctAscending (dim1 :: Nat) (dim2 :: Nat) :: Constraint where
+  DimsDistinctAscending dim1 dim2 = DimsDistinctAscendingCheck dim1 dim2 (CmpNat dim1 dim2)
 
 type family DiagEmbedShapeImpl (dim1 :: Nat) (dim2 :: Nat) (shape :: [Nat]) (n :: Nat) :: [Nat] where
   DiagEmbedShapeImpl dim1 dim2 shape n = Insert dim1 n (Insert (dim2 - 1) n (Init shape))
@@ -2304,7 +2301,7 @@ diagEmbed
      , KnownNat dim1
      , KnownNat dim2
      , shape' ~ DiagEmbedShape index dim1 dim2 shape
-     , DimsDistinctAscending shape' dim1 dim2
+     , DimsDistinctAscending dim1 dim2
      , StandardDTypeValidation device dtype
      )
   => Tri
@@ -2379,7 +2376,7 @@ diagonal
      , KnownNat dim1
      , KnownNat dim2
      , NDimAtLeast 2 shape
-     , DimsDistinctAscending shape dim1 dim2
+     , DimsDistinctAscending dim1 dim2
      , shape' ~ DiagonalShape tri index dim1 dim2 shape
      , StandardDTypeValidation device dtype
      )

--- a/hasktorch/src/Torch/Typed/Functional.hs
+++ b/hasktorch/src/Torch/Typed/Functional.hs
@@ -2303,16 +2303,6 @@ type family UnDim (shape :: [Nat]) (dim :: Dim) :: Nat where
 type family CmpDim (shape :: [Nat]) (dim :: Dim) (dim' :: Dim) :: Ordering where
   CmpDim shape dim dim' = CmpNat (UnDim shape dim) (UnDim shape dim')
 
-type family Init (xs :: [a]) :: [a] where
-  Init '[] = TypeError (Text "Init of empty list.")
-  Init (x ': '[]) = '[]
-  Init (x ': xs) = x ': Init xs
-
-type family Last (xs :: [a]) :: a where
-  Last '[] = TypeError (Text "Last of empty list.")
-  Last (x ': '[]) = x
-  Last (x ': xs) = Last xs
-
 type family DiagEmbedShapeImpl' (shape :: [Nat]) (n :: Nat) (dim1 :: Nat) (dim2 :: Nat) :: [Nat] where
   DiagEmbedShapeImpl' shape n dim1 dim2 = Insert dim1 n (Insert (dim2 - 1) n (Init shape))
 

--- a/hasktorch/test/Torch/Typed/FunctionalSpec.hs
+++ b/hasktorch/test/Torch/Typed/FunctionalSpec.hs
@@ -780,7 +780,7 @@ instance
   , KnownNat index
   , KnownDim dim1
   , KnownDim dim2
-  , 2 <= ListLength shape
+  , NDimAtLeast 2 shape
   , DimsDistinctAscending shape dim1 dim2
   , shape' ~ DiagonalShape tri index dim1 dim2 shape
   , StandardDTypeValidation device dtype
@@ -1139,7 +1139,7 @@ spec' device =
       it "diagonal" $ do
         let shapes1 = Proxy @'[2, 5, 4, 2] :. HNil
             shapes2 = Proxy @'[2, 3] :. shapes1
-            allShapes =  Proxy @'[0, 0] :. Proxy @'[0, 1] :. Proxy @'[1, 0] :. Proxy @'[2, 3] :. shapes2
+            allShapes =  Proxy @'[1, 0] :. Proxy @'[0, 1] :. Proxy @'[1, 0] :. Proxy @'[2, 3] :. shapes2
             tris = Proxy @'Upper :. Proxy @'Lower :. HNil
             indexes = Proxy @0 :. HNil
             allIndexes = Proxy @1 :. indexes

--- a/hasktorch/test/Torch/Typed/FunctionalSpec.hs
+++ b/hasktorch/test/Torch/Typed/FunctionalSpec.hs
@@ -1100,23 +1100,24 @@ spec' device =
             hfoldrM @IO DiagSpec () (hproduct (hproduct tris indexes') (hattach cuda0 (hproduct (withHalf standardDTypes) emptyShapes)))
       it "diagEmbed" $ do
         let shapes =
-              Proxy @'[0]
-                :. Proxy @'[1]
-                :. Proxy @'[2]
-                :. Proxy @'[0, 0]
-                :. Proxy @'[0, 1]
-                :. Proxy @'[1, 0]
-                :. HNil
-            allShapes = standardShapes `happend` shapes
+              standardShapes
+                `happend` ( Proxy @'[0]
+                              :. Proxy @'[1]
+                              :. Proxy @'[2]
+                              :. Proxy @'[0, 0]
+                              :. Proxy @'[0, 1]
+                              :. Proxy @'[1, 0]
+                              :. HNil
+                          )
             indexes = Proxy @0 :. Proxy @1 :. HNil
             dims = (Proxy @('NDim 2), Proxy @('NDim 1)) :. HNil
             allDims = (Proxy @('PDim 0), Proxy @('PDim 2)) :. dims
         case device of
-          Device { deviceType = CPU,  deviceIndex = 0 } -> do
-            hfoldrM @IO DiagEmbedSpec () (hproduct (hproduct indexes dims)    (hattach cpu   (hproduct standardDTypes allShapes)))
+          Device {deviceType = CPU, deviceIndex = 0} -> do
+            hfoldrM @IO DiagEmbedSpec () (hproduct (hproduct indexes dims)    (hattach cpu   (hproduct standardDTypes shapes)))
             hfoldrM @IO DiagEmbedSpec () (hproduct (hproduct indexes allDims) (hattach cpu   (hproduct standardDTypes standardShapes)))
-          Device { deviceType = CUDA, deviceIndex = 0 } -> do
-            hfoldrM @IO DiagEmbedSpec () (hproduct (hproduct indexes dims)    (hattach cuda0 (hproduct (withHalf standardDTypes) allShapes)))
+          Device {deviceType = CUDA, deviceIndex = 0} -> do
+            hfoldrM @IO DiagEmbedSpec () (hproduct (hproduct indexes dims)    (hattach cuda0 (hproduct (withHalf standardDTypes) shapes)))
             hfoldrM @IO DiagEmbedSpec () (hproduct (hproduct indexes allDims) (hattach cuda0 (hproduct (withHalf standardDTypes) standardShapes)))
       it "diagflat" $ do
         let shapes =

--- a/hasktorch/test/Torch/Typed/FunctionalSpec.hs
+++ b/hasktorch/test/Torch/Typed/FunctionalSpec.hs
@@ -781,7 +781,7 @@ instance
   , KnownDim dim1
   , KnownDim dim2
   , 2 <= ListLength shape
-  , CmpDim shape dim1 dim2 ~ 'LT
+  , DimsDistinctAscending shape' dim1 dim2
   , shape' ~ DiagonalShape tri index dim1 dim2 shape
   , StandardDTypeValidation device dtype
   ) => Apply' DiagonalSpec (((Proxy tri, (Proxy index, (Proxy dim1, Proxy dim2))), (Proxy device, (Proxy dtype, Proxy shape))), IO ()) (IO ()) where

--- a/hasktorch/test/Torch/Typed/FunctionalSpec.hs
+++ b/hasktorch/test/Torch/Typed/FunctionalSpec.hs
@@ -771,6 +771,24 @@ instance
       (\tri -> checkDynamicTensorAttributes $ diagflat @index tri t)
       [Upper, Lower]
 
+data DiagonalSpec = DiagonalSpec
+
+instance
+  ( TensorOptions shape dtype device
+  , TensorOptions shape' dtype device
+  , KnownTri tri
+  , KnownNat index
+  , KnownDim dim1
+  , KnownDim dim2
+  , 2 <= ListLength shape
+  , CmpDim shape dim1 dim2 ~ 'LT
+  , shape' ~ DiagonalShape tri index dim1 dim2 shape
+  , StandardDTypeValidation device dtype
+  ) => Apply' DiagonalSpec (((Proxy tri, (Proxy index, (Proxy dim1, Proxy dim2))), (Proxy device, (Proxy dtype, Proxy shape))), IO ()) (IO ()) where
+  apply' DiagonalSpec (_, agg) = agg >> do
+    let t = ones @shape @dtype @device
+    checkDynamicTensorAttributes $ diagonal @tri @index @dim1 @dim2 t
+
 data AnyAllSpec = AnySpec | AllSpec
 
 instance
@@ -1117,6 +1135,24 @@ spec' device =
             hfoldrM @IO DiagflatSpec () (hproduct indexes (hattach cpu   (hproduct standardDTypes shapes)))
           Device { deviceType = CUDA, deviceIndex = 0 } -> do
             hfoldrM @IO DiagflatSpec () (hproduct indexes (hattach cuda0 (hproduct (withHalf standardDTypes) shapes)))
+      it "diagonal" $ do
+        let shapes1 = Proxy @'[2, 5, 4, 2] :. HNil
+            shapes2 = Proxy @'[2, 3] :. shapes1
+            allShapes =  Proxy @'[0, 0] :. Proxy @'[0, 1] :. Proxy @'[1, 0] :. Proxy @'[2, 3] :. shapes2
+            tris = Proxy @'Upper :. Proxy @'Lower :. HNil
+            indexes = Proxy @0 :. HNil
+            allIndexes = Proxy @1 :. indexes
+            dims = (Proxy @('NDim 2), Proxy @('NDim 1)) :. HNil
+            allDims = (Proxy @('PDim 0), Proxy @('PDim 2)) :. dims
+        case device of
+          Device { deviceType = CPU,  deviceIndex = 0 } -> do
+            hfoldrM @IO DiagonalSpec () (hproduct (hproduct tris (hproduct indexes dims))       (hattach cpu   (hproduct standardDTypes allShapes)))
+            hfoldrM @IO DiagonalSpec () (hproduct (hproduct tris (hproduct allIndexes allDims)) (hattach cpu   (hproduct standardDTypes shapes1)))
+            hfoldrM @IO DiagonalSpec () (hproduct (hproduct tris (hproduct allIndexes dims))    (hattach cpu   (hproduct standardDTypes shapes2)))
+          Device { deviceType = CUDA, deviceIndex = 0 } -> do
+            hfoldrM @IO DiagonalSpec () (hproduct (hproduct tris (hproduct indexes dims))       (hattach cuda0 (hproduct (withHalf standardDTypes) allShapes)))
+            hfoldrM @IO DiagonalSpec () (hproduct (hproduct tris (hproduct allIndexes allDims)) (hattach cuda0 (hproduct (withHalf standardDTypes) shapes1)))
+            hfoldrM @IO DiagonalSpec () (hproduct (hproduct tris (hproduct allIndexes dims))    (hattach cuda0 (hproduct (withHalf standardDTypes) shapes2)))
 
     describe "loss functions" $ do
       let dispatch lossSpec = case device of

--- a/hasktorch/test/Torch/Typed/FunctionalSpec.hs
+++ b/hasktorch/test/Torch/Typed/FunctionalSpec.hs
@@ -744,8 +744,8 @@ instance
   ( TensorOptions shape dtype device
   , TensorOptions shape' dtype device
   , KnownNat index
-  , KnownDim dim1
-  , KnownDim dim2
+  , KnownNat dim1
+  , KnownNat dim2
   , DimsDistinctAscending shape' dim1 dim2
   , shape' ~ DiagEmbedShape index dim1 dim2 shape
   , StandardDTypeValidation device dtype
@@ -778,8 +778,8 @@ instance
   , TensorOptions shape' dtype device
   , KnownTri tri
   , KnownNat index
-  , KnownDim dim1
-  , KnownDim dim2
+  , KnownNat dim1
+  , KnownNat dim2
   , NDimAtLeast 2 shape
   , DimsDistinctAscending shape dim1 dim2
   , shape' ~ DiagonalShape tri index dim1 dim2 shape
@@ -1110,8 +1110,8 @@ spec' device =
                               :. HNil
                           )
             indexes = Proxy @0 :. Proxy @1 :. HNil
-            dims = (Proxy @('NDim 2), Proxy @('NDim 1)) :. HNil
-            allDims = (Proxy @('PDim 0), Proxy @('PDim 2)) :. dims
+            dims = (Proxy @0, Proxy @1) :. HNil
+            allDims = (Proxy @0, Proxy @2) :. dims
         case device of
           Device {deviceType = CPU, deviceIndex = 0} -> do
             hfoldrM @IO DiagEmbedSpec () (hproduct (hproduct indexes dims)    (hattach cpu   (hproduct standardDTypes shapes)))
@@ -1143,8 +1143,8 @@ spec' device =
             tris = Proxy @'Upper :. Proxy @'Lower :. HNil
             indexes = Proxy @0 :. HNil
             allIndexes = Proxy @1 :. indexes
-            dims = (Proxy @('NDim 2), Proxy @('NDim 1)) :. HNil
-            allDims = (Proxy @('PDim 0), Proxy @('PDim 2)) :. dims
+            dims = (Proxy @0, Proxy @1) :. HNil
+            allDims = (Proxy @0, Proxy @2) :. dims
         case device of
           Device { deviceType = CPU,  deviceIndex = 0 } -> do
             hfoldrM @IO DiagonalSpec () (hproduct (hproduct tris (hproduct indexes dims))       (hattach cpu   (hproduct standardDTypes allShapes)))

--- a/hasktorch/test/Torch/Typed/FunctionalSpec.hs
+++ b/hasktorch/test/Torch/Typed/FunctionalSpec.hs
@@ -781,7 +781,7 @@ instance
   , KnownDim dim1
   , KnownDim dim2
   , 2 <= ListLength shape
-  , DimsDistinctAscending shape' dim1 dim2
+  , DimsDistinctAscending shape dim1 dim2
   , shape' ~ DiagonalShape tri index dim1 dim2 shape
   , StandardDTypeValidation device dtype
   ) => Apply' DiagonalSpec (((Proxy tri, (Proxy index, (Proxy dim1, Proxy dim2))), (Proxy device, (Proxy dtype, Proxy shape))), IO ()) (IO ()) where

--- a/hasktorch/test/Torch/Typed/FunctionalSpec.hs
+++ b/hasktorch/test/Torch/Typed/FunctionalSpec.hs
@@ -746,7 +746,7 @@ instance
   , KnownNat index
   , KnownNat dim1
   , KnownNat dim2
-  , DimsDistinctAscending shape' dim1 dim2
+  , DimsDistinctAscending dim1 dim2
   , shape' ~ DiagEmbedShape index dim1 dim2 shape
   , StandardDTypeValidation device dtype
   ) => Apply' DiagEmbedSpec (((Proxy index, (Proxy dim1, Proxy dim2)), (Proxy device, (Proxy dtype, Proxy shape))), IO ()) (IO ()) where
@@ -781,7 +781,7 @@ instance
   , KnownNat dim1
   , KnownNat dim2
   , NDimAtLeast 2 shape
-  , DimsDistinctAscending shape dim1 dim2
+  , DimsDistinctAscending dim1 dim2
   , shape' ~ DiagonalShape tri index dim1 dim2 shape
   , StandardDTypeValidation device dtype
   ) => Apply' DiagonalSpec (((Proxy tri, (Proxy index, (Proxy dim1, Proxy dim2))), (Proxy device, (Proxy dtype, Proxy shape))), IO ()) (IO ()) where

--- a/hasktorch/test/Torch/Typed/FunctionalSpec.hs
+++ b/hasktorch/test/Torch/Typed/FunctionalSpec.hs
@@ -746,7 +746,7 @@ instance
   , KnownNat index
   , KnownDim dim1
   , KnownDim dim2
-  , CmpDim shape' dim1 dim2 ~ 'LT
+  , DimsDistinctAscending shape' dim1 dim2
   , shape' ~ DiagEmbedShape index dim1 dim2 shape
   , StandardDTypeValidation device dtype
   ) => Apply' DiagEmbedSpec (((Proxy index, (Proxy dim1, Proxy dim2)), (Proxy device, (Proxy dtype, Proxy shape))), IO ()) (IO ()) where


### PR DESCRIPTION
This PR adds typed versions of [`diagEmbed`](https://pytorch.org/docs/stable/torch.html?highlight=diag_embed#torch.diag_embed), [`diagflat`](https://pytorch.org/docs/stable/torch.html?highlight=diagflat#torch.diagflat), and [`diagonal`](https://pytorch.org/docs/stable/torch.html?highlight=diagonal#torch.diagonal).

~~This also introduces a new type/kind for signed dimensions:~~
```haskell
data Dim = PDim Nat | NDim Nat
```
~~This is useful for example in `diag_embed`, where you often want to the diagonal embedded in the last 2 dimensions (the PyTorch defaults are -2, -1). In retrospect I'm not sure it's a good idea to introduce this in this PR, since it will create some inconsistency with other functions that don't support signed dims yet. I'm happy to defer judgement on this and possibly remove the signed dimensions / save for a future PR.~~

**EDIT**: I decided to remove the signed dimension type from this PR to cut down on the complexity. I think it'd make sense to revisit this in the future after some discussion about the best interface to support natural, negative, and named dimensions (for example the `DimLike` type class proposed by @junjihashimoto https://github.com/hasktorch/hasktorch/pull/417#discussion_r451541354)

#### TODO
- [x] Eliminate some of the general-purpose types / type families introduced in this PR, or move them to `Torch.Typed.Aux` or `Torch.Typed.Tensor`
  - ~`Dim`, `KnownDim`, `UnDim`, `UnDimImpl`, `CmpDim`~ (removed these)
  - ~`Drop`~, ~`Take`~, ~`Last`~
  - ~`NatProd`~
- [x] Improve error messages
  - ~checking `dim1` comes before `dim2`: `CmpDim shape dim1 dim2 ~ 'LT`~
  - ~checking that input is at least 2D: `2 <= ListLength shape`~
- [x] Add haddocks / doctests
- [x] ~Fix overloading of "NDim" as both "number of dimensions" and "negative dimension"~ (removed `NDim`)