### PR TITLE
Call mallocTrim after performGC

### DIFF
--- a/hasktorch/src/Torch/Optim.hs
+++ b/hasktorch/src/Torch/Optim.hs
@@ -9,6 +9,7 @@ import Torch.Functional
 import Torch.NN
 import Torch.Tensor
 import Torch.TensorFactories
+import Torch.Internal.GC (mallocTrim)
 import Prelude hiding (sqrt)
 
 type LearningRate = Tensor
@@ -33,6 +34,7 @@ class Optimizer optimizer where
   runStep' :: (Parameterized model) => model -> optimizer -> Gradients -> LearningRate -> IO (model, optimizer)
   runStep' paramState optState gradients lr = do
     performGC
+    mallocTrim 0
     let (flatParameters', optState') = step lr gradients depParameters optState
     newFlatParam <- mapM makeIndependent flatParameters'
     pure (replaceParameters paramState newFlatParam, optState')

--- a/hasktorch/src/Torch/Optim/CppOptim.hs
+++ b/hasktorch/src/Torch/Optim/CppOptim.hs
@@ -13,6 +13,7 @@ import Foreign.ForeignPtr
 
 import Torch.Internal.Cast
 import Torch.Internal.Class (Castable(..), CppTuple2(..), CppTuple3(..), CppTuple4(..), CppObject(..))
+import Torch.Internal.GC (mallocTrim)
 import qualified Torch.Internal.Type as ATen
 import qualified Torch.Internal.Managed.Optim as LibTorch
 import qualified Torch.Optim as Optim
@@ -54,6 +55,7 @@ instance {-# OVERLAPS #-} CppOptimizer option => Optim.Optimizer (CppOptimizerSt
   step = error  "step is not implemented for CppOptimizer."
   runStep paramState optState lossValue lr = do
     performGC
+    mallocTrim 0
     unsafeStep paramState optState lossValue
 
   runStep' = error  "runStep' is not implemented for CppOptimizer."

--- a/hasktorch/src/Torch/Typed/Optim.hs
+++ b/hasktorch/src/Torch/Typed/Optim.hs
@@ -20,6 +20,7 @@ import Data.Kind
 import qualified Torch.DType as D
 import qualified Torch.Device as D
 import Torch.HList
+import Torch.Internal.GC (mallocTrim)
 import qualified Torch.Internal.Cast as ATen
 import qualified Torch.Internal.Class as ATen
 import qualified Torch.Tensor as D
@@ -73,6 +74,7 @@ runStep ::
   IO (model, optim)
 runStep model optim loss learningRate = do
   performGC
+  mallocTrim 0
   let parameters = flattenParameters model
       gradients = grad loss parameters
       tensors = hmap' ToDependent parameters
@@ -97,6 +99,7 @@ runStep' ::
   IO (model, optim)
 runStep' model optim learningRate gradients = do
   performGC
+  mallocTrim 0
   let parameters = flattenParameters model
       tensors = hmap' ToDependent parameters
       (tensors', optim') = step learningRate gradients tensors optim

--- a/hasktorch/src/Torch/Typed/Optim/CppOptim.hs
+++ b/hasktorch/src/Torch/Typed/Optim/CppOptim.hs
@@ -28,6 +28,7 @@ import qualified Torch.Internal.Type as ATen
 import qualified Torch.Internal.Managed.Optim as LibTorch
 import qualified Torch.Typed.Optim as Optim
 import System.Mem(performGC)
+import Torch.Internal.GC (mallocTrim)
 
 import Torch.HList
 import Torch.Typed.Tensor
@@ -138,4 +139,5 @@ runStep :: (CppOptimizer option, Parameterized model
         -> IO (model, CppOptimizerState option (Parameters model))
 runStep model optim loss = do
   performGC
+  mallocTrim 0
   unsafeStep model optim loss

--- a/libtorch-ffi/libtorch-ffi.cabal
+++ b/libtorch-ffi/libtorch-ffi.cabal
@@ -157,6 +157,7 @@ library
  extra-ghci-libraries: stdc++
  if os(darwin)
   ld-options: -Wl,-keep_dwarf_unwind
+  cpp-options: -DENABLE_DUMMY_MALLOC_TRIM
   if !flag(gcc)
     ghc-options:       -optc-std=c++14 -optc-xc++
     cxx-options:       -std=c++14

--- a/libtorch-ffi/src/Torch/Internal/GC.hs
+++ b/libtorch-ffi/src/Torch/Internal/GC.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE CPP #-}
 
 module Torch.Internal.GC where
 
@@ -26,8 +27,14 @@ import Foreign.C.Types
 foreign import ccall unsafe "hasktorch_finalizer.h showWeakPtrList"
   c_showWeakPtrList :: CInt -> IO ()
 
+-- malloc_trim is a glibc function. It doesn't exist on macos.
+#ifdef ENABLE_DUMMY_MALLOC_TRIM
+mallocTrim :: CInt -> IO ()
+mallocTrim _ = return ()
+#else
 foreign import ccall unsafe "malloc.h malloc_trim"
   mallocTrim :: CInt -> IO ()
+#endif
 
 -- | Returns all objects of libtorch. 
 -- Each time it is called, the age of the object increases by one.


### PR DESCRIPTION
libtorch causes memory fragmentation.
It can be solved by using jemalloc, but it cannot be used in the nix environment, because ghc causes a segmentation fault. (See https://github.com/hasktorch/hasktorch/pull/513 )

https://news.ycombinator.com/item?id=24232809
According to this, calling malloc_trim after GC can eliminate fragmentation, and when I actually tried calling malloc_trim, it is effective.