### PR TITLE
Add overwritable HasTypes to support generic dtype conversions

### DIFF
--- a/examples/examples.cabal
+++ b/examples/examples.cabal
@@ -207,6 +207,18 @@ executable mnist-mlp
                      , static-mnist
                      , pipes
 
+executable mnist-mixed-precision
+  import:              config
+  hs-source-dirs:      mnist-mixed-precision
+  main-is:             Main.hs
+  ghc-options:         -fno-warn-partial-type-signatures
+  build-depends:       libtorch-ffi
+                     , bytestring >= 0.10.8
+                     , random >= 1.1
+                     , safe-exceptions
+                     , static-mnist
+                     , pipes
+
 executable load-torchscript
   import:              config
   hs-source-dirs:      load-torchscript

--- a/examples/mnist-mixed-precision/Main.hs
+++ b/examples/mnist-mixed-precision/Main.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Main where
 
@@ -15,7 +17,10 @@ import Control.Monad.Cont (ContT (..))
 import GHC.Generics
 import Pipes
 import qualified Pipes.Prelude as P
+import System.Environment
 import Torch
+import Torch.Tensor
+import Torch.Lens
 import Torch.Serialize
 import Torch.Typed.Vision (initMnist)
 import qualified Torch.Vision as V
@@ -53,12 +58,13 @@ mlp MLP {..} input =
     . linear l0
     $ input
 
-trainLoop :: Optimizer o => MLP -> o -> ListT IO (Tensor, Tensor) -> IO MLP
-trainLoop model optimizer = P.foldM step begin done . enumerateData
+trainLoop :: Optimizer o => Device -> DType -> MLP -> o -> ListT IO (Tensor, Tensor) -> IO MLP
+trainLoop device' dtype' model optimizer = P.foldM step begin done . enumerateData
   where
     step :: MLP -> ((Tensor, Tensor), Int) -> IO MLP
-    step model ((input, label), iter) = do
-      let loss = nllLoss' label $ mlp model input
+    step model args = do
+      let ((input, label), iter) = toLocalModel device' dtype' args
+          loss = nllLoss' label $ mlp model input
       when (iter `mod` 50 == 0) $ do
         putStrLn $ "Iteration: " ++ show iter ++ " | Loss: " ++ show loss
       (newParam, _) <- runStep model optimizer loss 1e-3
@@ -72,18 +78,54 @@ displayImages model (testImg, testLabel) = do
   putStrLn $ "Model        : " ++ (show . (argmax (Dim 1) RemoveDim) . exp $ mlp model testImg)
   putStrLn $ "Ground Truth : " ++ (show testLabel)
 
+toLocalModel :: forall a. HasTypes a Tensor => Device -> DType -> a -> a
+toLocalModel device' dtype' model = over (types @Tensor @a) func model
+  where
+    func tensor =
+      let tensor' = toDevice device' tensor
+          tensor'' =
+            if isIntegral (dtype tensor')
+              then tensor'
+              else toType dtype' tensor'
+       in tensor''
+
+fromLocalModel :: forall a. HasTypes a Tensor => a -> a
+fromLocalModel model = over (types @Tensor @a) func model
+  where
+    func tensor =
+      let tensor' = toDevice (Device CPU 0) tensor
+          tensor'' =
+            if isIntegral (dtype tensor')
+              then tensor'
+              else toType Float tensor'
+       in tensor''
+
 main :: IO ()
 main = do
+  deviceStr <- try (getEnv "DEVICE") :: IO (Either SomeException String)
+  dtypeStr <- try (getEnv "DTYPE") :: IO (Either SomeException String)
+  let device' = case deviceStr of
+        Right "cpu" -> Device CPU 0
+        Right "cuda:0" -> Device CUDA 0
+        Right device -> error $ "Unknown device setting: " ++ device
+        _ -> Device CPU 0
+      dtype' = case dtypeStr of
+        Right "double" -> Double
+        Right "float" -> Float
+        Right "half" -> Half
+        Right "bfloat16" -> BFloat16
+        Right type' -> error $ "Unknown dtype setting: " ++ type'
+        _ -> Float
   (trainData, testData) <- initMnist "data"
   let trainMnist = V.MNIST {batchSize = 32, mnistData = trainData}
       testMnist = V.MNIST {batchSize = 1, mnistData = testData}
       spec = MLPSpec 784 64 32 10
       optimizer = GD
-  init <- sample spec
+  init <- toLocalModel device' dtype' <$> sample spec
   model <- foldLoop init 5 $ \model _ ->
-    runContT (streamFromMap (datasetOpts 2) trainMnist) $ trainLoop model optimizer . fst
+    runContT (streamFromMap (datasetOpts 2) trainMnist) $ trainLoop device' dtype' model optimizer . fst
 
   -- show test images + labels
-  forM_ [0 .. 10] $ displayImages model <=< getItem testMnist
+  forM_ [0 .. 10] $ displayImages (fromLocalModel model) <=< getItem testMnist
 
   putStrLn "Done"

--- a/examples/mnist-mixed-precision/README.md
+++ b/examples/mnist-mixed-precision/README.md
@@ -1,4 +1,4 @@
-# Untyped MNIST Example
+# Untyped Mixed Precision Example
 
 This is a simple MLP implementation of an MNIST classifier using untyped tensors.
 
@@ -8,7 +8,16 @@ Before running this example, from the linked `datasets/` directory, run:
 
 This downloads the mnist dataset into `datasets/mnist/`. Then run:
 
-`stack run mnist-mlp`
+```sh
+$ export DEVICE="cuda:0"          # Set device to CUDA
+$ export DTYPE="half"             # Set data type to half-precision floating point
+$ stack run mnist-mixed-precision # Run
+```
+or just run:
+
+```sh
+$ stack run mnist-mixed-precision
+```
 
 The code trains a model then prints some example images to the terminal as 
 ascii, showing model outputs and ground truth for the number shown.

--- a/examples/mnist-mixed-precision/setup-data.sh
+++ b/examples/mnist-mixed-precision/setup-data.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+mkdir data
+pushd data
+wget http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz
+wget http://yann.lecun.com/exdb/mnist/train-labels-idx1-ubyte.gz
+wget http://yann.lecun.com/exdb/mnist/t10k-images-idx3-ubyte.gz
+wget http://yann.lecun.com/exdb/mnist/t10k-labels-idx1-ubyte.gz
+popd
+

--- a/examples/mnist-mlp/Main.hs
+++ b/examples/mnist-mlp/Main.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Main where
 
@@ -17,6 +19,8 @@ import Pipes
 import qualified Pipes.Prelude as P
 import System.Environment
 import Torch
+import Torch.Tensor
+import Torch.Lens
 import Torch.Serialize
 import Torch.Typed.Vision (initMnist)
 import qualified Torch.Vision as V
@@ -54,13 +58,13 @@ mlp MLP {..} input =
     . linear l0
     $ input
 
-trainLoop :: Optimizer o => Device -> MLP -> o -> ListT IO (Tensor, Tensor) -> IO MLP
-trainLoop localDevice model optimizer = P.foldM step begin done . enumerateData
+trainLoop :: Optimizer o => Device -> DType -> MLP -> o -> ListT IO (Tensor, Tensor) -> IO MLP
+trainLoop device' dtype' model optimizer = P.foldM step begin done . enumerateData
   where
     step :: MLP -> ((Tensor, Tensor), Int) -> IO MLP
     step model args = do
-      let ((input, label), iter) = toDevice localDevice args
-      let loss = nllLoss' label $ mlp model input
+      let ((input, label), iter) = toLocalModel device' dtype' args
+          loss = nllLoss' label $ mlp model input
       when (iter `mod` 50 == 0) $ do
         putStrLn $ "Iteration: " ++ show iter ++ " | Loss: " ++ show loss
       (newParam, _) <- runStep model optimizer loss 1e-3
@@ -74,24 +78,54 @@ displayImages model (testImg, testLabel) = do
   putStrLn $ "Model        : " ++ (show . (argmax (Dim 1) RemoveDim) . exp $ mlp model testImg)
   putStrLn $ "Ground Truth : " ++ (show testLabel)
 
+toLocalModel :: forall a. HasTypes a Tensor => Device -> DType -> a -> a
+toLocalModel device' dtype' model = over (types @Tensor @a) func model
+  where
+    func tensor =
+      let tensor' = toDevice device' tensor
+          tensor'' =
+            if isIntegral (dtype tensor')
+              then tensor'
+              else toType dtype' tensor'
+       in tensor''
+
+fromLocalModel :: forall a. HasTypes a Tensor => a -> a
+fromLocalModel model = over (types @Tensor @a) func model
+  where
+    func tensor =
+      let tensor' = toDevice (Device CPU 0) tensor
+          tensor'' =
+            if isIntegral (dtype tensor')
+              then tensor'
+              else toType Float tensor'
+       in tensor''
+
 main :: IO ()
 main = do
   deviceStr <- try (getEnv "DEVICE") :: IO (Either SomeException String)
-  let localDevice = case deviceStr of
+  dtypeStr <- try (getEnv "DTYPE") :: IO (Either SomeException String)
+  let device' = case deviceStr of
         Right "cpu" -> Device CPU 0
         Right "cuda:0" -> Device CUDA 0
         Right device -> error $ "Unknown device setting: " ++ device
         _ -> Device CPU 0
+      dtype' = case dtypeStr of
+        Right "double" -> Double
+        Right "float" -> Float
+        Right "half" -> Half
+        Right "bfloat16" -> BFloat16
+        Right type' -> error $ "Unknown dtype setting: " ++ type'
+        _ -> Float
   (trainData, testData) <- initMnist "data"
   let trainMnist = V.MNIST {batchSize = 32, mnistData = trainData}
       testMnist = V.MNIST {batchSize = 1, mnistData = testData}
       spec = MLPSpec 784 64 32 10
       optimizer = GD
-  init <- toDevice localDevice <$> sample spec
+  init <- toLocalModel device' dtype' <$> sample spec
   model <- foldLoop init 5 $ \model _ ->
-    runContT (streamFromMap (datasetOpts 2) trainMnist) $ trainLoop localDevice model optimizer . fst
+    runContT (streamFromMap (datasetOpts 2) trainMnist) $ trainLoop device' dtype' model optimizer . fst
 
   -- show test images + labels
-  forM_ [0 .. 10] $ displayImages model <=< getItem testMnist
+  forM_ [0 .. 10] $ displayImages (fromLocalModel model) <=< getItem testMnist
 
   putStrLn "Done"

--- a/examples/mnist-mlp/README.md
+++ b/examples/mnist-mlp/README.md
@@ -8,7 +8,16 @@ Before running this example, from the linked `datasets/` directory, run:
 
 This downloads the mnist dataset into `datasets/mnist/`. Then run:
 
-`stack run mnist-mlp`
+```sh
+$ export DEVICE="cuda:0"        # Set device to CUDA
+$ export DTYPE="half"           # Set data type to half-precision floating point
+$ stack run mnist-mlp           # Run
+```
+or just run:
+
+```sh
+$ stack run mnist-mlp
+```
 
 The code trains a model then prints some example images to the terminal as 
 ascii, showing model outputs and ground truth for the number shown.

--- a/examples/rnn/Elman.hs
+++ b/examples/rnn/Elman.hs
@@ -41,7 +41,6 @@ instance Parameterized ElmanCell where
     hidden_weight <- nextParameter
     bias   <- nextParameter
     return $ ElmanCell{..}
-  replaceDevice = defaultReplaceDevice
 
 
 instance Show ElmanCell where

--- a/examples/rnn/GRU.hs
+++ b/examples/rnn/GRU.hs
@@ -73,7 +73,6 @@ instance Parameterized GRUCell where
     let update_gate = [ug_ih, ug_hh, ug_b]
     let gru_hidden_gate = [hg_ih, hg_hh, hg_b]
     return $ GRUCell{..}
-  replaceDevice = defaultReplaceDevice
 
 
 instance Show GRUCell where

--- a/examples/rnn/LSTM.hs
+++ b/examples/rnn/LSTM.hs
@@ -98,7 +98,6 @@ instance Parameterized LSTMCell where
     let hidden_gate = [hg_ih, hg_hh, hg_b]
     let output_gate = [og_ih, og_hh, og_b]
     return $ LSTMCell{..}
-  replaceDevice = defaultReplaceDevice
 
 instance Show LSTMCell where
   show LSTMCell{..} =

--- a/hasktorch/hasktorch.cabal
+++ b/hasktorch/hasktorch.cabal
@@ -49,6 +49,7 @@ library
                     , Torch.Random
                     , Torch.Script
                     , Torch.HList
+                    , Torch.Lens
                     , Torch.Typed
                     , Torch.Typed.Aux
                     , Torch.Typed.Factories
@@ -139,6 +140,7 @@ test-suite spec
                     , FunctionalSpec
                     , GradSpec
                     , InitializerSpec
+                    , LensSpec
                     , OptimSpec
                     , SparseSpec
                     , ScriptSpec

--- a/hasktorch/src/Torch/Autograd.hs
+++ b/hasktorch/src/Torch/Autograd.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE DeriveGeneric #-}
 
 module Torch.Autograd where
 
@@ -12,6 +13,7 @@ import qualified Torch.Internal.Managed.Autograd
 import qualified Torch.Internal.Managed.Type.Tensor as ATen
 import qualified Torch.Internal.Type as ATen
 import Torch.Tensor
+import GHC.Generics
 
 -- | Note: to create an `IndependentTensor` use `makeIndependent`;
 -- | otherwise, Torch will complain the parameter does not require a gradient.
@@ -19,7 +21,7 @@ newtype IndependentTensor
   = IndependentTensor
       { toDependent :: Tensor
       }
-  deriving (Show)
+  deriving (Show, Generic)
 
 grad :: Tensor -> [IndependentTensor] -> [Tensor]
 grad y inputs = unsafePerformIO $ cast2 Torch.Internal.Managed.Autograd.grad y (map toDependent inputs)

--- a/hasktorch/src/Torch/DType.hs
+++ b/hasktorch/src/Torch/DType.hs
@@ -31,7 +31,21 @@ data DType
     Float
   | -- | Double
     Double
-  deriving (Eq, Show)
+  | -- | ComplexHalf
+    ComplexHalf
+  | -- | ComplexFloat
+    ComplexFloat
+  | -- | ComplexDouble
+    ComplexDouble
+  | -- | QInt8
+    QInt8
+  | -- | QUInt8
+    QUInt8
+  | -- | QInt32
+    QInt32
+  | -- | BFloat16
+    BFloat16
+  deriving (Eq, Show, Read)
 
 instance Reifies Bool DType where
   reflect _ = Bool
@@ -91,6 +105,13 @@ instance Castable DType ATen.ScalarType where
   cast Half f = f ATen.kHalf
   cast Float f = f ATen.kFloat
   cast Double f = f ATen.kDouble
+  cast ComplexHalf f = f ATen.kComplexHalf
+  cast ComplexFloat f = f ATen.kComplexFloat
+  cast ComplexDouble f = f ATen.kComplexDouble
+  cast QInt8 f = f ATen.kQInt8
+  cast QUInt8 f = f ATen.kQUInt8
+  cast QInt32 f = f ATen.kQInt32
+  cast BFloat16 f = f ATen.kBFloat16
 
   uncast x f
     | x == ATen.kBool = f Bool
@@ -102,6 +123,13 @@ instance Castable DType ATen.ScalarType where
     | x == ATen.kHalf = f Half
     | x == ATen.kFloat = f Float
     | x == ATen.kDouble = f Double
+    | x == ATen.kComplexHalf = f ComplexHalf
+    | x == ATen.kComplexFloat = f ComplexFloat
+    | x == ATen.kComplexDouble = f ComplexDouble
+    | x == ATen.kQInt8 = f QInt8
+    | x == ATen.kQUInt8 = f QUInt8
+    | x == ATen.kQInt32 = f QInt32
+    | x == ATen.kBFloat16 = f BFloat16
 
 isIntegral :: DType -> Bool
 isIntegral Bool = True
@@ -113,6 +141,13 @@ isIntegral Int64 = True
 isIntegral Half = False
 isIntegral Float = False
 isIntegral Double = False
+isIntegral ComplexHalf = False
+isIntegral ComplexFloat = False
+isIntegral ComplexDouble = False
+isIntegral QInt8 = False
+isIntegral QUInt8 = False
+isIntegral QInt32 = False
+isIntegral BFloat16 = False
 
 byteLength :: DType -> Int
 byteLength dtype =
@@ -126,3 +161,10 @@ byteLength dtype =
     Half -> 2
     Float -> 4
     Double -> 8
+    ComplexHalf -> 4
+    ComplexFloat -> 8
+    ComplexDouble -> 16
+    QInt8 -> 1
+    QUInt8 -> 1
+    QInt32 -> 4
+    BFloat16 -> 2

--- a/hasktorch/src/Torch/Functional.hs
+++ b/hasktorch/src/Torch/Functional.hs
@@ -956,7 +956,7 @@ nllLoss' ::
 nllLoss' target t = unsafePerformIO $ cast5 ATen.nll_loss_tttll t target weight ReduceMean (-100 :: Int)
   where
     nClass = shape t !! 1 -- TODO: nicer runtime error if input dimensions don't conform
-    weight = toDevice (device target) $ ones' [nClass]
+    weight = toDType (dtype t) $ _toDevice (device target) $ ones' [nClass]
 
 -- | Returns cosine similarity between x1 and x2, computed along dim.
 cosineSimilarity ::

--- a/hasktorch/src/Torch/Lens.hs
+++ b/hasktorch/src/Torch/Lens.hs
@@ -1,0 +1,70 @@
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+
+module Torch.Lens where
+
+import Control.Monad.Identity
+import GHC.Generics
+
+type Traversal' s a
+  = forall f. Applicative f => (a -> f a) -> s -> f s
+
+class HasTypes s a where
+  types_ :: Traversal' s a
+  default types_ :: (Generic s, GHasTypes (Rep s) a) => Traversal' s a
+  types_ func s = to <$> gtypes func (from s)
+  {-# INLINE types_ #-}
+
+instance {-# OVERLAPS #-} (Generic s, GHasTypes (Rep s) a) => HasTypes s a
+
+over :: Traversal' s a -> (a -> a) -> s -> s
+over l f = runIdentity . l (Identity . f)
+
+types :: forall a s. HasTypes s a => Traversal' s a
+types = types_ @s @a
+
+class GHasTypes s a where
+  gtypes :: forall b . Traversal' (s b) a
+
+instance GHasTypes U1 a where
+  gtypes _ = pure
+  {-# INLINE gtypes #-}
+
+instance (GHasTypes f a, GHasTypes g a) => GHasTypes (f :+: g) a where
+  gtypes func (L1 x) = L1 <$> gtypes func x
+  gtypes func (R1 x) = R1 <$> gtypes func x
+
+instance (GHasTypes f a, GHasTypes g a) => GHasTypes (f :*: g) a where
+  gtypes func (x :*: y) = (:*:) <$> gtypes func x <*> gtypes func y
+  {-# INLINE gtypes #-}
+
+instance (HasTypes s a) => GHasTypes (K1 i s) a where
+  gtypes func (K1 x) = K1 <$> types func x
+  {-# INLINE gtypes #-}
+  
+instance GHasTypes s a => GHasTypes (M1 i t s) a where
+  gtypes func (M1 x) = M1 <$> gtypes func x
+  {-# INLINE gtypes #-}
+
+instance {-# OVERLAPS #-} (HasTypes s a) => HasTypes [s] a where
+  types_ func [] = pure []
+  types_ func (x:xs) = (:) <$> types_ func x <*> types_ func xs
+  {-# INLINE types_ #-}
+
+instance {-# OVERLAPS #-} (HasTypes s0 a, HasTypes s1 a) => HasTypes (s0,s1) a where
+  types_ func (s0,s1) = (,) <$> types_ func s0 <*> types_ func s1 
+  {-# INLINE types_ #-}
+
+instance {-# OVERLAPS #-} (HasTypes s0 a, HasTypes s1 a, HasTypes s2 a) => HasTypes (s0,s1,s2) a where
+  types_ func (s0,s1,s2) = (,,) <$> types_ func s0 <*> types_ func s1  <*> types_ func s2
+  {-# INLINE types_ #-}

--- a/hasktorch/src/Torch/Script.hs
+++ b/hasktorch/src/Torch/Script.hs
@@ -345,7 +345,6 @@ instance Parameterized ScriptModule where
     let len = length (getParameters module')
     ps' <- replicateM len nextParameter
     return $ updateParameters WithRequiredGrad module' (map toDependent ps')
-  replaceDevice = defaultReplaceDevice
 
 trace ::
   -- | moduleName

--- a/hasktorch/src/Torch/Tensor.hs
+++ b/hasktorch/src/Torch/Tensor.hs
@@ -46,6 +46,7 @@ import qualified Torch.Internal.Managed.Type.TensorOptions as ATen
 import qualified Torch.Internal.Type as ATen
 import qualified Torch.Internal.Unmanaged.Type.Tensor as Unmanaged (tensor_data_ptr)
 import Torch.TensorOptions
+import Torch.Lens
 
 type ATenTensor = ForeignPtr ATen.Tensor
 
@@ -126,20 +127,38 @@ toInt :: Tensor -> Int
 toInt t = unsafePerformIO $ cast1 ATen.tensor_item_int64_t t
 
 -- | Casts the input tensor to the given data type
-toType ::
+_toType ::
   -- | data type to cast input to
   DType ->
   -- | input
   Tensor ->
   -- | output
   Tensor
-toType dtype t = unsafePerformIO $ cast2 ATen.tensor_toType_s t dtype
+_toType dtype t = unsafePerformIO $ cast2 ATen.tensor_toType_s t dtype
 
-class ToDevice a where
-  toDevice :: Device -> a -> a
+instance HasTypes Tensor Tensor where
+  types_ = id
 
-instance ToDevice Tensor where
-  toDevice = _toDevice
+instance HasTypes (a -> a) Tensor where
+  types_ _ = pure
+
+instance HasTypes Int Tensor where
+  types_ _ = pure
+
+instance HasTypes Double Tensor where
+  types_ _ = pure
+
+instance HasTypes Float Tensor where
+  types_ _ = pure
+
+instance HasTypes Bool Tensor where
+  types_ _ = pure
+
+toType :: forall a. HasTypes a Tensor => DType -> a -> a
+toType dtype t = over (types @Tensor @a) (_toType dtype) t
+
+toDevice :: forall a. HasTypes a Tensor => Device -> a -> a
+toDevice device' t = over (types @Tensor @a) (_toDevice device') t
 
 -- | Casts the input tensor to given device
 _toDevice ::

--- a/hasktorch/src/Torch/Typed/NN/Recurrent/LSTM.hs
+++ b/hasktorch/src/Torch/Typed/NN/Recurrent/LSTM.hs
@@ -212,7 +212,6 @@ instance A.Parameterized (LSTMLayer inputSize hiddenSize directionality dtype de
           (UnsafeMkParameter bi')
           (UnsafeMkParameter bh')
       )
-  replaceDevice = A.defaultReplaceDevice
 
 data
   LSTMLayerStackSpec
@@ -376,7 +375,6 @@ instance A.Parameterized (LSTMLayerStack inputSize hiddenSize numLayers directio
     stack' <- A._replaceParameters stack
     layer' <- A._replaceParameters layer
     return $ LSTMLayerK stack' layer'
-  replaceDevice = A.defaultReplaceDevice
 
 newtype
   LSTMSpec
@@ -443,7 +441,6 @@ instance A.Parameterized (LSTM inputSize hiddenSize numLayers directionality dty
         { lstm_layer_stack = lstm_layer_stack',
           ..
         }
-  replaceDevice = A.defaultReplaceDevice
 
 -- | Helper to do xavier uniform initializations on weight matrices and
 -- orthagonal initializations for the gates. (When implemented.)
@@ -695,7 +692,6 @@ instance A.Parameterized (LSTMWithInit inputSize hiddenSize numLayers directiona
           lstmWithLearnedInit_c = UnsafeMkParameter lstmWithLearnedInit_c',
           lstmWithLearnedInit_h = UnsafeMkParameter lstmWithLearnedInit_h'
         }
-  replaceDevice = A.defaultReplaceDevice
 
 lstmForward ::
   forall

--- a/hasktorch/test/LensSpec.hs
+++ b/hasktorch/test/LensSpec.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE NoMonomorphismRestriction #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE FlexibleInstances #-}
+
+module LensSpec(spec) where
+
+import Test.Hspec
+
+import Torch.Lens
+import GHC.Generics
+import Control.Exception.Safe (catch,throwIO)
+import Language.C.Inline.Cpp.Exceptions (CppException(..))
+
+data WTree a w
+  = Leaf a
+  | Fork (WTree a w) (WTree a w)
+  | WithWeight (WTree a w) w
+  deriving (Generic, Show, Eq)
+
+myTree = WithWeight (Fork (Leaf (Just "hello")) (Leaf Nothing)) "world"
+
+instance {-# OVERLAPS #-} HasTypes String String where
+  types_ = id
+
+spec :: Spec
+spec = describe "lens" $ do
+  it "over for list" $ do
+    over (types @String) (++ "!") ["hello"] `shouldBe` ["hello!"]
+  it "over for tree" $ do
+    over (types @String) (++ "!") myTree `shouldBe` WithWeight (Fork (Leaf (Just "hello!")) (Leaf Nothing)) "world!"
+     

--- a/libtorch-ffi/src/Torch/Internal/Const.hs
+++ b/libtorch-ffi/src/Torch/Internal/Const.hs
@@ -65,6 +65,18 @@ kComplexFloat = [C.pure| int8_t { (int8_t) at::ScalarType::ComplexFloat } |]
 kComplexDouble :: ScalarType
 kComplexDouble = [C.pure| int8_t { (int8_t) at::ScalarType::ComplexDouble } |]
 
+kQInt8 :: ScalarType
+kQInt8 = [C.pure| int8_t { (int8_t) at::ScalarType::QInt8 } |]
+
+kQUInt8 :: ScalarType
+kQUInt8 = [C.pure| int8_t { (int8_t) at::ScalarType::QUInt8 } |]
+
+kQInt32 :: ScalarType
+kQInt32 = [C.pure| int8_t { (int8_t) at::ScalarType::QInt32 } |]
+
+kBFloat16 :: ScalarType
+kBFloat16 = [C.pure| int8_t { (int8_t) at::ScalarType::BFloat16 } |]
+
 kUndefined :: ScalarType
 kUndefined = [C.pure| int8_t { (int8_t) at::ScalarType::Undefined } |]
 


### PR DESCRIPTION
This PR provides HasTypes typeclass for general dtype conversions.
This HasTypes typeclass is similar to HasTypes in generic-lens, but the behavior of this PR's HasTypes can be overridden simply by defining an instance. 
This PR hasn't changed Parameterized typeclass at all.  (It is  not trying to force a merge of Parameterized and GTravelable typeclass like https://github.com/hasktorch/hasktorch/pull/505.)
