### PR TITLE
Experiment with adding tutorial module

### DIFF
--- a/fourmolu.yaml
+++ b/fourmolu.yaml
@@ -1,0 +1,1 @@
+haddock-style: multi-line

--- a/hasktorch/hasktorch.cabal
+++ b/hasktorch/hasktorch.cabal
@@ -87,6 +87,7 @@ library
                     , Torch.Data.Internal
                     , Torch.Data.Dataset
                     , Torch.Data.CsvDatastream
+                    , Torch.Tutorial
 
  other-modules:       Paths_hasktorch
  hs-source-dirs:      src

--- a/hasktorch/src/Torch/Tutorial.hs
+++ b/hasktorch/src/Torch/Tutorial.hs
@@ -28,6 +28,8 @@ by Soumith Chintala.
 == Tensors
 #tensors#
 
+>>> import Torch
+
 Initialize a tensor of zeros by specifying the dimensions of the
 tensor<#notes [1]>:
 

--- a/hasktorch/src/Torch/Tutorial.hs
+++ b/hasktorch/src/Torch/Tutorial.hs
@@ -31,16 +31,16 @@ by Soumith Chintala.
 Initialize a tensor of zeros by specifying the dimensions of the
 tensor<#notes [1]>:
 
-> > Torch.zeros' [3, 4]
-> Tensor Float [3,4] [[ 0.0000,  0.0000,  0.0000,  0.0000],
->                     [ 0.0000,  0.0000,  0.0000,  0.0000],
->                     [ 0.0000,  0.0000,  0.0000,  0.0000]]
+>>> Torch.zeros' [3, 4]
+Tensor Float [3,4] [[ 0.0000,  0.0000,  0.0000,  0.0000],
+                    [ 0.0000,  0.0000,  0.0000,  0.0000],
+                    [ 0.0000,  0.0000,  0.0000,  0.0000]]
 
 Initialize a tensor from a Haskell list:
 
-> > asTensor ([[4, 3], [2, 1]] :: [[Float]])
-> Tensor Float [2,2] [[ 4.0000   ,  3.0000   ],
->                     [ 2.0000   ,  1.0000   ]]
+>>> asTensor ([[4, 3], [2, 1]] :: [[Float]])
+Tensor Float [2,2] [[ 4.0000   ,  3.0000   ],
+                    [ 2.0000   ,  1.0000   ]]
 
 Note that the numerical type of the tensor is inferred from the types of
 the values in the list.
@@ -49,17 +49,18 @@ A single valued tensor can be passed to 'Torch.Tensor.asTensor' as
 well (and can be converted back to a scalar using
 'Torch.Tensor.asValue'):
 
-> > asTensor (3.5)
-> Tensor Float []  3.5000
-> > asValue (asTensor (3.5)) :: Float
-> 3.5
+>>> asTensor (3.5)
+Tensor Float []  3.5000
+
+>>> asValue (asTensor (3.5)) :: Float
+3.5
 
 Create a randomly initialized matrix:
 
-> > x <-randIO' [2, 2]
-> > x
-> Tensor Float [2,2] [[ 0.2019   ,  0.8406   ],
->                     [ 0.7256   ,  0.6436   ]]
+>>> x <-randIO' [2, 2]
+>>> x
+Tensor Float [2,2] [[ 0.2019   ,  0.8406   ],
+                    [ 0.7256   ,  0.6436   ]]
 
 Note that since random initialization returns a different result each
 time, unlike other tensor constructors, is monadic reflecting the
@@ -73,41 +74,40 @@ which the RNG is not explicit such as @randIO\'@ example above use the
 
 Construct a matrix filled with zeros of dtype long:
 
-> > zeros [4, 4] (withDType Int64 defaultOpts)
-> Tensor Int64 [4,4] [[ 0,  0,  0,  0],
->                     [ 0,  0,  0,  0],
->                     [ 0,  0,  0,  0],
->                     [ 0,  0,  0,  0]]
+>>> zeros [4, 4] (withDType Int64 defaultOpts)
+Tensor Int64 [4,4] [[ 0,  0,  0,  0],
+                    [ 0,  0,  0,  0],
+                    [ 0,  0,  0,  0],
+                    [ 0,  0,  0,  0]]
 
 Construct a vector filled with a specified constant:
 
-> > full' [3, 2] 4
-> Tensor Float [3,2] [[ 4.0000   ,  4.0000   ],
->                     [ 4.0000   ,  4.0000   ],
->                     [ 4.0000   ,  4.0000   ]]
+>>> full' [3, 2] 4
+Tensor Float [3,2] [[ 4.0000   ,  4.0000   ],
+                    [ 4.0000   ,  4.0000   ],
+                    [ 4.0000   ,  4.0000   ]]
 
 Construct a tensor from a Haskell list:
 
-> > asTensor [[1, 2, 3], [4, 5, 6]]
-> Tensor Double [2,3] [[ 1.0000   ,  2.0000   ,  3.0000   ],
->                      [ 4.0000   ,  5.0000   ,  6.0000   ]]
+>>> asTensor [[1, 2, 3], [4, 5, 6]]
+Tensor Double [2,3] [[ 1.0000   ,  2.0000   ,  3.0000   ],
+                     [ 4.0000   ,  5.0000   ,  6.0000   ]]
 
 Note when the type of values in the list is explicit, this type is
 reflected in the dtype of the tensor:
 
-> > asTensor ([[1, 2, 3], [4, 5, 6]] :: [[Int]])
-> Tensor Int64 [2,3] [[ 1,  2,  3],
->                     [ 4,  5,  6]]
-> >
+>>> asTensor ([[1, 2, 3], [4, 5, 6]] :: [[Int]])
+Tensor Int64 [2,3] [[ 1,  2,  3],
+                    [ 4,  5,  6]]
 
 Tensor constructors with a @-like@ suffix Create a tensor based on an
 existing tensor:
 
-> > x <- Torch.full' [3, 2] 4
-> > Torch.randLikeIO' x
-> Tensor Float [3,2] [[ 0.3411   ,  0.8137   ],
->                     [ 0.5252   ,  0.9109   ],
->                     [ 0.3809   ,  0.9191   ]]
+>>> x <- Torch.full' [3, 2] 4
+>>> Torch.randLikeIO' x
+Tensor Float [3,2] [[ 0.3411   ,  0.8137   ],
+                    [ 0.5252   ,  0.9109   ],
+                    [ 0.3809   ,  0.9191   ]]
 
 == Operations
 #operations#
@@ -117,36 +117,38 @@ math operations.
 
 Tensors implement the @Num@ typeclass:
 
-> > let x = ones' [4]
-> > x + x
-> Tensor Float [4] [ 2.0000   ,  2.0000   ,  2.0000   ,  2.0000   ]
+>>> let x = ones' [4]
+>>> x + x
+Tensor Float [4] [ 2.0000   ,  2.0000   ,  2.0000   ,  2.0000   ]
 
 Some operations transform a tensor:
 
-> > Torch.relu (asTensor ([-1.0, -0.5, 0.5, 1] :: [Float]))
-> Tensor Float [4] [ 0.0000,  0.0000,  0.5000   ,  1.0000   ]
+>>> Torch.relu (asTensor ([-1.0, -0.5, 0.5, 1] :: [Float]))
+Tensor Float [4] [ 0.0000,  0.0000,  0.5000   ,  1.0000   ]
 
-@select@ slices out a selection by specifying a dimension and index:
+'Torch.Tensor.select' slices out a selection by specifying a dimension and index:
 
-> > let x = asTensor [[[1, 2, 3]], [[4, 5, 6]], [[7, 8, 9]], [[10, 11, 12]]]
-> > shape x
-> [4,1,3]
-> > select x 2 1
-> Tensor Double [4,1] [[ 2.0000   ],
->                      [ 5.0000   ],
->                      [ 8.0000   ],
->                      [ 11.0000   ]]
-> > let y = asTensor [1, 2, 3]
-> > Torch.select y 0 1
-> Tensor Double []  2.0000
+>>> let x = asTensor [[[1, 2, 3]], [[4, 5, 6]], [[7, 8, 9]], [[10, 11, 12]]]
+>>> shape x
+[4,1,3]
+
+>>> select x 2 1
+Tensor Double [4,1] [[ 2.0000   ],
+                     [ 5.0000   ],
+                     [ 8.0000   ],
+                     [ 11.0000   ]]
+
+>>> let y = asTensor [1, 2, 3]
+>>> Torch.select y 0 1
+Tensor Double []  2.0000
 
 Values can be extracted from a tensor using @asValue@ so long as the
 dtype matches the Haskell type:
 
-> > let x = asTensor ([2] :: [Int])
-> > let y = asValue x :: Int
-> > y
-> 2
+>>> let x = asTensor ([2] :: [Int])
+>>> let y = asValue x :: Int
+>>> y
+2
 
 == Automatic Differentiation
 #automatic-differentiation#
@@ -165,13 +167,17 @@ from which a compute graph is constructed for differentiation, while
 @makeIndependent@ takes a tensor as input and returns an IO action
 which produces an 'Torch.Autograd.IndependentTensor':
 
-> makeIndependent :: Tensor -> IO IndependentTensor
+@
+  makeIndependent :: Tensor -> IO IndependentTensor
+@
 
 What is the definition of the @IndependentTensor@ type produced by the
 @makeIndependent@ action? It’s defined in the Hasktorch library as:
 
-> newtype IndependentTensor = IndependentTensor { toDependent :: Tensor }
-> deriving (Show)
+@
+  newtype IndependentTensor = IndependentTensor { toDependent :: Tensor }
+  deriving (Show)
+@
 
 Thus @IndependentTensor@ is simply a wrapper around the underlying
 Tensor that is passed in as the argument to @makeIndependent@. Building
@@ -183,16 +189,18 @@ All tensors have an underlying property that can be retrieved using
 the 'Torch.Autograd.requiresGrad' function which indicates whether
 they are a differentiable value in a compute graph. <#notes [2]>
 
-> > let x = asTensor [1, 2, 3]
-> > y <- makeIndependent (asTensor [4, 5, 6])
-> > let y' = toDependent y
-> > let z = x + y'
-> > requiresGrad x
-> False
-> > requiresGrad y'
-> True
-> > requiresGrad z
-> True
+>>> let x = asTensor [1, 2, 3]
+>>> y <- makeIndependent (asTensor [4, 5, 6])
+>>> let y' = toDependent y
+>>> let z = x + y'
+>>> requiresGrad x
+False
+
+>>> requiresGrad y'
+True
+
+>>> requiresGrad z
+True
 
 In summary, tensors that are computations of values derived from tensor
 constructors (e.g. @ones@, @zeros@, @fill@, @randIO@ etc.) outside the
@@ -211,42 +219,44 @@ function specifying in the first argument tensor corresponding to
 function value of interest and a list of @Independent@ tensor variables
 that the the derivative is taken with respect to:
 
-> grad :: Tensor -> [IndependentTensor] -> [Tensor]
+@
+  grad :: Tensor -> [IndependentTensor] -> [Tensor]
+@
 
 Let’s demonstrate this with a concrete example. We create a tensor and
 derive an @IndependentTensor@ from it:
 
-> > x <- makeIndependent (ones' [2, 2])
-> > let x' = toDependent x
-> > x'
-> Tensor Float [2,2] [[ 1.0000   ,  1.0000   ],
->                     [ 1.0000   ,  1.0000   ]]
+>>> x <- makeIndependent (ones' [2, 2])
+>>> let x' = toDependent x
+>>> x'
+Tensor Float [2,2] [[ 1.0000   ,  1.0000   ],
+                    [ 1.0000   ,  1.0000   ]]
 
 Now do some computations on the dependent tensor:
 
-> > let y = x' + 2
-> > y
-> Tensor Float [2,2] [[ 3.0000   ,  3.0000   ],
->                     [ 3.0000   ,  3.0000   ]]
+>>> let y = x' + 2
+>>> y
+Tensor Float [2,2] [[ 3.0000   ,  3.0000   ],
+                    [ 3.0000   ,  3.0000   ]]
 
 Since y is dependent on the x independent tensor, it is differentiable:
 
-> > requiresGrad y
-> True
+>>> requiresGrad y
+True
 
 Applying more operations:
 
-> > let z = y * y * 3
-> > let out = mean z
-> > z
-> Tensor Float [2,2] [[ 27.0000   ,  27.0000   ],
->                     [ 27.0000   ,  27.0000   ]]
+>>> let z = y * y * 3
+>>> let out = mean z
+>>> z
+Tensor Float [2,2] [[ 27.0000   ,  27.0000   ],
+                    [ 27.0000   ,  27.0000   ]]
 
 Now retrieve the gradient:
 
-> > grad out [x]
-> [Tensor Float [2,2] [[ 4.5000   ,  4.5000   ],
->                     [ 4.5000   ,  4.5000   ]]]
+>>> grad out [x]
+[Tensor Float [2,2] [[ 4.5000   ,  4.5000   ],
+                    [ 4.5000   ,  4.5000   ]]]
 
 == Differentiable Programs (Neural Networks)
 #differentiable-programs-neural-networks#
@@ -272,14 +282,16 @@ typeclasses to take on other functionality.
 The core interface that defines capability specific to differentiable
 programming is the 'Torch.NN.Parameterized' typeclass:
 
-> class Parameterized f where
->   flattenParameters :: f -> [Parameter]
->   default flattenParameters :: (Generic f, Parameterized' (Rep f)) => f -> [Parameter]
->   flattenParameters f = flattenParameters' (from f)
->
->   replaceOwnParameters :: f -> ParamStream f
->   default replaceOwnParameters :: (Generic f, Parameterized' (Rep f)) => f -> ParamStream f
->   replaceOwnParameters f = to <$> replaceOwnParameters' (from f)
+@
+  class Parameterized f where
+    flattenParameters :: f -> [Parameter]
+    default flattenParameters :: (Generic f, Parameterized' (Rep f)) => f -> [Parameter]
+    flattenParameters f = flattenParameters' (from f)
+
+    replaceOwnParameters :: f -> ParamStream f
+    default replaceOwnParameters :: (Generic f, Parameterized' (Rep f)) => f -> ParamStream f
+    replaceOwnParameters f = to <$> replaceOwnParameters' (from f)
+@
 
 Note @Parameter@ is simply a type alias for @IndependentTensor@ in the
 context of neural networks (i.e. @type Parameter = IndependentTensor@).
@@ -293,7 +305,9 @@ compute gradients.
 type alias for a State type with state represented by a @Parameter@ list
 and a value parameter corresponding to the ADT defining the model.
 
-> type ParamStream a = State [Parameter] a
+@
+  type ParamStream a = State [Parameter] a
+@
 
 Note the use of generics. Generics allow the compiler to usually
 automatically derive @flattenParameters@ and @replaceOwnParameter@
@@ -302,7 +316,9 @@ containers of tensors, or other types that are built from tensor values
 (for example, layer modules provided in @Torch.NN@. In many cases, as
 you’ll see in the following examples, you will only need to add
 
-> instance Parameterized MyNeuralNetwork
+@
+  instance Parameterized MyNeuralNetwork
+@
 
 (where @MyNeuralNetwork@ is an ADT definition for your model) and the
 compiler will derive implementations for the @flattenParameters@ and
@@ -323,36 +339,38 @@ In a standard supervised learning model, the neural network is
 initialized using a randomized initialization scheme. An iterative
 optimization is performed such that at each iteration a batch.
 
-> module Main where
->
-> import Control.Monad (when)
-> import Torch
->
-> groundTruth :: Tensor -> Tensor
-> groundTruth t = squeezeAll $ matmul t weight + bias
->   where
->     weight = asTensor ([42.0, 64.0, 96.0] :: [Float])
->     bias = full' [1] (3.14 :: Float)
->
-> model :: Linear -> Tensor -> Tensor
-> model state input = squeezeAll $ linear state input
->
-> main :: IO ()
-> main = do
->     init <- sample $ LinearSpec { in_features = numFeatures, out_features = 1 }
->     randGen <- mkGenerator (Device CPU 0) 12345
->     (trained, _) <- foldLoop (init, randGen) 2000 $ \(state, randGen) i -> do
->         let (input, randGen') = randn' [batchSize, numFeatures] randGen
->             (y, y') = (groundTruth input, model state input)
->             loss = mseLoss y y'
->         when (i `mod` 100 == 0) $ do
->             putStrLn $ "Iteration: " ++ show i ++ " | Loss: " ++ show loss
->         (newParam, _) <- runStep state GD loss 5e-3
->         pure (replaceParameters state newParam, randGen')
->     pure ()
->   where
->     batchSize = 4
->     numFeatures = 3
+@
+  module Main where
+
+  import Control.Monad (when)
+  import Torch
+
+  groundTruth :: Tensor -> Tensor
+  groundTruth t = squeezeAll $ matmul t weight + bias
+    where
+      weight = asTensor ([42.0, 64.0, 96.0] :: [Float])
+      bias = full' [1] (3.14 :: Float)
+
+  model :: Linear -> Tensor -> Tensor
+  model state input = squeezeAll $ linear state input
+
+  main :: IO ()
+  main = do
+      init <- sample $ LinearSpec { in_features = numFeatures, out_features = 1 }
+      randGen <- mkGenerator (Device CPU 0) 12345
+      (trained, _) <- foldLoop (init, randGen) 2000 $ \(state, randGen) i -> do
+          let (input, randGen') = randn' [batchSize, numFeatures] randGen
+              (y, y') = (groundTruth input, model state input)
+              loss = mseLoss y y'
+          when (i `mod` 100 == 0) $ do
+              putStrLn $ "Iteration: " ++ show i ++ " | Loss: " ++ show loss
+          (newParam, _) <- runStep state GD loss 5e-3
+          pure (replaceParameters state newParam, randGen')
+      pure ()
+    where
+      batchSize = 4
+      numFeatures = 3
+@
 
 Note the expression of the architecture in the 'Torch.NN.linear'
 function (a single linear layer, or alternatively a neural network
@@ -388,8 +406,10 @@ random initializations return different values. Initialization occurs
 by calling the 'Torch.NN.sample' function for an ADT (@spec@)
 implementing the 'Torch.NN.Randomizable' typeclass:
 
-> class Randomizable spec f | spec -> f where
->   sample :: spec -> IO f
+@
+  class Randomizable spec f | spec -> f where
+    sample :: spec -> IO f
+@
 
 In a typical (but not required) usage, @f@ is an ADT that implements the
 @Parameterized@ typeclass, so that there’s a pair of types - a
@@ -399,12 +419,16 @@ implementing @Parameterizable@ representing the model state.
 For example, a linear fully connected layer is provided by the
 @Torch.NN@ module and defined therein as:
 
-> data Linear = Linear { weight :: Parameter, bias :: Parameter } deriving (Show, Generic)
+@
+  data Linear = Linear { weight :: Parameter, bias :: Parameter } deriving (Show, Generic)
+@
 
 and is typically used with a specification type:
 
-> data LinearSpec = LinearSpec { in_features :: Int, out_features :: Int }
->   deriving (Show, Eq)
+@
+  data LinearSpec = LinearSpec { in_features :: Int, out_features :: Int }
+    deriving (Show, Eq)
+@
 
 Putting this together, in untyped tensor usage, the user can implement
 custom models or layers implementing the @Parameterizable@ typeclass
@@ -461,8 +485,10 @@ parameters, and optimizer state.
 This function interface is described in the 'Torch.Optim.Optimizer'
 typeclass interface:
 
-> class Optimizer o where
->     step :: LearningRate -> Gradients -> [Tensor] -> o -> ([Tensor], o)
+@
+  class Optimizer o where
+      step :: LearningRate -> Gradients -> [Tensor] -> o -> ([Tensor], o)
+@
 
 @Gradients@ is a newtype wrapper around a list of tensors to make
 intent explicit: @newtype Gradients = Gradients [Tensor]@.
@@ -473,20 +499,26 @@ Some illustrative example implementations follow.
 Being stateless, stochastic gradient descent has an ADT that has only
 one constructor value:
 
-> data GD = GD
+@
+  data GD = GD
+@
 
 and implements the step function as:
 
-> instance Optimizer GD where
->     step lr gradients depParameters dummy = (gd lr gradients depParameters, dummy)
->         where
->         step p dp = p - (lr * dp)
->         gd lr (Gradients gradients) parameters = zipWith step parameters gradients
+@
+  instance Optimizer GD where
+      step lr gradients depParameters dummy = (gd lr gradients depParameters, dummy)
+          where
+          step p dp = p - (lr * dp)
+          gd lr (Gradients gradients) parameters = zipWith step parameters gradients
+@
 
 The use of an optimizer was illustrated in the linear regression example
 using the function @runStep@
 
-> (newParam, _) <- runStep state GD loss 5e-3
+@
+  (newParam, _) <- runStep state GD loss 5e-3
+@
 
 In this case the new optimizer state returned is ignored (as @_@) since
 gradient descent does not have any internal state. Under the hood,
@@ -497,8 +529,10 @@ the optimizer to runStep as an abstracted interface which takes
 parameter values, the optimizer value, loss (a tensor), and learning
 rate as input and returns new parameters and an updated optimizer value.
 
-> runStep :: (Parameterized p, Optimizer o) =>
->         p -> o -> Tensor -> LearningRate -> IO ([Parameter], o)
+@
+  runStep :: (Parameterized p, Optimizer o) =>
+          p -> o -> Tensor -> LearningRate -> IO ([Parameter], o)
+@
 
 = Typed Tensors
 #typed-tensors#
@@ -529,16 +563,20 @@ Things we can do in typed Hasktorch:
 We can encode all Hasktorch tensor shapes on the type level using
 type-level lists and natural numbers:
 
-> type EmptyShape = '[]
-> type OneDimensionalShape (a :: Nat) = '[a]
-> type TwoDimensionalShape (a :: Nat) (b :: Nat) = '[a, b]
-> ...
+@
+  type EmptyShape = '[]
+  type OneDimensionalShape (a :: Nat) = '[a]
+  type TwoDimensionalShape (a :: Nat) (b :: Nat) = '[a, b]
+  -- ...
+@
 
 Tensor data types and compute device types are lifted to the type level
 using the @DataKinds@ language extension:
 
-> type BooleanCPUTensor (shape :: [Nat]) = Tensor '(CPU,  0) 'Bool  shape
-> type IntCUDATensor    (shape :: [Nat]) = Tensor '(CUDA, 1) 'Int64 shape
+@
+  type BooleanCPUTensor (shape :: [Nat]) = Tensor '(CPU,  0) 'Bool  shape
+  type IntCUDATensor    (shape :: [Nat]) = Tensor '(CUDA, 1) 'Int64 shape
+@
 
 Devices are represented as tuples consisting of a @DeviceType@ (here
 @CPU@ for the CPU and @CUDA@ for a CUDA device, respectively) and a
@@ -549,18 +587,22 @@ compile time is only possible if all tensor properties are constants and
 are statically known. If this were the case, then we could only write
 functions over fully specified tensors, say,
 
-> boring :: BooleanCPUTensor '[] -> BooleanCPUTensor '[]
-> boring = id
+@
+  boring :: BooleanCPUTensor '[] -> BooleanCPUTensor '[]
+  boring = id
+@
 
 Fortunately, Haskell has the ability to reason about type variables.
 This feature is called parametric polymorphism. Consider this simple
 example of a function:
 
-> tensorNoOp
->   :: forall (shape :: [Nat]) (dtype :: DType) (device :: (DeviceType, Nat))
->    . Tensor device dtype shape
->   -> Tensor device dtype shape
-> tensorNoOp = id
+@
+  tensorNoOp
+    :: forall (shape :: [Nat]) (dtype :: DType) (device :: (DeviceType, Nat))
+     . Tensor device dtype shape
+    -> Tensor device dtype shape
+  tensorNoOp = id
+@
 
 Here, @shape@, @dtype@, and @device@ are type variables that have been
 constrained to be of kind shape, data type, and device, respectively.

--- a/hasktorch/src/Torch/Tutorial.hs
+++ b/hasktorch/src/Torch/Tutorial.hs
@@ -1,0 +1,53 @@
+{-# OPTIONS_GHC -fno-warn-unused-imports #-}
+
+{- | Hasktorch is a library for tensor math and differentiable
+     programming in Haskell. It shares the backend C++ libtorch
+     library used by PyTorch and serves three primary objectives:
+
+    * Research on new functional programming methodology for
+      developing and representing models that are more productive or
+      lead to algorithm innovations.
+
+    * Building machine learning systems that are more reliable for the
+      model and its integration with the software in which the model
+      is embedded.
+
+    * Dissemination of new ideas from typed pure functional
+      programming for machine learning to other languages and machine
+      learning ecosystems.
+-}
+module Torch.Tutorial (
+    -- * Introduction
+    -- $introduction
+
+    -- * Usage
+    -- $usage
+
+    -- ** Tensors
+    -- $tensors
+
+    -- ** Typed Tensors
+    -- $typed-tensors
+) where
+
+{- $introduction
+   TODO
+-}
+
+{- $usage
+   In the following section we introduce Hasktorch usage at a high
+   level from an end-user perspective. In the sections that follow we
+   will delve into the underlying implementation concepts.
+
+   The sequence of topics and examples here is loosely based on the
+   PyTorch tutorial "Deep Learning with PyTorch: A 60 Minute Blitz" by
+   Soumith Chintala.
+-}
+
+{- $tensors
+   TODO
+-}
+
+{- $typed-tensors
+   TODO
+-}

--- a/hasktorch/src/Torch/Tutorial.hs
+++ b/hasktorch/src/Torch/Tutorial.hs
@@ -1,53 +1,599 @@
 {-# OPTIONS_GHC -fno-warn-unused-imports #-}
 
 {- | Hasktorch is a library for tensor math and differentiable
-     programming in Haskell. It shares the backend C++ libtorch
-     library used by PyTorch and serves three primary objectives:
-
-    * Research on new functional programming methodology for
-      developing and representing models that are more productive or
-      lead to algorithm innovations.
-
-    * Building machine learning systems that are more reliable for the
-      model and its integration with the software in which the model
-      is embedded.
-
-    * Dissemination of new ideas from typed pure functional
-      programming for machine learning to other languages and machine
-      learning ecosystems.
+programming in Haskell.
 -}
 module Torch.Tutorial (
-    -- * Introduction
-    -- $introduction
-
-    -- * Usage
-    -- $usage
-
-    -- ** Tensors
-    -- $tensors
-
-    -- ** Typed Tensors
-    -- $typed-tensors
+    -- $tutorial
 ) where
 
-{- $introduction
-   TODO
--}
+{- $tutorial
+= Introduction
+#introduction#
 
-{- $usage
-   In the following section we introduce Hasktorch usage at a high
-   level from an end-user perspective. In the sections that follow we
-   will delve into the underlying implementation concepts.
+TODO
 
-   The sequence of topics and examples here is loosely based on the
-   PyTorch tutorial "Deep Learning with PyTorch: A 60 Minute Blitz" by
-   Soumith Chintala.
--}
+= Usage
+#usage#
 
-{- $tensors
-   TODO
--}
+In the following section we introduce Hasktorch usage at a high level
+from an end-user perspective. In the sections that follow we will delve
+into the underlying implementation concepts.
 
-{- $typed-tensors
-   TODO
+The sequence of topics and examples here is loosely based on the PyTorch
+tutorial \"Deep Learning with PyTorch: A 60 Minute Blitz\" by Soumith
+Chintala.
+
+== Tensors
+#tensors#
+
+Initialize a tensor of zeros by specifying the dimensions of the
+tensor<#notes [1]>:
+
+> > Torch.zeros' [3, 4]
+> Tensor Float [3,4] [[ 0.0000,  0.0000,  0.0000,  0.0000],
+>                     [ 0.0000,  0.0000,  0.0000,  0.0000],
+>                     [ 0.0000,  0.0000,  0.0000,  0.0000]]
+
+Initialize a tensor from a Haskell list:
+
+> > asTensor ([[4, 3], [2, 1]] :: [[Float]])
+> Tensor Float [2,2] [[ 4.0000   ,  3.0000   ],
+>                     [ 2.0000   ,  1.0000   ]]
+
+Note that the numerical type of the tensor is inferred from the types of
+the values in the list.
+
+A single valued tensor can be passed to @asTensor@ as well (and can be
+converted back to a scalar using @asValue@):
+
+> > asTensor (3.5)
+> Tensor Float []  3.5000
+> > asValue (asTensor (3.5)) :: Float
+> 3.5
+
+Create a randomly initialized matrix:
+
+> > x <-randIO' [2, 2]
+> > x
+> Tensor Float [2,2] [[ 0.2019   ,  0.8406   ],
+>                     [ 0.7256   ,  0.6436   ]]
+
+Note that since random initialization returns a different result each
+time, unlike other tensor constructors, is monadic reflecting the
+context of an underlying random number generator (RNG) changing state.
+
+Hasktorch includes variations of random tensor initializers in which the
+RNG object is threaded explicitly rather than implicitly. See the
+@Torch.Random@ module functions for details and variations. Samplers for
+which the RNG is not explicit such as @randIO\'@ example above use the
+@-IO@ suffix.
+
+Construct a matrix filled with zeros of dtype long:
+
+> > zeros [4, 4] (withDType Int64 defaultOpts)
+> Tensor Int64 [4,4] [[ 0,  0,  0,  0],
+>                     [ 0,  0,  0,  0],
+>                     [ 0,  0,  0,  0],
+>                     [ 0,  0,  0,  0]]
+
+Construct a vector filled with a specified constant:
+
+> > full' [3, 2] 4
+> Tensor Float [3,2] [[ 4.0000   ,  4.0000   ],
+>                     [ 4.0000   ,  4.0000   ],
+>                     [ 4.0000   ,  4.0000   ]]
+
+Construct a tensor from a Haskell list:
+
+> > asTensor [[1, 2, 3], [4, 5, 6]]
+> Tensor Double [2,3] [[ 1.0000   ,  2.0000   ,  3.0000   ],
+>                      [ 4.0000   ,  5.0000   ,  6.0000   ]]
+
+Note when the type of values in the list is explicit, this type is
+reflected in the dtype of the tensor:
+
+> > asTensor ([[1, 2, 3], [4, 5, 6]] :: [[Int]])
+> Tensor Int64 [2,3] [[ 1,  2,  3],
+>                     [ 4,  5,  6]]
+> >
+
+Tensor constructors with a @-like@ suffix Create a tensor based on an
+existing tensor:
+
+> > x <- Torch.full' [3, 2] 4
+> > Torch.randLikeIO' x
+> Tensor Float [3,2] [[ 0.3411   ,  0.8137   ],
+>                     [ 0.5252   ,  0.9109   ],
+>                     [ 0.3809   ,  0.9191   ]]
+
+== Operations
+#operations#
+
+Most operations are pure functions, similar to Haskell standard library
+math operations.
+
+Tensors implement the Num typeclass:
+
+> > let x = ones' [4]
+> > x + x
+> Tensor Float [4] [ 2.0000   ,  2.0000   ,  2.0000   ,  2.0000   ]
+
+Some operations transform a tensor:
+
+> > Torch.relu (asTensor ([-1.0, -0.5, 0.5, 1] :: [Float]))
+> Tensor Float [4] [ 0.0000,  0.0000,  0.5000   ,  1.0000   ]
+
+@select@ slices out a selection by specifying a dimension and index:
+
+> > let x = asTensor [[[1, 2, 3]], [[4, 5, 6]], [[7, 8, 9]], [[10, 11, 12]]]
+> > shape x
+> [4,1,3]
+> > select x 2 1
+> Tensor Double [4,1] [[ 2.0000   ],
+>                      [ 5.0000   ],
+>                      [ 8.0000   ],
+>                      [ 11.0000   ]]
+> > let y = asTensor [1, 2, 3]
+> > Torch.select y 0 1
+> Tensor Double []  2.0000
+
+Values can be extracted from a tensor using @asValue@ so long as the
+dtype matches the Haskell type:
+
+> > let x = asTensor ([2] :: [Int])
+> > let y = asValue x :: Int
+> > y
+> 2
+
+== Automatic Differentiation
+#automatic-differentiation#
+
+Automatic differentiation is achieved through the use of two primary
+functions in @Torch.Autograd@ module, @makeIndependent@ and @grad@.
+
+=== Independent Tensors
+#independent-tensors#
+
+@makeIndependent@ is used to instantiate an independent tensor variable
+from which a compute graph is constructed for differentiation, while
+@grad@ uses compute graph to compute gradients.
+
+@makeIndependent@ takes a tensor as input and returns an IO action which
+produces an @IndependentTensor@:
+
+makeIndependent :: Tensor -> IO IndependentTensor
+
+What is the definition of the @IndependentTensor@ type produced by the
+@makeIndependent@ action? It’s defined in the Hasktorch library as:
+
+> newtype IndependentTensor = IndependentTensor { toDependent :: Tensor }
+> deriving (Show)
+
+Thus @IndependentTensor@ is simply a wrapper around the underlying
+Tensor that is passed in as the argument to @makeIndependent@. Building
+up computations using ops applied to the @toDependent@ tensor of an
+@IndependentTensor@ will implicitly construct a compute graph to which
+@grad@ can be applied.
+
+All tensors have an underlying property that can be retrieved using the
+@requiresGrad@ function which indicates whether they are a
+differentiable value in a compute graph. <#notes [2]>
+
+> > let x = asTensor [1, 2, 3]
+> > y <- makeIndependent (asTensor [4, 5, 6])
+> > let y' = toDependent y
+> > let z = x + y'
+> > requiresGrad x
+> False
+> > requiresGrad y'
+> True
+> > requiresGrad z
+> True
+
+In summary, tensors that are computations of values derived from tensor
+constructors (e.g. @ones@, @zeros@, @fill@, @randIO@ etc.) outside the
+context of a @IndependentTensor@ are not differentiable. Tensors that
+are derived from computations on the @toDependent@ value of an
+@IndependentTensor@ are differentiable, as the above example
+illustrates.
+
+=== Gradients
+#gradients#
+
+Once a computation graph is constructed by applying ops and computing
+derived quantities stemming from a @toDependent@ value of an
+@IndependentTensor@, a gradient can be taken by using the @grad@
+function specifying in the first argument tensor corresponding to
+function value of interest and a list of @Independent@ tensor variables
+that the the derivative is taken with respect to:
+
+> grad :: Tensor -> [IndependentTensor] -> [Tensor]
+
+Let’s demonstrate this with a concrete example. We create a tensor and
+derive an @IndependentTensor@ from it:
+
+> > x <- makeIndependent (ones' [2, 2])
+> > let x' = toDependent x
+> > x'
+> Tensor Float [2,2] [[ 1.0000   ,  1.0000   ],
+>                     [ 1.0000   ,  1.0000   ]]
+
+Now do some computations on the dependent tensor:
+
+> > let y = x' + 2
+> > y
+> Tensor Float [2,2] [[ 3.0000   ,  3.0000   ],
+>                     [ 3.0000   ,  3.0000   ]]
+
+Since y is dependent on the x independent tensor, it is differentiable:
+
+> > requiresGrad y
+> True
+
+Applying more operations:
+
+> > let z = y * y * 3
+> > let out = mean z
+> > z
+> Tensor Float [2,2] [[ 27.0000   ,  27.0000   ],
+>                     [ 27.0000   ,  27.0000   ]]
+
+Now retrieve the gradient:
+
+> > grad out [x]
+> [Tensor Float [2,2] [[ 4.5000   ,  4.5000   ],
+>                     [ 4.5000   ,  4.5000   ]]]
+
+== Differentiable Programs (Neural Networks)
+#differentiable-programs-neural-networks#
+
+From a functional programming perspective, a neural network is
+represented by data and functions, much like any other functional
+program. The only distinction that differentiates neural networks from
+any other functional program is that it implements a small interface
+surface to support differentiation. Thus, we can consider neural
+networks to be \"differentiable functional programming\".
+
+The data in neural networks are the values to be fitted that
+parameterize the functions which carry out the inference operation and
+are modified based on gradients of through those functions.
+
+As with a regular Haskell program, this data is represented by an
+algebraic data type (ADT). The ADT can take on any shape that’s needed
+to model the domain of interest, allowing a great deal of flexibility
+and enabling all of Haskell’s strenghts in data modeling - can use sum
+or product types, nest types, etc. The ADT can implement various
+typeclasses to take on other functionality.
+
+The core interface that defines capability specific to differentiable
+programming is the @Parameterized@ typeclass:
+
+> class Parameterized f where
+>   flattenParameters :: f -> [Parameter]
+>   default flattenParameters :: (Generic f, Parameterized' (Rep f)) => f -> [Parameter]
+>   flattenParameters f = flattenParameters' (from f)
+>
+>   replaceOwnParameters :: f -> ParamStream f
+>   default replaceOwnParameters :: (Generic f, Parameterized' (Rep f)) => f -> ParamStream f
+>   replaceOwnParameters f = to <$> replaceOwnParameters' (from f)
+
+Note @Paramater@ is simply a type alias for @IndependentTensor@ in the
+context of neural networks (i.e. @type Parameter = IndependentTensor@).
+
+The role of @flattenParameters@ is to unroll any arbitrary ADT
+representation of a neural network into a standard flattened
+representation consisting a list of @IndependentTensor@ which is used to
+compute gradients.
+
+@replaceOwnParameters@ is used to update parameters. ParamStream is a
+type alias for a State type with state represented by a @Parameter@ list
+and a value parameter corresponding to the ADT defining the model.
+
+> type ParamStream a = State [Parameter] a
+
+Note the use of generics. Generics allow the compiler to usually
+automatically derive @flattenParameters@ and @replaceOwnParameter@
+instances without any code if your type is built up on tensors,
+containers of tensors, or other types that are built from tensor values
+(for example, layer modules provided in @Torch.NN@. In many cases, as
+you’ll see in the following examples, you will only need to add
+
+> intance Paramaterized MyNeuralNetwork
+
+(where @MyNeuralNetwork@ is an ADT definition for your model) and the
+compiler will derive implementations for the @flattenParameters@ and
+@replaceOwnParameters@.
+
+=== Linear Regression
+#linear-regression#
+
+Lets start with a simple example of linear regression. Here we generate
+random data with an underlying affine relationship between the inputs
+and outputs, then fit a linear regression to reproduce that
+relationship.
+
+This example is adapted from
+<https://github.com/hasktorch/hasktorch/tree/master/examples/regression>.
+
+In a standard supervised learning model, the neural network is
+initialized using a randomized initialization scheme. An iterative
+optimization is performed such that at each iteration a batch.
+
+> module Main where
+>
+> import Control.Monad (when)
+> import Torch
+>
+> groundTruth :: Tensor -> Tensor
+> groundTruth t = squeezeAll $ matmul t weight + bias
+>   where
+>     weight = asTensor ([42.0, 64.0, 96.0] :: [Float])
+>     bias = full' [1] (3.14 :: Float)
+>
+> model :: Linear -> Tensor -> Tensor
+> model state input = squeezeAll $ linear state input
+>
+> main :: IO ()
+> main = do
+>     init <- sample $ LinearSpec { in_features = numFeatures, out_features = 1 }
+>     randGen <- mkGenerator (Device CPU 0) 12345
+>     (trained, _) <- foldLoop (init, randGen) 2000 $ \(state, randGen) i -> do
+>         let (input, randGen') = randn' [batchSize, numFeatures] randGen
+>             (y, y') = (groundTruth input, model state input)
+>             loss = mseLoss y y'
+>         when (i `mod` 100 == 0) $ do
+>             putStrLn $ "Iteration: " ++ show i ++ " | Loss: " ++ show loss
+>         (newParam, _) <- runStep state GD loss 5e-3
+>         pure (replaceParameters state newParam, randGen')
+>     pure ()
+>   where
+>     batchSize = 4
+>     numFeatures = 3
+
+Note the expression of the architecture in the @linear@ function (a
+single linear layer, or alternatively a neural network with zero hidden
+layers), does not require an explicit representation of the compute
+graph, but is simply a composition of tensor ops. Because of the
+autodiff mechanism described in the previous section, the graph is
+constructed automatically as pure functional ops are applied, given a
+context of a set of independent variables.
+
+The @init@ variable is initialized as a @Linear@ type (defined in
+@Torch.NN@) using @sample@ which randomly initializes a @Linear@ value.
+
+@Linear@ is a built-in ADT implementing the @Parameterized@ typeclass
+and representing a fully connected linear layer, equivalent to linear
+regression when no hidden layers are present.
+
+@init@ is passed into the @foldLoop@<#notes [3]> as the @state@
+variable.
+
+A new list of @Paramater@ values is passed back from @runStep@ (which
+calls @grad@ to retrieve gradients, given a loss function, learning
+rate, and optimizer) and the typeclass function @replaceParameters@ is
+used to update the model at each iteration.
+
+Initialization is discussed in more detail in the following section
+
+=== Weight Initialization
+#weight-initialization#
+
+Random initialization of weights is not a pure function since two random
+initializations return different values. Initialization occurs by
+calling the @sample@ function for an ADT (@spec@) implementing the
+@Randomizable@ typeclass:
+
+> class Randomizable spec f | spec -> f where
+>   sample :: spec -> IO f
+
+In a typical (but not required) usage, @f@ is an ADT that implements the
+@Parameterized@ typeclass, so that there’s a pair of types - a
+specification type implementing the @spec@ input to @sample@ and a type
+implementing @Parameterizable@ representing the model state.
+
+For example, a linear fully connected layer is provided by the
+@Torch.NN@ module and defined therein as:
+
+> data Linear = Linear { weight :: Parameter, bias :: Parameter } deriving (Show, Generic)
+
+and is typically used with a specification type:
+
+> data LinearSpec = LinearSpec { in_features :: Int, out_features :: Int }
+>   deriving (Show, Eq)
+
+Putting this together, in untyped tensor usage, the user can implement
+custom models or layers implementing the @Paramaterizable@ typeclass
+built up from other ADTs implementing @Paramaterizable@. The shape of
+the data required for initialization is described by a type implementing
+@Randomizable@’s @spec@ parameter, and the @sample@ implementation
+specifies the default weight initialization.
+
+Note this initialization approach is specific to untyped tensors. One
+consequence of using typed tensors is that the information in these
+@spec@ types is reflected in the type itself and thus are not needed.
+
+What if you want to use a custom initialization that differs from the
+default? You can define an alternative function with the same signature
+@spec -> IO f@ and use the alternative function instead of @sample@.
+
+=== Optimizers
+#optimizers#
+
+Optimization implementations are functions that take as input the
+current parameter values of a model, parameter gradient estimates of the
+loss function at those parameters for a single batch, and a
+characteristic learning describing how large a perturbation to make to
+the parameters in order to reduce the loss. Given those inputs, they
+output a new set of parameters.
+
+In the simple case of stochastic gradient descent, the function to
+output a new set of parameters is to subtract from the current parameter
+\(\theta\), the gradient of the loss \(\nabla J\) scaled by the learning
+rate \(\eta\):
+
+\[\theta_{i+1} = \theta_i - \eta \nabla J(\theta)\]
+
+While stochastic gradient descent is a stateless function of the
+parameters, loss, and gradient, some optimizers have a notion of
+internal state that is propagated from one step to the step, for
+example, retaining and updating momentum between steps:
+
+\[\begin{gathered}
+    \Delta \theta_i = \alpha \Delta \theta_{i-1} - \eta \nabla J(\theta) \\
+    \theta_{i+1} = \theta_i + \Delta \theta_i
+\end{gathered}\]
+
+In this case, the momentum term \(\Delta \theta_i\) is carried forward
+as internal state of the optimizer that is propagated to the next step.
+\(\alpha\) is an optimizer parameter which determines a weighting on the
+momentum term relative to the gradient.
+
+Implementation of an optimizer consists of defining an ADT describing
+the optimizer state and a @step@ function that implements a single step
+perturbation given the learning rate, loss gradients, current
+parameters, and optimizer state.
+
+This function interface is described in the Optimizer typeclass
+interface:
+
+> class Optimizer o where
+>     step :: LearningRate -> Gradients -> [Tensor] -> o -> ([Tensor], o)
+
+Gradients is a newtype wrapper around a list of tensors to make intent
+explicit: @newtype Gradients = Gradients [Tensor]@.
+
+Hasktorch provides built-in optimizer implementations in @Torch.Optim@.
+Some illustrative example implementations follow.
+
+Being stateless, stochastic gradient descent has an ADT that has only
+one constructor value:
+
+> data GD = GD
+
+and implements the step function as:
+
+> instance Optimizer GD where
+>     step lr gradients depParameters dummy = (gd lr gradients depParameters, dummy)
+>         where
+>         step p dp = p - (lr * dp)
+>         gd lr (Gradients gradients) parameters = zipWith step parameters gradients
+
+The use of an optimizer was illustrated in the linear regression example
+using the function @runStep@
+
+> (newParam, _) <- runStep state GD loss 5e-3
+
+In this case the new optimizer state returned is ignored (as @_@) since
+gradient descent does not have any internal state. Under the hood,
+@runStep@ does a little bookkeeping making independent variables from a
+model, computing gradients, and passing values to the @step@ function.
+Usually a user can ignore the details and just pass model parameters and
+the optimizer to runStep as an abstracted interface which takes
+parameter values, the optimizer value, loss (a tensor), and learning
+rate as input and returns new parameters and an updated optimizer value.
+
+> runStep :: (Parameterized p, Optimizer o) =>
+>         p -> o -> Tensor -> LearningRate -> IO ([Parameter], o)
+
+= Typed Tensors
+#typed-tensors#
+
+Typed tensors provide an alternative API for which tensor
+characteristics are encoded in the type of the tensor. The Hasktorch
+library is layered such that [ TODO ]
+
+Using typed tensors increases the expressiveness of program invariants
+that can be automatically checked by GHC at the cost of needing to be
+more explicit in writing code and also requiring working with Haskell’s
+type-level machinery. Type-level Haskell programming has arisen through
+progressive compiler iteration leading to mechanisms that have a higher
+degree of complexity compared to value-level Haskell code or other
+languages such as Idris which were designed with type-level computations
+from inception. In spite of these compromises, Haskell offers enough
+capability to express powerful type-level representations of models that
+is matched by few other languages used for production applications.
+
+Things we can do in typed Hasktorch:
+
+-   specify, check, and infer tensor shapes at compile time
+
+-   specify, check, and infer tensor data types at compile time
+
+-   specify, check, and infer tensor compute devices at compile time
+
+We can encode all Hasktorch tensor shapes on the type level using
+type-level lists and natural numbers:
+
+> type EmptyShape = '[]
+> type OneDimensionalShape (a :: Nat) = '[a]
+> type TwoDimensionalShape (a :: Nat) (b :: Nat) = '[a, b]
+> ...
+
+Tensor data types and compute device types are lifted to the type level
+using the @DataKinds@ language extension:
+
+> type BooleanCPUTensor (shape :: [Nat]) = Tensor '(CPU,  0) 'Bool  shape
+> type IntCUDATensor    (shape :: [Nat]) = Tensor '(CUDA, 1) 'Int64 shape
+
+Devices are represented as tuples consisting of a @DeviceType@ (here
+@CPU@ for the CPU and @CUDA@ for a CUDA device, respectively) and a
+device id (here the @Nat@s @0@ and @1@, respectively).
+
+It is a common misconception that specifying tensor properties at
+compile time is only possible if all tensor properties are constants and
+are statically known. If this were the case, then we could only write
+functions over fully specified tensors, say,
+
+> boring :: BooleanCPUTensor '[] -> BooleanCPUTensor '[]
+> boring = id
+
+Fortunately, Haskell has the ability to reason about type variables.
+This feature is called parametric polymorphism. Consider this simple
+example of a function:
+
+> tensorNoOp
+>   :: forall (shape :: [Nat]) (dtype :: DType) (device :: (DeviceType, Nat))
+>    . Tensor device dtype shape
+>   -> Tensor device dtype shape
+> tensorNoOp = id
+
+Here, @shape@, @dtype@, and @device@ are type variables that have been
+constrained to be of kind shape, data type, and device, respectively.
+The universal quantifier @forall@ implies that this function is
+well-defined for all inhabitants of the types that are compatible with
+the type variables and their constraints.
+
+The @tensorNoOp@ function may seem trivial, and that is because its type
+is very strongly constrained: Given any typed tensor, it must return a
+tensor of the same shape and with the same data type and on the same
+device. Besides by means of the identity, @id@, there are not many ways
+in which this function can be implemented.
+
+There is a connection between a type signature of a function and
+mathematical proofs. We can say that the fact that a function exists is
+witnessed by its implementation. The implementation, @tensorNoOp = id@,
+is the proof of the theorem stated by @tensorNoOp@’s type signature. And
+here we have a proof that we can run this function on any device and for
+any data type and tensor shape.
+
+This is the essence of typed Hasktorch. As soon as the compiler gives
+its OK, we hold a proof that our program will run without shape or CUDA
+errors.
+
+#notes#
+
+1.  Hasktorch functions use a convention where default versions of
+    functions use a prime suffix. The @zeros@ function without the prime
+    suffix expects an additional parameter specifying tensor parameters.
+
+2.  PyTorch users will be familiar with this as the @requires_grad@
+    member variable for the PyTorch tensor type. The Hasktorch mechanism
+    is distinct from PyTorch’s mechanism - by only allowing gradients to
+    be applied in the context of a set of @IndependentTensor@ variables,
+    it allows ops to be semantically pure and preserve referential
+    transparency.
+
+3.  @foldLoop@ is a convenience function defined in terms of @foldM@ as
+    @foldLoop x count block = foldM block x ([1 .. count] :: [a])@
 -}

--- a/hasktorch/src/Torch/Tutorial.hs
+++ b/hasktorch/src/Torch/Tutorial.hs
@@ -7,6 +7,13 @@ module Torch.Tutorial (
     -- $tutorial
 ) where
 
+import Torch.Internal.Managed.Type.Context (manual_seed_L)
+
+{- $setup
+>>> manual_seed_L 123
+>>> :set -XNoOverloadedLists
+-}
+
 {- $tutorial
 = Introduction
 #introduction#
@@ -51,18 +58,18 @@ A single valued tensor can be passed to 'Torch.Tensor.asTensor' as
 well (and can be converted back to a scalar using
 'Torch.Tensor.asValue'):
 
->>> asTensor (3.5)
-Tensor Float []  3.5000
+>>> asTensor 3.5
+Tensor Double []  3.5000
 
->>> asValue (asTensor (3.5)) :: Float
+>>> asValue (asTensor 3.5) :: Double
 3.5
 
 Create a randomly initialized matrix:
 
 >>> x <-randIO' [2, 2]
 >>> x
-Tensor Float [2,2] [[ 0.2019   ,  0.8406   ],
-                    [ 0.7256   ,  0.6436   ]]
+Tensor Float [2,2] [[ 0.2961   ,  0.5166   ],
+                    [ 0.2517   ,  0.6886   ]]
 
 Note that since random initialization returns a different result each
 time, unlike other tensor constructors, is monadic reflecting the
@@ -105,11 +112,11 @@ Tensor Int64 [2,3] [[ 1,  2,  3],
 Tensor constructors with a @-like@ suffix Create a tensor based on an
 existing tensor:
 
->>> x <- Torch.full' [3, 2] 4
+>>> let x = Torch.full' [3, 2] 4
 >>> Torch.randLikeIO' x
-Tensor Float [3,2] [[ 0.3411   ,  0.8137   ],
-                    [ 0.5252   ,  0.9109   ],
-                    [ 0.3809   ,  0.9191   ]]
+Tensor Float [3,2] [[ 7.3972e-2,  0.8665   ],
+                    [ 0.1366   ,  0.1025   ],
+                    [ 0.1841   ,  0.7264   ]]
 
 == Operations
 #operations#
@@ -134,14 +141,14 @@ Tensor Float [4] [ 0.0000,  0.0000,  0.5000   ,  1.0000   ]
 >>> shape x
 [4,1,3]
 
->>> select x 2 1
+>>> select 2 1 x
 Tensor Double [4,1] [[ 2.0000   ],
                      [ 5.0000   ],
                      [ 8.0000   ],
                      [ 11.0000   ]]
 
 >>> let y = asTensor [1, 2, 3]
->>> Torch.select y 0 1
+>>> Torch.select 0 1 y
 Tensor Double []  2.0000
 
 Values can be extracted from a tensor using @asValue@ so long as the

--- a/shell.nix
+++ b/shell.nix
@@ -28,6 +28,7 @@ let
 
     tools = {
       cabal = "3.2.0.0";
+      fourmolu = "0.3.0.0";
       haskell-language-server = "0.6.0";
     };
 


### PR DESCRIPTION
Experimental PR adding `Torch.Tutorial` module (in the style of [`Pipes.Tutorial`](https://hackage.haskell.org/package/pipes-4.3.14/docs/Pipes-Tutorial.html) and similar).

Seeded with initial content from a preprint by Hashimoto, Stites, Scholak, Paszke, and Huang.

To generate, run
``` shell
cabal haddock hasktorch
```
The docs should then be available at a path like `dist-newstyle/build/x86_64-linux/ghc-8.10.2/hasktorch-0.2.0.0/doc/html/hasktorch/index.html`

### Todo
- [ ] finish section on typed tensors
- [ ] edit for clarity and simplicity
- [ ] get working with doctest?
- [ ] style/export to format appropriate for hasktorch.org?

![image](https://user-images.githubusercontent.com/319411/106372344-96351b00-6323-11eb-9510-9cb92d1fa02d.png)
