### PR TITLE
Remove pytorch-repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "deps/pytorch"]
-	path = deps/pytorch
-	url = https://github.com/pytorch/pytorch.git

--- a/deps/get-deps.sh
+++ b/deps/get-deps.sh
@@ -113,7 +113,13 @@ fi
 # Generate ATen files.
 
 echo "Generate ATen files."
+
+if [ ! -e pytorch ] ; then
+    git clone https://github.com/pytorch/pytorch.git
+fi
+
 pushd pytorch
+git checkout v1.6.0
 
 if [[ ! -d build ]]; then
 mkdir build


### PR DESCRIPTION
For stack's bug, hasktorch's repo can not be cloned on stack.
We already have the bug-fix on the master branch of stack, but I'm not sure when it will be released.
This PR stops the pytorch submodule and embeds the tag used in get-deps.sh.