### PR TITLE
Remove dependency on singletons

### DIFF
--- a/hasktorch/hasktorch.cabal
+++ b/hasktorch/hasktorch.cabal
@@ -103,7 +103,7 @@ library
                     , safe-exceptions
                     , random
                     , reflection
-                    , singletons
+                    , singletons < 3
                     , stm
                     , JuicyPixels
                     , vector
@@ -212,7 +212,7 @@ test-suite doctests
                     , safe-exceptions
                     , random
                     , reflection
-                    , singletons
+                    , singletons < 3
                     , stm
                     , JuicyPixels
                     , vector

--- a/hasktorch/hasktorch.cabal
+++ b/hasktorch/hasktorch.cabal
@@ -103,7 +103,6 @@ library
                     , safe-exceptions
                     , random
                     , reflection
-                    , singletons < 3
                     , stm
                     , JuicyPixels
                     , vector
@@ -212,7 +211,6 @@ test-suite doctests
                     , safe-exceptions
                     , random
                     , reflection
-                    , singletons < 3
                     , stm
                     , JuicyPixels
                     , vector

--- a/hasktorch/src/Torch/Typed/Aux.hs
+++ b/hasktorch/src/Torch/Typed/Aux.hs
@@ -98,6 +98,10 @@ type family LastDim (l :: [a]) :: Nat where
   LastDim (_ ': '[]) = 0
   LastDim (_ ': t) = 1 + LastDim t
 
+type family Product (xs :: '[Nat]) :: Nat where
+  Product '[] = 1
+  Product (x ': xs) = x * Product xs
+
 type family BackwardsImpl (last :: Nat) (n :: Nat) :: Nat where
   BackwardsImpl last n = last - n
 

--- a/hasktorch/src/Torch/Typed/Aux.hs
+++ b/hasktorch/src/Torch/Typed/Aux.hs
@@ -9,6 +9,7 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE NoStarIsType #-}
 
 module Torch.Typed.Aux where
 
@@ -98,7 +99,7 @@ type family LastDim (l :: [a]) :: Nat where
   LastDim (_ ': '[]) = 0
   LastDim (_ ': t) = 1 + LastDim t
 
-type family Product (xs :: '[Nat]) :: Nat where
+type family Product (xs :: [Nat]) :: Nat where
   Product '[] = 1
   Product (x ': xs) = x * Product xs
 

--- a/hasktorch/src/Torch/Typed/Aux.hs
+++ b/hasktorch/src/Torch/Typed/Aux.hs
@@ -9,7 +9,6 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE NoStarIsType #-}
 
 module Torch.Typed.Aux where
 
@@ -101,7 +100,7 @@ type family LastDim (l :: [a]) :: Nat where
 
 type family Product (xs :: [Nat]) :: Nat where
   Product '[] = 1
-  Product (x ': xs) = x * Product xs
+  Product (x ': xs) = x GHC.TypeLits.* Product xs
 
 type family BackwardsImpl (last :: Nat) (n :: Nat) :: Nat where
   BackwardsImpl last n = last - n

--- a/hasktorch/src/Torch/Typed/Functional.hs
+++ b/hasktorch/src/Torch/Typed/Functional.hs
@@ -28,7 +28,6 @@ import Data.Kind
 import Data.Maybe
 import Data.Proxy
 import Data.Reflection
-import Data.Singletons.Prelude.List (Product)
 import Foreign.ForeignPtr
 import GHC.Generics (Generic)
 import GHC.Natural (Natural)


### PR DESCRIPTION
The 3.0 release of `singletons` split up into 3 packages so `Data.Singletons.Prelude` is now in `singletons-base`. I think this is the relevant [PR](https://github.com/goldfirere/singletons/pull/463).

This PR ~adds an upper bound to the hasktorch cabal file to fix for now~ removes the dependence on singletons, instead defining `Product` in `Torch.Typed.Aux`.