### PR TITLE
Revert "add temp CI job to test syspolicy impact"

### DIFF
--- a/.github/workflows/nix-macos.yml
+++ b/.github/workflows/nix-macos.yml
@@ -29,21 +29,3 @@ jobs:
           nix-build -j 2 -A haskellPackages.libtorch-ffi.checks.spec
           nix-build -j 1 -A haskellPackages.hasktorch.checks.spec
           nix-build -j 1 -A haskellPackages.examples.checks.spec
-  macos_perf_test:
-    runs-on: macOS-latest
-    steps:
-      - name: Disable syspolicy assessments
-        run: |
-          spctl --status
-          sudo spctl --master-disable
-      - uses: actions/checkout@v2
-      - uses: cachix/install-nix-action@v10
-      - uses: cachix/cachix-action@v6
-        with:
-          name: hasktorch
-          signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
-      - run: cachix use iohk
-      - run: |
-          nix-build -j 2 -A haskellPackages.libtorch-ffi.checks.spec
-          nix-build -j 1 -A haskellPackages.hasktorch.checks.spec
-          nix-build -j 1 -A haskellPackages.examples.checks.spec


### PR DESCRIPTION
Reverts #422 

Thanks for your help testing this out. The results were a bit of a bust with respect to any short-term hope of speeding up macOS builds, but they did help me tease out the fact that the approach I used here doesn't actually disable the whole assessment--it seems to just keep the result of the assessment from being used.

With the approach used here ruled out, the only way I'm aware of to fully disable the assessments and reclaim the associated time requires a GUI to set up. :/