### PR TITLE
Add ToDevice typeclass for untyped api

### DIFF
--- a/examples/rnn/Elman.hs
+++ b/examples/rnn/Elman.hs
@@ -41,6 +41,7 @@ instance Parameterized ElmanCell where
     hidden_weight <- nextParameter
     bias   <- nextParameter
     return $ ElmanCell{..}
+  replaceDevice = defaultReplaceDevice
 
 
 instance Show ElmanCell where

--- a/examples/rnn/GRU.hs
+++ b/examples/rnn/GRU.hs
@@ -73,6 +73,7 @@ instance Parameterized GRUCell where
     let update_gate = [ug_ih, ug_hh, ug_b]
     let gru_hidden_gate = [hg_ih, hg_hh, hg_b]
     return $ GRUCell{..}
+  replaceDevice = defaultReplaceDevice
 
 
 instance Show GRUCell where

--- a/examples/rnn/LSTM.hs
+++ b/examples/rnn/LSTM.hs
@@ -98,6 +98,7 @@ instance Parameterized LSTMCell where
     let hidden_gate = [hg_ih, hg_hh, hg_b]
     let output_gate = [og_ih, og_hh, og_b]
     return $ LSTMCell{..}
+  replaceDevice = defaultReplaceDevice
 
 instance Show LSTMCell where
   show LSTMCell{..} =

--- a/hasktorch/src/Torch/Script.hs
+++ b/hasktorch/src/Torch/Script.hs
@@ -27,6 +27,7 @@ import System.IO.Unsafe
 import Torch.Autograd
 import Torch.DType
 import Torch.Device
+import Torch.Tensor (toDevice)
 import Torch.Internal.Cast
 import Torch.Internal.Class (Castable (..), CppObject (..), CppTuple2 (..), CppTuple3 (..), CppTuple4 (..))
 import qualified Torch.Internal.Const as ATen
@@ -290,6 +291,7 @@ instance Parameterized ScriptModule where
     let len = length (getParameters module')
     ps' <- replicateM len nextParameter
     return $ updateParameters WithRequiredGrad module' (map toDependent ps')
+  replaceDevice = defaultReplaceDevice
 
 trace ::
   -- | moduleName

--- a/hasktorch/src/Torch/Tensor.hs
+++ b/hasktorch/src/Torch/Tensor.hs
@@ -135,15 +135,21 @@ toType ::
   Tensor
 toType dtype t = unsafePerformIO $ cast2 ATen.tensor_toType_s t dtype
 
+class ToDevice a where
+  toDevice :: Device -> a -> a
+
+instance ToDevice Tensor where
+  toDevice = _toDevice
+
 -- | Casts the input tensor to given device
-toDevice ::
+_toDevice ::
   -- | device to cast input to
   Device ->
   -- | input
   Tensor ->
   -- | output
   Tensor
-toDevice device' t = unsafePerformIO $ do
+_toDevice device' t = unsafePerformIO $ do
   hasCUDA <- cast0 ATen.hasCUDA :: IO Bool
   let device = Torch.Tensor.device t
   t' <-

--- a/hasktorch/src/Torch/Typed/NN/Recurrent/LSTM.hs
+++ b/hasktorch/src/Torch/Typed/NN/Recurrent/LSTM.hs
@@ -212,6 +212,7 @@ instance A.Parameterized (LSTMLayer inputSize hiddenSize directionality dtype de
           (UnsafeMkParameter bi')
           (UnsafeMkParameter bh')
       )
+  replaceDevice = A.defaultReplaceDevice
 
 data
   LSTMLayerStackSpec
@@ -375,6 +376,7 @@ instance A.Parameterized (LSTMLayerStack inputSize hiddenSize numLayers directio
     stack' <- A._replaceParameters stack
     layer' <- A._replaceParameters layer
     return $ LSTMLayerK stack' layer'
+  replaceDevice = A.defaultReplaceDevice
 
 newtype
   LSTMSpec
@@ -441,6 +443,7 @@ instance A.Parameterized (LSTM inputSize hiddenSize numLayers directionality dty
         { lstm_layer_stack = lstm_layer_stack',
           ..
         }
+  replaceDevice = A.defaultReplaceDevice
 
 -- | Helper to do xavier uniform initializations on weight matrices and
 -- orthagonal initializations for the gates. (When implemented.)
@@ -692,6 +695,7 @@ instance A.Parameterized (LSTMWithInit inputSize hiddenSize numLayers directiona
           lstmWithLearnedInit_c = UnsafeMkParameter lstmWithLearnedInit_c',
           lstmWithLearnedInit_h = UnsafeMkParameter lstmWithLearnedInit_h'
         }
+  replaceDevice = A.defaultReplaceDevice
 
 lstmForward ::
   forall

--- a/hasktorch/src/Torch/Typed/Parameter.hs
+++ b/hasktorch/src/Torch/Typed/Parameter.hs
@@ -34,7 +34,7 @@ import Torch.DType (DType)
 import Torch.Device (DeviceType)
 import Torch.HList
 import qualified Torch.NN (Parameter, Randomizable (..), sample)
-import qualified Torch.Tensor (toDevice, toType)
+import qualified Torch.Tensor (_toDevice, toType)
 import Torch.Typed.Aux
 import Torch.Typed.Factories
 import Torch.Typed.Functional
@@ -86,7 +86,7 @@ parameterToDevice ::
 parameterToDevice (UnsafeMkParameter t) =
   UnsafeMkParameter
     . Torch.Autograd.IndependentTensor
-    . Torch.Tensor.toDevice (deviceVal @device')
+    . Torch.Tensor._toDevice (deviceVal @device')
     . Torch.Autograd.toDependent
     $ t
 


### PR DESCRIPTION
This pr adds ToDevice typeclass to provide a general way to move the data from CPU to CUDA.