### PR TITLE
Add tensor_names function to get a list of at::Dimname from tensor

### DIFF
--- a/libtorch-ffi/src/Torch/Internal/Managed/Type/Extra.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Type/Extra.hs
@@ -66,3 +66,8 @@ tensor_assign2_t
   -> IO ()
 tensor_assign2_t = cast4 Unmanaged.tensor_assign2_t
 
+tensor_names
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr DimnameList)
+tensor_names = cast1 Unmanaged.tensor_names
+

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Extra.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Extra.hs
@@ -83,3 +83,15 @@ tensor_assign2_t _obj _idx0 _idx1 _val  =
   [C.throwBlock| void { (*$(at::Tensor* _obj))[$(int64_t _idx0)][$(int64_t _idx1)] = *$(at::Tensor* _val); }|]
 
 
+tensor_names
+  :: Ptr Tensor
+  -> IO (Ptr DimnameList)
+tensor_names _obj =
+  [C.throwBlock| std::vector<at::Dimname>* {
+      auto ref = (*$(at::Tensor* _obj)).names();
+      std::vector<at::Dimname>* vec = new std::vector<at::Dimname>();
+      for(int i=0;i<ref.size();i++){
+        vec->push_back(ref[i]);
+      }
+      return vec;
+  }|]


### PR DESCRIPTION
`tensor.name` function of c++ returns `c10::ArrayRef<at::Dimname>`.
ArrayRef does not own Dimname, and tensor owns Dimname.
We have to copy `ArrayRef` to `std::vector<at: Dimname>`, but libtorch don't provide the copy-constructor.
Since the constructor cannot be generated automatically, this pr provides the copy-operation by handwritten code.