### PR TITLE
Add Torch.Typed.Optim.CppOptim and associated example

### DIFF
--- a/examples/examples.cabal
+++ b/examples/examples.cabal
@@ -176,6 +176,17 @@ executable optimizers-cpp
                      , mtl >= 2.2.2
                      , data-default-class
 
+executable optimizers-cpp-typed
+  hs-source-dirs:      optimizers-cpp-typed
+  main-is:             Main.hs
+  other-modules:       TestFunctions
+  default-language:    Haskell2010
+  ghc-options:         -fno-warn-partial-type-signatures
+  build-depends:       base >= 4.7 && < 5
+                     , hasktorch
+                     , mtl >= 2.2.2
+                     , data-default-class
+
 executable image-processing
   hs-source-dirs:      image-processing
   main-is:             Main.hs

--- a/examples/optimizers-cpp-typed/Main.hs
+++ b/examples/optimizers-cpp-typed/Main.hs
@@ -1,0 +1,156 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Main where
+
+{- Optimizer implementations run on standard test functions -}
+
+import Control.Monad (foldM, when, forM_)
+import GHC.Generics
+import Prelude hiding (sqrt)
+import Text.Printf (printf)
+import Data.Default.Class
+import GHC.TypeNats
+
+import Torch.Typed hiding (runStep)
+import Torch.Optim (foldLoop)
+import TestFunctions
+import Torch.Typed.Optim.CppOptim
+
+-- import Data.IORef
+
+-- | show output after n iterations
+showLog :: (Show a) => Int -> Int -> Int -> Tensor dev 'Float '[] -> a -> IO ()
+showLog n i maxIter lossValue state = 
+    when (i == 0 || mod i n == 0 || i == maxIter-1) do
+        putStrLn ("Iter: " ++ printf "%6d" i
+            ++ " | Loss:" ++ printf "%05.4f" (toFloat lossValue)
+            ++ " | Parameters: " ++ show state)
+
+-- | Optimize convex quadratic with specified optimizer
+optConvQuad :: forall dev n opt. (KnownDevice dev, KnownNat n, CppOptimizer opt
+                                 ,RandDTypeIsValid dev 'Float
+                                 ,DotDTypeIsValid dev 'Float) 
+  => Int -> opt -> IO ()
+optConvQuad numIter optInit = do
+    let a = eyeSquare
+        b = zeros
+    paramInit <- sample $ ConvQuadSpec @dev @'Float @n
+    putStrLn ("Initial :" ++ show paramInit)
+    optimizer <- initOptimizer optInit paramInit
+    trained <- foldLoop (paramInit, optimizer) numIter $ \(paramState, optState) i -> do
+        let lossValue = (lossConvQuad a b) paramState
+        showLog 1000 i numIter lossValue paramState
+        runStep paramState optState lossValue
+    pure ()
+
+-- | Optimize Rosenbrock function with specified optimizer
+optRosen ::  forall dev opt. (KnownDevice dev, CppOptimizer opt
+                               ,RandDTypeIsValid dev 'Float
+                               ,DotDTypeIsValid dev 'Float) 
+  => Int -> opt -> IO ()
+optRosen numIter optInit = do
+    paramInit <- sample $ RosenSpec @dev @'Float
+    putStrLn ("Initial :" ++ show paramInit)
+    optimizer <- initOptimizer optInit paramInit
+    trained <- foldLoop (paramInit, optimizer) numIter $ \(paramState, optState) i -> do
+        let lossValue = lossRosen paramState
+        showLog 1000 i numIter lossValue paramState
+        runStep paramState optState lossValue
+    pure ()
+
+-- | Optimize Rosenbrock function with specified optimizer
+optLinear ::  forall dev n opt. (KnownDevice dev, KnownNat n, CppOptimizer opt
+                                ,RandDTypeIsValid dev 'Float
+                                ,DotDTypeIsValid dev 'Float
+                                ,_) 
+  => Int -> opt -> IO ()
+optLinear numIter optInit = do
+    paramInit <- sample $ LinearSpec @10 @1 @'Float @dev 
+    putStrLn ("Initial :" ++ show paramInit)
+    optimizer <- initOptimizer optInit paramInit
+    trained <- foldLoop (paramInit, optimizer) numIter $ \(linear, optState) i -> do
+        rt <- randn
+        let lossValue = linearForward linear rt
+        showLog 1000 i numIter lossValue linear
+        runStep linear optState lossValue
+    pure ()
+-- 
+-- -- | Optimize Ackley function with specified optimizer
+-- optAckley :: (CppOptimizer opt) => Int -> opt -> IO ()
+-- optAckley numIter optInit = do
+--     paramInit <- sample AckleySpec
+--     putStrLn ("Initial :" ++ show paramInit)
+--     optimizer <- initOptimizer optInit paramInit
+--     trained <- foldLoop (paramInit, optimizer) numIter $ \(paramState, optState) i -> do
+--         let lossValue = lossAckley paramState
+--         showLog 1000 i numIter lossValue paramState
+--         runStep paramState optState lossValue 5e-4
+--     pure ()
+-- 
+-- -- | Check global minimum point for Rosenbrock
+checkGlobalMinRosen :: IO ()
+checkGlobalMinRosen = do
+    putStrLn "\nCheck Actual Global Minimum (at 1, 1):"
+    print $ rosenbrock' @'(CPU, 0) 1.0 1.0 -- (asTensor (1.0 :: Float)) (asTensor (1.0 :: Float))
+
+-- | Check global minimum point for Convex Quadratic
+checkGlobalMinConvQuad :: IO ()
+checkGlobalMinConvQuad = do
+    putStrLn "\nCheck Actual Global Minimum (at 0, 0):"
+    let a = eyeSquare @2
+        b = zeros
+    print $ convexQuadratic @'(CPU, 0) @'Float a b zeros
+
+-- -- | Check global minimum point for Ackley
+-- checkGlobalMinAckley :: IO ()
+-- checkGlobalMinAckley = do
+--     putStrLn "\nCheck Actual Global Minimum (at 0, 0):"
+--     print $ ackley' (zeros' [2])
+
+main :: IO ()
+main = do
+    let numIter = 20000
+        adamOpt = (def { adamLr = 1e-4
+                       , adamBetas = (0.9, 0.999)
+                       , adamEps = 1e-8
+                       , adamWeightDecay = 0
+                       , adamAmsgrad = False
+                       } :: AdamOptions)
+
+    -- Convex Quadratic w/ GD, GD+Momentum, Adam
+    putStrLn "\nConvex Quadratic\n================"
+    putStrLn "\nGD"
+    optConvQuad @'(CPU, 0) @2 numIter (def :: SGDOptions)
+    putStrLn "\nAdam"
+    optConvQuad @'(CPU, 0) @2 numIter adamOpt
+    checkGlobalMinConvQuad
+
+    -- 2D Rosenbrock w/ GD, GD+Momentum, Adam
+    putStrLn "\n2D Rosenbrock\n================"
+    putStrLn "\nGD"
+    optRosen @'(CPU, 0) numIter (def :: SGDOptions)
+    putStrLn "\nAdam"
+    optRosen @'(CPU, 0) numIter adamOpt
+    checkGlobalMinRosen
+
+    -- -- Ackley w/ GD, GD+Momentum, Adam
+    -- putStrLn "\nAckley (Gradient methods fail)\n================"
+    -- putStrLn "\nGD"
+    -- optAckley numIter (def :: SGDOptions)
+    -- putStrLn "\nAdam"
+    -- optAckley numIter adamOpt
+    -- checkGlobalMinAckley

--- a/examples/optimizers-cpp-typed/README.md
+++ b/examples/optimizers-cpp-typed/README.md
@@ -1,0 +1,43 @@
+# Optimizers Example
+
+Implementations of optimizers run on simple test functions. This implementation is for untyped tensors.
+
+- `Main.hs` - main training loop execution
+- `TestFunction.hs` - differentiable implementations of [test functions](https://en.wikipedia.org/wiki/Test_functions_for_optimization)
+
+Optimizers are represented by libtorch's c++ codes.
+
+The `step` function can be called for any optimizer, and is defined as:
+
+```
+type OptimizerRef = ForeignPtr ATen.Optimizer
+data OptimizerState option p = OptimizerState option OptimizerRef p
+
+class Optimizer option where
+  initOptimizer :: Parameterized d => option -> d -> IO (OptimizerState option d)
+  step :: Parameterized d => OptimizerState option d -> (d -> IO Tensor) -> IO Tensor
+  getParams :: Parameterized d => OptimizerState option d -> IO d
+```
+
+The `step` function returns loss, and it updates parameters of OptimizerState.
+
+## Test Functions and OptimizersTest Functions
+
+3 Test functions are currently implemented - convex quadratic, rosenbrock, and ackley function.
+
+Optimization over convex quadratic and rosenbrock should converge, while optimization over the ackley function does not.
+
+# Running the Example
+
+Setup environment variables (run this from the top-level hasktorch project 
+directory where the `setenv` file is):
+
+```
+source setenv
+```
+
+Building and running:
+
+```
+stack run optimizers-cpp
+```

--- a/examples/optimizers-cpp-typed/TestFunctions.hs
+++ b/examples/optimizers-cpp-typed/TestFunctions.hs
@@ -1,0 +1,127 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+
+module TestFunctions where
+
+import GHC.Generics
+
+import Prelude hiding (exp, cos, sqrt)
+import qualified Prelude as P
+
+import GHC.TypeNats
+import Torch.Typed
+import Torch.Typed.Factories (eyeSquare, ones, rand, randn, zeros)
+import Torch.Typed.Functional
+import Torch.Typed.Autograd
+import Torch.Typed.NN hiding (sgd)
+
+-- Convex Quadratic
+
+data ConvQuadSpec (dev :: (DeviceType, Nat)) (dtype :: DType) (n::Nat) 
+  = ConvQuadSpec
+data ConvQuad dev dtype n = ConvQuad { w :: Parameter dev dtype '[n] }
+  deriving (Show, Generic)
+
+instance (RandDTypeIsValid dev dtype, KnownNat n, KnownDType dtype
+         ,KnownDevice dev)
+  => Randomizable (ConvQuadSpec dev dtype n) (ConvQuad dev dtype n) where
+  sample ConvQuadSpec = do
+    w <- makeIndependent =<< randn
+    pure $ ConvQuad w
+
+instance Parameterized (ConvQuad dev dtype n)
+
+convexQuadratic :: forall dev dtype n. (DotDTypeIsValid dev dtype, KnownDevice dev
+                                       ,KnownDType dtype, KnownNat n)
+                => Tensor dev dtype '[n,n] 
+                -> Tensor dev dtype '[n] 
+                -> Tensor dev dtype '[n]
+                -> Tensor dev dtype '[]
+convexQuadratic a b w =
+    mulScalar (0.5 :: Float) (dot w (mv a w)) - dot b w
+
+lossConvQuad :: (DotDTypeIsValid dev dtype, KnownDevice dev, KnownDType dtype, KnownNat n)
+             => Tensor dev dtype '[n,n]
+             -> Tensor  dev dtype '[n]
+             -> ConvQuad dev dtype n
+             -> Tensor dev dtype '[]
+lossConvQuad a b (ConvQuad w) = convexQuadratic a b w'
+    where w' = toDependent w
+
+-- 2D Rosenbrock
+
+data RosenSpec (dev :: (DeviceType, Nat)) (dtype :: DType)
+  = RosenSpec deriving (Show, Eq)
+data Rosen dev dtype = Rosen { x :: Parameter dev dtype '[]
+                             , y :: Parameter dev dtype '[] }
+                   deriving (Generic)
+
+instance Show (Rosen dev 'Float) where
+    show (Rosen x y) = show (toFloat $ toDependent x, toFloat $ toDependent y)
+
+instance (RandDTypeIsValid dev dtype, KnownDType dtype, KnownDevice dev)
+  => Randomizable (RosenSpec dev dtype) (Rosen dev dtype) where
+  sample RosenSpec = do
+      x <- makeIndependent =<< randn
+      y <- makeIndependent =<< randn
+      pure $ Rosen x y
+
+-- instance Parameterized Rosen
+
+instance Parameterized (Rosen dev dtype)
+
+rosenbrock2d :: KnownDevice dev
+             => Float 
+             -> Float 
+             -> Tensor dev 'Float '[] 
+             -> Tensor dev 'Float '[]
+             -> Tensor dev 'Float '[] 
+rosenbrock2d a b x y = square (addScalar a ((-1.0) * x )) 
+                          + mulScalar b (square (y - x*x))
+    where square c = powScalar (2::Float) c
+
+rosenbrock' :: KnownDevice dev
+            => Tensor dev 'Float '[] 
+            -> Tensor dev 'Float '[]
+            -> Tensor dev 'Float '[] 
+rosenbrock' = rosenbrock2d 1.0 100.0
+
+lossRosen :: KnownDevice dev => Rosen dev 'Float -> Tensor dev 'Float '[] 
+lossRosen  Rosen{..} = rosenbrock' (toDependent x) (toDependent y)
+-- 
+-- -- Ackley function
+-- 
+-- data AckleySpec = AckleySpec deriving (Show, Eq)
+-- data Ackley = Ackley { pos :: Parameter } deriving (Show, Generic)
+-- 
+-- instance Randomizable AckleySpec Ackley where
+--   sample AckleySpec = do
+--       pos <- makeIndependent =<< randnIO' [2]
+--       pure $ Ackley pos
+-- 
+-- instance Parameterized Ackley
+-- 
+-- ackley :: Float -> Float -> Float -> Tensor -> Tensor
+-- ackley a b c x = 
+--     mulScalar (-a) (exp (-b' * (sqrt $ (sumAll (x * x)) / d)))
+--     - exp (1.0 / d * sumAll (cos (mulScalar c x))) 
+--     + (asTensor $ a + P.exp 1.0)
+--     where
+--         b' = asTensor b
+--         c' = asTensor c
+--         d = asTensor . product $ shape x
+-- 
+-- ackley' = ackley 20.0 0.2 (2*pi :: Float)
+-- 
+-- lossAckley :: Ackley -> Tensor
+-- lossAckley (Ackley x) = ackley' x'
+--     where x' = toDependent x

--- a/hasktorch/hasktorch.cabal
+++ b/hasktorch/hasktorch.cabal
@@ -73,6 +73,7 @@ library
                     , Torch.Typed.DType
                     , Torch.Typed.Autograd
                     , Torch.Typed.Optim
+                    , Torch.Typed.Optim.CppOptim
                     , Torch.Typed.Serialize
                     , Torch.Typed.Vision
                     , Torch.Distributions.Constraints

--- a/hasktorch/src/Torch/Typed/Optim/CppOptim.hs
+++ b/hasktorch/src/Torch/Typed/Optim/CppOptim.hs
@@ -1,0 +1,141 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Torch.Typed.Optim.CppOptim
+  (module Torch.Typed.Optim.CppOptim
+  ,AdagradOptions(..)
+  ,AdamOptions(..)
+  ,AdamwOptions(..)
+  ,LbfgsOptions(..)
+  ,RmspropOptions(..)
+  ,SGDOptions(..)) where
+
+import Foreign.ForeignPtr
+
+import Torch.Internal.Cast
+import Torch.Internal.Class (Castable(..), CppTuple2(..), CppTuple3(..), CppTuple4(..), CppObject(..))
+import qualified Torch.Internal.Type as ATen
+import qualified Torch.Internal.Managed.Optim as LibTorch
+import qualified Torch.Typed.Optim as Optim
+import System.Mem(performGC)
+
+import Torch.HList
+import Torch.Typed.Tensor
+import Torch.Typed.Autograd
+import Torch.Typed.Parameter
+import Torch.Typed.NN
+import qualified Torch as TD
+import qualified Debug.Trace as Debug
+
+import Torch.Optim.CppOptim (AdagradOptions(..)
+                            ,AdamOptions(..)
+                            ,AdamwOptions(..)
+                            ,LbfgsOptions(..)
+                            ,RmspropOptions(..)
+                            ,SGDOptions(..))
+
+import Data.Default.Class
+import Data.Foldable (for_)
+
+type CppOptimizerRef = ForeignPtr ATen.Optimizer
+data CppOptimizerState option (params :: [*])
+  = CppOptimizerState option CppOptimizerRef
+
+data ToParameter = ToParameter
+instance Apply' ToParameter (Tensor dev dtype shape) (Parameter dev dtype shape) where
+  apply' _ (UnsafeMkTensor tensor) = UnsafeMkParameter . TD.IndependentTensor $ tensor
+
+class CppOptimizer option where
+
+  initOptimizer :: forall model tensors.
+                   (Parameterized model
+                   ,HMap' ToDependent (Parameters model) tensors
+                   ,Castable (HList tensors) [TD.ATenTensor])
+    => option -> model -> IO (CppOptimizerState option (Parameters model))
+
+  unsafeStep :: forall model dev dtype lossShape tensors res. 
+    (Parameterized model
+    ,HMap' ToDependent (Parameters model) tensors
+    ,HMap' ToParameter tensors (Parameters model)
+    ,Castable (HList tensors) [TD.ATenTensor]
+    )
+      => model 
+      -> CppOptimizerState option (Parameters model)
+      -> Tensor dev dtype lossShape
+      -> IO (model, CppOptimizerState option (Parameters model))
+  unsafeStep model o@(CppOptimizerState _ optimizer) loss = do
+    let deps :: HList tensors
+        deps = hmap' ToDependent $ flattenParameters model
+
+    -- Debug.traceIO $ "Tensors in: "
+    -- cast deps (Debug.traceIO . show . map (TD.shape . TD.Unsafe))
+    v :: [TD.ATenTensor] <- cast3 LibTorch.unsafeStep optimizer deps loss
+    -- Debug.traceIO $ "Params returned by unsafeStep: "<>show (length v)
+    
+    newParamTensors :: HList tensors <- uncast v pure
+    -- Debug.traceIO $ "Tensors out: "
+    -- cast newParamTensors (Debug.traceIO . show . map (TD.shape . TD.Unsafe))
+    let newParams = hmap' ToParameter newParamTensors
+    let newModel = replaceParameters model newParams
+    return (newModel, o)
+
+instance CppOptimizer AdamOptions where
+  initOptimizer  opt@AdamOptions{..} model = do
+    v <- cast7 LibTorch.adam adamLr (fst adamBetas) (snd adamBetas)
+                             adamEps adamWeightDecay adamAmsgrad initParams'
+    return $ CppOptimizerState opt v
+    where
+      initParams'= hmap' ToDependent $ flattenParameters model
+
+
+instance CppOptimizer AdamwOptions where
+  initOptimizer  opt@AdamwOptions{..} model = do
+    v <- cast7 LibTorch.adamw adamwLr (fst adamwBetas) (snd adamwBetas) adamwEps adamwWeightDecay adamwAmsgrad initParams'
+    return $ CppOptimizerState opt v
+    where
+      initParams'= hmap' ToDependent $ flattenParameters model
+
+
+instance CppOptimizer LbfgsOptions where
+  initOptimizer opt@LbfgsOptions{..} model = do
+    v <- cast8 LibTorch.lbfgs lbfgsLr lbfgsMaxIter lbfgsMaxEval lbfgsToleranceGrad lbfgsToleranceChange lbfgsHistorySize lbfgsLineSearchFn initParams'
+    return $ CppOptimizerState opt v
+    where
+      initParams'= hmap' ToDependent $ flattenParameters model
+
+instance CppOptimizer RmspropOptions where
+  initOptimizer opt@RmspropOptions{..} model = do
+    v <- cast7 LibTorch.rmsprop rmspropLr rmspropAlpha rmspropEps rmspropWeightDecay rmspropMomentum rmspropCentered initParams'
+    return $ CppOptimizerState opt v
+    where
+      initParams'= hmap' ToDependent $ flattenParameters model
+
+instance CppOptimizer SGDOptions where
+  initOptimizer  opt@SGDOptions{..} model = do
+    v <- cast6 LibTorch.sgd sgdLr sgdMomentum sgdDampening sgdWeightDecay sgdNesterov initParams'
+    return $ CppOptimizerState opt v
+    where
+      initParams'= hmap' ToDependent $ flattenParameters model
+
+runStep :: (CppOptimizer option, Parameterized model
+           ,HMap' ToDependent (Parameters model) tensors
+           ,HMap' ToParameter tensors (Parameters model)
+           ,Castable (HList tensors) [TD.ATenTensor]
+           )
+        => model 
+        -> CppOptimizerState option (Parameters model)
+        -> Optim.Loss dev dtype 
+        -> IO (model, CppOptimizerState option (Parameters model))
+runStep model optim loss = do
+  performGC
+  unsafeStep model optim loss


### PR DESCRIPTION
A typed version of Torch.Optim.CppOptim.  I have also added a partial reimplementation of the `optimizers-cpp` example under `optimizers-cpp-typed` to demonstrate usage.  