### PR TITLE
Add makeIndependent with requires_grad argument

### DIFF
--- a/hasktorch/src/Torch/Autograd.hs
+++ b/hasktorch/src/Torch/Autograd.hs
@@ -28,4 +28,7 @@ requiresGrad :: Tensor -> Bool
 requiresGrad t = unsafePerformIO $ cast1 ATen.tensor_requires_grad t
 
 makeIndependent :: Tensor -> IO IndependentTensor
-makeIndependent t = IndependentTensor <$> cast1 Torch.Internal.Managed.Autograd.makeIndependent t
+makeIndependent tensor = makeIndependentWithRequiresGrad tensor True
+
+makeIndependentWithRequiresGrad :: Tensor -> Bool -> IO IndependentTensor
+makeIndependentWithRequiresGrad tensor requires_grad = IndependentTensor <$> cast2 Torch.Internal.Managed.Autograd.makeIndependent tensor requires_grad

--- a/hasktorch/src/Torch/NN.hs
+++ b/hasktorch/src/Torch/NN.hs
@@ -339,8 +339,8 @@ instance Randomizable BatchNormSpec BatchNorm where
   sample BatchNormSpec {..} = do
     w <- makeIndependent (ones' [numFeatures])
     b <- makeIndependent (zeros' [numFeatures])
-    mean <- toDependent <$> makeIndependent (zeros' [numFeatures])
-    var <- toDependent <$> makeIndependent (ones' [numFeatures])
+    mean <- toDependent <$> makeIndependentWithRequiresGrad (zeros' [numFeatures]) False
+    var <- toDependent <$> makeIndependentWithRequiresGrad (ones' [numFeatures]) False
     return $ BatchNorm w b mean var
 
 data UpSampleSpec = UpSampleSpec

--- a/libtorch-ffi/src/Torch/Internal/Managed/Autograd.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Autograd.hs
@@ -8,14 +8,15 @@ import Torch.Internal.Type
 import Torch.Internal.Class
 import Torch.Internal.Cast
 import Torch.Internal.Objects
+import Foreign.C.Types (CBool)
 
 
 grad :: ForeignPtr Tensor -> ForeignPtr TensorList -> IO (ForeignPtr TensorList)
 grad = cast2 Unmanaged.grad
 
 
-makeIndependent :: ForeignPtr Tensor -> IO (ForeignPtr Tensor)
-makeIndependent = cast1 Unmanaged.makeIndependent
+makeIndependent :: ForeignPtr Tensor -> CBool -> IO (ForeignPtr Tensor)
+makeIndependent = cast2 Unmanaged.makeIndependent
 
 dropVariable :: ForeignPtr Tensor -> IO (ForeignPtr Tensor)
 dropVariable = cast1 Unmanaged.dropVariable

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Autograd.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Autograd.hs
@@ -12,6 +12,7 @@ import qualified Language.C.Inline.Cpp as C
 import qualified Language.C.Inline.Cpp.Exceptions as C
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Types as C
+import Foreign.C.Types (CBool)
 
 import Torch.Internal.Type
 
@@ -65,9 +66,9 @@ grad y inputs = [C.throwBlock| std::vector<at::Tensor>* {
     return new std::vector<at::Tensor>(at::fmap<at::Tensor>(outputs));
   }|]
 
-makeIndependent :: Ptr Tensor -> IO (Ptr Tensor)
-makeIndependent t = [C.throwBlock| at::Tensor* {
-    return new at::Tensor($(at::Tensor* t)->detach().set_requires_grad(true));
+makeIndependent :: Ptr Tensor -> CBool -> IO (Ptr Tensor)
+makeIndependent tensor requires_grad = [C.throwBlock| at::Tensor* {
+    return new at::Tensor($(at::Tensor* tensor)->detach().set_requires_grad($(bool requires_grad)));
   }|]
 
 dropVariable :: Ptr Tensor -> IO (Ptr Tensor)


### PR DESCRIPTION
Add a requires_grad argument to make a tensor of requires_grad=False, because running_mean argument of batchNorm function requires a tensor with requires_grad = False.
