### PR TITLE
Add rename

### DIFF
--- a/libtorch-ffi/src/Torch/Internal/Managed/Type/Tensor/Tensor0.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Type/Tensor/Tensor0.hs
@@ -442,6 +442,12 @@ tensor__fw_primal_l
   -> IO (ForeignPtr Tensor)
 tensor__fw_primal_l = cast2 Unmanaged.tensor__fw_primal_l
 
+tensor_rename_N
+  :: ForeignPtr Tensor
+  -> ForeignPtr DimnameList
+  -> IO (ForeignPtr Tensor)
+tensor_rename_N = cast2 Unmanaged.tensor_rename_N
+
 tensor_align_to_N
   :: ForeignPtr Tensor
   -> ForeignPtr DimnameList
@@ -960,9 +966,4 @@ tensor_cosh
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
 tensor_cosh = cast1 Unmanaged.tensor_cosh
-
-tensor_cosh_
-  :: ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-tensor_cosh_ = cast1 Unmanaged.tensor_cosh_
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Type/Tensor/Tensor1.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Type/Tensor/Tensor1.hs
@@ -24,6 +24,11 @@ import qualified Torch.Internal.Unmanaged.Type.Tensor.Tensor1 as Unmanaged
 
 
 
+tensor_cosh_
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_cosh_ = cast1 Unmanaged.tensor_cosh_
+
 tensor_count_nonzero_l
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
@@ -1028,11 +1033,4 @@ tensor_prelu_t
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
 tensor_prelu_t = cast2 Unmanaged.tensor_prelu_t
-
-tensor_prelu_backward_tt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-tensor_prelu_backward_tt = cast3 Unmanaged.tensor_prelu_backward_tt
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Type/Tensor/Tensor2.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Type/Tensor/Tensor2.hs
@@ -24,6 +24,13 @@ import qualified Torch.Internal.Unmanaged.Type.Tensor.Tensor2 as Unmanaged
 
 
 
+tensor_prelu_backward_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+tensor_prelu_backward_tt = cast3 Unmanaged.tensor_prelu_backward_tt
+
 tensor_hardshrink_s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
@@ -1065,10 +1072,4 @@ tensor___or___s
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
 tensor___or___s = cast2 Unmanaged.tensor___or___s
-
-tensor___or___t
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-tensor___or___t = cast2 Unmanaged.tensor___or___t
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Type/Tensor/Tensor3.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Type/Tensor/Tensor3.hs
@@ -24,6 +24,12 @@ import qualified Torch.Internal.Unmanaged.Type.Tensor.Tensor3 as Unmanaged
 
 
 
+tensor___or___t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor___or___t = cast2 Unmanaged.tensor___or___t
+
 tensor___ior___s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Tensor/Tensor0.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Tensor/Tensor0.hs
@@ -688,6 +688,15 @@ tensor__fw_primal_l _obj _level =
     $(int64_t _level)));
   }|]
 
+tensor_rename_N
+  :: Ptr Tensor
+  -> Ptr DimnameList
+  -> IO (Ptr Tensor)
+tensor_rename_N _obj _names =
+  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).rename(
+    *$(std::vector<at::Dimname>* _names)));
+  }|]
+
 tensor_align_to_N
   :: Ptr Tensor
   -> Ptr DimnameList
@@ -1504,14 +1513,6 @@ tensor_cosh
   -> IO (Ptr Tensor)
 tensor_cosh _obj =
   [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).cosh(
-    ));
-  }|]
-
-tensor_cosh_
-  :: Ptr Tensor
-  -> IO (Ptr Tensor)
-tensor_cosh_ _obj =
-  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).cosh_(
     ));
   }|]
 

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Tensor/Tensor1.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Tensor/Tensor1.hs
@@ -32,6 +32,14 @@ C.include "<vector>"
 
 
 
+tensor_cosh_
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_cosh_ _obj =
+  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).cosh_(
+    ));
+  }|]
+
 tensor_count_nonzero_l
   :: Ptr Tensor
   -> Ptr IntArray
@@ -1598,16 +1606,5 @@ tensor_prelu_t
 tensor_prelu_t _obj _weight =
   [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).prelu(
     *$(at::Tensor* _weight)));
-  }|]
-
-tensor_prelu_backward_tt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-tensor_prelu_backward_tt _obj _grad_output _weight =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>((*$(at::Tensor* _obj)).prelu_backward(
-    *$(at::Tensor* _grad_output)
-  , *$(at::Tensor* _weight)));
   }|]
 

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Tensor/Tensor2.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Tensor/Tensor2.hs
@@ -32,6 +32,17 @@ C.include "<vector>"
 
 
 
+tensor_prelu_backward_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+tensor_prelu_backward_tt _obj _grad_output _weight =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>((*$(at::Tensor* _obj)).prelu_backward(
+    *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _weight)));
+  }|]
+
 tensor_hardshrink_s
   :: Ptr Tensor
   -> Ptr Scalar
@@ -1675,14 +1686,5 @@ tensor___or___s
 tensor___or___s _obj _other =
   [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).__or__(
     *$(at::Scalar* _other)));
-  }|]
-
-tensor___or___t
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-tensor___or___t _obj _other =
-  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).__or__(
-    *$(at::Tensor* _other)));
   }|]
 

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Tensor/Tensor3.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Tensor/Tensor3.hs
@@ -32,6 +32,15 @@ C.include "<vector>"
 
 
 
+tensor___or___t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor___or___t _obj _other =
+  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).__or__(
+    *$(at::Tensor* _other)));
+  }|]
+
 tensor___ior___s
   :: Ptr Tensor
   -> Ptr Scalar

--- a/spec/cppclass/tensor.yaml
+++ b/spec/cppclass/tensor.yaml
@@ -126,6 +126,7 @@ methods:
 - requires_grad_(bool requires_grad=true) -> Tensor
 - retain_grad() -> void
 - _fw_primal(int64_t level) -> Tensor
+- rename(DimnameList names) -> Tensor
 - align_to(DimnameList names) -> Tensor
 - align_to(DimnameList order, int64_t ellipsis_idx) -> Tensor
 - align_as(Tensor  other) -> Tensor


### PR DESCRIPTION
Low level api does not have `rename` function of named-tensor.
This PR adds the function.
https://pytorch.org/docs/stable/named_tensor.html

The way to add the function is adhoc.
https://github.com/hasktorch/hasktorch/blob/master/spec/cppclass/gen.sh
I should stop using this `gen.sh` and use `Declarations.yaml`.