### PR TITLE
Don't assume taskset is in path

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -47,7 +47,7 @@ let
         nproc = ''
           case "$(uname)" in
             "Linux")
-                taskset -pc 0-1000 $$
+                ${pkgs.utillinux}/bin/taskset -pc 0-1000 $$
             ;;
           esac
         '';


### PR DESCRIPTION
Updates `shellHook` to give the full path to `taskset` on Linux. This fixes the following issue with `lorri`:
```
$ lorri shell
…
/nix/store/n4qv0ad1rg8rafppb4dh59n080m94bxy-stdenv-linux/setup: line 84: taskset: command not found
```
(I'm not sure why the current code doesn't cause the same issue with `nix-shell`, since `shellHook` should be run in either case…)