### PR TITLE
Added named tensor

### DIFF
--- a/hasktorch/hasktorch.cabal
+++ b/hasktorch/hasktorch.cabal
@@ -191,6 +191,7 @@ test-suite spec
                     , pipes
                     , random
                     , vector-sized
+                    , lens-family-core
 
   build-tool-depends:  hspec-discover:hspec-discover
 

--- a/hasktorch/hasktorch.cabal
+++ b/hasktorch/hasktorch.cabal
@@ -77,6 +77,7 @@ library
                     , Torch.Typed.Optim.CppOptim
                     , Torch.Typed.Serialize
                     , Torch.Typed.Vision
+                    , Torch.Typed.Lens
                     , Torch.Distributions.Constraints
                     , Torch.Distributions.Distribution
                     , Torch.Distributions.Bernoulli

--- a/hasktorch/hasktorch.cabal
+++ b/hasktorch/hasktorch.cabal
@@ -192,6 +192,7 @@ test-suite spec
                     , random
                     , vector-sized
                     , lens-family-core
+                    , data-default-class
 
   build-tool-depends:  hspec-discover:hspec-discover
 

--- a/hasktorch/hasktorch.cabal
+++ b/hasktorch/hasktorch.cabal
@@ -163,6 +163,7 @@ test-suite spec
                     , Torch.Typed.NN.Recurrent.Cell.GRUSpec
                     , Torch.Typed.NN.TransformerSpec
                     , Torch.Typed.VisionSpec
+                    , Torch.Typed.NamedTensorSpec
                     , SerializeSpec
                     , RandomSpec
                     , VisionSpec
@@ -188,6 +189,7 @@ test-suite spec
                     , async
                     , pipes
                     , random
+                    , vector-sized
 
   build-tool-depends:  hspec-discover:hspec-discover
 

--- a/hasktorch/src/Torch/Tensor.hs
+++ b/hasktorch/src/Torch/Tensor.hs
@@ -53,7 +53,7 @@ type ATenTensor = ForeignPtr ATen.Tensor
 -- do not use the constructor
 newtype Tensor = Unsafe ATenTensor
 
-instance {-# OVERLAPS #-} Castable Tensor ATenTensor where
+instance Castable Tensor ATenTensor where
   cast (Unsafe aten_tensor) f = f aten_tensor
   uncast aten_tensor f = f $ Unsafe aten_tensor
 

--- a/hasktorch/src/Torch/Tensor.hs
+++ b/hasktorch/src/Torch/Tensor.hs
@@ -53,7 +53,7 @@ type ATenTensor = ForeignPtr ATen.Tensor
 -- do not use the constructor
 newtype Tensor = Unsafe ATenTensor
 
-instance Castable Tensor ATenTensor where
+instance {-# OVERLAPS #-} Castable Tensor ATenTensor where
   cast (Unsafe aten_tensor) f = f aten_tensor
   uncast aten_tensor f = f $ Unsafe aten_tensor
 

--- a/hasktorch/src/Torch/Typed/Factories.hs
+++ b/hasktorch/src/Torch/Typed/Factories.hs
@@ -36,6 +36,18 @@ import Torch.Typed.Aux
 import Torch.Typed.Tensor
 import Prelude hiding (sin)
 
+instance Semigroup (Tensor device dtype shape) where
+  (<>) a b = UnsafeMkTensor $ D.add (toDynamic a) (toDynamic b)
+
+instance (TensorOptions shape dtype device) => Monoid (Tensor device dtype shape) where
+  mempty = zeros
+
+instance Semigroup (NamedTensor device dtype shape) where
+  (<>) a b = fromUnnamed . UnsafeMkTensor $ D.add (toDynamic a) (toDynamic b)
+
+instance (TensorOptions shape' dtype device, shape' ~ ToNats shape) => Monoid (NamedTensor device dtype shape) where
+  mempty = fromUnnamed zeros
+
 zeros ::
   forall shape dtype device.
   (TensorOptions shape dtype device) =>

--- a/hasktorch/src/Torch/Typed/Factories.hs
+++ b/hasktorch/src/Torch/Typed/Factories.hs
@@ -35,18 +35,13 @@ import qualified Torch.TensorOptions as D
 import Torch.Typed.Aux
 import Torch.Typed.Tensor
 import Prelude hiding (sin)
+import Data.Default.Class
 
-instance Semigroup (Tensor device dtype shape) where
-  (<>) a b = UnsafeMkTensor $ D.add (toDynamic a) (toDynamic b)
+instance (TensorOptions shape dtype device) => Default (Tensor device dtype shape) where
+  def = zeros
 
-instance (TensorOptions shape dtype device) => Monoid (Tensor device dtype shape) where
-  mempty = zeros
-
-instance Semigroup (NamedTensor device dtype shape) where
-  (<>) a b = fromUnnamed . UnsafeMkTensor $ D.add (toDynamic a) (toDynamic b)
-
-instance (TensorOptions shape' dtype device, shape' ~ ToNats shape) => Monoid (NamedTensor device dtype shape) where
-  mempty = fromUnnamed zeros
+instance (TensorOptions shape' dtype device, shape' ~ ToNats shape) => Default (NamedTensor device dtype shape) where
+  def = fromUnnamed zeros
 
 zeros ::
   forall shape dtype device.

--- a/hasktorch/src/Torch/Typed/Functional.hs
+++ b/hasktorch/src/Torch/Typed/Functional.hs
@@ -654,13 +654,15 @@ pow exponent input = unsafePerformIO $ ATen.cast2 ATen.Managed.pow_tt input expo
 -- >>> dtype &&& shape $ relu (ones :: CPUTensor 'D.Float '[3,2])
 -- (Float,[3,2])
 relu ::
-  forall shape dtype device.
-  (StandardFloatingPointDTypeValidation device dtype) =>
+  forall shape dtype device t.
+  (StandardFloatingPointDTypeValidation device dtype,
+   Unnamed t, device ~ (UTDevice t), dtype ~ (UTDType t), shape ~ (UTShape t)
+  ) =>
   -- | input
-  Tensor device dtype shape ->
+  t ->
   -- | output
-  Tensor device dtype shape
-relu input = unsafePerformIO $ ATen.cast1 ATen.Managed.relu_t input
+  t
+relu input = unWrap $ unsafePerformIO $ ATen.cast1 ATen.Managed.relu_t (Wrap input)
 
 -- | selu
 --
@@ -708,49 +710,57 @@ sigmoid input = unsafePerformIO $ ATen.cast1 ATen.Managed.sigmoid_t input
 -- >>> dtype &&& shape $ sin (ones :: CPUTensor 'D.Float '[3,2])
 -- (Float,[3,2])
 sin ::
-  forall shape dtype device.
-  (StandardFloatingPointDTypeValidation device dtype) =>
+  forall shape dtype device t.
+  (StandardFloatingPointDTypeValidation device dtype,
+   Unnamed t, device ~ (UTDevice t), dtype ~ (UTDType t), shape ~ (UTShape t)
+  ) =>
   -- | input
-  Tensor device dtype shape ->
+  t ->
   -- | output
-  Tensor device dtype shape
-sin input = unsafePerformIO $ ATen.cast1 ATen.Managed.sin_t input
+  t
+sin input = unWrap $ unsafePerformIO $ ATen.cast1 ATen.Managed.sin_t (Wrap input)
 
 -- | sinh
 --
 -- >>> dtype &&& shape $ sinh (ones :: CPUTensor 'D.Float '[3,2])
 -- (Float,[3,2])
 sinh ::
-  forall shape dtype device.
-  (StandardFloatingPointDTypeValidation device dtype) =>
+  forall shape dtype device t.
+  (StandardFloatingPointDTypeValidation device dtype,
+   Unnamed t, device ~ (UTDevice t), dtype ~ (UTDType t), shape ~ (UTShape t)
+  ) =>
   -- | input
-  Tensor device dtype shape ->
+  t ->
   -- | output
-  Tensor device dtype shape
-sinh input = unsafePerformIO $ ATen.cast1 ATen.Managed.sinh_t input
+  t
+sinh input = unWrap $ unsafePerformIO $ ATen.cast1 ATen.Managed.sinh_t (Wrap input)
 
 -- | cos
 --
 -- >>> dtype &&& shape $ cos (ones :: CPUTensor 'D.Float '[3,2])
 -- (Float,[3,2])
 cos ::
-  forall shape dtype device.
-  (StandardFloatingPointDTypeValidation device dtype) =>
+  forall shape dtype device t.
+  (StandardFloatingPointDTypeValidation device dtype,
+   Unnamed t, device ~ (UTDevice t), dtype ~ (UTDType t), shape ~ (UTShape t)
+  ) =>
   -- | input
-  Tensor device dtype shape ->
+  t ->
   -- | output
-  Tensor device dtype shape
-cos input = unsafePerformIO $ ATen.cast1 ATen.Managed.cos_t input
+  t
+cos input = unWrap $ unsafePerformIO $ ATen.cast1 ATen.Managed.cos_t (Wrap input)
 
 -- | sqrt
 sqrt ::
-  forall shape dtype device.
-  (StandardFloatingPointDTypeValidation device dtype) =>
+  forall shape dtype device t.
+  (StandardFloatingPointDTypeValidation device dtype,
+   Unnamed t, device ~ (UTDevice t), dtype ~ (UTDType t), shape ~ (UTShape t)
+  ) =>
   -- | input
-  Tensor device dtype shape ->
+  t ->
   -- | output
-  Tensor device dtype shape
-sqrt input = unsafePerformIO $ ATen.cast1 ATen.Managed.sqrt_t input
+  t
+sqrt input = unWrap $ unsafePerformIO $ ATen.cast1 ATen.Managed.sqrt_t (Wrap input)
 
 -- | tanh
 tanh ::

--- a/hasktorch/src/Torch/Typed/Functional.hs
+++ b/hasktorch/src/Torch/Typed/Functional.hs
@@ -656,8 +656,7 @@ pow exponent input = unsafePerformIO $ ATen.cast2 ATen.Managed.pow_tt input expo
 relu ::
   forall shape dtype device t.
   (StandardFloatingPointDTypeValidation device dtype,
-   Unnamed t, device ~ (UTDevice t), dtype ~ (UTDType t), shape ~ (UTShape t)
-  ) =>
+   IsUnnamed t device dtype shape) =>
   -- | input
   t ->
   -- | output
@@ -712,8 +711,7 @@ sigmoid input = unsafePerformIO $ ATen.cast1 ATen.Managed.sigmoid_t input
 sin ::
   forall shape dtype device t.
   (StandardFloatingPointDTypeValidation device dtype,
-   Unnamed t, device ~ (UTDevice t), dtype ~ (UTDType t), shape ~ (UTShape t)
-  ) =>
+   IsUnnamed t device dtype shape) =>
   -- | input
   t ->
   -- | output
@@ -727,8 +725,7 @@ sin input = unWrap $ unsafePerformIO $ ATen.cast1 ATen.Managed.sin_t (Wrap input
 sinh ::
   forall shape dtype device t.
   (StandardFloatingPointDTypeValidation device dtype,
-   Unnamed t, device ~ (UTDevice t), dtype ~ (UTDType t), shape ~ (UTShape t)
-  ) =>
+   IsUnnamed t device dtype shape) =>
   -- | input
   t ->
   -- | output
@@ -742,8 +739,7 @@ sinh input = unWrap $ unsafePerformIO $ ATen.cast1 ATen.Managed.sinh_t (Wrap inp
 cos ::
   forall shape dtype device t.
   (StandardFloatingPointDTypeValidation device dtype,
-   Unnamed t, device ~ (UTDevice t), dtype ~ (UTDType t), shape ~ (UTShape t)
-  ) =>
+   IsUnnamed t device dtype shape) =>
   -- | input
   t ->
   -- | output
@@ -754,8 +750,7 @@ cos input = unWrap $ unsafePerformIO $ ATen.cast1 ATen.Managed.cos_t (Wrap input
 sqrt ::
   forall shape dtype device t.
   (StandardFloatingPointDTypeValidation device dtype,
-   Unnamed t, device ~ (UTDevice t), dtype ~ (UTDType t), shape ~ (UTShape t)
-  ) =>
+   IsUnnamed t device dtype shape) =>
   -- | input
   t ->
   -- | output

--- a/hasktorch/src/Torch/Typed/Lens.hs
+++ b/hasktorch/src/Torch/Typed/Lens.hs
@@ -1,0 +1,124 @@
+{-#LANGUAGE RankNTypes#-}
+{-#LANGUAGE TypeFamilies #-}
+{-#LANGUAGE TypeApplications#-}
+{-#LANGUAGE TypeOperators#-}
+{-#LANGUAGE DefaultSignatures#-}
+{-#LANGUAGE KindSignatures#-}
+{-#LANGUAGE FlexibleContexts#-}
+{-#LANGUAGE DeriveGeneric#-}
+{-#LANGUAGE DataKinds#-}
+{-#LANGUAGE MultiParamTypeClasses#-}
+{-#LANGUAGE AllowAmbiguousTypes#-}
+{-#LANGUAGE FlexibleInstances#-}
+{-#LANGUAGE ScopedTypeVariables#-}
+{-#LANGUAGE UndecidableInstances#-}
+{-#LANGUAGE FunctionalDependencies#-}
+
+module Torch.Typed.Lens where
+
+import Data.Kind
+import GHC.Generics
+import GHC.TypeLits
+import Control.Monad.State.Strict
+import Data.Maybe (fromJust)
+import Data.Proxy
+import Data.Type.Bool
+import qualified Torch.Tensor as T
+import qualified Torch.DType as D
+import qualified Torch.Device as D
+import qualified Torch.Functional as D hiding (select)
+import Torch.Typed.Tensor
+import Data.Reflection hiding (D)
+import qualified Torch.Internal.Managed.Type.TensorIndex as ATen
+import System.IO.Unsafe
+
+-- | Type alias for lens
+type Lens' s a
+  = Lens s s a a
+
+type Lens s t a b
+  = forall f. Functor f => (a -> f b) -> s -> f t
+
+class HasField (field :: Symbol) shape where
+  field :: FieldIdx field shape => Lens' (NamedTensor device dtype shape) (NamedTensor device dtype (DropField field shape))
+  field func s = fmap func' (func a')
+    where
+      index = fieldIdx @field @shape Proxy
+      func' :: NamedTensor device dtype (DropField field shape) -> NamedTensor device dtype shape
+      func' v = fromUnnamed . UnsafeMkTensor $ T.maskedFill s' index (toDynamic v)
+      s' = toDynamic s
+      a' :: NamedTensor device dtype (DropField field shape)
+      a' = fromUnnamed . UnsafeMkTensor $ (s' T.! index)
+
+type family GHasField (field :: Symbol) f :: Bool where
+  GHasField field (S1 ( 'MetaSel ( 'Just field) _ _ _) _) = 'True
+  GHasField field (S1 ( 'MetaSel _ _ _ _) _) = 'False
+  GHasField field (D1 _ f ) = GHasField field f
+  GHasField field (C1 _ f ) = GHasField field f
+  GHasField field (l :*: r) = GHasField field l || GHasField field r
+  GHasField field (l :+: r) = GHasField field l || GHasField field r
+  GHasField field (K1 _ _) = 'False
+  GHasField field U1 = 'False
+
+type family DropField (field :: Symbol) (a :: [Type->Type]) :: [Type->Type] where
+  DropField field '[] = '[]
+  DropField field (x ': xs) = If (GHasField field (Rep (x ()))) xs (DropField field xs)
+
+instance {-# OVERLAPS #-} T.TensorIndex [Maybe Int] where
+  pushIndex vec list_of_maybe_int = unsafePerformIO $ do
+    idx <- forM list_of_maybe_int $ \i -> do
+      case i of
+        Nothing -> T.RawTensorIndex <$> ATen.newTensorIndexWithSlice 0 maxBound 1
+        Just v -> T.RawTensorIndex <$> ATen.newTensorIndexWithInt (fromIntegral v)
+    return $ idx ++ vec
+
+class FieldIdx (field::Symbol) (a :: [Type->Type]) where
+  -- | Return field-id
+  fieldIdx :: Proxy a -> [Maybe Int]
+
+instance FieldIdx field '[] where
+  fieldIdx _ = []
+
+instance (FieldId field (x ()), FieldIdx field xs) => FieldIdx field (x ': xs) where
+  fieldIdx _ = fieldId @field @(x ()) Proxy : fieldIdx @field @xs Proxy
+
+class FieldId (field::Symbol) a where
+  -- | Return field-id
+  fieldId :: Proxy a -> Maybe Int
+  default fieldId :: (Generic a, GFieldId field (Rep a)) => Proxy a -> Maybe Int
+  fieldId _ = fst $ runState (gfieldId @field @(Rep a) (from (undefined :: a))) 0
+
+class GFieldId (field::Symbol) a where
+  gfieldId :: a b -> State Int (Maybe Int)
+
+instance GFieldId field V1 where
+  gfieldId _ = return Nothing
+
+instance GFieldId field U1 where
+  gfieldId _ = return Nothing
+
+instance (KnownSymbol field, KnownSymbol field_) => GFieldId field (S1 ('MetaSel ('Just field_) p f b) (Rec0 a)) where
+  gfieldId _ = do
+    i <- get
+    put (i+1)
+    if (symbolVal (Proxy :: Proxy field) == symbolVal (Proxy :: Proxy field_)) 
+      then return (Just i)
+      else return Nothing
+
+instance GFieldId field f => GFieldId field (M1 D c f) where
+  gfieldId (M1 x) = gfieldId @field x
+
+instance GFieldId field f => GFieldId field (M1 C c f) where
+  gfieldId (M1 x) = gfieldId @field x
+
+instance (GFieldId field a, GFieldId field b) => GFieldId field (a :+: b) where
+  gfieldId (L1 x) = gfieldId @field x
+  gfieldId (R1 x) = gfieldId @field x
+
+instance (GFieldId field a, GFieldId field b) => GFieldId field (a :*: b) where
+  gfieldId (a :*: b) = do
+    v <- gfieldId @field a
+    case v of
+      Just v' -> return v
+      Nothing -> gfieldId @field b
+

--- a/hasktorch/src/Torch/Typed/Lens.hs
+++ b/hasktorch/src/Torch/Typed/Lens.hs
@@ -39,8 +39,8 @@ type Lens' s a
 type Lens s t a b
   = forall f. Functor f => (a -> f b) -> s -> f t
 
-class HasField (field :: Symbol) shape where
-  field :: FieldIdx field shape => Lens' (NamedTensor device dtype shape) (NamedTensor device dtype (DropField field shape))
+class FieldIdx field shape => HasField (field :: Symbol) shape where
+  field :: Lens' (NamedTensor device dtype shape) (NamedTensor device dtype (DropField field shape))
   field func s = fmap func' (func a')
     where
       index = fieldIdx @field @shape Proxy

--- a/hasktorch/src/Torch/Typed/Lens.hs
+++ b/hasktorch/src/Torch/Typed/Lens.hs
@@ -132,4 +132,3 @@ instance (GFieldId field a, GFieldId field b) => GFieldId field (a :*: b) where
     case v of
       Just v' -> return v
       Nothing -> gfieldId @field b
-

--- a/hasktorch/src/Torch/Typed/Lens.hs
+++ b/hasktorch/src/Torch/Typed/Lens.hs
@@ -1,44 +1,44 @@
-{-#LANGUAGE RankNTypes#-}
-{-#LANGUAGE TypeFamilies #-}
-{-#LANGUAGE TypeApplications#-}
-{-#LANGUAGE TypeOperators#-}
-{-#LANGUAGE DefaultSignatures#-}
-{-#LANGUAGE KindSignatures#-}
-{-#LANGUAGE FlexibleContexts#-}
-{-#LANGUAGE DeriveGeneric#-}
-{-#LANGUAGE DataKinds#-}
-{-#LANGUAGE MultiParamTypeClasses#-}
-{-#LANGUAGE AllowAmbiguousTypes#-}
-{-#LANGUAGE FlexibleInstances#-}
-{-#LANGUAGE ScopedTypeVariables#-}
-{-#LANGUAGE UndecidableInstances#-}
-{-#LANGUAGE FunctionalDependencies#-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Torch.Typed.Lens where
 
-import Data.Kind
-import GHC.Generics
-import GHC.TypeLits
 import Control.Monad.State.Strict
+import Data.Kind
 import Data.Maybe (fromJust)
 import Data.Proxy
+import Data.Reflection hiding (D)
 import Data.Type.Bool
-import qualified Torch.Tensor as T
+import Data.Vector.Sized (Vector)
+import GHC.Generics
+import GHC.TypeLits
+import System.IO.Unsafe
 import qualified Torch.DType as D
 import qualified Torch.Device as D
 import qualified Torch.Functional as D hiding (select)
-import Torch.Typed.Tensor
-import Data.Reflection hiding (D)
 import qualified Torch.Internal.Managed.Type.TensorIndex as ATen
-import System.IO.Unsafe
-import Data.Vector.Sized (Vector)
+import qualified Torch.Tensor as T
+import Torch.Typed.Tensor
 
 -- | Type alias for lens
-type Lens' s a
-  = Lens s s a a
+type Lens' s a =
+  Lens s s a a
 
-type Lens s t a b
-  = forall f. Functor f => (a -> f b) -> s -> f t
+type Lens s t a b =
+  forall f. Functor f => (a -> f b) -> s -> f t
 
 class HasField (field :: Symbol) shape where
   field :: Lens' (NamedTensor device dtype shape) (NamedTensor device dtype (DropField field shape))
@@ -57,8 +57,8 @@ instance {-# OVERLAPS #-} FieldIdx field shape => HasField field shape
 type family GHasField (field :: Symbol) f :: Bool where
   GHasField field (S1 ( 'MetaSel ( 'Just field) _ _ _) _) = 'True
   GHasField field (S1 ( 'MetaSel _ _ _ _) _) = 'False
-  GHasField field (D1 _ f ) = GHasField field f
-  GHasField field (C1 _ f ) = GHasField field f
+  GHasField field (D1 _ f) = GHasField field f
+  GHasField field (C1 _ f) = GHasField field f
   GHasField field (l :*: r) = GHasField field l || GHasField field r
   GHasField field (l :+: r) = GHasField field l || GHasField field r
   GHasField field (K1 _ _) = 'False
@@ -66,7 +66,7 @@ type family GHasField (field :: Symbol) f :: Bool where
   GHasField field (Vector n) = 'False
   GHasField field a = GHasField field (Rep (a ()))
 
-type family DropField (field :: Symbol) (a :: [Type->Type]) :: [Type->Type] where
+type family DropField (field :: Symbol) (a :: [Type -> Type]) :: [Type -> Type] where
   DropField field '[] = '[]
   DropField field (x ': xs) = If (GHasField field x) xs (x ': DropField field xs)
 
@@ -78,7 +78,7 @@ instance {-# OVERLAPS #-} T.TensorIndex [Maybe Int] where
         Just v -> T.RawTensorIndex <$> ATen.newTensorIndexWithInt (fromIntegral v)
     return $ idx ++ vec
 
-class FieldIdx (field::Symbol) (a :: [Type->Type]) where
+class FieldIdx (field :: Symbol) (a :: [Type -> Type]) where
   -- | Return field-id
   fieldIdx :: Proxy a -> [Maybe Int]
 
@@ -88,7 +88,7 @@ instance FieldIdx field '[] where
 instance (FieldId field (x ()), FieldIdx field xs) => FieldIdx field (x ': xs) where
   fieldIdx _ = fieldId @field @(x ()) Proxy : fieldIdx @field @xs Proxy
 
-class FieldId (field::Symbol) a where
+class FieldId (field :: Symbol) a where
   -- | Return field-id
   fieldId :: Proxy a -> Maybe Int
   default fieldId :: (Generic a, GFieldId field (Rep a)) => Proxy a -> Maybe Int
@@ -99,22 +99,22 @@ instance FieldId field (Vector n v) where
 
 instance {-# OVERLAPS #-} (Generic s, GFieldId field (Rep s)) => FieldId field s
 
-class GFieldId (field::Symbol) (a :: Type -> Type) where
+class GFieldId (field :: Symbol) (a :: Type -> Type) where
   gfieldId :: Proxy a -> Maybe Int
-  gfieldId p =  fst $ gfieldId' @field @a p
+  gfieldId p = fst $ gfieldId' @field @a p
   gfieldId' :: Proxy a -> (Maybe Int, Int)
 
 instance (GFieldId field f) => GFieldId field (M1 D t f) where
-  gfieldId' _ = gfieldId' @field (Proxy :: Proxy f) 
+  gfieldId' _ = gfieldId' @field (Proxy :: Proxy f)
 
 instance (GFieldId field f) => GFieldId field (M1 C t f) where
-  gfieldId' _ = gfieldId' @field (Proxy :: Proxy f) 
+  gfieldId' _ = gfieldId' @field (Proxy :: Proxy f)
 
-instance (KnownSymbol field, KnownSymbol field_) => GFieldId field (S1 ('MetaSel ('Just field_) p f b) (Rec0 a)) where
+instance (KnownSymbol field, KnownSymbol field_) => GFieldId field (S1 ( 'MetaSel ( 'Just field_) p f b) (Rec0 a)) where
   gfieldId' _ =
-    if symbolVal (Proxy :: Proxy field) == symbolVal (Proxy :: Proxy field_) 
-    then (Just 0,1)
-    else (Nothing,1)
+    if symbolVal (Proxy :: Proxy field) == symbolVal (Proxy :: Proxy field_)
+      then (Just 0, 1)
+      else (Nothing, 1)
 
 instance GFieldId field (K1 c f) where
   gfieldId' _ = (Nothing, 1)
@@ -125,13 +125,12 @@ instance GFieldId field U1 where
 instance (GFieldId field f, GFieldId field g) => GFieldId field (f :*: g) where
   gfieldId' _ =
     case (gfieldId' @field (Proxy :: Proxy f), gfieldId' @field (Proxy :: Proxy g)) of
-      ((Nothing, t0), (Nothing, t1)) -> (Nothing, t0+t1)
-      ((Nothing, t0), (Just v1, t1)) -> (Just (v1+t0), t1+t0)
+      ((Nothing, t0), (Nothing, t1)) -> (Nothing, t0 + t1)
+      ((Nothing, t0), (Just v1, t1)) -> (Just (v1 + t0), t1 + t0)
       ((Just v0, t0), (_, t1)) -> (Just v0, t0 + t1)
 
 instance (GFieldId field f, GFieldId field g) => GFieldId field (f :+: g) where
   gfieldId' _ =
     case (gfieldId' @field (Proxy :: Proxy f), gfieldId' @field (Proxy :: Proxy g)) of
-      ((Nothing, _) , a1) -> a1
-      (a0@(Just _, _) , _) -> a0
-
+      ((Nothing, _), a1) -> a1
+      (a0@(Just _, _), _) -> a0

--- a/hasktorch/src/Torch/Typed/Tensor.hs
+++ b/hasktorch/src/Torch/Typed/Tensor.hs
@@ -1,3 +1,4 @@
+
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
@@ -682,21 +683,21 @@ instance Unnamed (NamedTensor device dtype shape) where
   toDynamic (FromTensor (UnsafeMkTensor t)) = t
 
 instance (KnownDevice device) => Num (NamedTensor device dtype shape) where
-  (+) a b = fromUnnamed $ UnsafeMkTensor $ toDynamic a + toDynamic b
-  (-) a b = fromUnnamed $ UnsafeMkTensor $ toDynamic a - toDynamic b
-  (*) a b = fromUnnamed $ UnsafeMkTensor $ toDynamic a * toDynamic b
-  negate t = fromUnnamed $ UnsafeMkTensor $ negate $ toDynamic t
-  abs t = fromUnnamed $ UnsafeMkTensor $ abs $ toDynamic t
-  signum t = fromUnnamed $ UnsafeMkTensor $ signum $ toDynamic t
-  fromInteger i = fromUnnamed $ UnsafeMkTensor . D.toDevice (deviceVal @device) . D.asTensor @Int $ fromInteger @Int i
+  (+) a b = fromUnnamed $ toUnnamed a + toUnnamed b
+  (-) a b = fromUnnamed $ toUnnamed a - toUnnamed b
+  (*) a b = fromUnnamed $ toUnnamed a * toUnnamed b
+  negate = fromUnnamed . negate . toUnnamed
+  abs = fromUnnamed . abs . toUnnamed
+  signum = fromUnnamed . signum . toUnnamed
+  fromInteger = fromUnnamed . fromInteger
 
 instance KnownDevice device => Fractional (NamedTensor device dtype shape) where
-  a / b = fromUnnamed $ UnsafeMkTensor $ toDynamic a / toDynamic b
-  recip t = fromUnnamed $ UnsafeMkTensor $ recip $ toDynamic t
-  fromRational i = fromUnnamed $ UnsafeMkTensor . D.toDevice (deviceVal @device) . D.asTensor @Float $ fromRational @Float i
+  a / b = fromUnnamed $ toUnnamed a / toUnnamed b
+  recip = fromUnnamed . recip . toUnnamed
+  fromRational = fromUnnamed . fromRational
 
 instance Show (NamedTensor device dtype shape) where
-  show (FromTensor (UnsafeMkTensor dynamic)) = show dynamic
+  show = show . toUnnamed
 
 type family ReplaceDevice'' (tensor :: t) (device :: (D.DeviceType, Nat)) :: t where
   ReplaceDevice'' (Tensor device0 dtype shape) device1 = Tensor device1 dtype shape

--- a/hasktorch/test/Torch/Typed/NamedTensorSpec.hs
+++ b/hasktorch/test/Torch/Typed/NamedTensorSpec.hs
@@ -45,15 +45,13 @@ data RGB a = RGB {
   b :: a
 } deriving (Show, Eq, Generic)
 
-type instance ToNat RGB = 3
-
 data YCoCg a = YCoCg {
   y :: a,
   co :: a,
   cg :: a
 } deriving (Show, Eq, Generic)
 
-type instance ToNat YCoCg = 3
+data RGBA a = RGBA a a a a deriving (Show, Eq, Generic)
 
 testFieldLens :: HasField "r" shape => Lens' (NamedTensor '(D.CPU,0) 'D.Float shape) (NamedTensor '(D.CPU,0) 'D.Float (DropField "r" shape))
 testFieldLens = field @"r"
@@ -66,6 +64,15 @@ testDropField = id
 
 testDropField2 :: Proxy (DropField "y" '[Vector 2,YCoCg]) -> Proxy '[Vector 2]
 testDropField2 = id
+
+testCountField :: Proxy (ToNat YCoCg) -> Proxy 3
+testCountField = id
+
+testCountField2 :: Proxy (ToNat (Vector n)) -> Proxy n
+testCountField2 = id
+
+testCountField3 :: Proxy (ToNat RGBA) -> Proxy 4
+testCountField3 = id
 
 toYCoCG :: (KnownNat n, KnownDType dtype, KnownDevice device) => NamedTensor device dtype [Vector n, RGB] -> NamedTensor device dtype [Vector n, YCoCg]
 toYCoCG rgb =

--- a/hasktorch/test/Torch/Typed/NamedTensorSpec.hs
+++ b/hasktorch/test/Torch/Typed/NamedTensorSpec.hs
@@ -111,7 +111,7 @@ spec = do
       checkDynamicTensorAttributes' t2
     it "check a shape of lens" $ do
       let t :: NamedTensor '(D.CPU,0) 'D.Float '[Vector 2,Vector 3,Vector 4,RGB]
-          t = mempty
+          t = def
           t2 :: NamedTensor '(D.CPU,0) 'D.Float '[Vector 2,Vector 3,Vector 4]
           t2 = t ^. field @"r"
       print $ shape t2

--- a/hasktorch/test/Torch/Typed/NamedTensorSpec.hs
+++ b/hasktorch/test/Torch/Typed/NamedTensorSpec.hs
@@ -108,3 +108,17 @@ spec = do
           t2 = fromUnnamed t
       print t2
       checkDynamicTensorAttributes' t2
+    it "check a shape of lens" $ do
+      let t :: NamedTensor '(D.CPU,0) 'D.Float '[Vector 2,Vector 3,Vector 4,RGB]
+          t = mempty
+          t2 :: NamedTensor '(D.CPU,0) 'D.Float '[Vector 2,Vector 3,Vector 4]
+          t2 = t ^. field @"r"
+      print $ shape t2
+      checkDynamicTensorAttributes' t
+      checkDynamicTensorAttributes' t2
+    it "check fieldids" $ do
+      let v = RGB () () ()
+      fieldId @"r" (Proxy :: Proxy (RGB ())) `shouldBe` Just 0
+      fieldId @"g" (Proxy :: Proxy (RGB ())) `shouldBe` Just 1
+      fieldId @"b" (Proxy :: Proxy (RGB ())) `shouldBe` Just 2
+      fieldId @"y" (Proxy :: Proxy (RGB ())) `shouldBe` Nothing

--- a/hasktorch/test/Torch/Typed/NamedTensorSpec.hs
+++ b/hasktorch/test/Torch/Typed/NamedTensorSpec.hs
@@ -38,6 +38,7 @@ import Torch.Typed.Lens
 import Lens.Family
 import GHC.Generics
 import Data.Proxy
+import Data.Default.Class
 
 data RGB a = RGB {
   r :: a,
@@ -79,7 +80,7 @@ toYCoCG rgb =
   set (field @"y")  ((r + g * 2+ b)/4) $
   set (field @"co")  ((r - b)/2)  $
   set (field @"cg")  ((-r + g * 2 - b)/4)  $
-  mempty
+  def
   where
     r = rgb ^. field @"r"
     g = rgb ^. field @"g"

--- a/hasktorch/test/Torch/Typed/NamedTensorSpec.hs
+++ b/hasktorch/test/Torch/Typed/NamedTensorSpec.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
+{-# LANGUAGE NoStarIsType #-}
+
+module Torch.Typed.NamedTensorSpec (spec) where
+
+import Data.Kind
+import Test.Hspec
+import GHC.Exts
+import qualified Torch.Device as D
+import qualified Torch.Tensor as D
+import qualified Torch.DType as D
+import qualified Torch.Functional as F
+import Torch.Typed.Tensor
+import Torch.Typed.Factories
+import Data.Vector.Sized (Vector)
+import qualified Data.Vector.Sized as V
+
+data RGB a = RGB {
+  r :: a,
+  g :: a,
+  b :: a
+} deriving (Show, Eq)
+
+type instance ToNat RGB = 3
+
+checkDynamicTensorAttributes' ::
+  forall device dtype shape t.
+  ( Unnamed t, device ~ (UTDevice t), dtype ~ (UTDType t), shape ~ (UTShape t)
+  , TensorOptions shape dtype device) =>
+  t ->
+  IO ()
+checkDynamicTensorAttributes' t = do
+  D.device untyped `shouldBe` optionsRuntimeDevice @shape @dtype @device
+  D.dtype untyped `shouldBe` optionsRuntimeDType @shape @dtype @device
+  D.shape untyped `shouldBe` optionsRuntimeShape @shape @dtype @device
+  where
+    untyped = toDynamic t
+
+spec :: Spec
+spec = do
+  describe "NamedTensor" $ do
+    it "create" $ do
+      let t :: Tensor '(D.CPU,0) 'D.Float '[2,3]
+          t = ones
+          t2 :: NamedTensor '(D.CPU,0) 'D.Float '[Vector 2,RGB]
+          t2 = fromUnnamed t
+      print t2
+      checkDynamicTensorAttributes' t2

--- a/hasktorch/test/Torch/Typed/NamedTensorSpec.hs
+++ b/hasktorch/test/Torch/Typed/NamedTensorSpec.hs
@@ -32,6 +32,7 @@ import Torch.Typed.Tensor
 import Torch.Typed.Factories
 import Data.Vector.Sized (Vector)
 import qualified Data.Vector.Sized as V
+import Torch.Typed.Lens
 
 data RGB a = RGB {
   r :: a,
@@ -40,6 +41,9 @@ data RGB a = RGB {
 } deriving (Show, Eq)
 
 type instance ToNat RGB = 3
+
+testFieldLens :: HasField "r" shape => Lens' (NamedTensor '(D.CPU,0) 'D.Float shape) (NamedTensor '(D.CPU,0) 'D.Float (DropField "r" shape))
+testFieldLens = field @"r"
 
 checkDynamicTensorAttributes' ::
   forall device dtype shape t.

--- a/hasktorch/test/Torch/Typed/NamedTensorSpec.hs
+++ b/hasktorch/test/Torch/Typed/NamedTensorSpec.hs
@@ -54,25 +54,28 @@ data YCoCg a = YCoCg {
 
 type instance ToNat YCoCg = 3
 
-
-
 testFieldLens :: HasField "r" shape => Lens' (NamedTensor '(D.CPU,0) 'D.Float shape) (NamedTensor '(D.CPU,0) 'D.Float (DropField "r" shape))
 testFieldLens = field @"r"
+
+testFieldLens2 :: Lens' (NamedTensor '(D.CPU,0) 'D.Float '[Vector n,RGB]) (NamedTensor '(D.CPU,0) 'D.Float '[Vector n])
+testFieldLens2 = field @"r"
 
 testDropField :: Proxy (DropField "r" '[Vector 2,RGB]) -> Proxy '[Vector 2]
 testDropField = id
 
--- toYCoCG :: (KnownDevice device) => NamedTensor device dtype [Vector n, RGB] -> NamedTensor device dtype [Vector n, YCoCg]
--- toYCoCG rgb =
---   set (field @"y")  ((r + g * 2+ b)/4) $
---   set (field @"co")  ((r - b)/2)  $
---   set (field @"cg")  ((-r + g * 2 - b)/4)  $
---   undefined
---   --mempty
---   where
---     r = rgb ^. field @"r"
---     g = rgb ^. field @"g"
---     b = rgb ^. field @"b" 
+testDropField2 :: Proxy (DropField "y" '[Vector 2,YCoCg]) -> Proxy '[Vector 2]
+testDropField2 = id
+
+toYCoCG :: (KnownDevice device) => NamedTensor device dtype [Vector n, RGB] -> NamedTensor device dtype [Vector n, YCoCg]
+toYCoCG rgb =
+  set (field @"y")  ((r + g * 2+ b)/4) $
+  set (field @"co")  ((r - b)/2)  $
+  set (field @"cg")  ((-r + g * 2 - b)/4)  $
+  mempty
+  where
+    r = rgb ^. field @"r"
+    g = rgb ^. field @"g"
+    b = rgb ^. field @"b" 
 
 checkDynamicTensorAttributes' ::
   forall device dtype shape t.

--- a/hasktorch/test/Torch/Typed/NamedTensorSpec.hs
+++ b/hasktorch/test/Torch/Typed/NamedTensorSpec.hs
@@ -18,6 +18,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE UndecidableSuperClasses #-}
 {-# LANGUAGE NoStarIsType #-}
+{-# LANGUAGE DeriveGeneric #-}
 
 module Torch.Typed.NamedTensorSpec (spec) where
 
@@ -33,17 +34,45 @@ import Torch.Typed.Factories
 import Data.Vector.Sized (Vector)
 import qualified Data.Vector.Sized as V
 import Torch.Typed.Lens
+import Lens.Family
+import GHC.Generics
+import Data.Proxy
 
 data RGB a = RGB {
   r :: a,
   g :: a,
   b :: a
-} deriving (Show, Eq)
+} deriving (Show, Eq, Generic)
 
 type instance ToNat RGB = 3
 
+data YCoCg a = YCoCg {
+  y :: a,
+  co :: a,
+  cg :: a
+} deriving (Show, Eq, Generic)
+
+type instance ToNat YCoCg = 3
+
+
+
 testFieldLens :: HasField "r" shape => Lens' (NamedTensor '(D.CPU,0) 'D.Float shape) (NamedTensor '(D.CPU,0) 'D.Float (DropField "r" shape))
 testFieldLens = field @"r"
+
+testDropField :: Proxy (DropField "r" '[Vector 2,RGB]) -> Proxy '[Vector 2]
+testDropField = id
+
+-- toYCoCG :: (KnownDevice device) => NamedTensor device dtype [Vector n, RGB] -> NamedTensor device dtype [Vector n, YCoCg]
+-- toYCoCG rgb =
+--   set (field @"y")  ((r + g * 2+ b)/4) $
+--   set (field @"co")  ((r - b)/2)  $
+--   set (field @"cg")  ((-r + g * 2 - b)/4)  $
+--   undefined
+--   --mempty
+--   where
+--     r = rgb ^. field @"r"
+--     g = rgb ^. field @"g"
+--     b = rgb ^. field @"b" 
 
 checkDynamicTensorAttributes' ::
   forall device dtype shape t.

--- a/hasktorch/test/Torch/Typed/NamedTensorSpec.hs
+++ b/hasktorch/test/Torch/Typed/NamedTensorSpec.hs
@@ -23,6 +23,7 @@
 module Torch.Typed.NamedTensorSpec (spec) where
 
 import Data.Kind
+import GHC.TypeLits
 import Test.Hspec
 import GHC.Exts
 import qualified Torch.Device as D
@@ -66,7 +67,7 @@ testDropField = id
 testDropField2 :: Proxy (DropField "y" '[Vector 2,YCoCg]) -> Proxy '[Vector 2]
 testDropField2 = id
 
-toYCoCG :: (KnownDevice device) => NamedTensor device dtype [Vector n, RGB] -> NamedTensor device dtype [Vector n, YCoCg]
+toYCoCG :: (KnownNat n, KnownDType dtype, KnownDevice device) => NamedTensor device dtype [Vector n, RGB] -> NamedTensor device dtype [Vector n, YCoCg]
 toYCoCG rgb =
   set (field @"y")  ((r + g * 2+ b)/4) $
   set (field @"co")  ((r - b)/2)  $


### PR DESCRIPTION
I implemented 3 different tensors to define named-tensor as follows.

- This PR with `Unnamed`-typeclass.
- https://github.com/hasktorch/hasktorch/pull/537
- https://github.com/hasktorch/hasktorch/pull/524

The method other than this PR is a lot of modification of the existing code.
When considering a way to gradually update an existing implementation to a new tensor (Named Tensor), it is better to put a layer that abstracts the `Unnamed Tensor` instead of modifying the definition of `Tensor` directly. 
So I'm making `Unnamed-typeclass` as the layer.
In addition to this, we can use multiple Tensor definitions by using that layer.

I'm thinking broadcast for the namedtensor.