### PR TITLE
Change get-deps.sh to brew-install

### DIFF
--- a/.github/workflows/stack-macos.yaml
+++ b/.github/workflows/stack-macos.yaml
@@ -19,14 +19,16 @@ jobs:
         wget -qO- https://get.haskellstack.org/ | sh || true
         clang --version
         stack --version
-        pushd deps/ ; ./get-deps.sh -a cpu -c ;popd 
+        brew tap hasktorch/libtorch-prebuild https://github.com/hasktorch/homebrew-libtorch-prebuild || true
+        brew install libtorch-prebuild || true
+        #pushd deps/ ; ./get-deps.sh -a cpu -c ;popd
     - name: Build
       run: |
-        . setenv
+        #. setenv
         stack build
     - name: Test
       run: |
-        . setenv
+        #. setenv
         stack test codegen
         stack test libtorch-ffi
         stack test hasktorch


### PR DESCRIPTION
This PR changes get-deps.sh to brew-install for macos.
When we use this, we do not have to set extra library settings like `DYLD_LIBRARY_PATH`.