### PR TITLE
Typed tensor semantics: graded monad, staged element-wise ops, indexing, lenses, and NMS

### DIFF
--- a/.github/workflows/cabal-linux.yml
+++ b/.github/workflows/cabal-linux.yml
@@ -85,6 +85,32 @@ jobs:
         cabal v2-exec codegen-exe
         cabal v2-exec xor-mlp
 
+    - name: Build tutorial
+      run: |
+        # tintin (hasktorch's GHC 9.8/cabal fork) renders hasktorch/doc/;
+        # the documentation pages execute real hasktorch code via runghc.
+        git clone --depth 1 -b feature/ghc98-cabal https://github.com/hasktorch/tintin.git /tmp/tintin
+        (cd /tmp/tintin && cabal v2-build --jobs=2 exe:tintin exe:inlitpp)
+        (cd /tmp/tintin && cabal install --lib inliterate --package-env /tmp/inlit.env)
+        TINTIN=$(cd /tmp/tintin && cabal list-bin exe:tintin)
+        INLITPP_DIR=$(dirname "$(cd /tmp/tintin && cabal list-bin exe:inlitpp)")
+        # runghc needs a package environment in which both hasktorch (built
+        # in-place above) and inliterate (in the cabal store) are visible
+        sed "s|^package-db dist-newstyle/|package-db ${GITHUB_WORKSPACE}/dist-newstyle/|" .ghc.environment.* > /tmp/tutorial.env
+        grep -E "^package-db|^package-id inliterate" /tmp/inlit.env >> /tmp/tutorial.env
+        export GHC_ENVIRONMENT=/tmp/tutorial.env
+        export PATH="$INLITPP_DIR:$PATH"
+        export LD_LIBRARY_PATH="${GITHUB_WORKSPACE}/deps/libtorch/lib:${GITHUB_WORKSPACE}/deps/mklml/lib:${LD_LIBRARY_PATH}"
+        mkdir -p public/tutorial
+        (cd hasktorch && "$TINTIN" run --runghc --outputDirectory "${GITHUB_WORKSPACE}/public/tutorial")
+        ls public/tutorial
+
+    - name: Archive tutorial
+      uses: actions/upload-artifact@v4
+      with:
+        name: tutorial
+        path: public/tutorial
+
     # - name: Benchmark
     #   run: |
     #     cabal v2-bench hasktorch:runtime --benchmark-options='--output benchmark-runtime.html'

--- a/flake.nix
+++ b/flake.nix
@@ -71,13 +71,30 @@
                   # hasktorch-gradually-typed
                   libtorch-ffi
                   libtorch-ffi-helper
-                  cabal-install
                 ];
+              # Developer tools belong here, not in `packages`: shellFor treats
+              # `packages` as the set of packages being developed and brings in
+              # only their dependencies, so a tool listed there never lands on
+              # PATH.
               nativeBuildInputs = p: [
+                  p.cabal-install
+                  p.haskell.packages.${ghc}.haskell-language-server
+                  p.pkg-config
                   (p.python3.withPackages (pp: with pp; [
                     pyyaml
                     typing-extensions
                   ]))
+                ]
+              ;
+              # C libraries that Haskell dependencies link against. `packages`
+              # only brings in the *Haskell* dependency closure, so when cabal
+              # builds e.g. the `zlib` package from Hackage (which it does
+              # whenever the version pinned in cabal.project.freeze differs
+              # from the one nixpkgs provides) the C headers must come from
+              # here or the configure step fails.
+              buildInputs = p: [
+                  p.zlib
+                  p.zlib.dev
                 ]
               ;
             in
@@ -86,10 +103,12 @@
               cpu = pkgs.haskell.packages.${ghc}.shellFor {
                 inherit packages;
                 nativeBuildInputs = nativeBuildInputs pkgs;
+                buildInputs = buildInputs pkgs;
               };
               cuda = pkgsCuda.haskell.packages.${ghc}.shellFor {
                 inherit packages;
                 nativeBuildInputs = nativeBuildInputs pkgsCuda;
+                buildInputs = buildInputs pkgsCuda;
               };
             };
           checks = self'.packages;

--- a/hasktorch/doc/07-typed-tensors.md
+++ b/hasktorch/doc/07-typed-tensors.md
@@ -94,3 +94,69 @@ any device and for any data type and tensor shape.
 This is the essence of typed Hasktorch. As soon as the compiler gives
 its OK, we hold a proof that our program will run without shape or
 CUDA errors.
+
+## Autograd with typed tensors
+
+Chapter [4](04-automatic-differentiation.html) introduced automatic
+differentiation through the untyped API. The typed API exposes the
+same machinery — the same ATen tape runs underneath — but the types
+document and enforce the calling convention that the untyped API
+leaves implicit.
+
+Trainable values are `Parameter device dtype shape`, the typed
+counterpart of the untyped `IndependentTensor`:
+
+```haskell
+w  <- makeIndependent =<< randn @'[2, 1] @'D.Float @'( 'D.CPU, 0)
+let w' = toDependent w   -- Tensor '( 'D.CPU, 0) 'D.Float '[2, 1], tracked
+```
+
+Gradients are computed with `grad`:
+
+```haskell
+grad :: Tensor device dtype '[] -> a -> b
+```
+
+Two things are worth reading off this signature. First, the loss
+argument has shape `'[]`: *the type demands a scalar*. Calling
+autograd on a non-scalar — a runtime error (or a silent
+implicit-sum surprise) in dynamic frameworks — does not compile
+here. Second, `grad loss (flattenParameters model)` returns an
+`HList` of gradient tensors whose shapes are, by type, exactly the
+shapes of the parameters they belong to. A shape mismatch between a
+parameter and its gradient update cannot be expressed.
+
+Models are ordinary records of typed layers; deriving `Generic` and
+`Parameterized` gives parameter traversal for free, and `HasForward`
+states the shape contract of the forward pass:
+
+```haskell
+data MLP ... = MLP
+  { layer0 :: Linear inputFeatures hiddenFeatures dtype device,
+    layer1 :: Linear hiddenFeatures outputFeatures dtype device
+  }
+  deriving (Show, Generic, Parameterized)
+
+instance ... => HasForward (MLP ...)
+    (Tensor device dtype '[batchSize, inputFeatures])
+    (Tensor device dtype '[batchSize, outputFeatures])
+  where
+  forward MLP {..} = forward layer1 . tanh . forward layer0
+```
+
+Random initialization comes from `Randomizable` (`sample MLPSpec`),
+and a training step is one call:
+
+```haskell
+(model', optim') <- runStep model optim loss learningRate
+```
+
+where `optim` is `mkGD`, `mkGDM`, or `mkAdam`, and
+`loss = mseLoss @ReduceMean actual expected` is again forced by its
+type to be a scalar on the right device and dtype. The complete
+program is in `examples/static-xor-mlp`.
+
+The end-to-end guarantee is the one this chapter has been building
+towards: if the program compiles, the forward pass, the loss, every
+gradient, and every optimizer update agree about shapes, dtype, and
+device — the whole training loop, not just individual operations.

--- a/hasktorch/doc/08-named-tensors.md
+++ b/hasktorch/doc/08-named-tensors.md
@@ -159,3 +159,21 @@ half-precision model as far as GHC is concerned. Every forward pass,
 loss, and optimizer step is now checked against `'D.Half`, so a stray
 `'D.Float` batch fed to it — the classic silent-upcast bug of mixed
 precision work — is a compile-time error, not a performance mystery.
+
+The `types` traversal itself also works at *typed* targets, where it
+gains an ability the untyped version cannot have: shape selectivity.
+`Torch.Typed.Lens` provides the leaf instances, and then
+
+```haskell
+over (types @(Tensor '( 'D.CPU, 0) 'D.Float '[2, 3])) f model
+flattenValues (types @(Parameter '( 'D.CPU, 0) 'D.Float '[5, 10])) model
+replaceValues (types @(Tensor ... '[2, 3])) model newTensors
+```
+
+visit exactly the tensors (or parameters) of the named device, dtype
+and shape inside a structure — a `'[3, 4]` layer sitting next to a
+`'[2, 3]` one is left untouched. Where untyped `types @Tensor` means
+"every tensor", the typed version means "every tensor *of this
+structure*", which is what makes targeted surgery on a model — swap
+these embeddings, freeze that projection — expressible as one
+traversal.

--- a/hasktorch/doc/08-named-tensors.md
+++ b/hasktorch/doc/08-named-tensors.md
@@ -1,0 +1,114 @@
+---
+title: Named Tensors and Lenses
+---
+
+# Named Tensors and Lenses
+
+Typed tensors (see [Typed Tensors](07-typed-tensors.html)) check the
+*sizes* of dimensions at compile time. Named tensors go one step
+further: they give dimensions *meanings*. A `Tensor` of shape
+`'[2, 3]` and another of shape `'[2, 3]` are the same type even when
+one holds RGB channels and the other holds YCoCg channels; a
+`NamedTensor` distinguishes them.
+
+## Shapes made of types
+
+A `NamedTensor` is indexed by a list of *type constructors* rather
+than a list of naturals:
+
+```haskell
+import Torch.Typed
+
+data RGB a = RGB
+  { r :: a,
+    g :: a,
+    b :: a
+  }
+  deriving (Show, Eq, Generic)
+
+newtype Batch (n :: Nat) a = Batch (Vector n a) deriving (Generic)
+
+type Image = NamedTensor '( 'D.CPU, 0) 'D.Float '[Batch 2, RGB]
+```
+
+The runtime shape is derived from the types by the `ToNat` type
+family: `Batch 2` contributes 2, and `RGB` contributes 3 because it is
+a record with three fields. No registration is needed — `ToNat` walks
+the `Generic` representation, so any record or sized-vector newtype
+works as a dimension out of the box.
+
+`'[Batch 2, RGB]` and `'[Batch 2, YCoCg]` both erase to `[2, 3]` at
+runtime, but they are different types, and converting between them is
+an explicit, checked function. This is the property that plain size
+types (including those of array languages like Futhark) cannot
+express.
+
+## Field lenses
+
+Because `RGB` is a record, its fields address positions of the
+dimension. The `field` lens extracts one:
+
+```haskell
+import Torch.Typed.Lens
+
+red :: NamedTensor device dtype '[Batch 2] -- the RGB dimension is dropped
+red = image ^. field @"r"
+```
+
+Field names are checked: `field @"q"` on a shape containing `RGB`
+does not compile. Whole dimensions can be addressed by name with the
+`name` traversal:
+
+```haskell
+channels :: Traversal' (NamedTensor dev dt '[Batch 2, RGB])
+                       (NamedTensor dev dt '[Batch 2])
+channels = name @RGB
+```
+
+A worked conversion, from the test suite:
+
+```haskell
+toYCoCG :: NamedTensor device dtype '[Vector n, RGB]
+        -> NamedTensor device dtype '[Vector n, YCoCg]
+toYCoCG rgb =
+  set (field @"y")  ((r + g * 2 + b) / 4) $
+  set (field @"co") ((r - b) / 2) $
+  set (field @"cg") ((- r + g * 2 - b) / 4) $
+  def
+  where
+    r = rgb ^. field @"r"
+    g = rgb ^. field @"g"
+    b = rgb ^. field @"b"
+```
+
+Nothing in this code mentions a numeric channel index.
+
+## Tensors as functions of their index
+
+`Torch.Typed.Representable` treats a named tensor as what it
+mathematically is: a function from an index to an element.
+
+```haskell
+import Torch.Typed.Representable
+
+-- Log (index type) of Image is HList '[Finite 2, Finite 3]:
+-- one bounds-checked index per dimension.
+
+image :: Image
+image = tabulate (\(i :. j :. HNil) -> fromIntegral (fromEnum i) * 10
+                                     + fromIntegral (fromEnum j))
+
+x :: Float
+x = index image (1 :. 2 :. HNil)
+```
+
+`tabulate` builds the whole tensor from the function in a single
+batched call; `index` reads one element. The laws
+`index (tabulate f) i == f i` and `tabulate (index t) == t` are
+checked in the test suite against real tensors.
+
+Note the granularity: `tabulate` is efficient (one `asTensor` call),
+`index` costs a few FFI calls per element, so it is for spot reads,
+not for loops over all elements. For whole-tensor element-wise
+computation, see [Graded and Staged Tensor
+Programs](10-graded-and-staged.html).

--- a/hasktorch/doc/08-named-tensors.md
+++ b/hasktorch/doc/08-named-tensors.md
@@ -112,3 +112,50 @@ Note the granularity: `tabulate` is efficient (one `asTensor` call),
 not for loops over all elements. For whole-tensor element-wise
 computation, see [Graded and Staged Tensor
 Programs](10-graded-and-staged.html).
+
+## Lenses over whole models: changing dtype and device
+
+Field and dimension lenses address parts of one tensor. The other
+direction lenses work in Hasktorch is *outward*: traversing every
+tensor inside an arbitrary structure — a model record, a tuple of
+parameters, a list of batches.
+
+In the untyped API this is `Torch.Lens`'s `HasTypes` traversal, and
+the conversions built on it:
+
+```haskell
+import Torch
+
+modelHalf = toType Half model      -- every tensor inside, converted
+modelCuda = toDevice (Device CUDA 0) model
+edited    = over (types @Tensor @MyModel) f model  -- any tensor rewrite
+```
+
+`HasTypes` is derived generically, so any record of tensors (or of
+records of tensors) works without instances. This is how you switch a
+whole network to half precision, or move it to a GPU, in one line —
+but nothing in `model`'s *type* records that it happened.
+
+The typed API has the same one-liners, with one important difference:
+the conversion changes the type of the structure.
+
+```haskell
+import qualified Torch.Typed.DType as D
+import qualified Torch.Typed.Device as Dev
+
+model                                :: Linear 10 1 'D.Float '( 'D.CPU, 0)
+D.toDType @'D.Half @'D.Float model   :: Linear 10 1 'D.Half  '( 'D.CPU, 0)
+Dev.toDevice @'( 'D.CUDA, 0) @'( 'D.CPU, 0) model
+                                     :: Linear 10 1 'D.Float '( 'D.CUDA, 0)
+```
+
+`HasToDType`/`HasToDevice` are again derived generically for records
+of layers, and the `ReplaceDType` type family rewrites the dtype
+parameter everywhere it occurs in the model's type. The functional
+dependencies make the conversion bidirectional and unambiguous.
+
+The payoff is downstream: after `toDType @'D.Half`, the model *is* a
+half-precision model as far as GHC is concerned. Every forward pass,
+loss, and optimizer step is now checked against `'D.Half`, so a stray
+`'D.Float` batch fed to it — the classic silent-upcast bug of mixed
+precision work — is a compile-time error, not a performance mystery.

--- a/hasktorch/doc/09-indexing.md
+++ b/hasktorch/doc/09-indexing.md
@@ -27,7 +27,7 @@ The syntax is parsed at compile time, but the *semantics* are dynamic:
 shapes and bounds are only known when the program runs, so a mistake
 surfaces as a runtime error, exactly as in Python.
 
-## Typed: `slice` and the `ix` quasiquoter
+## Typed: `getSlice` and the `slice` quasiquoter
 
 In the typed API (`Torch.Typed.Index`) the index is a type-level
 list, and the result shape is computed by the `IndexedShape` type
@@ -38,9 +38,9 @@ import Torch.Typed.Index
 
 t :: Tensor '( 'D.CPU, 0) 'D.Float '[2, 3, 4]
 
-slice @'[SliceAt 1] t                   :: Tensor _ _ '[3, 4]
-slice @'[SliceAll, SliceAt 0] t         :: Tensor _ _ '[2, 4]
-slice @'[NewAxis, SliceFromUpTo 1 3] t  :: Tensor _ _ '[1, 2, 3, 4]
+getSlice @'[SliceAt 1] t                   :: Tensor _ _ '[3, 4]
+getSlice @'[SliceAll, SliceAt 0] t         :: Tensor _ _ '[2, 4]
+getSlice @'[NewAxis, SliceFromUpTo 1 3] t  :: Tensor _ _ '[1, 2, 3, 4]
 ```
 
 The index constructors follow the naming of the gradually-typed API's
@@ -49,19 +49,20 @@ indexing (PR #613): `SliceAt`, `SliceAll`, `NewAxis`, `SliceFrom`,
 are computed by ceiling division. Dimensions beyond the given indices
 are kept unchanged, as in PyTorch.
 
-Because the index is a type, PyTorch's textual syntax can live in a
-*type* quasiquoter, used inside the type application:
+Because the index is a type, the *same* `slice` quasiquoter that the
+untyped API uses in expression position works here in type position —
+one syntax for both APIs:
 
 ```haskell
-slice @[ix| 1, :, 1:3:2 |] t
--- ≡ slice @'[SliceAt 1, SliceAll, SliceFromUpToWithStep 1 3 2] t
+getSlice @[slice| 1, :, 1:3:2 |] t
+-- ≡ getSlice @'[SliceAt 1, SliceAll, SliceFromUpToWithStep 1 3 2] t
 
-slice @[ix| None, :, 1:3 |] t   -- insert an axis, keep, then slice
-slice @[ix| :, ::2 |] t         -- every second element of dimension 1
+getSlice @[slice| None, :, 1:3 |] t   -- insert an axis, keep, then slice
+getSlice @[slice| :, ::2 |] t         -- every second element of dimension 1
 ```
 
 `setSlice` is the writing counterpart; the value's shape is forced to
-match what `slice` with the same indices would produce:
+match what `getSlice` with the same indices would produce:
 
 ```haskell
 u = setSlice @'[SliceAt 0] t zeros
@@ -79,7 +80,7 @@ steps are all compile-time errors with readable messages:
 ```
 
 These checks compose with the quasiquoter. During development of the
-test suite, `slice @[ix| None, 1:3 |]` applied to a `'[2, 3, 4]`
+test suite, `getSlice @[slice| None, 1:3 |]` applied to a `'[2, 3, 4]`
 tensor was rejected at compile time — after `None` inserts an axis,
 the `1:3` lands on the dimension of size 2 — a mistake that in Python
 would only surface (or worse, silently clamp) at runtime.

--- a/hasktorch/doc/09-indexing.md
+++ b/hasktorch/doc/09-indexing.md
@@ -62,10 +62,16 @@ getSlice @[slice| :, ::2 |] t         -- every second element of dimension 1
 ```
 
 `setSlice` is the writing counterpart; the value's shape is forced to
-match what `getSlice` with the same indices would produce:
+match what `getSlice` with the same indices would produce.  The two
+combine into `sliceLens`, the typed counterpart of the untyped
+`lslice` lens:
 
 ```haskell
 u = setSlice @'[SliceAt 0] t zeros
+
+t ^. sliceLens @[slice| 1, : |]
+t &  sliceLens @[slice| 0 |] .~ zeros
+t &  sliceLens @[slice| :, 1 |] %~ (* 100)
 ```
 
 ## What the types catch

--- a/hasktorch/doc/09-indexing.md
+++ b/hasktorch/doc/09-indexing.md
@@ -1,0 +1,95 @@
+---
+title: Indexing and Slicing
+---
+
+# Indexing and Slicing
+
+PyTorch programs lean heavily on `t[1, :, 1:3:2]`-style indexing.
+Hasktorch supports this in both APIs: dynamically in the untyped API,
+and with compile-time shape checking in the typed API.
+
+## Untyped: `!` and the `slice` quasiquoter
+
+The untyped `Torch.Tensor` module provides `(!)` together with a
+family of index values (`None`, `Ellipsis`, `Slice`, booleans,
+integers, tensors), and `Torch.Index` provides a quasiquoter for
+PyTorch's textual syntax:
+
+```haskell
+import Torch
+import Torch.Index
+
+u = t ! (1 :: Int)               -- select
+v = t ! [slice| 1, :, 1:3:2 |]   -- pytorch syntax, parsed at compile time
+```
+
+The syntax is parsed at compile time, but the *semantics* are dynamic:
+shapes and bounds are only known when the program runs, so a mistake
+surfaces as a runtime error, exactly as in Python.
+
+## Typed: `slice` and the `ix` quasiquoter
+
+In the typed API (`Torch.Typed.Index`) the index is a type-level
+list, and the result shape is computed by the `IndexedShape` type
+family:
+
+```haskell
+import Torch.Typed.Index
+
+t :: Tensor '( 'D.CPU, 0) 'D.Float '[2, 3, 4]
+
+slice @'[SliceAt 1] t                   :: Tensor _ _ '[3, 4]
+slice @'[SliceAll, SliceAt 0] t         :: Tensor _ _ '[2, 4]
+slice @'[NewAxis, SliceFromUpTo 1 3] t  :: Tensor _ _ '[1, 2, 3, 4]
+```
+
+The index constructors follow the naming of the gradually-typed API's
+indexing (PR #613): `SliceAt`, `SliceAll`, `NewAxis`, `SliceFrom`,
+`SliceUpTo`, `SliceFromUpTo`, and `WithStep` variants; step lengths
+are computed by ceiling division. Dimensions beyond the given indices
+are kept unchanged, as in PyTorch.
+
+Because the index is a type, PyTorch's textual syntax can live in a
+*type* quasiquoter, used inside the type application:
+
+```haskell
+slice @[ix| 1, :, 1:3:2 |] t
+-- ≡ slice @'[SliceAt 1, SliceAll, SliceFromUpToWithStep 1 3 2] t
+
+slice @[ix| None, :, 1:3 |] t   -- insert an axis, keep, then slice
+slice @[ix| :, ::2 |] t         -- every second element of dimension 1
+```
+
+`setSlice` is the writing counterpart; the value's shape is forced to
+match what `slice` with the same indices would produce:
+
+```haskell
+u = setSlice @'[SliceAt 0] t zeros
+```
+
+## What the types catch
+
+Out-of-bounds indices, oversized slices, inverted ranges and zero
+steps are all compile-time errors with readable messages:
+
+```
+• Index 5 is out of bounds for a dimension of size 2.
+• Slice end 3 is out of bounds for a dimension of size 2.
+• Slice step must be positive.
+```
+
+These checks compose with the quasiquoter. During development of the
+test suite, `slice @[ix| None, 1:3 |]` applied to a `'[2, 3, 4]`
+tensor was rejected at compile time — after `None` inserts an axis,
+the `1:3` lands on the dimension of size 2 — a mistake that in Python
+would only surface (or worse, silently clamp) at runtime.
+
+## Limitations
+
+Indices in the typed API are type-level naturals, so indices computed
+at runtime do not fit this interface (use the untyped `!` for those,
+or `Torch.Typed.Representable.index` for bounds-checked single-element
+reads with `Finite` indices). Negative indices, `Ellipsis`, and
+boolean or tensor ("fancy") indexing are not supported in the typed
+layer — the latter two because their result shapes are not functions
+of the types.

--- a/hasktorch/doc/10-graded-and-staged.md
+++ b/hasktorch/doc/10-graded-and-staged.md
@@ -76,7 +76,10 @@ inspect at `a = Tensor`), so it goes through the `Cond` class:
 `maxE`/`minE` are overridden with native ATen calls in the `Tensor`
 instance.
 
-The entry points:
+The classes live in the untyped layer — `Torch.Elementwise` — so this
+style is not tied to typed tensors: `emap relu' t` works on a plain
+`Tensor`, and the typed module re-exports the same `Cond`. The typed
+entry points add shape tracking on top:
 
 ```haskell
 emap     :: (forall a. (Floating a, Cond a) => a -> a)      -> NamedTensor d t s -> NamedTensor d t s

--- a/hasktorch/doc/10-graded-and-staged.md
+++ b/hasktorch/doc/10-graded-and-staged.md
@@ -1,0 +1,123 @@
+---
+title: Graded and Staged Tensor Programs
+---
+
+# Graded and Staged Tensor Programs
+
+This chapter covers three modules that grew out of one question: can
+tensor programs be written element-by-element — the way the math is
+written — without giving up whole-tensor execution?
+
+## Why `Tensor` is not a `Monad`
+
+A `Monad` instance must keep the type constructor fixed while the
+element type changes. Tensor computations do the opposite: binding a
+`'[Batch 2]` computation to a per-element continuation that produces
+`'[RGB]` values yields a `'[Batch 2, RGB]` tensor — the *shape*
+changes, and the element type (fixed by the dtype) does not. The
+structure this actually is, is a monad *graded* by the monoid of
+shapes under concatenation:
+
+```haskell
+-- Torch.Typed.Graded
+greturn :: Grade m -> m '[]
+gbind   :: m s -> (Grade m -> m t) -> m (s ++ t)
+```
+
+`'[]` is the unit of `++` and `++` is associative, so the graded
+monad laws hold — and because they hold *definitionally* at the type
+level, GHC accepts both sides of the associativity law at the same
+type without any coercions. `QualifiedDo` gives back `do`-notation:
+
+```haskell
+{-# LANGUAGE QualifiedDo #-}
+import qualified Torch.Typed.Graded as G
+
+rgbOf :: TensorMonad '( 'D.CPU, 0) 'D.Float '[Batch 2, RGB]
+rgbOf = G.do
+  x <- batch          -- '[Batch 2]
+  channelwise x       -- each element expands to '[RGB]
+```
+
+All three laws are verified against real tensors in the test suite.
+`gbind` evaluates its continuation once per element, which makes it
+the *reference semantics* — correct, slow, and the oracle that the
+fast path below is tested against.
+
+## Staged element-wise code
+
+The fast path is Coyoneda-shaped: write the element function once,
+*polymorphically*, and reinterpret it.
+
+```haskell
+-- Torch.Typed.Staged
+f :: (Floating a, Cond a) => a -> a
+f x = whereE (gtE x 0) (sin x * 10) 0
+```
+
+The same `f` runs under two instantiations:
+
+- `a = Float` — per-element reference semantics;
+- `a = Tensor` — every operation is a whole-tensor ATen call, so the
+  body executes *once* regardless of tensor size, no per-element FFI
+  happens, and autograd sees every step.
+
+This works because the untyped `Tensor` has `Num`, `Fractional` and
+`Floating` instances, and because the rank-2 type means the only
+operations available inside `f` are class methods — parametricity
+guarantees the function is a pointwise expression, so reinterpreting
+it is sound. An already-monomorphic `Float -> Float` cannot be
+vectorized this way; the polymorphic type is what keeps the code
+inspectable.
+
+Value-dependent control flow cannot use `if` (there is no `Bool` to
+inspect at `a = Tensor`), so it goes through the `Cond` class:
+`whereE` compiles to `torch.where`, comparisons return 0/1 masks, and
+`maxE`/`minE` are overridden with native ATen calls in the `Tensor`
+instance.
+
+The entry points:
+
+```haskell
+emap     :: (forall a. (Floating a, Cond a) => a -> a)      -> NamedTensor d t s -> NamedTensor d t s
+ezipWith :: (forall a. (Floating a, Cond a) => a -> a -> a) -> ...
+gbindV   :: TensorMonad d dt s
+         -> (forall a. (Floating a, Cond a) => a -> HList (ToFinites t) -> a)
+         -> TensorMonad d dt (s ++ t)
+```
+
+`gbindV` satisfies `gbindV m k = gbind m (fromNamed . tabulate . k)`
+— an equation the test suite checks with `gbind` as the oracle. The
+two instantiations of a formula built from `+`, `*`, comparisons and
+`whereE` agree bit-for-bit (IEEE basic operations are deterministic);
+only transcendental functions differ within float tolerance.
+
+## Case study: non-maximum suppression
+
+`Torch.Typed.Vision` implements NMS in this style. The whole
+algorithmic content of the pairwise step is one scalar formula:
+
+```haskell
+iou :: (Fractional a, Cond a) => Box a -> Box a -> a
+iou a b = inter / (area a + area b - inter)
+  where
+    iw = maxE 0 (minE (x2 a) (x2 b) - maxE (x1 a) (x1 b))
+    ih = maxE 0 (minE (y2 a) (y2 b) - maxE (y1 a) (y1 b))
+    inter = iw * ih
+    area v = (x2 v - x1 v) * (y2 v - y1 v)
+```
+
+`boxIou` instantiates it at `a = Tensor` with fields shaped `[n,1]`
+and `[1,n]`, so broadcasting produces the whole matrix from one
+evaluation; the tests instantiate the same code at `a = Float` as the
+reference. The greedy suppression itself is three lines of list
+recursion — the sequential part of the algorithm is where plain
+Haskell is already the clearest notation, and no tensor machinery is
+forced onto it. `nms` computes IoU rows lazily, only for boxes that
+are actually kept, so memory stays `O(n)`.
+
+Indicative CPU timings (FHD-scale boxes, `n` = pre-NMS top-k):
+`n`=1000 ≈ 8 ms, `n`=3000 ≈ 22 ms, `n`=6000 ≈ 48 ms. A native C++
+kernel is still a few times faster at the top end — the remaining gap
+is eager per-op dispatch, discussed in
+[TorchScript and the JIT](11-torchscript-and-jit.html).

--- a/hasktorch/doc/11-torchscript-and-jit.md
+++ b/hasktorch/doc/11-torchscript-and-jit.md
@@ -1,0 +1,96 @@
+---
+title: TorchScript and the JIT
+---
+
+# TorchScript and the JIT
+
+Hasktorch executes eagerly: every tensor operation is one ATen call
+that materializes its result. For a formula like the `iou` of the
+previous chapter that means a dozen intermediate `n × n` tensors per
+evaluation — correct, but memory-bandwidth-bound. PyTorch's answer to
+this is fusion: compile chains of pointwise operations into a single
+kernel. This chapter explains what of that machinery is reachable
+from Hasktorch, and — importantly — why tracing alone will *not* make
+your CPU code faster today.
+
+## Tracing
+
+`Torch.Script` binds TorchScript's tracer. Any Haskell function on
+(untyped) tensors can be traced — including, unchanged, the
+`a = Tensor` instantiation of a staged formula:
+
+```haskell
+import Torch.Script
+import Torch.NN (forward)
+
+m  <- trace "IoU" "forward" (\[a, b] -> return [iouOn a b]) exampleInputs
+sm <- toScriptModule m
+let IVTensor r = forward sm (map IVTensor inputs)
+```
+
+Tracing runs the function once while ATen records every dispatched
+operation; the recorded graph can be saved (`saveScript`), loaded and
+executed independently of the Haskell code that produced it. Tracing
+the staged `iou` yields exactly the expected 15-node graph of
+`aten::minimum`, `aten::maximum`, `aten::sub`, `aten::mul`,
+`aten::add`, `aten::div`.
+
+## Why it does not get faster on CPU
+
+Measured on the `iou` formula at `n = 6000` (CPU):
+
+| | ms/iter |
+|---|---|
+| eager | ≈ 86 |
+| traced, default settings | ≈ 113 |
+
+Traced execution is *slower*: the profiling executor adds overhead
+and, by default, never fuses on CPU. Two internal switches control
+this, exposed in `Torch.Internal.Unmanaged.Type.Module`:
+
+```haskell
+overrideCanFuseOnCPU 1       -- allow the fuser to take CPU graphs
+setTensorExprFuserEnabled 1  -- enable the TensorExpr (NNC) fusion pass
+```
+
+With these on, the fuser does engage — it grabs the pointwise chain
+and attempts to compile a fused kernel — and then fails at runtime
+with:
+
+```
+LLVM Backend not found
+```
+
+The official libtorch binaries ship without NNC's LLVM code
+generator. So CPU fusion via TorchScript is not a configuration away;
+it requires a libtorch built with `USE_LLVM=ON`. This is a property
+of the libtorch distribution, not of Hasktorch — upstream PyTorch
+moved CPU fusion effort to `torch.compile`/Inductor, which is
+Python-only.
+
+The situation on CUDA is different: the CUDA fuser generates kernels
+through NVRTC and has no LLVM dependency, so a traced module on GPU
+can genuinely fuse. The switches above (`overrideCanFuseOnGPU`) apply
+there as well.
+
+## What to do instead, on CPU
+
+Two things that *did* measurably help the eager path, both applied in
+`Torch.Typed.Staged` and `Torch.Typed.Vision`:
+
+1. **Cheaper interpreters.** `maxE`/`minE` are `Cond` class methods
+   with a `whereE`-based default; the `Tensor` instance overrides
+   them with native `aten::maximum`/`minimum` — one call instead of
+   four. This roughly halved the op count of `iou` without touching
+   any formula. Optimizing the interpreter rather than the programs
+   is the point of writing element code against a class.
+
+2. **Computing less.** `nms` stopped materializing the `n × n` IoU
+   matrix and evaluates only the rows of boxes that are actually
+   kept (`O(n)` memory, one broadcast evaluation per kept box) —
+   a 7× end-to-end improvement at `n = 6000`.
+
+The honest summary: eager Hasktorch reaches within a small factor of
+native kernels when the operation count is kept down; closing the
+rest needs either a CUDA device, an LLVM-enabled libtorch, or a
+different backend behind the same polymorphic element code.

--- a/hasktorch/doc/12-lenses.md
+++ b/hasktorch/doc/12-lenses.md
@@ -1,0 +1,186 @@
+---
+title: Lenses
+---
+
+# Lenses
+
+Hasktorch uses lenses in two directions: *inward*, addressing parts
+of a single tensor (slices, named fields), and *outward*, traversing
+every tensor inside an arbitrary structure. Both come in untyped and
+typed flavors. This chapter walks through all four quadrants with
+executable examples.
+
+```haskell top hide
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ExtendedDefaultRules #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+import Inliterate.Import (AskInliterate)
+import qualified Torch.DType
+```
+
+```haskell top
+import Torch
+import Torch.Index (lslice)
+import Torch.Lens (types, flattenValues, replaceValues)
+import Lens.Family
+import GHC.Generics (Generic)
+import qualified Torch.Typed as T
+import qualified Torch.Typed.Lens as TL
+import Data.Vector.Sized (Vector)
+```
+
+```haskell top hide
+instance AskInliterate Tensor
+instance AskInliterate Torch.DType.DType
+```
+
+## Slicing lenses (untyped)
+
+The `lslice` quasiquoter turns PyTorch indexing syntax into a *lens*
+into a tensor: something you can read through, but also write
+through.
+
+```haskell do
+let t = asTensor ([[0, 1, 2], [3, 4, 5]] :: [[Float]])
+```
+
+Reading a slice with `^.`:
+
+```haskell eval
+t ^. [lslice|1|] :: Tensor
+```
+
+```haskell eval
+t ^. [lslice|:, ::2|] :: Tensor
+```
+
+Writing through the same lens with `.~` returns an updated tensor,
+with everything outside the slice untouched:
+
+```haskell eval
+t & [lslice|0|] .~ zeros' [3]
+```
+
+And `%~` modifies the focused slice with a function:
+
+```haskell eval
+t & [lslice|:, 1|] %~ ((* 100) :: Tensor -> Tensor)
+```
+
+This is the lens counterpart of `t[0] = ...` in Python — but pure:
+the original `t` is unchanged.
+
+## Structure traversals (untyped)
+
+`Torch.Lens` provides `types`, a generic traversal of every value of
+a given type inside a structure. Any record with a `Generic` instance
+works.
+
+```haskell top
+data TwoLayer = TwoLayer
+  { weight1 :: Tensor
+  , weight2 :: Tensor
+  , steps   :: Int
+  } deriving (Generic, Show)
+```
+
+```haskell do
+let m = TwoLayer (ones' [2, 3]) (ones' [3]) 0
+```
+
+Collect every tensor:
+
+```haskell eval
+map shape (flattenValues (types @Tensor) m)
+```
+
+Rewrite every tensor — this is exactly how `toType` and `toDevice`
+convert whole models; here we switch the model to half precision:
+
+```haskell eval
+map dtype (flattenValues (types @Tensor) (toType Half m))
+```
+
+Note the `Int` field rides along untouched; only the tensors are
+visited.
+
+## Field and shape lenses (typed)
+
+In the typed API, dimensions can be records, and record fields become
+lenses. `field @"r"` reads or writes the `r` component of an RGB
+dimension, and its very existence is checked at compile time —
+`field @"q"` would not compile.
+
+```haskell top
+data RGB a = RGB { r :: a, g :: a, b :: a } deriving (Generic, Show)
+```
+
+```haskell do
+let img = T.fromUnnamed T.ones :: T.NamedTensor '( 'CPU, 0) 'Float '[Vector 2, RGB]
+```
+
+```haskell eval
+T.toDynamic (img ^. TL.field @"r")
+```
+
+```haskell eval
+T.toDynamic (img & TL.field @"g" .~ T.fromUnnamed T.zeros)
+```
+
+The outward traversal also exists in typed form, where it becomes
+*shape-selective*: `types` at a typed tensor target visits only the
+tensors of exactly that device, dtype and shape.
+
+```haskell top
+data TypedNet device = TypedNet
+  { l1 :: T.Tensor device 'Float '[2, 3]
+  , l2 :: T.Tensor device 'Float '[3, 4]
+  , l3 :: T.Tensor device 'Float '[2, 3]
+  } deriving Generic
+```
+
+```haskell do
+let net = TypedNet T.ones T.ones T.zeros :: TypedNet '( 'CPU, 0)
+```
+
+Only the two `'[2, 3]` layers are visited; the `'[3, 4]` one is not:
+
+```haskell eval
+length (flattenValues (types @(T.Tensor '( 'CPU, 0) 'Float '[2, 3])) net)
+```
+
+```haskell eval
+T.toDynamic (l3 (over (types @(T.Tensor '( 'CPU, 0) 'Float '[2, 3])) (+ 1) net))
+```
+
+`replaceValues` swaps specific structures wholesale — replace the two
+`'[2, 3]` tensors and leave everything else:
+
+```haskell eval
+T.toDynamic (l1 (replaceValues (types @(T.Tensor '( 'CPU, 0) 'Float '[2, 3])) net [T.zeros, T.ones]))
+```
+
+## Retyping conversions (typed)
+
+Finally, the typed counterparts of `toType`/`toDevice` change the
+*type* along with the values. `Torch.Typed.DType.toDType` converts
+every tensor in a model and rewrites the model's dtype parameter, so
+after converting to `'Half` a stray `'Float` batch is a compile-time
+error rather than a silent upcast:
+
+```haskell
+model                                :: Linear 10 1 'Float '( 'CPU, 0)
+toDType @'Half @'Float model         :: Linear 10 1 'Half  '( 'CPU, 0)
+toDevice @'( 'CUDA, 0) @'( 'CPU, 0) model
+                                     :: Linear 10 1 'Float '( 'CUDA, 0)
+```
+
+See [Named Tensors and Lenses](08-named-tensors.html) for the
+reference treatment of these conversions.

--- a/hasktorch/doc/12-lenses.md
+++ b/hasktorch/doc/12-lenses.md
@@ -27,12 +27,13 @@ import qualified Torch.DType
 
 ```haskell top
 import Torch
-import Torch.Index (lslice)
+import Torch.Index (lslice, slice)
 import Torch.Lens (types, flattenValues, replaceValues)
 import Lens.Family
 import GHC.Generics (Generic)
 import qualified Torch.Typed as T
 import qualified Torch.Typed.Lens as TL
+import qualified Torch.Typed.Index as TI
 import Data.Vector.Sized (Vector)
 ```
 
@@ -132,6 +133,24 @@ T.toDynamic (img ^. TL.field @"r")
 
 ```haskell eval
 T.toDynamic (img & TL.field @"g" .~ T.fromUnnamed T.zeros)
+```
+
+Slicing lenses exist here too: `sliceLens` is the typed `lslice`,
+built from `getSlice` and `setSlice`, and the same `slice` quasiquoter
+works in type position.  The focused shape is computed at compile
+time, so writing a wrongly-shaped value through the lens does not
+compile.
+
+```haskell do
+let tt = T.ones :: T.Tensor '( 'CPU, 0) 'Float '[2, 3]
+```
+
+```haskell eval
+T.toDynamic (tt ^. TI.sliceLens @[slice| 1 |])
+```
+
+```haskell eval
+T.toDynamic (tt & TI.sliceLens @[slice| :, 1 |] %~ (* 100))
 ```
 
 The outward traversal also exists in typed form, where it becomes

--- a/hasktorch/doc/13-attention.md
+++ b/hasktorch/doc/13-attention.md
@@ -1,0 +1,86 @@
+---
+title: Attention, Equation by Equation
+---
+
+# Attention, Equation by Equation
+
+The library ships a full transformer
+(`Torch.Typed.NN.Transformer`, ~640 lines), and it is fair to say
+that reading it does not make the *idea* of attention visible. This
+chapter makes the opposite trade: a complete, trainable decoder block
+where each equation of the paper is one definition, with the paper's
+shape annotations as checked types. The full listing is
+`test/Torch/Typed/AttentionSpec.hs`; CI trains it and checks that it
+learns.
+
+## The three equations
+
+A paper writes attention as
+
+> M ∈ ℝ^{s×s},  M_{ij} = 0 if j ≤ i, −∞ otherwise
+>
+> Attention(Q, K, V) = softmax(QKᵀ/√d + M) V
+
+and the code says exactly that. The mask is a tensor *defined by its
+formula*, through `tabulate`:
+
+```haskell
+causalMask :: T '[S, S]
+causalMask = toUnnamed (tabulateList @'[Vector S, Vector S] @'D.Float @Dev mask)
+  where
+    mask [i, j] = if j <= i then 0 else -1 / 0
+```
+
+and attention is its equation, with the ℝ^{s×e} annotations moved
+into the type where the compiler can read them:
+
+```haskell
+attend :: T '[S, E] -> T '[S, E] -> T '[S, E] -> T '[S, E]
+attend q k v =
+  softmax @1 (divScalar sqrtD (q `matmul` transpose2D k) + causalMask) `matmul` v
+```
+
+A decoder block is four more lines, each one a line of the
+architecture diagram:
+
+```haskell
+gptForward GPT {..} tokens = forward unembed x''
+  where
+    x   = embedding @'Nothing False False (toDependent embed) tokens
+    x'  = x  + forward wo (attend (forward wq xn) (forward wk xn) (forward wv xn))
+    x'' = x' + forward ff2 (relu (forward ff1 (forward norm2 x')))
+    xn  = forward norm1 x
+```
+
+The parameters are an ordinary record of `Linear`s, `LayerNorm`s and
+an embedding table with `deriving (Generic, Parameterized)`; the
+whole model, mask to logits, is about sixty lines.
+
+## And it learns
+
+The test trains this block with Adam on next-token prediction over a
+repeating sequence and asserts the outcome: the loss starts near
+ln 4 ≈ 1.39 (uniform guessing over four tokens), ends below 0.1
+after a thousand steps, and the trained block predicts every next
+token correctly. The whole run takes about a second on CPU. That
+closes the loop this chapter is about: the code above is not
+pseudocode — it is the model, the types are its shape discipline, and
+the test is its meaning.
+
+## Why the library version is ten times longer
+
+`Torch.Typed.NN.Transformer` is not long because attention is
+complicated. It is long because it is *general*: separate embedding
+dimensions for queries, keys and values; any number of heads, with
+the reshape/transpose plumbing that heads require; optional key
+padding masks and attention masks; dropout at four sites; batch
+dimensions; and polymorphism over dtype and device, each generalized
+parameter carrying its constraints through every signature. The
+mathematics you can see above is in there, spread thin across that
+generality.
+
+The practical reading order is therefore: understand this chapter's
+sixty lines first, then read the library transformer as "the same
+equations, made reusable" — and let the types tell you which of its
+parameters is which, because every shape annotation in its long
+signatures is one of the ℝ^{...} superscripts from the paper, checked.

--- a/hasktorch/doc/index.md
+++ b/hasktorch/doc/index.md
@@ -27,6 +27,7 @@ The tutorial chapters:
 9. [Indexing and Slicing](09-indexing.html)
 10. [Graded and Staged Tensor Programs](10-graded-and-staged.html)
 11. [TorchScript and the JIT](11-torchscript-and-jit.html)
+12. [Lenses](12-lenses.html)
 
 Looking for a reference? See the [API docs][api-docs] hosted on
 [hasktorch.org][hasktorch-org].

--- a/hasktorch/doc/index.md
+++ b/hasktorch/doc/index.md
@@ -14,6 +14,20 @@ programming][olah-nn-types-fp].
 Interested in learning more? [Keep reading][getting-started] for
 installation instructions, walkthrough, and tutorial.
 
+The tutorial chapters:
+
+1. [Getting Started](01-getting-started.html)
+2. [Tensors](02-tensors.html)
+3. [Randomness](03-randomness.html)
+4. [Automatic Differentiation](04-automatic-differentiation.html)
+5. [Differentiable Programs](05-differentiable-programs.html)
+6. [Linear Regression](06-linear-regression.html)
+7. [Typed Tensors](07-typed-tensors.html)
+8. [Named Tensors and Lenses](08-named-tensors.html)
+9. [Indexing and Slicing](09-indexing.html)
+10. [Graded and Staged Tensor Programs](10-graded-and-staged.html)
+11. [TorchScript and the JIT](11-torchscript-and-jit.html)
+
 Looking for a reference? See the [API docs][api-docs] hosted on
 [hasktorch.org][hasktorch-org].
 

--- a/hasktorch/doc/index.md
+++ b/hasktorch/doc/index.md
@@ -28,6 +28,7 @@ The tutorial chapters:
 10. [Graded and Staged Tensor Programs](10-graded-and-staged.html)
 11. [TorchScript and the JIT](11-torchscript-and-jit.html)
 12. [Lenses](12-lenses.html)
+13. [Attention, Equation by Equation](13-attention.html)
 
 Looking for a reference? See the [API docs][api-docs] hosted on
 [hasktorch.org][hasktorch-org].

--- a/hasktorch/hasktorch.cabal
+++ b/hasktorch/hasktorch.cabal
@@ -192,6 +192,7 @@ test-suite spec
                     , Torch.Typed.StagedSpec
                     , Torch.Typed.NMSSpec
                     , Torch.Typed.IndexSpec
+                    , Torch.Typed.LensSpec
                     , Torch.Typed.SerializeSpec
                     , SerializeSpec
                     , RandomSpec

--- a/hasktorch/hasktorch.cabal
+++ b/hasktorch/hasktorch.cabal
@@ -88,6 +88,7 @@ library
                     , Torch.Typed.Representable
                     , Torch.Typed.Graded
                     , Torch.Typed.Staged
+                    , Torch.Typed.Index
                     , Torch.Typed.VLTensor
                     , Torch.Distributions.Constraints
                     , Torch.Distributions.Distribution
@@ -190,6 +191,7 @@ test-suite spec
                     , Torch.Typed.GradedSpec
                     , Torch.Typed.StagedSpec
                     , Torch.Typed.NMSSpec
+                    , Torch.Typed.IndexSpec
                     , Torch.Typed.SerializeSpec
                     , SerializeSpec
                     , RandomSpec

--- a/hasktorch/hasktorch.cabal
+++ b/hasktorch/hasktorch.cabal
@@ -56,6 +56,7 @@ library
                     , Torch.Script
                     , Torch.HList
                     , Torch.Lens
+                    , Torch.Elementwise
                     , Torch.Typed
                     , Torch.Typed.Auxiliary
                     , Torch.Typed.Factories
@@ -163,6 +164,7 @@ test-suite spec
                     , GradSpec
                     , InitializerSpec
                     , LensSpec
+                    , ElementwiseSpec
                     , OptimSpec
                     , SparseSpec
                     , ScriptSpec

--- a/hasktorch/hasktorch.cabal
+++ b/hasktorch/hasktorch.cabal
@@ -195,6 +195,7 @@ test-suite spec
                     , Torch.Typed.NMSSpec
                     , Torch.Typed.IndexSpec
                     , Torch.Typed.LensSpec
+                    , Torch.Typed.AttentionSpec
                     , Torch.Typed.SerializeSpec
                     , SerializeSpec
                     , RandomSpec

--- a/hasktorch/hasktorch.cabal
+++ b/hasktorch/hasktorch.cabal
@@ -85,6 +85,9 @@ library
                     , Torch.Typed.Vision
                     , Torch.Typed.Lens
                     , Torch.Typed.NamedTensor
+                    , Torch.Typed.Representable
+                    , Torch.Typed.Graded
+                    , Torch.Typed.Staged
                     , Torch.Typed.VLTensor
                     , Torch.Distributions.Constraints
                     , Torch.Distributions.Distribution
@@ -183,6 +186,9 @@ test-suite spec
                     , Torch.Typed.NN.TransformerSpec
                     , Torch.Typed.VisionSpec
                     , Torch.Typed.NamedTensorSpec
+                    , Torch.Typed.RepresentableSpec
+                    , Torch.Typed.GradedSpec
+                    , Torch.Typed.StagedSpec
                     , Torch.Typed.SerializeSpec
                     , SerializeSpec
                     , RandomSpec
@@ -213,6 +219,7 @@ test-suite spec
                     , pipes
                     , random
                     , vector-sized
+                    , finite-typelits
                     , lens-family-core
                     , data-default-class
                     , half

--- a/hasktorch/hasktorch.cabal
+++ b/hasktorch/hasktorch.cabal
@@ -189,6 +189,7 @@ test-suite spec
                     , Torch.Typed.RepresentableSpec
                     , Torch.Typed.GradedSpec
                     , Torch.Typed.StagedSpec
+                    , Torch.Typed.NMSSpec
                     , Torch.Typed.SerializeSpec
                     , SerializeSpec
                     , RandomSpec

--- a/hasktorch/src/Torch/Elementwise.hs
+++ b/hasktorch/src/Torch/Elementwise.hs
@@ -1,0 +1,102 @@
+{-# LANGUAGE RankNTypes #-}
+
+-- | Element-wise code over untyped tensors, written once and interpreted
+-- twice.
+--
+-- The untyped 'Torch.Tensor.Tensor' has 'Num', 'Fractional' and 'Floating'
+-- instances, so a function written polymorphically,
+--
+-- > f :: (Floating a, Cond a) => a -> a
+-- > f x = whereE (gtE x 0) (sin x * 10) 0
+--
+-- runs under two instantiations: at @a = Float@ one element at a time (the
+-- reference semantics), and at @a = 'Torch.Tensor.Tensor'@ as whole-tensor
+-- ATen operations — the body executes once regardless of tensor size, no
+-- per-element FFI happens, and autograd sees every step.
+--
+-- 'Cond' supplies the part 'Floating' cannot: value-dependent control flow.
+-- @if@ on the element is not available at @a = Tensor@ (there is no 'Bool' to
+-- inspect), so branching goes through 'whereE', which compiles to
+-- @torch.where@.
+--
+-- The typed layer ("Torch.Typed.Staged") builds on exactly these classes and
+-- adds shape tracking; this module is their untyped home.
+module Torch.Elementwise
+  ( -- * Value-dependent control flow
+    Cond (..),
+
+    -- * Vectorized element-wise application
+    emap,
+    ezipWith,
+  )
+where
+
+import qualified Torch.DType as DT
+import qualified Torch.Functional as F
+import qualified Torch.Functional.Internal as I
+import Torch.Tensor (Tensor)
+import qualified Torch.Tensor as T
+
+-- | Branching and comparisons for staged element code.  Comparisons return
+-- @0@\/@1@ masks in the same type @a@ so they compose with arithmetic.
+class Cond a where
+  -- | @whereE c t e@ is elementwise @if c /= 0 then t else e@.
+  whereE :: a -> a -> a -> a
+
+  ltE :: a -> a -> a
+  leE :: a -> a -> a
+  gtE :: a -> a -> a
+  geE :: a -> a -> a
+  eqE :: a -> a -> a
+  neE :: a -> a -> a
+
+  -- | Elementwise maximum.  The default goes through 'whereE'; instances can
+  -- (and the 'Tensor' instance does) override it with a native operation.
+  maxE :: a -> a -> a
+  maxE a b = whereE (gtE a b) a b
+
+  -- | Elementwise minimum, see 'maxE'.
+  minE :: a -> a -> a
+  minE a b = whereE (ltE a b) a b
+
+instance Cond Float where
+  whereE c t e = if c /= 0 then t else e
+  ltE a b = if a < b then 1 else 0
+  leE a b = if a <= b then 1 else 0
+  gtE a b = if a > b then 1 else 0
+  geE a b = if a >= b then 1 else 0
+  eqE a b = if a == b then 1 else 0
+  neE a b = if a /= b then 1 else 0
+
+instance Cond Double where
+  whereE c t e = if c /= 0 then t else e
+  ltE a b = if a < b then 1 else 0
+  leE a b = if a <= b then 1 else 0
+  gtE a b = if a > b then 1 else 0
+  geE a b = if a >= b then 1 else 0
+  eqE a b = if a == b then 1 else 0
+  neE a b = if a /= b then 1 else 0
+
+instance Cond Tensor where
+  whereE c t e = I.where' (F.toDType DT.Bool c) t e
+  ltE a b = F.toDType (T.dtype a) (F.lt a b)
+  leE a b = F.toDType (T.dtype a) (F.le a b)
+  gtE a b = F.toDType (T.dtype a) (F.gt a b)
+  geE a b = F.toDType (T.dtype a) (F.ge a b)
+  eqE a b = F.toDType (T.dtype a) (F.eq a b)
+  neE a b = F.toDType (T.dtype a) (F.ne a b)
+  maxE = I.maximum
+  minE = I.minimum
+
+-- | Apply an element function to a whole tensor.  Operationally this is just
+-- application — the function /is/ the vectorized code — but the rank-2 type
+-- earns its keep: the only operations available inside @f@ are class methods,
+-- so parametricity guarantees @f@ is a pointwise expression, and the same
+-- @f@ can be run at @a = Float@ as its own per-element specification.
+emap :: (forall a. (Floating a, Cond a) => a -> a) -> Tensor -> Tensor
+emap f = f
+
+-- | Element-wise combination of two tensors (with broadcasting, as the
+-- underlying ATen operations provide it).
+ezipWith :: (forall a. (Floating a, Cond a) => a -> a -> a) -> Tensor -> Tensor -> Tensor
+ezipWith f = f

--- a/hasktorch/src/Torch/Functional.hs
+++ b/hasktorch/src/Torch/Functional.hs
@@ -93,6 +93,28 @@ instance Fractional Tensor where
   recip t = unsafePerformIO $ cast1 ATen.reciprocal_t t
   fromRational i = asTensor @Float $ fromRational @Float i
 
+-- | Pointwise transcendental functions on tensors.  Together with the 'Num'
+-- and 'Fractional' instances this lets element-wise code written against
+-- @Floating a => a -> a@ run vectorized at @a = Tensor@.
+instance Floating Tensor where
+  pi = asTensor @Float pi
+  exp t = unsafePerformIO $ cast1 ATen.exp_t t
+  log t = unsafePerformIO $ cast1 ATen.log_t t
+  sqrt t = unsafePerformIO $ cast1 ATen.sqrt_t t
+  (**) a b = unsafePerformIO $ cast2 ATen.pow_tt a b
+  sin t = unsafePerformIO $ cast1 ATen.sin_t t
+  cos t = unsafePerformIO $ cast1 ATen.cos_t t
+  tan t = unsafePerformIO $ cast1 ATen.tan_t t
+  asin t = unsafePerformIO $ cast1 ATen.asin_t t
+  acos t = unsafePerformIO $ cast1 ATen.acos_t t
+  atan t = unsafePerformIO $ cast1 ATen.atan_t t
+  sinh t = unsafePerformIO $ cast1 ATen.sinh_t t
+  cosh t = unsafePerformIO $ cast1 ATen.cosh_t t
+  tanh t = unsafePerformIO $ cast1 ATen.tanh_t t
+  asinh t = unsafePerformIO $ cast1 ATen.asinh_t t
+  acosh t = unsafePerformIO $ cast1 ATen.acosh_t t
+  atanh t = unsafePerformIO $ cast1 ATen.atanh_t t
+
 -- Return upper or lower triangular matrices
 data Tri = Upper | Lower deriving (Eq, Show)
 

--- a/hasktorch/src/Torch/Index.hs
+++ b/hasktorch/src/Torch/Index.hs
@@ -19,6 +19,7 @@ import Text.Megaparsec as M
 import Text.Megaparsec.Char hiding (space)
 import Text.Megaparsec.Char.Lexer
 import Torch.Tensor
+import qualified Torch.Typed.Index (parseIndices)
 
 type Parser = Parsec Void String
 
@@ -157,7 +158,11 @@ slice =
     { quoteExp = parseSlice >=> qconcat,
       quotePat = error "quotePat is not implemented for slice.",
       quoteDec = error "quoteDec is not implemented for slice.",
-      quoteType = error "quoteType is not implemented for slice."
+      -- In type position the same syntax produces the promoted
+      -- @'[Torch.Typed.Index.IndexType]@ list, so one quasiquoter serves the
+      -- untyped API (@t ! [slice|1,:|]@) and the typed one
+      -- (@getSlice \@[slice|1,:|] t@).
+      quoteType = Torch.Typed.Index.parseIndices
     }
   where
     qconcat :: [Exp] -> Q Exp
@@ -175,7 +180,7 @@ lslice =
     { quoteExp = parseSlice >=> qconcat,
       quotePat = error "quotePat is not implemented for slice.",
       quoteDec = error "quoteDec is not implemented for slice.",
-      quoteType = error "quoteType is not implemented for slice."
+      quoteType = error "quoteType is not implemented for lslice."
     }
   where
     qconcat :: [Exp] -> Q Exp

--- a/hasktorch/src/Torch/Typed/Graded.hs
+++ b/hasktorch/src/Torch/Typed/Graded.hs
@@ -1,0 +1,176 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE NoStarIsType #-}
+
+-- | A graded (indexed) monad over tensor shapes.
+--
+-- Binding a tensor computation /concatenates/ shapes rather than preserving
+-- them, so the shape cannot be a fixed parameter of a 'Monad' instance.  It is
+-- instead a grade drawn from the monoid @('[], '(++)')@:
+--
+-- > greturn :: a           -> m '[]
+-- > gbind   :: m s -> (a -> m t) -> m (s ++ t)
+--
+-- Because @'[]@ is a unit for @++@ and @++@ is associative, the graded monad
+-- laws hold, and GHC discharges the required equalities definitionally — no
+-- proof terms or coercions are needed.
+--
+-- This is deliberately /not/ a restricted monad.  A restricted monad would
+-- keep the @Monad@ shape and attach constraints, which costs you @do@ notation
+-- and every @Traversable@ combinator.  Here @do@ notation still works through
+-- @QualifiedDo@ (GHC 9.0+):
+--
+-- > {-# LANGUAGE QualifiedDo #-}
+-- > import qualified Torch.Typed.Graded as G
+-- >
+-- > rgbOf :: TensorMonad '( 'D.CPU, 0) 'D.Float '[Batch 2, RGB]
+-- > rgbOf = G.do
+-- >   x <- batch
+-- >   channelwise x
+--
+-- The element type is fixed by the tensor's @dtype@, so unlike a
+-- @Monad@ the grade parameter is the shape and the \"value\" type is constant.
+-- That makes this a graded monad in the shape only, which is exactly the
+-- structure tensor reshaping has.
+module Torch.Typed.Graded
+  ( -- * Shape concatenation
+    --
+    -- | Re-exported from "Torch.HList": the shape monoid's multiplication.
+    type (++),
+
+    -- * Graded monad
+    GradedMonad (..),
+    (>>=),
+    (>>),
+    return,
+
+    -- * Tensors as a graded monad
+    TensorMonad (..),
+    fromNamed,
+    toNamed,
+  )
+where
+
+import Data.Kind (Constraint, Type)
+import Data.Proxy (Proxy (..))
+import GHC.TypeLits (Nat)
+import qualified Torch.DType as D
+import qualified Torch.Device as D
+import Torch.HList (type (++))
+import qualified Torch.Tensor as D
+import Torch.Typed.Representable
+import Torch.Typed.Tensor
+import Prelude hiding (return, (>>), (>>=))
+
+-- | A monad graded by a monoid of shapes.
+--
+-- The grading multiplication is 'Torch.HList.++', the type-level list
+-- concatenation already used for 'HList' appending.
+--
+-- @m@ is indexed by a 'Shape' rather than by an element type, so 'gbind'
+-- multiplies grades with '++' instead of leaving them fixed.
+class GradedMonad (m :: Shape -> Type) where
+  -- | The element type produced at each index.
+  type Grade m :: Type
+
+  -- | Whatever @m@ needs to know about a shape in order to build one.  For
+  -- tensors this carries the runtime dimensions and tensor options.
+  type Ok m (s :: Shape) :: Constraint
+
+  -- | Unit of the grading: a scalar (rank-0) computation.
+  greturn :: (Ok m '[]) => Grade m -> m '[]
+
+  -- | Bind, concatenating the outer and inner shapes.  For each element of the
+  -- outer tensor, @k@ produces an inner tensor; the results are spliced into a
+  -- single tensor of the concatenated shape.
+  gbind ::
+    forall s t.
+    (Ok m s, Ok m t, Ok m (s ++ t)) =>
+    m s ->
+    (Grade m -> m t) ->
+    m (s ++ t)
+
+-- | 'gbind' under the name @QualifiedDo@ desugars to.
+(>>=) ::
+  forall m s t.
+  (GradedMonad m, Ok m s, Ok m t, Ok m (s ++ t)) =>
+  m s ->
+  (Grade m -> m t) ->
+  m (s ++ t)
+(>>=) = gbind
+
+infixl 1 >>=
+
+-- | Sequencing that ignores the bound element, for @QualifiedDo@ statements
+-- without a binder.
+(>>) ::
+  forall m s t.
+  (GradedMonad m, Ok m s, Ok m t, Ok m (s ++ t)) =>
+  m s ->
+  m t ->
+  m (s ++ t)
+a >> b = gbind a (const b)
+
+infixl 1 >>
+
+-- | 'greturn' under the name @QualifiedDo@ desugars to.
+return :: forall m. (GradedMonad m, Ok m '[]) => Grade m -> m '[]
+return = greturn
+
+-- | A 'NamedTensor' with its device and dtype pinned, so that only the shape
+-- remains as a type parameter and the result has kind @Shape -> Type@.
+newtype TensorMonad (device :: (D.DeviceType, Nat)) (dtype :: D.DType) (shape :: Shape)
+  = TensorMonad (NamedTensor device dtype shape)
+
+-- | Wrap a named tensor so it can be used with 'gbind'.
+fromNamed :: NamedTensor device dtype shape -> TensorMonad device dtype shape
+fromNamed = TensorMonad
+
+-- | Unwrap back to a plain named tensor.
+toNamed :: TensorMonad device dtype shape -> NamedTensor device dtype shape
+toNamed (TensorMonad t) = t
+
+instance
+  (D.TensorLike (ComputeHaskellType dtype)) =>
+  GradedMonad (TensorMonad device dtype)
+  where
+  type Grade (TensorMonad device dtype) = ComputeHaskellType dtype
+  type
+    Ok (TensorMonad device dtype) s =
+      ( HasIndex s,
+        TensorOptions (ToNats s) dtype device
+      )
+
+  greturn x = TensorMonad (tabulateList @'[] @dtype @device (const x))
+
+  gbind ::
+    forall s t.
+    ( Ok (TensorMonad device dtype) s,
+      Ok (TensorMonad device dtype) t,
+      Ok (TensorMonad device dtype) (s ++ t)
+    ) =>
+    TensorMonad device dtype s ->
+    (ComputeHaskellType dtype -> TensorMonad device dtype t) ->
+    TensorMonad device dtype (s ++ t)
+  gbind (TensorMonad outer) k =
+    TensorMonad $
+      tabulateList @(s ++ t) @dtype @device $ \ix ->
+        -- an index into (s ++ t) splits into an outer and an inner index
+        let (outerIx, innerIx) = splitAt rank ix
+            x = indexList outer outerIx
+         in indexList (toNamed (k x)) innerIx
+    where
+      rank = length (dims (Proxy @s))

--- a/hasktorch/src/Torch/Typed/Index.hs
+++ b/hasktorch/src/Torch/Typed/Index.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TemplateHaskellQuotes #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE KindSignatures #-}
@@ -27,6 +28,9 @@ module Torch.Typed.Index
   ( -- * The index language
     IndexType (..),
 
+    -- * PyTorch-style syntax
+    ix,
+
     -- * Result-shape computation
     IndexedShape,
 
@@ -37,8 +41,11 @@ module Torch.Typed.Index
   )
 where
 
+import Data.Char (isDigit, isSpace)
 import Data.Type.Bool (If)
 import GHC.TypeLits
+import qualified Language.Haskell.TH as TH
+import Language.Haskell.TH.Quote (QuasiQuoter (..))
 import System.IO.Unsafe (unsafePerformIO)
 import qualified Torch.Internal.Managed.Type.TensorIndex as ATen
 import qualified Torch.Tensor as T
@@ -63,6 +70,8 @@ data IndexType
     SliceFromWithStep Nat Nat
   | -- | @[:to:step]@
     SliceUpToWithStep Nat Nat
+  | -- | @[::step]@
+    SliceWithStep Nat
   | -- | @[from:to:step]@
     SliceFromUpToWithStep Nat Nat Nat
 
@@ -117,6 +126,7 @@ type family IndexedShape (ixs :: [IndexType]) (shape :: [Nat]) :: [Nat] where
   IndexedShape ('SliceFromUpTo f t ': ixs) (n ': sh) = SliceLen f t 1 n ': IndexedShape ixs sh
   IndexedShape ('SliceFromWithStep f s ': ixs) (n ': sh) = SliceLen f n s n ': IndexedShape ixs sh
   IndexedShape ('SliceUpToWithStep t s ': ixs) (n ': sh) = SliceLen 0 t s n ': IndexedShape ixs sh
+  IndexedShape ('SliceWithStep s ': ixs) (n ': sh) = SliceLen 0 n s n ': IndexedShape ixs sh
   IndexedShape ('SliceFromUpToWithStep f t s ': ixs) (n ': sh) = SliceLen f t s n ': IndexedShape ixs sh
   IndexedShape (ix ': ixs) '[] =
     TypeError ('Text "Too many indices for the shape of the tensor.")
@@ -176,6 +186,12 @@ instance (KnownNat t, KnownNat s, KnownIndices ixs) => KnownIndices ('SliceUpToW
       <$> (T.RawTensorIndex <$> ATen.newTensorIndexWithSlice 0 (fromIntegral (natValI @t)) (fromIntegral (natValI @s)))
       <*> rawIndices @ixs
 
+instance (KnownNat s, KnownIndices ixs) => KnownIndices ('SliceWithStep s ': ixs) where
+  rawIndices =
+    (:)
+      <$> (T.RawTensorIndex <$> ATen.newTensorIndexWithSlice 0 maxBound (fromIntegral (natValI @s)))
+      <*> rawIndices @ixs
+
 instance (KnownNat f, KnownNat t, KnownNat s, KnownIndices ixs) => KnownIndices ('SliceFromUpToWithStep f t s ': ixs) where
   rawIndices =
     (:)
@@ -213,3 +229,62 @@ setSlice ::
 setSlice t v = unsafePerformIO $ do
   raws <- rawIndices @ixs
   pure . UnsafeMkTensor $ T.maskedFill (toDynamic t) (RawIndices raws) (toDynamic v)
+
+--------------------------------------------------------------------------------
+-- PyTorch-style syntax
+--------------------------------------------------------------------------------
+
+-- | A /type/ quasiquoter for PyTorch indexing syntax, usable wherever the
+-- type-level index list goes:
+--
+-- > slice @[ix| 1, :, 1:3:2 |] t  ==  slice @'[SliceAt 1, SliceAll, SliceFromUpToWithStep 1 3 2] t
+--
+-- Supported per-dimension forms, as in PyTorch: @i@, @:@, @::@, @from:@,
+-- @:to@, @from:to@, @from::step@, @:to:step@, @::step@, @from:to:step@ and
+-- @None@ (insert an axis).  Negative indices, @...@ and boolean\/tensor
+-- indices are not supported; indices here are type-level naturals.
+ix :: QuasiQuoter
+ix =
+  QuasiQuoter
+    { quoteType = parseIndices,
+      quoteExp = const (fail "ix is a type quasiquoter; use it as slice @[ix|...|] t"),
+      quotePat = const (fail "ix is a type quasiquoter; use it as slice @[ix|...|] t"),
+      quoteDec = const (fail "ix is a type quasiquoter; use it as slice @[ix|...|] t")
+    }
+
+parseIndices :: String -> TH.Q TH.Type
+parseIndices str = do
+  items <-
+    if all isSpace str
+      then pure []
+      else mapM (parseItem . filter (not . isSpace)) (splitOn ',' str)
+  pure (foldr (\x xs -> TH.PromotedConsT `TH.AppT` x `TH.AppT` xs) TH.PromotedNilT items)
+  where
+    nat :: String -> TH.Q TH.Type
+    nat s
+      | not (null s) && all isDigit s = pure (TH.LitT (TH.NumTyLit (read s)))
+      | otherwise = fail ("ix: expected a natural number, got " <> show s)
+    con :: TH.Name -> [TH.Q TH.Type] -> TH.Q TH.Type
+    con name args = foldl (\acc a -> TH.AppT <$> acc <*> a) (pure (TH.PromotedT name)) args
+    parseItem :: String -> TH.Q TH.Type
+    parseItem "None" = con 'NewAxis []
+    parseItem s = case splitOn ':' s of
+      [i] -> con 'SliceAt [nat i]
+      ["", ""] -> con 'SliceAll []
+      [f, ""] -> con 'SliceFrom [nat f]
+      ["", t] -> con 'SliceUpTo [nat t]
+      [f, t] -> con 'SliceFromUpTo [nat f, nat t]
+      ["", "", ""] -> con 'SliceAll []
+      [f, "", ""] -> con 'SliceFrom [nat f]
+      ["", t, ""] -> con 'SliceUpTo [nat t]
+      [f, t, ""] -> con 'SliceFromUpTo [nat f, nat t]
+      ["", "", s'] -> con 'SliceWithStep [nat s']
+      [f, "", s'] -> con 'SliceFromWithStep [nat f, nat s']
+      ["", t, s'] -> con 'SliceUpToWithStep [nat t, nat s']
+      [f, t, s'] -> con 'SliceFromUpToWithStep [nat f, nat t, nat s']
+      _ -> fail ("ix: cannot parse index " <> show s)
+
+splitOn :: Char -> String -> [String]
+splitOn c s = case break (== c) s of
+  (chunk, []) -> [chunk]
+  (chunk, _ : rest) -> chunk : splitOn c rest

--- a/hasktorch/src/Torch/Typed/Index.hs
+++ b/hasktorch/src/Torch/Typed/Index.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -41,6 +42,7 @@ module Torch.Typed.Index
     -- * Indexing
     getSlice,
     setSlice,
+    sliceLens,
     KnownIndices (..),
   )
 where
@@ -50,6 +52,7 @@ import Data.Type.Bool (If)
 import GHC.TypeLits
 import qualified Language.Haskell.TH as TH
 import System.IO.Unsafe (unsafePerformIO)
+import Torch.Lens (Lens')
 import qualified Torch.Internal.Managed.Type.TensorIndex as ATen
 import qualified Torch.Tensor as T
 import Torch.Typed.Auxiliary (natValI)
@@ -221,6 +224,21 @@ getSlice ::
 getSlice t = unsafePerformIO $ do
   raws <- rawIndices @ixs
   pure . UnsafeMkTensor $ toDynamic t T.! RawIndices raws
+
+-- | The lens made of 'getSlice' and 'setSlice': the typed counterpart of the
+-- untyped 'Torch.Index.lslice' quasiquoter.  Read a slice with @^.@, write
+-- one with @.~@, modify one with @%~@:
+--
+-- > t ^. sliceLens @[slice| 1, : |]
+-- > t &  sliceLens @[slice| 0 |] .~ zeros
+-- > t &  sliceLens @[slice| :, 1 |] %~ (* 100)
+sliceLens ::
+  forall ixs device dtype shape.
+  KnownIndices ixs =>
+  Lens'
+    (Tensor device dtype shape)
+    (Tensor device dtype (IndexedShape ixs shape))
+sliceLens f t = setSlice @ixs t <$> f (getSlice @ixs t)
 
 -- | Replace the indexed part of a tensor.  The value must have exactly the
 -- shape that 'slice' with the same indices would produce.

--- a/hasktorch/src/Torch/Typed/Index.hs
+++ b/hasktorch/src/Torch/Typed/Index.hs
@@ -18,24 +18,28 @@
 --
 -- Given @t :: Tensor device dtype '[2, 3, 4]@:
 --
--- > slice @'[SliceAt 1] t                    :: Tensor device dtype '[3, 4]
--- > slice @'[SliceAll, SliceAt 0] t          :: Tensor device dtype '[2, 4]
--- > slice @'[NewAxis, SliceFromUpTo 1 3] t   :: Tensor device dtype '[1, 2, 3, 4]
--- > slice @'[SliceFromUpToWithStep 0 3 2] t  :: Tensor device dtype '[2, 3, 4]
+-- > getSlice @'[SliceAt 1] t                    :: Tensor device dtype '[3, 4]
+-- > getSlice @'[SliceAll, SliceAt 0] t          :: Tensor device dtype '[2, 4]
+-- > getSlice @'[NewAxis, SliceFromUpTo 1 3] t   :: Tensor device dtype '[1, 2, 3, 4]
+-- > getSlice @'[SliceFromUpToWithStep 0 3 2] t  :: Tensor device dtype '[2, 3, 4]
 --
--- @slice \@'[SliceAt 5] t@ on a dimension of size 2 does not compile.
+-- @getSlice \@'[SliceAt 5] t@ on a dimension of size 2 does not compile.
 module Torch.Typed.Index
   ( -- * The index language
     IndexType (..),
 
     -- * PyTorch-style syntax
-    ix,
+    --
+    -- | The 'Torch.Index.slice' quasiquoter works in type position and
+    -- produces the promoted @'[IndexType]@ list; 'parseIndices' is its
+    -- implementation.
+    parseIndices,
 
     -- * Result-shape computation
     IndexedShape,
 
     -- * Indexing
-    slice,
+    getSlice,
     setSlice,
     KnownIndices (..),
   )
@@ -45,7 +49,6 @@ import Data.Char (isDigit, isSpace)
 import Data.Type.Bool (If)
 import GHC.TypeLits
 import qualified Language.Haskell.TH as TH
-import Language.Haskell.TH.Quote (QuasiQuoter (..))
 import System.IO.Unsafe (unsafePerformIO)
 import qualified Torch.Internal.Managed.Type.TensorIndex as ATen
 import qualified Torch.Tensor as T
@@ -208,13 +211,14 @@ instance T.TensorIndex RawIndices where
 -- | Index a tensor with a type-level list of indices; the result shape is
 -- computed (and bounds are checked) at compile time.
 --
--- > slice @'[SliceAt 1, SliceFromUpTo 0 2] t
-slice ::
+-- > getSlice @'[SliceAt 1, SliceFromUpTo 0 2] t
+-- > getSlice @[slice| 1, 0:2 |] t              -- Torch.Index's quasiquoter, in type position
+getSlice ::
   forall ixs device dtype shape.
   KnownIndices ixs =>
   Tensor device dtype shape ->
   Tensor device dtype (IndexedShape ixs shape)
-slice t = unsafePerformIO $ do
+getSlice t = unsafePerformIO $ do
   raws <- rawIndices @ixs
   pure . UnsafeMkTensor $ toDynamic t T.! RawIndices raws
 
@@ -234,24 +238,6 @@ setSlice t v = unsafePerformIO $ do
 -- PyTorch-style syntax
 --------------------------------------------------------------------------------
 
--- | A /type/ quasiquoter for PyTorch indexing syntax, usable wherever the
--- type-level index list goes:
---
--- > slice @[ix| 1, :, 1:3:2 |] t  ==  slice @'[SliceAt 1, SliceAll, SliceFromUpToWithStep 1 3 2] t
---
--- Supported per-dimension forms, as in PyTorch: @i@, @:@, @::@, @from:@,
--- @:to@, @from:to@, @from::step@, @:to:step@, @::step@, @from:to:step@ and
--- @None@ (insert an axis).  Negative indices, @...@ and boolean\/tensor
--- indices are not supported; indices here are type-level naturals.
-ix :: QuasiQuoter
-ix =
-  QuasiQuoter
-    { quoteType = parseIndices,
-      quoteExp = const (fail "ix is a type quasiquoter; use it as slice @[ix|...|] t"),
-      quotePat = const (fail "ix is a type quasiquoter; use it as slice @[ix|...|] t"),
-      quoteDec = const (fail "ix is a type quasiquoter; use it as slice @[ix|...|] t")
-    }
-
 parseIndices :: String -> TH.Q TH.Type
 parseIndices str = do
   items <-
@@ -263,7 +249,7 @@ parseIndices str = do
     nat :: String -> TH.Q TH.Type
     nat s
       | not (null s) && all isDigit s = pure (TH.LitT (TH.NumTyLit (read s)))
-      | otherwise = fail ("ix: expected a natural number, got " <> show s)
+      | otherwise = fail ("slice: expected a natural number, got " <> show s)
     con :: TH.Name -> [TH.Q TH.Type] -> TH.Q TH.Type
     con name args = foldl (\acc a -> TH.AppT <$> acc <*> a) (pure (TH.PromotedT name)) args
     parseItem :: String -> TH.Q TH.Type
@@ -282,7 +268,7 @@ parseIndices str = do
       [f, "", s'] -> con 'SliceFromWithStep [nat f, nat s']
       ["", t, s'] -> con 'SliceUpToWithStep [nat t, nat s']
       [f, t, s'] -> con 'SliceFromUpToWithStep [nat f, nat t, nat s']
-      _ -> fail ("ix: cannot parse index " <> show s)
+      _ -> fail ("slice: cannot parse index " <> show s)
 
 splitOn :: Char -> String -> [String]
 splitOn c s = case break (== c) s of

--- a/hasktorch/src/Torch/Typed/Index.hs
+++ b/hasktorch/src/Torch/Typed/Index.hs
@@ -1,0 +1,215 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE NoStarIsType #-}
+
+-- | Typed indexing and slicing, in the style of PR #613's
+-- @Torch.GraduallyTyped.Tensor.Indexing@ but for the 'Torch.Typed' API: the
+-- index is a type-level list, the result shape is computed by a type family,
+-- and out-of-bounds indices are compile-time errors.
+--
+-- Given @t :: Tensor device dtype '[2, 3, 4]@:
+--
+-- > slice @'[SliceAt 1] t                    :: Tensor device dtype '[3, 4]
+-- > slice @'[SliceAll, SliceAt 0] t          :: Tensor device dtype '[2, 4]
+-- > slice @'[NewAxis, SliceFromUpTo 1 3] t   :: Tensor device dtype '[1, 2, 3, 4]
+-- > slice @'[SliceFromUpToWithStep 0 3 2] t  :: Tensor device dtype '[2, 3, 4]
+--
+-- @slice \@'[SliceAt 5] t@ on a dimension of size 2 does not compile.
+module Torch.Typed.Index
+  ( -- * The index language
+    IndexType (..),
+
+    -- * Result-shape computation
+    IndexedShape,
+
+    -- * Indexing
+    slice,
+    setSlice,
+    KnownIndices (..),
+  )
+where
+
+import Data.Type.Bool (If)
+import GHC.TypeLits
+import System.IO.Unsafe (unsafePerformIO)
+import qualified Torch.Internal.Managed.Type.TensorIndex as ATen
+import qualified Torch.Tensor as T
+import Torch.Typed.Auxiliary (natValI)
+import Torch.Typed.Tensor
+
+-- | One index per dimension, at the type level.  The names follow PR #613.
+data IndexType
+  = -- | select a position, dropping the dimension
+    SliceAt Nat
+  | -- | keep the dimension as is
+    SliceAll
+  | -- | insert a dimension of size 1
+    NewAxis
+  | -- | @[from:]@
+    SliceFrom Nat
+  | -- | @[:to]@
+    SliceUpTo Nat
+  | -- | @[from:to]@
+    SliceFromUpTo Nat Nat
+  | -- | @[from::step]@
+    SliceFromWithStep Nat Nat
+  | -- | @[:to:step]@
+    SliceUpToWithStep Nat Nat
+  | -- | @[from:to:step]@
+    SliceFromUpToWithStep Nat Nat Nat
+
+-- | The number of elements a slice @[from:to:step]@ of a dimension of size
+-- @n@ keeps, with all bounds checked.
+type family SliceLen (from :: Nat) (to :: Nat) (step :: Nat) (n :: Nat) :: Nat where
+  SliceLen _ _ 0 _ = TypeError ('Text "Slice step must be positive.")
+  SliceLen from to step n =
+    If
+      (from <=? to)
+      ( If
+          (to <=? n)
+          (Div (to - from + step - 1) step)
+          ( TypeError
+              ( 'Text "Slice end "
+                  ':<>: 'ShowType to
+                  ':<>: 'Text " is out of bounds for a dimension of size "
+                  ':<>: 'ShowType n
+                  ':<>: 'Text "."
+              )
+          )
+      )
+      ( TypeError
+          ( 'Text "Slice start "
+              ':<>: 'ShowType from
+              ':<>: 'Text " is greater than its end "
+              ':<>: 'ShowType to
+              ':<>: 'Text "."
+          )
+      )
+
+-- | The shape produced by applying a list of indices to a shape.  Dimensions
+-- beyond the indices are kept unchanged, as in PyTorch.
+type family IndexedShape (ixs :: [IndexType]) (shape :: [Nat]) :: [Nat] where
+  IndexedShape '[] shape = shape
+  IndexedShape ('NewAxis ': ixs) shape = 1 ': IndexedShape ixs shape
+  IndexedShape ('SliceAt i ': ixs) (n ': sh) =
+    If
+      (i + 1 <=? n)
+      (IndexedShape ixs sh)
+      ( TypeError
+          ( 'Text "Index "
+              ':<>: 'ShowType i
+              ':<>: 'Text " is out of bounds for a dimension of size "
+              ':<>: 'ShowType n
+              ':<>: 'Text "."
+          )
+      )
+  IndexedShape ('SliceAll ': ixs) (n ': sh) = n ': IndexedShape ixs sh
+  IndexedShape ('SliceFrom f ': ixs) (n ': sh) = SliceLen f n 1 n ': IndexedShape ixs sh
+  IndexedShape ('SliceUpTo t ': ixs) (n ': sh) = SliceLen 0 t 1 n ': IndexedShape ixs sh
+  IndexedShape ('SliceFromUpTo f t ': ixs) (n ': sh) = SliceLen f t 1 n ': IndexedShape ixs sh
+  IndexedShape ('SliceFromWithStep f s ': ixs) (n ': sh) = SliceLen f n s n ': IndexedShape ixs sh
+  IndexedShape ('SliceUpToWithStep t s ': ixs) (n ': sh) = SliceLen 0 t s n ': IndexedShape ixs sh
+  IndexedShape ('SliceFromUpToWithStep f t s ': ixs) (n ': sh) = SliceLen f t s n ': IndexedShape ixs sh
+  IndexedShape (ix ': ixs) '[] =
+    TypeError ('Text "Too many indices for the shape of the tensor.")
+
+-- | Reify a type-level index list to ATen tensor indices.
+class KnownIndices (ixs :: [IndexType]) where
+  rawIndices :: IO [T.RawTensorIndex]
+
+instance KnownIndices '[] where
+  rawIndices = pure []
+
+instance (KnownNat i, KnownIndices ixs) => KnownIndices ('SliceAt i ': ixs) where
+  rawIndices =
+    (:)
+      <$> (T.RawTensorIndex <$> ATen.newTensorIndexWithInt (fromIntegral (natValI @i)))
+      <*> rawIndices @ixs
+
+instance KnownIndices ixs => KnownIndices ('SliceAll ': ixs) where
+  rawIndices =
+    (:)
+      <$> (T.RawTensorIndex <$> ATen.newTensorIndexWithSlice 0 maxBound 1)
+      <*> rawIndices @ixs
+
+instance KnownIndices ixs => KnownIndices ('NewAxis ': ixs) where
+  rawIndices =
+    (:)
+      <$> (T.RawTensorIndex <$> ATen.newTensorIndexWithNone)
+      <*> rawIndices @ixs
+
+instance (KnownNat f, KnownIndices ixs) => KnownIndices ('SliceFrom f ': ixs) where
+  rawIndices =
+    (:)
+      <$> (T.RawTensorIndex <$> ATen.newTensorIndexWithSlice (fromIntegral (natValI @f)) maxBound 1)
+      <*> rawIndices @ixs
+
+instance (KnownNat t, KnownIndices ixs) => KnownIndices ('SliceUpTo t ': ixs) where
+  rawIndices =
+    (:)
+      <$> (T.RawTensorIndex <$> ATen.newTensorIndexWithSlice 0 (fromIntegral (natValI @t)) 1)
+      <*> rawIndices @ixs
+
+instance (KnownNat f, KnownNat t, KnownIndices ixs) => KnownIndices ('SliceFromUpTo f t ': ixs) where
+  rawIndices =
+    (:)
+      <$> (T.RawTensorIndex <$> ATen.newTensorIndexWithSlice (fromIntegral (natValI @f)) (fromIntegral (natValI @t)) 1)
+      <*> rawIndices @ixs
+
+instance (KnownNat f, KnownNat s, KnownIndices ixs) => KnownIndices ('SliceFromWithStep f s ': ixs) where
+  rawIndices =
+    (:)
+      <$> (T.RawTensorIndex <$> ATen.newTensorIndexWithSlice (fromIntegral (natValI @f)) maxBound (fromIntegral (natValI @s)))
+      <*> rawIndices @ixs
+
+instance (KnownNat t, KnownNat s, KnownIndices ixs) => KnownIndices ('SliceUpToWithStep t s ': ixs) where
+  rawIndices =
+    (:)
+      <$> (T.RawTensorIndex <$> ATen.newTensorIndexWithSlice 0 (fromIntegral (natValI @t)) (fromIntegral (natValI @s)))
+      <*> rawIndices @ixs
+
+instance (KnownNat f, KnownNat t, KnownNat s, KnownIndices ixs) => KnownIndices ('SliceFromUpToWithStep f t s ': ixs) where
+  rawIndices =
+    (:)
+      <$> (T.RawTensorIndex <$> ATen.newTensorIndexWithSlice (fromIntegral (natValI @f)) (fromIntegral (natValI @t)) (fromIntegral (natValI @s)))
+      <*> rawIndices @ixs
+
+-- | The reified indices, routed through the untyped 'T.TensorIndex'
+-- machinery.
+newtype RawIndices = RawIndices [T.RawTensorIndex]
+
+instance T.TensorIndex RawIndices where
+  pushIndex vec (RawIndices l) = l ++ vec
+
+-- | Index a tensor with a type-level list of indices; the result shape is
+-- computed (and bounds are checked) at compile time.
+--
+-- > slice @'[SliceAt 1, SliceFromUpTo 0 2] t
+slice ::
+  forall ixs device dtype shape.
+  KnownIndices ixs =>
+  Tensor device dtype shape ->
+  Tensor device dtype (IndexedShape ixs shape)
+slice t = unsafePerformIO $ do
+  raws <- rawIndices @ixs
+  pure . UnsafeMkTensor $ toDynamic t T.! RawIndices raws
+
+-- | Replace the indexed part of a tensor.  The value must have exactly the
+-- shape that 'slice' with the same indices would produce.
+setSlice ::
+  forall ixs device dtype shape.
+  KnownIndices ixs =>
+  Tensor device dtype shape ->
+  Tensor device dtype (IndexedShape ixs shape) ->
+  Tensor device dtype shape
+setSlice t v = unsafePerformIO $ do
+  raws <- rawIndices @ixs
+  pure . UnsafeMkTensor $ T.maskedFill (toDynamic t) (RawIndices raws) (toDynamic v)

--- a/hasktorch/src/Torch/Typed/Lens.hs
+++ b/hasktorch/src/Torch/Typed/Lens.hs
@@ -33,9 +33,10 @@ import qualified Torch.Device as D
 import qualified Torch.Functional as D hiding (select)
 import qualified Torch.Functional.Internal as I
 import qualified Torch.Internal.Managed.Type.TensorIndex as ATen
-import Torch.Lens (Lens, Lens', Traversal, Traversal')
+import Torch.Lens (HasTypes (..), Lens, Lens', Traversal, Traversal')
 import qualified Torch.Tensor as T
 import Torch.Typed.Auxiliary hiding (If)
+import Torch.Typed.Parameter (Parameter)
 import Torch.Typed.Tensor
 
 class HasName (name :: Type -> Type) shape where
@@ -158,3 +159,97 @@ instance (GFieldId field f, GFieldId field g) => GFieldId field (f :+: g) where
     case (gfieldId' @field (Proxy :: Proxy f), gfieldId' @field (Proxy :: Proxy g)) of
       ((Nothing, _), a1) -> a1
       (a0@(Just _, _), _) -> a0
+
+--------------------------------------------------------------------------------
+-- HasTypes leaves for typed tensors: shape-selective structure traversals
+--------------------------------------------------------------------------------
+
+-- $typedTypes
+--
+-- The generic 'Torch.Lens.types' traversal is polymorphic in its target type,
+-- so it works over typed tensors as well - and becomes /shape-selective/:
+-- where the untyped @types \@Tensor@ visits every tensor in a structure,
+--
+-- > over (types @(Tensor '( 'D.CPU, 0) 'D.Float '[2, 3])) f model
+--
+-- visits only the tensors of exactly that device, dtype and shape, leaving
+-- every other field (including tensors of other shapes) untouched.  The
+-- instances below tell the generic machinery which leaves to visit, which
+-- tensor leaves to skip (a shape mismatch), and that primitive fields are
+-- never targets.
+
+-- visit: the leaf is exactly the target
+instance {-# OVERLAPPING #-} HasTypes (Tensor device dtype shape) (Tensor device dtype shape) where
+  types_ f = f
+
+instance {-# OVERLAPPING #-} HasTypes (NamedTensor device dtype shape) (NamedTensor device dtype shape) where
+  types_ f = f
+
+instance {-# OVERLAPPING #-} HasTypes (Parameter device dtype shape) (Parameter device dtype shape) where
+  types_ f = f
+
+-- skip: a tensor leaf whose device, dtype or shape does not match the target
+instance {-# OVERLAPPING #-} HasTypes (Tensor device dtype shape) (Tensor device' dtype' shape') where
+  types_ _ = pure
+
+instance {-# OVERLAPPING #-} HasTypes (NamedTensor device dtype shape) (NamedTensor device' dtype' shape') where
+  types_ _ = pure
+
+instance {-# OVERLAPPING #-} HasTypes (Parameter device dtype shape) (Parameter device' dtype' shape') where
+  types_ _ = pure
+
+-- skip: leaves of a different tensor kind than the target
+instance {-# OVERLAPPING #-} HasTypes (Tensor device dtype shape) (NamedTensor device' dtype' shape') where
+  types_ _ = pure
+
+instance {-# OVERLAPPING #-} HasTypes (Tensor device dtype shape) (Parameter device' dtype' shape') where
+  types_ _ = pure
+
+instance {-# OVERLAPPING #-} HasTypes (NamedTensor device dtype shape) (Tensor device' dtype' shape') where
+  types_ _ = pure
+
+instance {-# OVERLAPPING #-} HasTypes (NamedTensor device dtype shape) (Parameter device' dtype' shape') where
+  types_ _ = pure
+
+instance {-# OVERLAPPING #-} HasTypes (Parameter device dtype shape) (Tensor device' dtype' shape') where
+  types_ _ = pure
+
+instance {-# OVERLAPPING #-} HasTypes (Parameter device dtype shape) (NamedTensor device' dtype' shape') where
+  types_ _ = pure
+
+-- skip: primitive fields are never typed-tensor targets
+instance HasTypes Int (Tensor device dtype shape) where
+  types_ _ = pure
+
+instance HasTypes Float (Tensor device dtype shape) where
+  types_ _ = pure
+
+instance HasTypes Double (Tensor device dtype shape) where
+  types_ _ = pure
+
+instance HasTypes Bool (Tensor device dtype shape) where
+  types_ _ = pure
+
+instance HasTypes Int (NamedTensor device dtype shape) where
+  types_ _ = pure
+
+instance HasTypes Float (NamedTensor device dtype shape) where
+  types_ _ = pure
+
+instance HasTypes Double (NamedTensor device dtype shape) where
+  types_ _ = pure
+
+instance HasTypes Bool (NamedTensor device dtype shape) where
+  types_ _ = pure
+
+instance HasTypes Int (Parameter device dtype shape) where
+  types_ _ = pure
+
+instance HasTypes Float (Parameter device dtype shape) where
+  types_ _ = pure
+
+instance HasTypes Double (Parameter device dtype shape) where
+  types_ _ = pure
+
+instance HasTypes Bool (Parameter device dtype shape) where
+  types_ _ = pure

--- a/hasktorch/src/Torch/Typed/Representable.hs
+++ b/hasktorch/src/Torch/Typed/Representable.hs
@@ -1,0 +1,157 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE NoStarIsType #-}
+
+-- | A 'Representable'-style view of 'NamedTensor'.
+--
+-- A tensor of shape @'[Batch 2, RGB]@ is a function from an index to an
+-- element, so it can be read with 'index' and built with 'tabulate'.  The index
+-- type ('Log') is an 'HList' of 'Finite's, one per named dimension, so indices
+-- are bounds-checked at compile time:
+--
+-- > Log (NamedTensor '( 'D.CPU, 0) 'D.Float '[Batch 2, RGB]) ~ HList '[Finite 2, Finite 3]
+--
+-- Unlike @Data.Functor.Rep.Representable@ this is not a class over a
+-- @Type -> Type@: a 'NamedTensor' fixes its element type via its @dtype@, so it
+-- is not a functor in the element.  The laws are the usual ones:
+--
+-- > index (tabulate f) i == f i
+-- > tabulate (index t)   == t
+module Torch.Typed.Representable
+  ( Representable (..),
+    HasIndex (..),
+    ToFinites,
+    dimsOf,
+    indexList,
+    tabulateList,
+    allIndices,
+  )
+where
+
+import Data.Finite (Finite, getFinite, packFinite)
+import Data.Kind (Type)
+import Data.Proxy (Proxy (..))
+import GHC.TypeLits (KnownNat)
+import Torch.HList
+import qualified Torch.Tensor as D
+import qualified Torch.TensorOptions as D
+import Torch.Typed.Auxiliary (natValI)
+import Torch.Typed.Tensor
+
+-- | The index type of a named shape: one 'Finite' per dimension, each bounded
+-- by that dimension's 'ToNat'.
+type family ToFinites (shape :: Shape) :: [Type] where
+  ToFinites '[] = '[]
+  ToFinites (x ': xs) = Finite (ToNat x) ': ToFinites xs
+
+-- | Shapes whose indices can be converted to and from plain @[Int]@, and whose
+-- dimensions can be reified at runtime.
+--
+-- Defined over the named 'Shape' rather than over @ToNats shape@ so that GHC
+-- never has to prove @ToFinites shape ~ ToFinites' (ToNats shape)@.
+class HasIndex (shape :: Shape) where
+  -- | The runtime dimensions, e.g. @[2,3]@ for @'[Batch 2, RGB]@.
+  dims :: Proxy shape -> [Int]
+
+  -- | Erase a typed index to a list of plain @Int@s.
+  toInts :: HList (ToFinites shape) -> [Int]
+
+  -- | Reconstruct a typed index.  The list must be in range; 'tabulateList'
+  -- only ever supplies in-range indices.
+  fromInts :: [Int] -> HList (ToFinites shape)
+
+instance HasIndex '[] where
+  dims _ = []
+  toInts HNil = []
+  fromInts _ = HNil
+
+instance (KnownNat (ToNat x), HasIndex xs) => HasIndex (x ': xs) where
+  dims _ = natValI @(ToNat x) : dims (Proxy @xs)
+  toInts (i :. is) = fromIntegral (getFinite i) : toInts @xs is
+  fromInts (i : is) = case packFinite (fromIntegral i) of
+    Just f -> f :. fromInts @xs is
+    Nothing ->
+      error $
+        "Torch.Typed.Representable.fromInts: index "
+          <> show i
+          <> " is out of range for a dimension of size "
+          <> show (natValI @(ToNat x))
+  fromInts [] =
+    error "Torch.Typed.Representable.fromInts: index list is shorter than the shape"
+
+-- | The runtime dimensions of a named tensor's shape.
+dimsOf ::
+  forall shape dtype device.
+  (HasIndex shape) =>
+  Proxy (NamedTensor device dtype shape) ->
+  [Int]
+dimsOf _ = dims (Proxy @shape)
+
+-- | Containers that are isomorphic to a function from an index.
+class Representable t where
+  -- | The index ("logarithm") of the container.
+  type Log t :: Type
+
+  -- | The element type held at each index.
+  type Elem t :: Type
+
+  index :: t -> Log t -> Elem t
+  tabulate :: (Log t -> Elem t) -> t
+
+instance
+  ( HasIndex shape,
+    TensorOptions (ToNats shape) dtype device,
+    D.TensorLike (ComputeHaskellType dtype)
+  ) =>
+  Representable (NamedTensor device dtype shape)
+  where
+  type Log (NamedTensor device dtype shape) = HList (ToFinites shape)
+  type Elem (NamedTensor device dtype shape) = ComputeHaskellType dtype
+
+  index t = indexList t . toInts @shape
+  tabulate f = tabulateList @shape @dtype @device (f . fromInts @shape)
+
+-- | Read a single element, addressed by one index per dimension.
+indexList ::
+  forall shape dtype device.
+  (D.TensorLike (ComputeHaskellType dtype)) =>
+  NamedTensor device dtype shape ->
+  [Int] ->
+  ComputeHaskellType dtype
+indexList t = D.asValue . foldl (\acc i -> D.select 0 i acc) (toDynamic t)
+
+-- | Build a named tensor from a function on index lists.
+tabulateList ::
+  forall shape dtype device.
+  ( HasIndex shape,
+    TensorOptions (ToNats shape) dtype device,
+    D.TensorLike (ComputeHaskellType dtype)
+  ) =>
+  ([Int] -> ComputeHaskellType dtype) ->
+  NamedTensor device dtype shape
+tabulateList f =
+  fromUnnamed . UnsafeMkTensor . D.reshape ds $
+    D.asTensor'
+      (map f (allIndices ds))
+      ( D.withDevice (optionsRuntimeDevice @(ToNats shape) @dtype @device)
+          . D.withDType (optionsRuntimeDType @(ToNats shape) @dtype @device)
+          $ D.defaultOpts
+      )
+  where
+    ds = dims (Proxy @shape)
+
+-- | Every index list for a shape, in row-major (C) order — matching the
+-- element order that 'D.asTensor' plus 'D.reshape' produces.
+allIndices :: [Int] -> [[Int]]
+allIndices = foldr (\n acc -> [i : rest | i <- [0 .. n - 1], rest <- acc]) [[]]

--- a/hasktorch/src/Torch/Typed/Staged.hs
+++ b/hasktorch/src/Torch/Typed/Staged.hs
@@ -39,6 +39,8 @@
 module Torch.Typed.Staged
   ( -- * Value-dependent control flow
     Cond (..),
+    maxE,
+    minE,
 
     -- * Vectorized element-wise operations
     emap,
@@ -93,6 +95,14 @@ instance Cond Double where
   geE a b = if a >= b then 1 else 0
   eqE a b = if a == b then 1 else 0
   neE a b = if a /= b then 1 else 0
+
+-- | Elementwise maximum, via 'whereE'.
+maxE :: Cond a => a -> a -> a
+maxE a b = whereE (gtE a b) a b
+
+-- | Elementwise minimum, via 'whereE'.
+minE :: Cond a => a -> a -> a
+minE a b = whereE (ltE a b) a b
 
 instance Cond D.Tensor where
   whereE c t e = I.where' (F.toDType DT.Bool c) t e

--- a/hasktorch/src/Torch/Typed/Staged.hs
+++ b/hasktorch/src/Torch/Typed/Staged.hs
@@ -39,8 +39,6 @@
 module Torch.Typed.Staged
   ( -- * Value-dependent control flow
     Cond (..),
-    maxE,
-    minE,
 
     -- * Vectorized element-wise operations
     emap,
@@ -78,6 +76,15 @@ class Cond a where
   eqE :: a -> a -> a
   neE :: a -> a -> a
 
+  -- | Elementwise maximum.  The default goes through 'whereE'; instances can
+  -- (and the 'D.Tensor' instance does) override it with a native operation.
+  maxE :: a -> a -> a
+  maxE a b = whereE (gtE a b) a b
+
+  -- | Elementwise minimum, see 'maxE'.
+  minE :: a -> a -> a
+  minE a b = whereE (ltE a b) a b
+
 instance Cond Float where
   whereE c t e = if c /= 0 then t else e
   ltE a b = if a < b then 1 else 0
@@ -96,14 +103,6 @@ instance Cond Double where
   eqE a b = if a == b then 1 else 0
   neE a b = if a /= b then 1 else 0
 
--- | Elementwise maximum, via 'whereE'.
-maxE :: Cond a => a -> a -> a
-maxE a b = whereE (gtE a b) a b
-
--- | Elementwise minimum, via 'whereE'.
-minE :: Cond a => a -> a -> a
-minE a b = whereE (ltE a b) a b
-
 instance Cond D.Tensor where
   whereE c t e = I.where' (F.toDType DT.Bool c) t e
   ltE a b = F.toDType (D.dtype a) (F.lt a b)
@@ -112,6 +111,8 @@ instance Cond D.Tensor where
   geE a b = F.toDType (D.dtype a) (F.ge a b)
   eqE a b = F.toDType (D.dtype a) (F.eq a b)
   neE a b = F.toDType (D.dtype a) (F.ne a b)
+  maxE = I.maximum
+  minE = I.minimum
 
 -- | Element-wise map, executed as whole-tensor operations.
 --

--- a/hasktorch/src/Torch/Typed/Staged.hs
+++ b/hasktorch/src/Torch/Typed/Staged.hs
@@ -38,6 +38,9 @@
 -- the code inspectable.
 module Torch.Typed.Staged
   ( -- * Value-dependent control flow
+    --
+    -- | Re-exported from "Torch.Elementwise", their untyped home: the same
+    -- classes drive element-wise code over untyped tensors.
     Cond (..),
 
     -- * Vectorized element-wise operations
@@ -50,69 +53,13 @@ module Torch.Typed.Staged
 where
 
 import Data.Proxy (Proxy (..))
-import qualified Torch.DType as DT
+import Torch.Elementwise (Cond (..))
 import qualified Torch.Functional as F
-import qualified Torch.Functional.Internal as I
 import Torch.HList (HList, type (++))
 import qualified Torch.Tensor as D
 import Torch.Typed.Graded (TensorMonad, fromNamed, toNamed)
 import Torch.Typed.Representable
 import Torch.Typed.Tensor
-
--- | Branching and comparisons for staged element code.
---
--- @if@\/pattern matching on the element value cannot be reinterpreted at
--- @Tensor@ (there is no @Bool@ to inspect), so value-dependent control flow
--- goes through 'whereE', which compiles to @torch.where@.  Comparisons return
--- @0@\/@1@ masks in the same type @a@ so they compose with arithmetic.
-class Cond a where
-  -- | @whereE c t e@ is elementwise @if c /= 0 then t else e@.
-  whereE :: a -> a -> a -> a
-
-  ltE :: a -> a -> a
-  leE :: a -> a -> a
-  gtE :: a -> a -> a
-  geE :: a -> a -> a
-  eqE :: a -> a -> a
-  neE :: a -> a -> a
-
-  -- | Elementwise maximum.  The default goes through 'whereE'; instances can
-  -- (and the 'D.Tensor' instance does) override it with a native operation.
-  maxE :: a -> a -> a
-  maxE a b = whereE (gtE a b) a b
-
-  -- | Elementwise minimum, see 'maxE'.
-  minE :: a -> a -> a
-  minE a b = whereE (ltE a b) a b
-
-instance Cond Float where
-  whereE c t e = if c /= 0 then t else e
-  ltE a b = if a < b then 1 else 0
-  leE a b = if a <= b then 1 else 0
-  gtE a b = if a > b then 1 else 0
-  geE a b = if a >= b then 1 else 0
-  eqE a b = if a == b then 1 else 0
-  neE a b = if a /= b then 1 else 0
-
-instance Cond Double where
-  whereE c t e = if c /= 0 then t else e
-  ltE a b = if a < b then 1 else 0
-  leE a b = if a <= b then 1 else 0
-  gtE a b = if a > b then 1 else 0
-  geE a b = if a >= b then 1 else 0
-  eqE a b = if a == b then 1 else 0
-  neE a b = if a /= b then 1 else 0
-
-instance Cond D.Tensor where
-  whereE c t e = I.where' (F.toDType DT.Bool c) t e
-  ltE a b = F.toDType (D.dtype a) (F.lt a b)
-  leE a b = F.toDType (D.dtype a) (F.le a b)
-  gtE a b = F.toDType (D.dtype a) (F.gt a b)
-  geE a b = F.toDType (D.dtype a) (F.ge a b)
-  eqE a b = F.toDType (D.dtype a) (F.eq a b)
-  neE a b = F.toDType (D.dtype a) (F.ne a b)
-  maxE = I.maximum
-  minE = I.minimum
 
 -- | Element-wise map, executed as whole-tensor operations.
 --

--- a/hasktorch/src/Torch/Typed/Staged.hs
+++ b/hasktorch/src/Torch/Typed/Staged.hs
@@ -1,0 +1,159 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE NoStarIsType #-}
+
+-- | Staged element-wise operations: write per-element code once, run it
+-- vectorized.
+--
+-- The trick is Coyoneda-shaped, with the function space restricted to what can
+-- be reinterpreted: element functions are written polymorphically,
+--
+-- > f :: (Floating a, Cond a) => a -> a
+-- > f x = whereE (gtE x 0) (sin x * 10) 0
+--
+-- and the /same/ code runs under two instantiations:
+--
+-- * @a = Float@ — reference semantics, one call per element (what
+--   'Torch.Typed.Representable.tabulate' and 'Torch.Typed.Graded.gbind' do);
+-- * @a = Tensor@ — each operation is a whole-tensor ATen call, so the function
+--   body executes /once/ regardless of tensor size, autograd sees every step,
+--   and no per-element FFI happens.
+--
+-- Because the argument type is universally quantified, the only operations
+-- available inside @f@ are the class methods — parametricity guarantees the
+-- function is a pointwise arithmetic expression, so reinterpreting it at
+-- @Tensor@ is sound.
+--
+-- An opaque, already-monomorphic @Float -> Float@ cannot be vectorized this
+-- way (GHC has no runtime code inspection); the polymorphic type is what keeps
+-- the code inspectable.
+module Torch.Typed.Staged
+  ( -- * Value-dependent control flow
+    Cond (..),
+
+    -- * Vectorized element-wise operations
+    emap,
+    ezipWith,
+
+    -- * Staged graded bind
+    gbindV,
+  )
+where
+
+import Data.Proxy (Proxy (..))
+import qualified Torch.DType as DT
+import qualified Torch.Functional as F
+import qualified Torch.Functional.Internal as I
+import Torch.HList (HList, type (++))
+import qualified Torch.Tensor as D
+import Torch.Typed.Graded (TensorMonad, fromNamed, toNamed)
+import Torch.Typed.Representable
+import Torch.Typed.Tensor
+
+-- | Branching and comparisons for staged element code.
+--
+-- @if@\/pattern matching on the element value cannot be reinterpreted at
+-- @Tensor@ (there is no @Bool@ to inspect), so value-dependent control flow
+-- goes through 'whereE', which compiles to @torch.where@.  Comparisons return
+-- @0@\/@1@ masks in the same type @a@ so they compose with arithmetic.
+class Cond a where
+  -- | @whereE c t e@ is elementwise @if c /= 0 then t else e@.
+  whereE :: a -> a -> a -> a
+
+  ltE :: a -> a -> a
+  leE :: a -> a -> a
+  gtE :: a -> a -> a
+  geE :: a -> a -> a
+  eqE :: a -> a -> a
+  neE :: a -> a -> a
+
+instance Cond Float where
+  whereE c t e = if c /= 0 then t else e
+  ltE a b = if a < b then 1 else 0
+  leE a b = if a <= b then 1 else 0
+  gtE a b = if a > b then 1 else 0
+  geE a b = if a >= b then 1 else 0
+  eqE a b = if a == b then 1 else 0
+  neE a b = if a /= b then 1 else 0
+
+instance Cond Double where
+  whereE c t e = if c /= 0 then t else e
+  ltE a b = if a < b then 1 else 0
+  leE a b = if a <= b then 1 else 0
+  gtE a b = if a > b then 1 else 0
+  geE a b = if a >= b then 1 else 0
+  eqE a b = if a == b then 1 else 0
+  neE a b = if a /= b then 1 else 0
+
+instance Cond D.Tensor where
+  whereE c t e = I.where' (F.toDType DT.Bool c) t e
+  ltE a b = F.toDType (D.dtype a) (F.lt a b)
+  leE a b = F.toDType (D.dtype a) (F.le a b)
+  gtE a b = F.toDType (D.dtype a) (F.gt a b)
+  geE a b = F.toDType (D.dtype a) (F.ge a b)
+  eqE a b = F.toDType (D.dtype a) (F.eq a b)
+  neE a b = F.toDType (D.dtype a) (F.ne a b)
+
+-- | Element-wise map, executed as whole-tensor operations.
+--
+-- Semantically @emap f t = tabulate (f . index t)@, but @f@ runs once at
+-- @a = Tensor@ instead of once per element.
+emap ::
+  forall shape dtype device.
+  (forall a. (Floating a, Cond a) => a -> a) ->
+  NamedTensor device dtype shape ->
+  NamedTensor device dtype shape
+emap f = fromUnnamed . UnsafeMkTensor . f . toDynamic
+
+-- | Element-wise combination of two same-shaped tensors, executed as
+-- whole-tensor operations.
+ezipWith ::
+  forall shape dtype device.
+  (forall a. (Floating a, Cond a) => a -> a -> a) ->
+  NamedTensor device dtype shape ->
+  NamedTensor device dtype shape ->
+  NamedTensor device dtype shape
+ezipWith f x y = fromUnnamed . UnsafeMkTensor $ f (toDynamic x) (toDynamic y)
+
+-- | Staged version of 'Torch.Typed.Graded.gbind'.  Definitionally,
+--
+-- > gbindV m k = gbind m (\x -> fromNamed (tabulate (k x)))
+--
+-- (this equation is checked in the test suite, with
+-- 'Torch.Typed.Graded.gbind' as the oracle), but where 'Torch.Typed.Graded.gbind'
+-- evaluates @k@ per element, 'gbindV' evaluates it once per /inner index/ on
+-- the whole outer tensor: the cost is @numel t@ chains of ATen calls instead
+-- of @numel s * numel t@ per-element FFI round trips, and gradients flow
+-- through every step.
+--
+-- The inner indices are enumerated concretely, so this suits small inner
+-- dimensions (channels, coordinates, classes).  A large inner dimension would
+-- need a symbolic index (@arange@-based) instead.
+gbindV ::
+  forall t s device dtype.
+  (HasIndex s, HasIndex t) =>
+  TensorMonad device dtype s ->
+  (forall a. (Floating a, Cond a) => a -> HList (ToFinites t) -> a) ->
+  TensorMonad device dtype (s ++ t)
+gbindV m k =
+  fromNamed . fromUnnamed . UnsafeMkTensor $
+    D.reshape (outerDims ++ innerDims) stacked
+  where
+    x = toDynamic (toNamed m)
+    outerDims = dims (Proxy @s)
+    innerDims = dims (Proxy @t)
+    -- one whole-tensor evaluation of k per inner index, row-major, matching
+    -- the element order of the reference gbind
+    stacked =
+      F.stack
+        (F.Dim (length outerDims))
+        [k x (fromInts @t ix) | ix <- allIndices innerDims]

--- a/hasktorch/src/Torch/Typed/Vision.hs
+++ b/hasktorch/src/Torch/Typed/Vision.hs
@@ -200,15 +200,23 @@ boxIou ::
 boxIou dets = fromUnnamed . UnsafeMkTensor $ iou rows cols
   where
     n = natValI @n
-    rows = D.reshape [n, 1] <$> sides
-    cols = D.reshape [1, n] <$> sides
-    sides =
-      Box
-        (viewL (field @"x1"))
-        (viewL (field @"y1"))
-        (viewL (field @"x2"))
-        (viewL (field @"y2"))
-        (viewL (field @"score"))
+    rows = D.reshape [n, 1] <$> boxFields dets
+    cols = D.reshape [1, n] <$> boxFields dets
+
+-- | The fields of all detections at once, each as a plain @[n]@ tensor,
+-- extracted via the named-field lenses.
+boxFields ::
+  forall n device.
+  NamedTensor device 'D.Float '[Vector n, Box] ->
+  Box D.Tensor
+boxFields dets =
+  Box
+    (viewL (field @"x1"))
+    (viewL (field @"y1"))
+    (viewL (field @"x2"))
+    (viewL (field @"y2"))
+    (viewL (field @"score"))
+  where
     viewL ::
       Lens'
         (NamedTensor device 'D.Float '[Vector n, Box])
@@ -220,10 +228,12 @@ boxIou dets = fromUnnamed . UnsafeMkTensor $ iou rows cols
 -- remaining box whose IoU with it exceeds the threshold, recurse.  Returns
 -- indices into the input, best score first.
 --
--- The pairwise matrix costs @O(n^2)@ memory — with the pre-NMS top-k of a
--- typical detector (@n@ between 1000 and 6000) that is 4 to 144 MB.  The
--- suppression itself is plain list recursion, which is where the algorithm is
--- easiest to read.
+-- Only the IoU rows of boxes that are actually kept get computed: 'iou' is
+-- evaluated once per kept box — the box's fields as scalars, broadcast
+-- against all boxes at once — so memory stays @O(n)@ and no @n^2@ matrix is
+-- materialized.  ('boxIou' is there when the full matrix is wanted.)  The
+-- suppression itself is plain list recursion, which is where the algorithm
+-- is easiest to read.
 nms ::
   forall n device.
   KnownNat n =>
@@ -235,10 +245,14 @@ nms ::
   [Finite n]
 nms threshold dets = map (fromJust . packFinite . fromIntegral) (go order)
   where
-    n = natValI @n
     go [] = []
-    go (i : rest) = i : go [j | j <- rest, m VS.! (i * n + j) <= threshold]
+    go (i : rest) = i : go [j | j <- rest, row VS.! j <= threshold]
+      where
+        row = iouRow i
+    -- IoU of box i against every box: the same scalar formula, its left
+    -- argument a box of 0-dim tensors broadcast against [n] tensors
+    iouRow i = D.asValue (cpu (iou (D.select 0 i <$> allBoxes) allBoxes)) :: VS.Vector Float
+    allBoxes = boxFields dets
     order = map snd (sortOn (Down . fst) (zip (VS.toList scores) [0 ..]))
+    scores = D.asValue (cpu (score allBoxes)) :: VS.Vector Float
     cpu = D.toDevice (D.Device D.CPU 0)
-    scores = D.asValue (D.reshape [-1] (cpu (toDynamic (getConst (field @"score" Const dets))))) :: VS.Vector Float
-    m = D.asValue (D.reshape [-1] (cpu (toDynamic (boxIou dets)))) :: VS.Vector Float

--- a/hasktorch/src/Torch/Typed/Vision.hs
+++ b/hasktorch/src/Torch/Typed/Vision.hs
@@ -1,6 +1,10 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -14,9 +18,16 @@ import qualified Codec.Compression.GZip as GZip
 import Control.Monad (forM_)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Internal as BSI
+import Data.Finite (Finite, packFinite)
+import Data.Functor.Const (Const (..))
+import Data.List (sortOn)
+import Data.Maybe (fromJust)
+import Data.Ord (Down (..))
+import Data.Vector.Sized (Vector)
 import Foreign.Marshal.Utils (copyBytes)
 import qualified Data.ByteString.Lazy as BS.Lazy
 import Data.Kind
+import GHC.Generics (Generic)
 import qualified Foreign.ForeignPtr as F
 import qualified Foreign.Ptr as F
 import GHC.Exts (IsList (fromList))
@@ -29,8 +40,11 @@ import Torch.Internal.Cast
 import qualified Torch.Internal.Managed.TensorFactories as LibTorch
 import qualified Torch.Tensor as D
 import qualified Torch.TensorOptions as D
+import Torch.Lens (Lens')
 import Torch.Typed.Auxiliary
 import Torch.Typed.Functional
+import Torch.Typed.Lens (field)
+import Torch.Typed.Staged (Cond, maxE, minE)
 import Torch.Typed.Tensor
 
 data MNIST (m :: Type -> Type) (device :: (D.DeviceType, Nat)) (batchSize :: Nat) = MNIST {mnistData :: MnistData}
@@ -142,3 +156,85 @@ initMnist path = do
   testImagesBS <- decompressFile path "t10k-images-idx3-ubyte.gz"
   testLabelsBS <- decompressFile path "t10k-labels-idx1-ubyte.gz"
   return (MnistData imagesBS labelsBS, MnistData testImagesBS testLabelsBS)
+
+--------------------------------------------------------------------------------
+-- Non-maximum suppression
+--------------------------------------------------------------------------------
+
+-- | A detection: box coordinates and a confidence score, addressed by name.
+-- Used as a named dimension, so detections have type
+-- @NamedTensor device dtype '[Vector n, Box]@ and nothing below indexes a
+-- coordinate by number.
+data Box a = Box
+  { x1 :: a,
+    y1 :: a,
+    x2 :: a,
+    y2 :: a,
+    score :: a
+  }
+  deriving (Show, Eq, Generic, Functor)
+
+-- | Intersection over union of two boxes, as a formula on scalars.
+--
+-- Written against @(Fractional a, Cond a)@ so that the one definition serves
+-- both as the vectorized implementation ('boxIou' instantiates it at
+-- @a = Tensor@) and as a per-element reference (at @a = Float@); the test
+-- suite checks the two instantiations agree exactly.
+iou :: (Fractional a, Cond a) => Box a -> Box a -> a
+iou a b = inter / (area a + area b - inter)
+  where
+    iw = maxE 0 (minE (x2 a) (x2 b) - maxE (x1 a) (x1 b))
+    ih = maxE 0 (minE (y2 a) (y2 b) - maxE (y1 a) (y1 b))
+    inter = iw * ih
+    area v = (x2 v - x1 v) * (y2 v - y1 v)
+
+-- | The pairwise IoU matrix of a set of detections: 'iou' evaluated once at
+-- @a = Tensor@, with the coordinate fields shaped as a column and a row so
+-- broadcasting produces the whole \(n \times n\) matrix.
+boxIou ::
+  forall n device.
+  KnownNat n =>
+  NamedTensor device 'D.Float '[Vector n, Box] ->
+  NamedTensor device 'D.Float '[Vector n, Vector n]
+boxIou dets = fromUnnamed . UnsafeMkTensor $ iou rows cols
+  where
+    n = natValI @n
+    rows = D.reshape [n, 1] <$> sides
+    cols = D.reshape [1, n] <$> sides
+    sides =
+      Box
+        (viewL (field @"x1"))
+        (viewL (field @"y1"))
+        (viewL (field @"x2"))
+        (viewL (field @"y2"))
+        (viewL (field @"score"))
+    viewL ::
+      Lens'
+        (NamedTensor device 'D.Float '[Vector n, Box])
+        (NamedTensor device 'D.Float '[Vector n]) ->
+      D.Tensor
+    viewL l = toDynamic (getConst (l Const dets))
+
+-- | Greedy non-maximum suppression: take the best-scoring box, drop every
+-- remaining box whose IoU with it exceeds the threshold, recurse.  Returns
+-- indices into the input, best score first.
+--
+-- The pairwise matrix costs @O(n^2)@ memory; the suppression itself is plain
+-- list recursion, which is where the algorithm is easiest to read.
+nms ::
+  forall n device.
+  KnownNat n =>
+  -- | IoU threshold
+  Float ->
+  -- | detections
+  NamedTensor device 'D.Float '[Vector n, Box] ->
+  -- | kept indices, best score first
+  [Finite n]
+nms threshold dets = map (fromJust . packFinite . fromIntegral) (go order)
+  where
+    go [] = []
+    go (i : rest) = i : go [j | j <- rest, m !! i !! j <= threshold]
+    order = sortOn (Down . (scores !!)) [0 .. natValI @n - 1]
+    cpu = D.toDevice (D.Device D.CPU 0)
+    scores = D.asValue (cpu (toDynamic (getConst (field @"score" Const dets)))) :: [Float]
+    m = D.asValue (cpu (toDynamic (boxIou dets))) :: [[Float]]

--- a/hasktorch/src/Torch/Typed/Vision.hs
+++ b/hasktorch/src/Torch/Typed/Vision.hs
@@ -24,6 +24,7 @@ import Data.List (sortOn)
 import Data.Maybe (fromJust)
 import Data.Ord (Down (..))
 import Data.Vector.Sized (Vector)
+import qualified Data.Vector.Storable as VS
 import Foreign.Marshal.Utils (copyBytes)
 import qualified Data.ByteString.Lazy as BS.Lazy
 import Data.Kind
@@ -219,8 +220,10 @@ boxIou dets = fromUnnamed . UnsafeMkTensor $ iou rows cols
 -- remaining box whose IoU with it exceeds the threshold, recurse.  Returns
 -- indices into the input, best score first.
 --
--- The pairwise matrix costs @O(n^2)@ memory; the suppression itself is plain
--- list recursion, which is where the algorithm is easiest to read.
+-- The pairwise matrix costs @O(n^2)@ memory — with the pre-NMS top-k of a
+-- typical detector (@n@ between 1000 and 6000) that is 4 to 144 MB.  The
+-- suppression itself is plain list recursion, which is where the algorithm is
+-- easiest to read.
 nms ::
   forall n device.
   KnownNat n =>
@@ -232,9 +235,10 @@ nms ::
   [Finite n]
 nms threshold dets = map (fromJust . packFinite . fromIntegral) (go order)
   where
+    n = natValI @n
     go [] = []
-    go (i : rest) = i : go [j | j <- rest, m !! i !! j <= threshold]
-    order = sortOn (Down . (scores !!)) [0 .. natValI @n - 1]
+    go (i : rest) = i : go [j | j <- rest, m VS.! (i * n + j) <= threshold]
+    order = map snd (sortOn (Down . fst) (zip (VS.toList scores) [0 ..]))
     cpu = D.toDevice (D.Device D.CPU 0)
-    scores = D.asValue (cpu (toDynamic (getConst (field @"score" Const dets)))) :: [Float]
-    m = D.asValue (cpu (toDynamic (boxIou dets))) :: [[Float]]
+    scores = D.asValue (D.reshape [-1] (cpu (toDynamic (getConst (field @"score" Const dets))))) :: VS.Vector Float
+    m = D.asValue (D.reshape [-1] (cpu (toDynamic (boxIou dets)))) :: VS.Vector Float

--- a/hasktorch/test/ElementwiseSpec.hs
+++ b/hasktorch/test/ElementwiseSpec.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE RankNTypes #-}
+
+-- | The staged element-wise layer, exercised from the untyped API: the same
+-- polymorphic formula runs per element at @a = Float@ and vectorized at
+-- @a = Tensor@, and the two agree.
+module ElementwiseSpec (spec) where
+
+import Test.Hspec
+import Torch
+import Torch.Elementwise
+
+relu' :: (Floating a, Cond a) => a -> a
+relu' x = whereE (gtE x 0) x 0
+
+clamp01 :: (Floating a, Cond a) => a -> a
+clamp01 x = minE 1 (maxE 0 x)
+
+spec :: Spec
+spec = do
+  describe "Torch.Elementwise" $ do
+    it "emap agrees with the Float instantiation of the same formula" $ do
+      let t = asTensor ([-2, -0.5, 0, 0.5, 2] :: [Float])
+      (asValue (emap relu' t) :: [Float]) `shouldBe` map relu' [-2, -0.5, 0, 0.5, 2]
+      (asValue (emap clamp01 t) :: [Float]) `shouldBe` map clamp01 [-2, -0.5, 0, 0.5, 2]
+    it "ezipWith computes an elementwise maximum via native maxE" $ do
+      let x = asTensor ([1, 5, 3] :: [Float])
+          y = asTensor ([4, 2, 3] :: [Float])
+      (asValue (ezipWith maxE x y) :: [Float]) `shouldBe` [4, 5, 3]
+    it "whereE keeps gradients flowing (autograd sees every step)" $ do
+      t <- makeIndependent (asTensor ([-1, 2] :: [Float]))
+      let loss = sumAll (emap relu' (toDependent t))
+          [g] = grad loss [t]
+      (asValue g :: [Float]) `shouldBe` [0, 1]

--- a/hasktorch/test/Spec.hs
+++ b/hasktorch/test/Spec.hs
@@ -36,6 +36,7 @@ import qualified Torch.Typed.NNSpec
 import qualified Torch.Typed.NamedTensorSpec
 import qualified Torch.Typed.OptimSpec
 import qualified Torch.Typed.RepresentableSpec
+import qualified Torch.Typed.NMSSpec
 import qualified Torch.Typed.StagedSpec
 import qualified Torch.Typed.TensorSpec0
 import qualified Torch.Typed.TensorSpec1
@@ -79,6 +80,7 @@ main = hspec $ do
   Torch.Typed.NamedTensorSpec.spec
   Torch.Typed.OptimSpec.spec
   Torch.Typed.RepresentableSpec.spec
+  Torch.Typed.NMSSpec.spec
   Torch.Typed.StagedSpec.spec
   Torch.Typed.TensorSpec0.spec
   Torch.Typed.TensorSpec1.spec

--- a/hasktorch/test/Spec.hs
+++ b/hasktorch/test/Spec.hs
@@ -2,6 +2,7 @@ module Main where
 
 import Test.Hspec (hspec)
 import qualified DimnameSpec
+import qualified ElementwiseSpec
 import qualified FactorySpec
 import qualified FunctionalSpec
 import qualified GradSpec
@@ -48,6 +49,7 @@ import qualified Torch.Typed.SerializeSpec
 main :: IO ()
 main = hspec $ do
   DimnameSpec.spec
+  ElementwiseSpec.spec
   FactorySpec.spec
   FunctionalSpec.spec
   GradSpec.spec

--- a/hasktorch/test/Spec.hs
+++ b/hasktorch/test/Spec.hs
@@ -21,6 +21,7 @@ import qualified VisionSpec
 import qualified Torch.Distributions.BernoulliSpec
 import qualified Torch.Distributions.CategoricalSpec
 import qualified Torch.Distributions.ConstraintsSpec
+import qualified Torch.Typed.AttentionSpec
 import qualified Torch.Typed.AutogradSpec
 import qualified Torch.Typed.AuxiliarySpec
 import qualified Torch.Typed.FactoriesSpec
@@ -68,6 +69,7 @@ main = hspec $ do
   Torch.Distributions.BernoulliSpec.spec
   Torch.Distributions.CategoricalSpec.spec
   Torch.Distributions.ConstraintsSpec.spec
+  Torch.Typed.AttentionSpec.spec
   Torch.Typed.AutogradSpec.spec
   Torch.Typed.AuxiliarySpec.spec
   Torch.Typed.FactoriesSpec.spec

--- a/hasktorch/test/Spec.hs
+++ b/hasktorch/test/Spec.hs
@@ -24,6 +24,7 @@ import qualified Torch.Typed.AutogradSpec
 import qualified Torch.Typed.AuxiliarySpec
 import qualified Torch.Typed.FactoriesSpec
 import qualified Torch.Typed.GradedSpec
+import qualified Torch.Typed.IndexSpec
 import qualified Torch.Typed.FunctionalSpec0
 import qualified Torch.Typed.FunctionalSpec1
 import qualified Torch.Typed.FunctionalSpec2
@@ -68,6 +69,7 @@ main = hspec $ do
   Torch.Typed.AuxiliarySpec.spec
   Torch.Typed.FactoriesSpec.spec
   Torch.Typed.GradedSpec.spec
+  Torch.Typed.IndexSpec.spec
   Torch.Typed.FunctionalSpec0.spec
   Torch.Typed.FunctionalSpec1.spec
   Torch.Typed.FunctionalSpec2.spec

--- a/hasktorch/test/Spec.hs
+++ b/hasktorch/test/Spec.hs
@@ -23,6 +23,7 @@ import qualified Torch.Distributions.ConstraintsSpec
 import qualified Torch.Typed.AutogradSpec
 import qualified Torch.Typed.AuxiliarySpec
 import qualified Torch.Typed.FactoriesSpec
+import qualified Torch.Typed.GradedSpec
 import qualified Torch.Typed.FunctionalSpec0
 import qualified Torch.Typed.FunctionalSpec1
 import qualified Torch.Typed.FunctionalSpec2
@@ -34,6 +35,8 @@ import qualified Torch.Typed.NN.TransformerSpec
 import qualified Torch.Typed.NNSpec
 import qualified Torch.Typed.NamedTensorSpec
 import qualified Torch.Typed.OptimSpec
+import qualified Torch.Typed.RepresentableSpec
+import qualified Torch.Typed.StagedSpec
 import qualified Torch.Typed.TensorSpec0
 import qualified Torch.Typed.TensorSpec1
 import qualified Torch.Typed.VisionSpec
@@ -63,6 +66,7 @@ main = hspec $ do
   Torch.Typed.AutogradSpec.spec
   Torch.Typed.AuxiliarySpec.spec
   Torch.Typed.FactoriesSpec.spec
+  Torch.Typed.GradedSpec.spec
   Torch.Typed.FunctionalSpec0.spec
   Torch.Typed.FunctionalSpec1.spec
   Torch.Typed.FunctionalSpec2.spec
@@ -74,6 +78,8 @@ main = hspec $ do
   Torch.Typed.NNSpec.spec
   Torch.Typed.NamedTensorSpec.spec
   Torch.Typed.OptimSpec.spec
+  Torch.Typed.RepresentableSpec.spec
+  Torch.Typed.StagedSpec.spec
   Torch.Typed.TensorSpec0.spec
   Torch.Typed.TensorSpec1.spec
   Torch.Typed.VisionSpec.spec

--- a/hasktorch/test/Spec.hs
+++ b/hasktorch/test/Spec.hs
@@ -25,6 +25,7 @@ import qualified Torch.Typed.AuxiliarySpec
 import qualified Torch.Typed.FactoriesSpec
 import qualified Torch.Typed.GradedSpec
 import qualified Torch.Typed.IndexSpec
+import qualified Torch.Typed.LensSpec
 import qualified Torch.Typed.FunctionalSpec0
 import qualified Torch.Typed.FunctionalSpec1
 import qualified Torch.Typed.FunctionalSpec2
@@ -70,6 +71,7 @@ main = hspec $ do
   Torch.Typed.FactoriesSpec.spec
   Torch.Typed.GradedSpec.spec
   Torch.Typed.IndexSpec.spec
+  Torch.Typed.LensSpec.spec
   Torch.Typed.FunctionalSpec0.spec
   Torch.Typed.FunctionalSpec1.spec
   Torch.Typed.FunctionalSpec2.spec

--- a/hasktorch/test/Torch/Typed/AttentionSpec.hs
+++ b/hasktorch/test/Torch/Typed/AttentionSpec.hs
@@ -1,0 +1,144 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE NoStarIsType #-}
+
+-- | A decoder block, equation by equation.
+--
+-- This is the pedagogical counterpart of "Torch.Typed.NN.Transformer": the
+-- same mathematics, written so that each equation of the paper is one
+-- definition, with the paper's shape annotations as checked types.  The test
+-- at the bottom trains it on a next-token task and checks that it learns.
+module Torch.Typed.AttentionSpec (spec) where
+
+import Control.Monad (foldM)
+import Data.List (elemIndices)
+import Data.Vector.Sized (Vector)
+import GHC.Generics (Generic)
+import Test.Hspec
+import Prelude
+import qualified Torch.DType as D
+import qualified Torch.Device as D
+import qualified Torch.Tensor as UT
+import Torch.Typed hiding (length)
+import Torch.Typed.Representable (tabulateList)
+
+-- vocabulary, context length, model width, feed-forward width
+type V = 4
+
+type S = 8
+
+type E = 16
+
+type H = 32
+
+type Dev = '(D.CPU, 0)
+
+type T shape = Tensor Dev 'D.Float shape
+
+--------------------------------------------------------------------------------
+-- The equations
+--------------------------------------------------------------------------------
+
+-- M[i,j] = 0 if j <= i, -inf otherwise: a tensor defined by its formula
+causalMask :: T '[S, S]
+causalMask = toUnnamed (tabulateList @'[Vector S, Vector S] @'D.Float @Dev mask)
+  where
+    mask [i, j] = if j <= i then 0 else -1 / 0
+    mask _ = 0
+
+-- Attention(Q, K, V) = softmax(Q Kᵀ / √d + M) V
+attend :: T '[S, E] -> T '[S, E] -> T '[S, E] -> T '[S, E]
+attend q k v = softmax @1 (divScalar sqrtD (q `matmul` transpose2D k) + causalMask) `matmul` v
+  where
+    sqrtD = Prelude.sqrt (fromIntegral (natValI @E)) :: Float
+
+--------------------------------------------------------------------------------
+-- A one-block decoder
+--------------------------------------------------------------------------------
+
+data GPT = GPT
+  { embed :: Parameter Dev 'D.Float '[V, E],
+    wq :: Linear E E 'D.Float Dev,
+    wk :: Linear E E 'D.Float Dev,
+    wv :: Linear E E 'D.Float Dev,
+    wo :: Linear E E 'D.Float Dev,
+    norm1 :: LayerNorm '[E] 'D.Float Dev,
+    norm2 :: LayerNorm '[E] 'D.Float Dev,
+    ff1 :: Linear E H 'D.Float Dev,
+    ff2 :: Linear H E 'D.Float Dev,
+    unembed :: Linear E V 'D.Float Dev
+  }
+  deriving (Generic, Parameterized)
+
+data GPTSpec = GPTSpec
+
+instance Randomizable GPTSpec GPT where
+  sample GPTSpec =
+    GPT
+      <$> (makeIndependent . mulScalar (0.1 :: Float) =<< randn)
+      <*> sample LinearSpec
+      <*> sample LinearSpec
+      <*> sample LinearSpec
+      <*> sample LinearSpec
+      <*> sample (LayerNormSpec 1e-5)
+      <*> sample (LayerNormSpec 1e-5)
+      <*> sample LinearSpec
+      <*> sample LinearSpec
+      <*> sample LinearSpec
+
+-- x   = Embed[tokens]                (token embedding)
+-- x'  = x  + Wo · Attend(Wq xn, Wk xn, Wv xn)   where xn = LN1 x
+-- x'' = x' + FF(LN2 x')                          (residual + feed-forward)
+-- out = Unembed x''                              (logits over the vocabulary)
+gptForward :: GPT -> Tensor Dev 'D.Int64 '[S] -> T '[S, V]
+gptForward GPT {..} tokens = forward unembed x''
+  where
+    x = embedding @'Nothing False False (toDependent embed) tokens
+    xn = forward norm1 x
+    x' = x + forward wo (attend (forward wq xn) (forward wk xn) (forward wv xn))
+    x'' = x' + forward ff2 (relu (forward ff1 (forward norm2 x')))
+
+--------------------------------------------------------------------------------
+-- It learns: next-token prediction on a repeating sequence
+--------------------------------------------------------------------------------
+
+tokens, targets :: Tensor Dev 'D.Int64 '[S]
+tokens = UnsafeMkTensor (UT.asTensor ([0, 1, 2, 3, 0, 1, 2, 3] :: [Int]))
+targets = UnsafeMkTensor (UT.asTensor ([1, 2, 3, 0, 1, 2, 3, 0] :: [Int]))
+
+lossOf :: GPT -> T '[]
+lossOf m = nllLoss @ReduceMean ones (-100) (logSoftmax @1 (gptForward m tokens)) targets
+
+predictions :: GPT -> [Int]
+predictions m = map argmaxRow (UT.asValue (toDynamic (gptForward m tokens)) :: [[Float]])
+  where
+    argmaxRow row = head (elemIndices (maximum row) row)
+
+spec :: Spec
+spec = describe "a decoder block, equation by equation" $ do
+  it "the causal mask never lets position i attend to j > i" $ do
+    let m = UT.asValue (toDynamic causalMask) :: [[Float]]
+    and [m !! i !! j == 0 | i <- [0 .. 7], j <- [0 .. i]] `shouldBe` True
+    and [m !! i !! j < -1e30 | i <- [0 .. 7], j <- [i + 1 .. 7]] `shouldBe` True
+  it "learns next-token prediction on a repeating sequence" $ do
+    model <- sample GPTSpec
+    let optim = mkAdam 0 0.9 0.999 (flattenParameters model)
+        loss0 = toFloat (lossOf model)
+    (trained, _) <-
+      foldM
+        (\(m, o) _ -> runStep m o (lossOf m) 1e-2)
+        (model, optim)
+        [1 .. 1000 :: Int]
+    let loss1 = toFloat (lossOf trained)
+    loss0 `shouldSatisfy` (> 0.5) -- untrained: near ln 4 ≈ 1.39
+    loss1 `shouldSatisfy` (< 0.1) -- trained: near zero
+    predictions trained `shouldBe` [1, 2, 3, 0, 1, 2, 3, 0]

--- a/hasktorch/test/Torch/Typed/GradedSpec.hs
+++ b/hasktorch/test/Torch/Typed/GradedSpec.hs
@@ -1,0 +1,108 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE ExplicitNamespaces #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE QualifiedDo #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE NoStarIsType #-}
+
+module Torch.Typed.GradedSpec (spec) where
+
+import Data.Default.Class
+import Data.Proxy
+import Data.Vector.Sized (Vector)
+import GHC.Generics
+import GHC.TypeLits
+import Test.Hspec
+import qualified Torch.DType as D
+import qualified Torch.Device as D
+import Torch.HList
+import qualified Torch.Tensor as D
+import Torch.Typed.Graded (GradedMonad (..), TensorMonad, fromNamed, toNamed)
+import qualified Torch.Typed.Graded as G
+import Torch.Typed.Representable
+import Torch.Typed.Tensor
+
+newtype Batch (n :: Nat) a = Batch (Vector n a) deriving (Show, Eq, Generic)
+
+data RGB a = RGB
+  { r :: a,
+    g :: a,
+    b :: a
+  }
+  deriving (Show, Eq, Generic, Default)
+
+type M = TensorMonad '(D.CPU, 0) 'D.Float
+
+-- The shape monoid: '[] is the unit and ++ is associative, definitionally.
+testUnitL :: Proxy ('[] ++ '[Batch 2, RGB]) -> Proxy '[Batch 2, RGB]
+testUnitL = id
+
+testUnitR :: Proxy ('[Batch 2, RGB] ++ '[]) -> Proxy '[Batch 2, RGB]
+testUnitR = id
+
+testAssoc ::
+  Proxy (('[Batch 2] ++ '[RGB]) ++ '[Batch 2]) ->
+  Proxy ('[Batch 2] ++ ('[RGB] ++ '[Batch 2]))
+testAssoc = id
+
+-- a rank-1 tensor holding [0, 1]
+base :: M '[Batch 2]
+base = fromNamed (tabulate (\(i :. HNil) -> fromIntegral (fromEnum i)))
+
+-- for each element x, an RGB triple [x*10, x*10+1, x*10+2]
+toRGB :: Float -> M '[RGB]
+toRGB x = fromNamed (tabulate (\(j :. HNil) -> x * 10 + fromIntegral (fromEnum j)))
+
+toBatch :: Float -> M '[Batch 2]
+toBatch y = fromNamed (tabulate (\(k :. HNil) -> y * 100 + fromIntegral (fromEnum k)))
+
+elems :: M s -> [Float]
+elems = D.asValue . D.reshape [-1] . toDynamic . toNamed
+
+dimsM :: M s -> [Int]
+dimsM = D.shape . toDynamic . toNamed
+
+-- do-notation over the graded monad, via QualifiedDo
+viaDo :: M '[Batch 2, RGB]
+viaDo = G.do
+  x <- base
+  toRGB x
+
+spec :: Spec
+spec = do
+  describe "GradedMonad TensorMonad" $ do
+    it "gbind concatenates shapes" $ do
+      let t = gbind base toRGB
+      dimsM t `shouldBe` [2, 3]
+      elems t `shouldBe` [0, 1, 2, 10, 11, 12]
+    it "greturn produces a scalar" $ do
+      let t = greturn 7 :: M '[]
+      dimsM t `shouldBe` []
+      elems t `shouldBe` [7]
+    it "satisfies the left identity law" $ do
+      elems (gbind (greturn 5 :: M '[]) toRGB) `shouldBe` elems (toRGB 5)
+      dimsM (gbind (greturn 5 :: M '[]) toRGB) `shouldBe` dimsM (toRGB 5)
+    it "satisfies the right identity law" $ do
+      elems (gbind base greturn) `shouldBe` elems base
+      dimsM (gbind base greturn) `shouldBe` dimsM base
+    it "satisfies the associativity law" $ do
+      let lhs = gbind (gbind base toRGB) toBatch :: M '[Batch 2, RGB, Batch 2]
+          rhs = gbind base (\x -> gbind (toRGB x) toBatch) :: M '[Batch 2, RGB, Batch 2]
+      dimsM lhs `shouldBe` [2, 3, 2]
+      elems lhs `shouldBe` elems rhs
+    it "works with QualifiedDo notation" $ do
+      dimsM viaDo `shouldBe` [2, 3]
+      elems viaDo `shouldBe` [0, 1, 2, 10, 11, 12]

--- a/hasktorch/test/Torch/Typed/IndexSpec.hs
+++ b/hasktorch/test/Torch/Typed/IndexSpec.hs
@@ -9,6 +9,7 @@
 module Torch.Typed.IndexSpec (spec) where
 
 import Data.Proxy
+import Lens.Family ((&), (.~), (^.), (%~))
 import Test.Hspec
 import qualified Torch.DType as D
 import qualified Torch.Device as D
@@ -65,6 +66,13 @@ spec = do
       shape (getSlice @[slice| None, :, 1:3 |] t) `shouldBe` [1, 2, 2, 4]
       elems (getSlice @[slice| 1:2, :2, 1::2 |] t) `shouldBe` [13, 15, 17, 19]
       shape (getSlice @[slice| :, ::2 |] t) `shouldBe` [2, 2, 4]
+  describe "sliceLens" $ do
+    it "reads, writes and modifies through the lens" $ do
+      elems (t ^. sliceLens @'[SliceAt 1]) `shouldBe` [12 .. 23]
+      elems (getSlice @'[SliceAt 0] (t & sliceLens @[slice| 0 |] .~ zeros)) `shouldBe` replicate 12 0
+      let u = t & sliceLens @[slice| :, 1 |] %~ (* 100)
+      elems (getSlice @[slice| :, 1 |] u) `shouldBe` map (* 100) ([4 .. 7] ++ [16 .. 19])
+      elems (getSlice @[slice| :, 0 |] u) `shouldBe` ([0 .. 3] ++ [12 .. 15])
   describe "setSlice" $ do
     it "replaces the indexed part and leaves the rest" $ do
       let u = setSlice @'[SliceAt 0] t zeros

--- a/hasktorch/test/Torch/Typed/IndexSpec.hs
+++ b/hasktorch/test/Torch/Typed/IndexSpec.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -57,6 +58,12 @@ spec = do
       let s = slice @'[SliceAll, SliceFromUpToWithStep 0 3 2] t
       shape s `shouldBe` [2, 2, 4]
       elems s `shouldBe` ([0 .. 3] ++ [8 .. 11] ++ [12 .. 15] ++ [20 .. 23])
+    it "accepts PyTorch-style syntax via the ix quasiquoter" $ do
+      elems (slice @[ix| 1 |] t) `shouldBe` elems (slice @'[SliceAt 1] t)
+      elems (slice @[ix| :, 0 |] t) `shouldBe` elems (slice @'[SliceAll, SliceAt 0] t)
+      shape (slice @[ix| None, :, 1:3 |] t) `shouldBe` [1, 2, 2, 4]
+      elems (slice @[ix| 1:2, :2, 1::2 |] t) `shouldBe` [13, 15, 17, 19]
+      shape (slice @[ix| :, ::2 |] t) `shouldBe` [2, 2, 4]
   describe "setSlice" $ do
     it "replaces the indexed part and leaves the rest" $ do
       let u = setSlice @'[SliceAt 0] t zeros

--- a/hasktorch/test/Torch/Typed/IndexSpec.hs
+++ b/hasktorch/test/Torch/Typed/IndexSpec.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE NoStarIsType #-}
+
+module Torch.Typed.IndexSpec (spec) where
+
+import Data.Proxy
+import Test.Hspec
+import qualified Torch.DType as D
+import qualified Torch.Device as D
+import qualified Torch.Tensor as D
+import Torch.Typed.Factories (zeros)
+import Torch.Typed.Index
+import Torch.Typed.Tensor
+
+-- t[i][j][k] = i*12 + j*4 + k
+t :: Tensor '(D.CPU, 0) 'D.Float '[2, 3, 4]
+t = UnsafeMkTensor (D.reshape [2, 3, 4] (D.asTensor [0 .. 23 :: Float]))
+
+elems :: Tensor '(D.CPU, 0) 'D.Float sh -> [Float]
+elems = D.asValue . D.reshape [-1] . toDynamic
+
+-- compile-time checks of the shape computation
+testAt :: Proxy (IndexedShape '[SliceAt 1] '[2, 3, 4]) -> Proxy '[3, 4]
+testAt = id
+
+testNewAxis :: Proxy (IndexedShape '[NewAxis, SliceAll] '[2, 3]) -> Proxy '[1, 2, 3]
+testNewAxis = id
+
+testSteps :: Proxy (IndexedShape '[SliceFromUpToWithStep 0 3 2] '[3]) -> Proxy '[2]
+testSteps = id
+
+testTrailing :: Proxy (IndexedShape '[SliceAt 0] '[2, 3, 4]) -> Proxy '[3, 4]
+testTrailing = id
+
+spec :: Spec
+spec = do
+  describe "slice" $ do
+    it "selects with SliceAt, dropping the dimension" $ do
+      let s = slice @'[SliceAt 1] t
+      shape s `shouldBe` [3, 4]
+      elems s `shouldBe` [12 .. 23]
+    it "reaches inner dimensions through SliceAll" $ do
+      let s = slice @'[SliceAll, SliceAt 0] t
+      shape s `shouldBe` [2, 4]
+      elems s `shouldBe` [0, 1, 2, 3, 12, 13, 14, 15]
+    it "inserts a dimension with NewAxis" $ do
+      shape (slice @'[NewAxis] t) `shouldBe` [1, 2, 3, 4]
+    it "slices ranges and steps" $ do
+      let s = slice @'[SliceFromUpTo 1 2, SliceUpTo 2, SliceFromWithStep 1 2] t
+      shape s `shouldBe` [1, 2, 2]
+      elems s `shouldBe` [13, 15, 17, 19]
+    it "computes step lengths by ceiling division" $ do
+      let s = slice @'[SliceAll, SliceFromUpToWithStep 0 3 2] t
+      shape s `shouldBe` [2, 2, 4]
+      elems s `shouldBe` ([0 .. 3] ++ [8 .. 11] ++ [12 .. 15] ++ [20 .. 23])
+  describe "setSlice" $ do
+    it "replaces the indexed part and leaves the rest" $ do
+      let u = setSlice @'[SliceAt 0] t zeros
+      elems (slice @'[SliceAt 0] u) `shouldBe` replicate 12 0
+      elems (slice @'[SliceAt 1] u) `shouldBe` [12 .. 23]

--- a/hasktorch/test/Torch/Typed/IndexSpec.hs
+++ b/hasktorch/test/Torch/Typed/IndexSpec.hs
@@ -14,6 +14,7 @@ import qualified Torch.DType as D
 import qualified Torch.Device as D
 import qualified Torch.Tensor as D
 import Torch.Typed.Factories (zeros)
+import Torch.Index (slice)
 import Torch.Typed.Index
 import Torch.Typed.Tensor
 
@@ -39,33 +40,33 @@ testTrailing = id
 
 spec :: Spec
 spec = do
-  describe "slice" $ do
+  describe "getSlice" $ do
     it "selects with SliceAt, dropping the dimension" $ do
-      let s = slice @'[SliceAt 1] t
+      let s = getSlice @'[SliceAt 1] t
       shape s `shouldBe` [3, 4]
       elems s `shouldBe` [12 .. 23]
     it "reaches inner dimensions through SliceAll" $ do
-      let s = slice @'[SliceAll, SliceAt 0] t
+      let s = getSlice @'[SliceAll, SliceAt 0] t
       shape s `shouldBe` [2, 4]
       elems s `shouldBe` [0, 1, 2, 3, 12, 13, 14, 15]
     it "inserts a dimension with NewAxis" $ do
-      shape (slice @'[NewAxis] t) `shouldBe` [1, 2, 3, 4]
+      shape (getSlice @'[NewAxis] t) `shouldBe` [1, 2, 3, 4]
     it "slices ranges and steps" $ do
-      let s = slice @'[SliceFromUpTo 1 2, SliceUpTo 2, SliceFromWithStep 1 2] t
+      let s = getSlice @'[SliceFromUpTo 1 2, SliceUpTo 2, SliceFromWithStep 1 2] t
       shape s `shouldBe` [1, 2, 2]
       elems s `shouldBe` [13, 15, 17, 19]
     it "computes step lengths by ceiling division" $ do
-      let s = slice @'[SliceAll, SliceFromUpToWithStep 0 3 2] t
+      let s = getSlice @'[SliceAll, SliceFromUpToWithStep 0 3 2] t
       shape s `shouldBe` [2, 2, 4]
       elems s `shouldBe` ([0 .. 3] ++ [8 .. 11] ++ [12 .. 15] ++ [20 .. 23])
-    it "accepts PyTorch-style syntax via the ix quasiquoter" $ do
-      elems (slice @[ix| 1 |] t) `shouldBe` elems (slice @'[SliceAt 1] t)
-      elems (slice @[ix| :, 0 |] t) `shouldBe` elems (slice @'[SliceAll, SliceAt 0] t)
-      shape (slice @[ix| None, :, 1:3 |] t) `shouldBe` [1, 2, 2, 4]
-      elems (slice @[ix| 1:2, :2, 1::2 |] t) `shouldBe` [13, 15, 17, 19]
-      shape (slice @[ix| :, ::2 |] t) `shouldBe` [2, 2, 4]
+    it "accepts PyTorch-style syntax via the slice quasiquoter in type position" $ do
+      elems (getSlice @[slice| 1 |] t) `shouldBe` elems (getSlice @'[SliceAt 1] t)
+      elems (getSlice @[slice| :, 0 |] t) `shouldBe` elems (getSlice @'[SliceAll, SliceAt 0] t)
+      shape (getSlice @[slice| None, :, 1:3 |] t) `shouldBe` [1, 2, 2, 4]
+      elems (getSlice @[slice| 1:2, :2, 1::2 |] t) `shouldBe` [13, 15, 17, 19]
+      shape (getSlice @[slice| :, ::2 |] t) `shouldBe` [2, 2, 4]
   describe "setSlice" $ do
     it "replaces the indexed part and leaves the rest" $ do
       let u = setSlice @'[SliceAt 0] t zeros
-      elems (slice @'[SliceAt 0] u) `shouldBe` replicate 12 0
-      elems (slice @'[SliceAt 1] u) `shouldBe` [12 .. 23]
+      elems (getSlice @'[SliceAt 0] u) `shouldBe` replicate 12 0
+      elems (getSlice @'[SliceAt 1] u) `shouldBe` [12 .. 23]

--- a/hasktorch/test/Torch/Typed/LensSpec.hs
+++ b/hasktorch/test/Torch/Typed/LensSpec.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE NoStarIsType #-}
+
+-- | Shape-selective structure traversals: the generic 'types' traversal from
+-- "Torch.Lens", instantiated at /typed/ tensor targets, visits exactly the
+-- tensors of the named device, dtype and shape inside a structure.
+module Torch.Typed.LensSpec (spec) where
+
+import GHC.Generics
+import Test.Hspec
+import qualified Torch.DType as D
+import qualified Torch.Device as D
+import Torch.Lens (flattenValues, over, replaceValues, types)
+import Torch.NN (sample)
+import qualified Torch.Tensor as T
+import Torch.Typed.Factories (ones, zeros)
+import Torch.Typed.Lens ()
+import Torch.Typed.NN (Linear, LinearSpec (..))
+import Torch.Typed.Parameter (Parameter)
+import Torch.Typed.Tensor
+
+data Net = Net
+  { l1 :: Tensor '(D.CPU, 0) 'D.Float '[2, 3],
+    l2 :: Tensor '(D.CPU, 0) 'D.Float '[3, 4],
+    l3 :: Tensor '(D.CPU, 0) 'D.Float '[2, 3],
+    steps :: Int
+  }
+  deriving (Generic)
+
+net :: Net
+net = Net ones ones zeros 7
+
+elems :: Tensor '(D.CPU, 0) 'D.Float sh -> [Float]
+elems = T.asValue . T.reshape [-1] . toDynamic
+
+spec :: Spec
+spec = do
+  describe "types at typed tensors" $ do
+    it "selects tensors by their shape" $ do
+      length (flattenValues (types @(Tensor '(D.CPU, 0) 'D.Float '[2, 3])) net) `shouldBe` 2
+      length (flattenValues (types @(Tensor '(D.CPU, 0) 'D.Float '[3, 4])) net) `shouldBe` 1
+      length (flattenValues (types @(Tensor '(D.CPU, 0) 'D.Float '[5, 5])) net) `shouldBe` 0
+    it "rewrites only the tensors of the targeted shape" $ do
+      let net' = over (types @(Tensor '(D.CPU, 0) 'D.Float '[2, 3])) (+ 1) net
+      elems (l1 net') `shouldBe` replicate 6 2 -- was ones
+      elems (l3 net') `shouldBe` replicate 6 1 -- was zeros
+      elems (l2 net') `shouldBe` replicate 12 1 -- untouched
+      steps net' `shouldBe` 7
+    it "replaces specific structures wholesale" $ do
+      let net' = replaceValues (types @(Tensor '(D.CPU, 0) 'D.Float '[2, 3])) net [zeros, ones]
+      elems (l1 net') `shouldBe` replicate 6 0
+      elems (l3 net') `shouldBe` replicate 6 1
+      elems (l2 net') `shouldBe` replicate 12 1
+  describe "types at typed parameters" $ do
+    it "selects parameters of a model by their shape" $ do
+      (model :: Linear 10 5 'D.Float '(D.CPU, 0)) <- sample LinearSpec
+      length (flattenValues (types @(Parameter '(D.CPU, 0) 'D.Float '[5, 10])) model) `shouldBe` 1
+      length (flattenValues (types @(Parameter '(D.CPU, 0) 'D.Float '[5])) model) `shouldBe` 1
+      length (flattenValues (types @(Parameter '(D.CPU, 0) 'D.Float '[10, 5])) model) `shouldBe` 0

--- a/hasktorch/test/Torch/Typed/NMSSpec.hs
+++ b/hasktorch/test/Torch/Typed/NMSSpec.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE NoStarIsType #-}
+
+-- | Tests for the non-maximum suppression in "Torch.Typed.Vision".
+--
+-- The central check: 'iou' is one polymorphic formula, and its two
+-- instantiations — @a = Tensor@ (the vectorized 'boxIou') and @a = Float@
+-- (the per-element reference below) — must agree /exactly/.  The reference
+-- implementation is not hand-written a second time; it is the same code.
+module Torch.Typed.NMSSpec (spec) where
+
+import Data.Vector.Sized (Vector)
+import Test.Hspec
+import qualified Torch.DType as D
+import qualified Torch.Device as D
+import qualified Torch.Tensor as D
+import Torch.Typed.Representable
+import Torch.Typed.Tensor
+import Torch.Typed.Vision (Box (..), boxIou, iou, nms)
+
+-- five detections: 1 overlaps 0, 3 sits inside 2, 4 stands alone
+-- columns: x1, y1, x2, y2, score
+boxData :: [[Float]]
+boxData =
+  [ [0, 0, 10, 10, 0.9],
+    [1, 1, 11, 11, 0.8],
+    [20, 20, 30, 30, 0.7],
+    [21, 21, 29, 29, 0.6],
+    [50, 50, 60, 60, 0.5]
+  ]
+
+dets5 :: NamedTensor '(D.CPU, 0) 'D.Float '[Vector 5, Box]
+dets5 = tabulateList @'[Vector 5, Box] @'D.Float @'(D.CPU, 0) (\[i, k] -> boxData !! i !! k)
+
+-- the same iou formula at a = Float, one pair at a time
+boxAt :: Int -> Box Float
+boxAt i = Box (at 0) (at 1) (at 2) (at 3) (at 4)
+  where
+    at k = indexList dets5 [i, k]
+
+iouMat :: [[Float]]
+iouMat = D.asValue (toDynamic (boxIou dets5))
+
+spec :: Spec
+spec = do
+  describe "boxIou" $ do
+    it "the Tensor instantiation of iou agrees exactly with the Float one" $ do
+      iouMat `shouldBe` [[iou (boxAt i) (boxAt j) | j <- [0 .. 4]] | i <- [0 .. 4]]
+    it "is 1 on the diagonal and symmetric" $ do
+      [iouMat !! i !! i | i <- [0 .. 4]] `shouldBe` [1, 1, 1, 1, 1]
+      [iouMat !! i !! j | i <- [0 .. 4], j <- [0 .. 4]]
+        `shouldBe` [iouMat !! j !! i | i <- [0 .. 4], j <- [0 .. 4]]
+  describe "nms" $ do
+    it "keeps the best box of each cluster" $ do
+      map fromEnum (nms 0.5 dets5) `shouldBe` [0, 2, 4]
+    it "keeps everything when the threshold admits all overlap" $ do
+      map fromEnum (nms 1.0 dets5) `shouldBe` [0, 1, 2, 3, 4]
+    it "keeps only non-overlapping boxes when the threshold is zero" $ do
+      map fromEnum (nms 0.0 dets5) `shouldBe` [0, 2, 4]

--- a/hasktorch/test/Torch/Typed/RepresentableSpec.hs
+++ b/hasktorch/test/Torch/Typed/RepresentableSpec.hs
@@ -1,0 +1,98 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE NoStarIsType #-}
+
+module Torch.Typed.RepresentableSpec (spec) where
+
+import Data.Default.Class
+import Data.Finite (Finite)
+import Data.Proxy
+import Data.Vector.Sized (Vector)
+import GHC.Generics
+import GHC.TypeLits
+import Test.Hspec
+import qualified Torch.DType as D
+import qualified Torch.Device as D
+import Torch.HList
+import qualified Torch.Tensor as D
+import Torch.Typed.Representable
+import Torch.Typed.Tensor
+
+newtype Batch (n :: Nat) a = Batch (Vector n a) deriving (Show, Eq, Generic)
+
+data RGB a = RGB
+  { r :: a,
+    g :: a,
+    b :: a
+  }
+  deriving (Show, Eq, Generic, Default)
+
+-- 'ToNat' is derived from 'Generic', so a user-defined structure needs no
+-- registration to be usable as a dimension.
+testToNatRGB :: Proxy (ToNat RGB) -> Proxy 3
+testToNatRGB = id
+
+-- The index type of a named shape is one 'Finite' per dimension.
+testLog ::
+  Proxy (Log (NamedTensor '(D.CPU, 0) 'D.Float '[Batch 2, RGB])) ->
+  Proxy (HList '[Finite 2, Finite 3])
+testLog = id
+
+testElem ::
+  Proxy (Elem (NamedTensor '(D.CPU, 0) 'D.Float '[Batch 2, RGB])) ->
+  Proxy Float
+testElem = id
+
+type Image = NamedTensor '(D.CPU, 0) 'D.Float '[Batch 2, RGB]
+
+spec :: Spec
+spec = do
+  describe "Representable NamedTensor" $ do
+    it "reifies the dimensions of a named shape" $ do
+      dimsOf (Proxy @(NamedTensor '(D.CPU, 0) 'D.Float '[Batch 2, RGB, Vector 4]))
+        `shouldBe` [2, 3, 4]
+    it "tabulate builds a tensor of the right shape and dtype" $ do
+      let t = tabulate (\_ -> 1.0) :: Image
+      shape t `shouldBe` [2, 3]
+      dtype t `shouldBe` D.Float
+    it "index reads back what tabulate wrote" $ do
+      -- the element value encodes its own index, so a wrong lookup is visible
+      let t =
+            tabulate
+              (\(i :. j :. HNil) -> fromIntegral (fromEnum i) * 10 + fromIntegral (fromEnum j))
+              :: Image
+      index t (0 :. 0 :. HNil) `shouldBe` 0
+      index t (0 :. 2 :. HNil) `shouldBe` 2
+      index t (1 :. 0 :. HNil) `shouldBe` 10
+      index t (1 :. 2 :. HNil) `shouldBe` 12
+    it "satisfies index (tabulate f) i == f i" $ do
+      let f (i :. j :. HNil) = fromIntegral (fromEnum i) * 3 + fromIntegral (fromEnum j) :: Float
+          t = tabulate f :: Image
+          ix = [i :. j :. HNil | i <- [0 .. 1], j <- [0 .. 2]]
+      map (index t) ix `shouldBe` map f ix
+    it "satisfies tabulate (index t) == t" $ do
+      let t = tabulate (\(i :. _ :. HNil) -> fromIntegral (fromEnum i)) :: Image
+          t' = tabulate (index t) :: Image
+      D.asValue (toDynamic t') `shouldBe` (D.asValue (toDynamic t) :: [[Float]])
+    it "round-trips a named index through plain Ints" $ do
+      toInts @'[Batch 2, RGB] (fromInts @'[Batch 2, RGB] [1, 2]) `shouldBe` [1, 2]
+    it "indexes a field-structured dimension positionally" $ do
+      -- RGB's fields are laid out in declaration order: r=0, g=1, b=2
+      let t = tabulate (\(_ :. j :. HNil) -> fromIntegral (fromEnum j)) :: Image
+      index t (0 :. 0 :. HNil) `shouldBe` 0
+      index t (0 :. 1 :. HNil) `shouldBe` 1
+      index t (0 :. 2 :. HNil) `shouldBe` 2

--- a/hasktorch/test/Torch/Typed/StagedSpec.hs
+++ b/hasktorch/test/Torch/Typed/StagedSpec.hs
@@ -1,0 +1,112 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE NoStarIsType #-}
+
+module Torch.Typed.StagedSpec (spec) where
+
+import Data.Vector.Sized (Vector)
+import GHC.Generics
+import GHC.TypeLits
+import Test.Hspec
+import qualified Torch.DType as D
+import qualified Torch.Device as D
+import Torch.HList
+import qualified Torch.Tensor as D
+import Torch.Typed.Graded (GradedMonad (..), TensorMonad, fromNamed, toNamed)
+import Torch.Typed.Representable
+import Torch.Typed.Staged
+import Torch.Typed.Tensor
+
+newtype Batch (n :: Nat) a = Batch (Vector n a) deriving (Show, Eq, Generic)
+
+data RGB a = RGB
+  { r :: a,
+    g :: a,
+    b :: a
+  }
+  deriving (Show, Eq, Generic)
+
+type M = TensorMonad '(D.CPU, 0) 'D.Float
+
+type Img = NamedTensor '(D.CPU, 0) 'D.Float '[Batch 2, RGB]
+
+-- All element functions below are written ONCE, polymorphically.  The tests
+-- run each at a = Float (per-element reference) and at a = Tensor (vectorized)
+-- and compare the results.
+
+fPoly :: (Floating a, Cond a) => a -> a
+fPoly x = x * x + 1
+
+fRelu :: (Floating a, Cond a) => a -> a
+fRelu x = whereE (gtE x 0) x 0
+
+fTrans :: (Floating a, Cond a) => a -> a
+fTrans x = sin x * 10 + cos x
+
+fMax :: (Floating a, Cond a) => a -> a -> a
+fMax x y = whereE (gtE x y) x y
+
+kAffine :: (Floating a, Cond a) => a -> HList (ToFinites '[RGB]) -> a
+kAffine x (j :. HNil) = x * 10 + fromIntegral (fromEnum j)
+
+kClip :: (Floating a, Cond a) => a -> HList (ToFinites '[RGB]) -> a
+kClip x (j :. HNil) = whereE (gtE x 0) x (negate x) + fromIntegral (fromEnum j)
+
+elemsOf :: NamedTensor '(D.CPU, 0) 'D.Float s -> [Float]
+elemsOf = D.asValue . D.reshape [-1] . toDynamic
+
+-- a test tensor holding [-3, -2, -1, 0, 1, 2]
+timg :: Img
+timg = tabulateList @'[Batch 2, RGB] @'D.Float @'(D.CPU, 0) (\[i, j] -> fromIntegral (i * 3 + j) - 3)
+
+-- the per-element reference for emap: same f, instantiated at Float
+emapRef :: (forall a. (Floating a, Cond a) => a -> a) -> Img -> Img
+emapRef f t = tabulateList @'[Batch 2, RGB] @'D.Float @'(D.CPU, 0) (f . indexList t)
+
+baseT :: M '[Batch 2]
+baseT = fromNamed (tabulateList @'[Batch 2] @'D.Float @'(D.CPU, 0) (\[i] -> fromIntegral i - 0.5))
+
+-- reference: run k per element through the graded bind (the oracle)
+oracleG ::
+  (forall a. (Floating a, Cond a) => a -> HList (ToFinites '[RGB]) -> a) ->
+  M '[Batch 2, RGB]
+oracleG k = gbind baseT (\x -> fromNamed (tabulate (k x)))
+
+-- staged: run the same k once per inner index on the whole outer tensor
+stagedG ::
+  (forall a. (Floating a, Cond a) => a -> HList (ToFinites '[RGB]) -> a) ->
+  M '[Batch 2, RGB]
+stagedG k = gbindV @'[RGB] baseT k
+
+spec :: Spec
+spec = do
+  describe "Staged element-wise ops" $ do
+    it "emap agrees exactly with the element-wise reference (polynomial)" $ do
+      elemsOf (emap fPoly timg) `shouldBe` elemsOf (emapRef fPoly timg)
+    it "emap agrees exactly with the element-wise reference (whereE/relu)" $ do
+      elemsOf (emap fRelu timg) `shouldBe` elemsOf (emapRef fRelu timg)
+      elemsOf (emap fRelu timg) `shouldBe` [0, 0, 0, 0, 1, 2]
+    it "emap agrees with the reference within float tolerance (transcendental)" $ do
+      let d = zipWith (\a c -> abs (a - c)) (elemsOf (emap fTrans timg)) (elemsOf (emapRef fTrans timg))
+      maximum d `shouldSatisfy` (< 1e-4)
+    it "ezipWith computes an elementwise max via whereE" $ do
+      let u = emap fRelu timg
+      elemsOf (ezipWith fMax timg u) `shouldBe` zipWith max (elemsOf timg) (elemsOf u)
+    it "emap preserves shape and dtype" $ do
+      shape (emap fPoly timg) `shouldBe` [2, 3]
+      dtype (emap fPoly timg) `shouldBe` D.Float
+  describe "gbindV vs gbind (oracle)" $ do
+    it "satisfies gbindV m k == gbind m (fromNamed . tabulate . k) (affine)" $ do
+      elemsOf (toNamed (stagedG kAffine)) `shouldBe` elemsOf (toNamed (oracleG kAffine))
+    it "satisfies the equation with value-dependent control flow (whereE)" $ do
+      elemsOf (toNamed (stagedG kClip)) `shouldBe` elemsOf (toNamed (oracleG kClip))
+    it "produces the concatenated shape" $ do
+      D.shape (toDynamic (toNamed (stagedG kAffine))) `shouldBe` [2, 3]

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Module.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Module.hs
@@ -36,6 +36,10 @@ C.include "<torch/csrc/jit/serialization/export.h>"
 
 C.include "<torch/csrc/jit/frontend/tracer.h>"
 
+C.include "<torch/csrc/jit/codegen/fuser/interface.h>"
+
+C.include "<torch/csrc/jit/passes/tensorexpr_fuser.h>"
+
 C.include "<vector>"
 
 C.include "<iostream>"
@@ -485,4 +489,32 @@ dumpToStr obj print_method_bodies print_attr_values print_param_values =
     , $(bool print_attr_values)
     , $(bool print_param_values)
     ));
+  }|]
+
+-- | Allow the TorchScript executor to fuse pointwise chains on CPU.
+-- Off by default in libtorch; the TensorExpr fuser only consumes CPU graphs
+-- when this is set.
+overrideCanFuseOnCPU :: CBool -> IO ()
+overrideCanFuseOnCPU flag =
+  [C.throwBlock| void {
+    torch::jit::overrideCanFuseOnCPU($(bool flag));
+  }|]
+
+overrideCanFuseOnGPU :: CBool -> IO ()
+overrideCanFuseOnGPU flag =
+  [C.throwBlock| void {
+    torch::jit::overrideCanFuseOnGPU($(bool flag));
+  }|]
+
+-- | Enable/disable the TensorExpr (NNC) fusion pass in the profiling executor.
+setTensorExprFuserEnabled :: CBool -> IO ()
+setTensorExprFuserEnabled flag =
+  [C.throwBlock| void {
+    torch::jit::setTensorExprFuserEnabled($(bool flag));
+  }|]
+
+tensorExprFuserEnabled :: IO CBool
+tensorExprFuserEnabled =
+  [C.throwBlock| bool {
+    return torch::jit::tensorExprFuserEnabled();
   }|]


### PR DESCRIPTION
This PR replaces the original free-monad `Tensor` GADT draft with a set of layers that give tensors *meaning in types* while executing on the ordinary ATen runtime. The guiding question stayed the same — can tensor programs be written element-by-element, the way the math is written? — but the answer turned out to be a graded monad plus a staged element language, not a restricted monad.

## The layers

| Module | What it adds |
|---|---|
| `Torch.Typed.Representable` | `index`/`tabulate` for `NamedTensor`; the index (`Log`) is an `HList` of per-dimension `Finite`s, so element access is bounds-checked at compile time |
| `Torch.Typed.Graded` | A monad graded by the shape monoid `('[], ++)`: `gbind :: m s -> (Grade m -> m t) -> m (s ++ t)`. The laws hold definitionally (no coercions), `QualifiedDo` works, and `gbind` serves as the reference semantics / test oracle |
| `Torch.Elementwise` (untyped) | The `Cond` class (`whereE`/comparisons/`maxE`/`minE`) and a `Floating` instance for the untyped `Tensor`: element functions written as `(Floating a, Cond a) => a -> a` run per element at `a = Float` (their own specification) and vectorized at `a = Tensor`, with autograd seeing every step (verified by a gradient-through-`whereE` test) |
| `Torch.Typed.Staged` | The shape-tracked wrappers (`emap`, `ezipWith`, `gbindV`), with `gbindV m k = gbind m (fromNamed . tabulate . k)` checked against the oracle |
| `Torch.Typed.Index` | Typed indexing/slicing in the style of #613: `getSlice @'[SliceAt 1, SliceFromUpTo 0 2] t`, `setSlice`, and `sliceLens` (the typed `lslice`). The untyped `[slice\|...\|]` quasiquoter gained a `quoteType`, so **one syntax serves both APIs**: `t ! [slice\| 1, :, 1:3:2 \|]` untyped, `getSlice @[slice\| 1, :, 1:3:2 \|] t` typed. Out-of-bounds indices and bad slices are compile-time errors |
| `Torch.Typed.Lens` | The generic `types` traversal now works at typed targets and becomes *shape-selective*: `over (types @(Tensor dev dtype '[2,3])) f model` rewrites only the tensors of exactly that shape |
| `Torch.Typed.Vision` | `nms`/`boxIou` as a worked example (supersedes #630): IoU is one scalar formula instantiated at `Tensor` (vectorized, broadcast) and at `Float` (the test reference — bit-exact agreement), and the greedy suppression is three lines of list recursion. FHD-scale timings: n=1000 ≈ 8 ms, n=3000 ≈ 22 ms, n=6000 ≈ 48 ms on CPU |

## Verification

408 spec examples, 0 failures. The recurring pattern: the slow, obviously-correct implementation (per-element `gbind`, `Float` instantiation of a formula) is kept as the oracle that the fast path is tested against, so no reference implementation is hand-written twice.

## Also in this PR

- `instance Floating Tensor` (untyped), which is what lets polymorphic element code run vectorized
- TorchScript fuser controls in libtorch-ffi (`overrideCanFuseOnCPU` etc.), with measurements showing why traced code does **not** fuse on CPU with official libtorch binaries (the NNC LLVM backend is absent — the fuser engages and fails with "LLVM Backend not found"); the CUDA path has no such dependency
- Five new tutorial chapters (named tensors & lenses, indexing, graded/staged, TorchScript, lenses — the lens chapter is fully executable) and a CI step that renders the tutorial with the [GHC 9.8/cabal port of tintin](https://github.com/hasktorch/tintin/tree/feature/ghc98-cabal), uploaded as a `tutorial` artifact
- devShell fixes: `cabal-install`/HLS moved out of `shellFor`'s `packages` (where they never reach `PATH`), `zlib` added to `buildInputs`

## Known issue

`cabal-macos` fails in the Tests step while `stack-macos` passes on the same commits; Linux cabal with the same dependency plan also passes. The remaining suspect is the parallel test invocation (`cabal v2-test --jobs=2 all`) on macOS; logs from the runner are needed to pin it down.
