### PR TITLE
Add stack-ghc88.yaml to keep supporting ghc-88

### DIFF
--- a/.github/workflows/stack-macos.yaml
+++ b/.github/workflows/stack-macos.yaml
@@ -25,16 +25,16 @@ jobs:
     - name: Build
       run: |
         #. setenv
-        stack build
+        stack build --stack-yaml stack-ghc88.yaml
     - name: Test
       run: |
         #. setenv
-        stack test codegen
-        stack test libtorch-ffi
-        stack test hasktorch
-        stack exec codegen-exe
-        stack exec xor-mlp
-        stack exec regression
-        stack exec gaussian-process
-        stack exec vae
-        stack exec optimizers
+        stack test codegen  --stack-yaml stack-ghc88.yaml
+        stack test libtorch-ffi  --stack-yaml stack-ghc88.yaml
+        stack test hasktorch --stack-yaml stack-ghc88.yaml
+        stack exec codegen-exe --stack-yaml stack-ghc88.yaml
+        stack exec xor-mlp --stack-yaml stack-ghc88.yaml
+        stack exec regression --stack-yaml stack-ghc88.yaml
+        stack exec gaussian-process --stack-yaml stack-ghc88.yaml
+        stack exec vae --stack-yaml stack-ghc88.yaml
+        stack exec optimizers --stack-yaml stack-ghc88.yaml

--- a/stack-ghc88.yaml
+++ b/stack-ghc88.yaml
@@ -1,0 +1,45 @@
+resolver: lts-15.5
+
+compiler: ghc-8.8.4
+
+packages:
+- codegen
+- libtorch-ffi
+- libtorch-ffi-helper
+- hasktorch
+- examples
+- experimental
+
+# see https://github.com/commercialhaskell/stack/issues/4073
+# with-gcc: /usr/local/bin/gcc-7
+
+extra-include-dirs:
+- deps/libtorch/include/torch/csrc/api/include
+- deps/libtorch/include
+
+extra-lib-dirs:
+- deps/libtorch/lib
+- deps/mklml/lib
+
+extra-deps:
+# libtorch-ffi
+# - inline-c-cpp-0.4.0.0
+# hasktorch
+# - ghc-typelits-natnormalise-0.7
+# - ghc-typelits-knownnat-0.7
+# - ghc-typelits-extra-0.3.2
+# examples/typed-transformer
+- git: git://github.com/hasktorch/pipes-text.git
+  commit: 3dd3d9519306ea06f0c15ad71bdf57e1dfd0b747
+# experimental/dataloader-cifar10
+- datasets-0.4.0@sha256:9bfd5b54c6c5e1e72384a890cf29bf85a02007e0a31c98753f7d225be3c7fa6a,4929
+- stm-2.5.0.0@sha256:c238075f9f0711cd6a78eab6001b3e218cdaa745d6377bf83cc21e58ceec2ea1,2100
+- streaming-attoparsec-1.0.0.1@sha256:fe9b878072423d3f075534fe8af24722d9ded1a1129e9a6ed5b71c4a29681b39,1146
+- streaming-cassava-0.1.0.1@sha256:2d1dfeb09af62009e88311fe92f44d06dafb5cdd38879b437ea6adb3bc40acfe,1739
+
+nix:
+  shell-file: nix/stack-shell.nix
+
+# ghc-options:
+#   libtorch-ffi: -j +RTS -A128m -n2m -RTS
+#   hasktorch: -j +RTS -A128m -n2m -RTS


### PR DESCRIPTION
To support ghc-810 for macos, we need to upgrade Cabal package of stack command.
https://github.com/haskell/cabal/issues/6421

Since it takes time to upgrade, we will continue to support ghc88 of macos for the time being.