### PR TITLE
Csv cleanup, Torch.Tensor fix

### DIFF
--- a/examples/iris-classification/README.md
+++ b/examples/iris-classification/README.md
@@ -1,0 +1,10 @@
+# Iris-classification 
+
+This is a simple example which showcases the use of csv data. 
+Run 
+`./setup_data.sh` 
+which creates a `./data` directory and downloads `iris.data` into it.
+After the data is downloaded you can run the example:
+
+`cabal run iris-classification`
+

--- a/examples/iris-classification/setup_data.sh
+++ b/examples/iris-classification/setup_data.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+mkdir data
+pushd data
+# wget http://yann.lecun.com/exdb/mnist/t10k-labels-idx1-ubyte.gz
+wget https://archive.ics.uci.edu/ml/machine-learning-databases/iris/iris.data
+popd

--- a/hasktorch/src/Torch/Data/CsvDataset.hs
+++ b/hasktorch/src/Torch/Data/CsvDataset.hs
@@ -82,17 +82,13 @@ csvDataset filePath  = CsvDataset { filePath = filePath
                                   , dropLast = True
                                   }
 
-instance ( MonadPlus m
-         , MonadBase IO m
-         , MonadBaseControl IO m
+instance ( MonadBaseControl IO m
          , Safe.MonadSafe m
          , FromRecord batch 
          ) => Datastream m () (CsvDataset' batch Unnamed) (Vector batch) where
   streamBatch csv@CsvDataset{..} _ = readCsv csv (decodeWith (defaultDecodeOptions { decDelimiter = delimiter }) hasHeader)
 
-instance ( MonadPlus m
-         , MonadBase IO m
-         , MonadBaseControl IO m
+instance ( MonadBaseControl IO m
          , Safe.MonadSafe m
          , FromNamedRecord batch
          ) => Datastream m () (CsvDataset' batch Named) (Vector batch) where

--- a/hasktorch/src/Torch/Data/StreamedPipeline.hs
+++ b/hasktorch/src/Torch/Data/StreamedPipeline.hs
@@ -22,6 +22,8 @@ module Torch.Data.StreamedPipeline
     Datastream (..),
     MonadBase (..),
     MonadBaseControl (..),
+    module Pipes,
+    module Pipes.Safe
   )
 where
 

--- a/hasktorch/src/Torch/Data/StreamedPipeline.hs
+++ b/hasktorch/src/Torch/Data/StreamedPipeline.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -45,7 +46,7 @@ import qualified Pipes.Safe as Safe
 import           Torch.Typed
 
 
-class (MonadBase IO m) => Datastream m seed dataset batch where
+class (MonadBase IO m) => Datastream m seed dataset batch | dataset -> batch where
   streamBatch :: dataset -> seed -> ListT m batch
 
 -- TODO : incorporate these options

--- a/hasktorch/src/Torch/Functional.hs
+++ b/hasktorch/src/Torch/Functional.hs
@@ -299,6 +299,14 @@ embedding' weights indices =
     unsafePerformIO $ (cast5 ATen.embedding_ttlbb)
         weights indices (-1 :: Int) False False
 
+-- | A one hot encoding of the given input. The encoding is based on the given number of
+-- classes.
+oneHot
+  :: Int -- ^ number of classes
+  -> Tensor -- ^ input
+  -> Tensor -- ^ 
+oneHot numClasses t = unsafePerformIO $ (cast2 ATen.one_hot_tl) t numClasses
+
 --
 -- element-wise transformations / non-linearities
 --

--- a/hasktorch/src/Torch/Tensor.hs
+++ b/hasktorch/src/Torch/Tensor.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DefaultSignatures #-}
-{-# LANGUAGE IncoherentInstances #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE TypeSynonymInstances #-}

--- a/hasktorch/test/Torch/Typed/OptimSpec.hs
+++ b/hasktorch/test/Torch/Typed/OptimSpec.hs
@@ -259,13 +259,8 @@ instance
         learningRate = 0.002
         numIter      = 15000
     (model, _optim) <- optimize initModel' initOptim loss learningRate numIter
-    -- print "GD Rosen"
-    -- print $ cat @0 . hmap' ToDependent . flattenParameters $ model
     let close =  isclose 1e-01 1e-01 False (cat @0 . hmap' ToDependent . flattenParameters $ model) ones
-    -- print close
-    -- print $ (toList . Just) close
     (toList . Just) close `shouldBe` [True,True]
-    -- (toList . Just) (isclose 1 1 False (cat @0 . hmap' ToDependent . flattenParameters $ model) ones) `shouldBe` [True, True]
     isNonZero (isclose 1e-04 1e-04 False (loss model) zeros) `shouldBe` True
   apply' GDMRosenbrockSpec (_, agg) = agg >> do
     manual_seed_L 123
@@ -278,13 +273,8 @@ instance
         learningRate = 0.001
         numIter      = 10000
     (model, _optim) <- optimize initModel' initOptim loss learningRate numIter
-    -- print "GDM Rosen"
-    print $ cat @0 . hmap' ToDependent . flattenParameters $ model
     let close =  (isclose 1e-01 1e-01 False (cat @0 . hmap' ToDependent . flattenParameters $ model) ones)
-    -- print close
-    -- print $ (toList . Just) close
     (toList . Just) close `shouldBe` [True,True]
-    -- (toList . Just) (isclose 1 1 False (cat @0 . hmap' ToDependent . flattenParameters $ model) ones) `shouldBe` [True, True]
     isNonZero (isclose 1e-04 1e-04 False (loss model) zeros) `shouldBe` True
   apply' AdamRosenbrockSpec (_, agg) = agg >> do
     manual_seed_L 123
@@ -297,13 +287,8 @@ instance
         learningRate = 0.005
         numIter      = 5000
     (model, _optim) <- optimize initModel' initOptim loss learningRate numIter
-    -- print "Adam Rosen"
-    -- print $ cat @0 . hmap' ToDependent . flattenParameters $ model
     let close =  (isclose 1e-02 1e-02 False (cat @0 . hmap' ToDependent . flattenParameters $ model) ones)
-    -- print close
-    -- print this
     (toList . Just) close `shouldBe` [True, True]
-    -- (toList . Just) (isclose 1e-01 1e-01 False (cat @0 . hmap' ToDependent . flattenParameters $ model) ones) `shouldBe` [True, True]
     isNonZero (isclose 1e-04 1e-04 False (loss model) zeros) `shouldBe` True
 
 data OptimAckleySpec = GDAckleySpec | GDMAckleySpec | AdamAckleySpec
@@ -329,14 +314,8 @@ instance
         numIter      = 5000
     (model, _optim) <- optimize initModel' initOptim loss learningRate numIter
     let finalLoss = loss model
-    -- print "GD Ackley"
-    -- print $ cat @0 . hmap' ToDependent . flattenParameters $ model
-
     let close =  isclose 1e-03 1e-03 False (cat @0 . hmap' ToDependent . flattenParameters $ model) zeros
-    -- print close
-    -- print this
     (toList . Just) close `shouldBe` [True, True]
-    -- (toList . Just) (isclose 1e-01 1e-01 False (cat @0 . hmap' ToDependent . flattenParameters $ model) zeros) `shouldBe` [True, True]
     isNonZero (isclose 1e-04 1e-04 False (loss model) zeros) `shouldBe` True
   apply' GDMAckleySpec (_, agg) = agg >> do
     manual_seed_L 123
@@ -351,8 +330,6 @@ instance
         numIter      = 5000
     (model, _optim) <- optimize initModel' initOptim loss learningRate numIter
     let finalLoss = loss model
-    -- print "GDM Ackley"
-    -- print $ cat @0 . hmap' ToDependent . flattenParameters $ model
     let close =  isclose 1e-03 1e-03 False (cat @0 . hmap' ToDependent . flattenParameters $ model) zeros
     (toList . Just) close `shouldBe` [True, True]
     isNonZero (isclose 1e-04 1e-04 False (loss model) zeros) `shouldBe` True
@@ -369,18 +346,11 @@ instance
         numIter      = 2000
     (model, _optim) <- optimize initModel' initOptim loss learningRate numIter
     let finalLoss = loss model
-    -- print "Adam Ackley"
-    -- print $ cat @0 . hmap' ToDependent . flattenParameters $ model
     let close =  isclose 1e-03 1e-03 False (cat @0 . hmap' ToDependent . flattenParameters $ model) zeros
-    -- print close
-    -- print $ (toList . Just) close
     (toList . Just) close `shouldBe` [True,True]
-    -- (toList . Just) (isclose 1e-01 1e-01 False (cat @0 . hmap' ToDependent . flattenParameters $ model) zeros) `shouldBe` [True, True]
     isNonZero (isclose 1e-04 1e-04 False (loss model) zeros) `shouldBe` True
 
 spec = foldMap spec' availableDevices
-
--- testThis = (toList . Just) (isclose 1e-04 1e-04 False (1e-5 * ones :: CPUTensor 'Float '[2]) zeros) == [True, True]
 
 spec' :: Device -> Spec
 spec' device = describe ("for " <> show device) $ do


### PR DESCRIPTION
- [x] Makes some small fixes to the csv dataset which makes the constraints more usable.
- [x] Removes the IncoherentInstances extension from Torch.Tensor that I accidently added in my previous pr (this fixes Austin's 
      regularization example). 
- [x] Add a functional dependency to datastream.