### PR TITLE
Add some features of typed namedtensor

### DIFF
--- a/hasktorch/hasktorch.cabal
+++ b/hasktorch/hasktorch.cabal
@@ -78,6 +78,7 @@ library
                     , Torch.Typed.Serialize
                     , Torch.Typed.Vision
                     , Torch.Typed.Lens
+                    , Torch.Typed.NamedTensor
                     , Torch.Distributions.Constraints
                     , Torch.Distributions.Distribution
                     , Torch.Distributions.Bernoulli

--- a/hasktorch/src/Torch/Lens.hs
+++ b/hasktorch/src/Torch/Lens.hs
@@ -17,8 +17,15 @@ import Control.Monad.Identity
 import GHC.Generics
 import Control.Monad.State.Strict
 
-type Traversal' s a
-  = forall f. Applicative f => (a -> f a) -> s -> f s
+-- | Type synonym for lens
+
+type Lens s t a b = forall f. Functor f => (a -> f b) -> s -> f t
+
+type Lens' s a = Lens s s a a
+
+type Traversal s t a b = forall f. Applicative f => (a -> f b) -> s -> f t
+
+type Traversal' s a = Traversal s s a a
 
 class HasTypes s a where
   types_ :: Traversal' s a

--- a/hasktorch/src/Torch/Tensor.hs
+++ b/hasktorch/src/Torch/Tensor.hs
@@ -154,6 +154,18 @@ instance HasTypes Float Tensor where
 instance HasTypes Bool Tensor where
   types_ _ = pure
 
+instance HasTypes Int Int where
+  types_ = id
+
+instance HasTypes Float Float where
+  types_ = id
+
+instance HasTypes Double Double where
+  types_ = id
+
+instance HasTypes Bool Bool where
+  types_ = id
+
 toType :: forall a. HasTypes a Tensor => DType -> a -> a
 toType dtype t = over (types @Tensor @a) (_toType dtype) t
 

--- a/hasktorch/src/Torch/Typed/Functional.hs
+++ b/hasktorch/src/Torch/Typed/Functional.hs
@@ -348,6 +348,7 @@ meanDim input = unsafePerformIO $ ATen.cast2 ATen.Managed.mean_tl input (natValI
 
 -- | Computes the mean and reduces the tensor over the specified dimension.
 --
+-- >>> :m + Torch.Typed.Factories
 -- >>> t = def :: NamedTensor '( D.CPU, 0) 'D.Float '[Vector 3, Vector 4, Vector 5]
 -- >>> dtype &&& shape $ meanNamedDim @(Vector 2) t
 -- (Float,[Vector 4,Vector 5])

--- a/hasktorch/src/Torch/Typed/Functional.hs
+++ b/hasktorch/src/Torch/Typed/Functional.hs
@@ -348,10 +348,11 @@ meanDim input = unsafePerformIO $ ATen.cast2 ATen.Managed.mean_tl input (natValI
 
 -- | Computes the mean and reduces the tensor over the specified dimension.
 --
--- >>> :m + Torch.Typed.Factories
+-- >>> import Torch.Typed.Factories
+-- >>> import Data.Default.Class
 -- >>> t = def :: NamedTensor '( D.CPU, 0) 'D.Float '[Vector 3, Vector 4, Vector 5]
--- >>> dtype &&& shape $ meanNamedDim @(Vector 2) t
--- (Float,[Vector 4,Vector 5])
+-- >>> dtype &&& shape $ meanNamedDim @(Vector 4) t
+-- (Float,[3,5])
 meanNamedDim ::
   forall dim shape' shape dtype device.
   ( KnownNat (FindDim dim shape),
@@ -5036,9 +5037,9 @@ type family HasDim (dim :: Nat) (shape :: [Nat]) :: Constraint where
 -- | sortDim
 --
 -- >>> t = ones :: CPUTensor 'D.Float '[3,4,5]
--- >>> dtype &&& shape $ fst $ sortDim @0 t
+-- >>> dtype &&& shape $ fst $ sortDim @0 True t
 -- (Float,[3,4,5])
--- >>> dtype &&& shape $ snd $ sortDim @0 t
+-- >>> dtype &&& shape $ snd $ sortDim @0 True t
 -- (Int64,[3,4,5])
 sortDim ::
   forall dim shape dtype device.
@@ -5058,6 +5059,15 @@ sortDim _descending _input =
     func _input = unsafePerformIO $ (ATen.cast3 ATen.Managed.sort_tlb) _input _dim _descending
     _dim = natValI @dim
 
+-- | sortNamedDim
+--
+-- >>> import Torch.Typed.Factories
+-- >>> import Data.Default.Class
+-- >>> t = def :: NamedTensor '( D.CPU, 0) 'D.Float '[Vector 3, Vector 4, Vector 5]
+-- >>> dtype &&& shape $ fst $ sortNamedDim @(Vector 3) True t
+-- (Float,[3,4,5])
+-- >>> dtype &&& shape $ snd $ sortNamedDim @(Vector 3) True t
+-- (Int64,[3,4,5])
 sortNamedDim ::
   forall dim shape dtype device.
   ( KnownNat (FindDim dim shape)
@@ -5078,7 +5088,7 @@ sortNamedDim _descending _input =
 -- | argSortDim
 --
 -- >>> t = ones :: CPUTensor 'D.Float '[3,4,5]
--- >>> dtype &&& shape $ argSortDim @0 t
+-- >>> dtype &&& shape $ argSortDim @0 True t
 -- (Int64,[3,4,5])
 argSortDim ::
   forall dim shape dtype device.
@@ -5092,11 +5102,6 @@ argSortDim _descending _input = unsafePerformIO $ (ATen.cast3 ATen.Managed.argso
   where
     _dim = natValI @dim
 
--- | argSortDim
---
--- >>> t = ones :: CPUTensor 'D.Float '[3,4,5]
--- >>> dtype &&& shape $ argSortDim @0 t
--- (Int64,[3,4,5])
 argSortNamedDim ::
   forall dim shape dtype device.
   ( KnownNat (FindDim dim shape)

--- a/hasktorch/src/Torch/Typed/Lens.hs
+++ b/hasktorch/src/Torch/Typed/Lens.hs
@@ -157,3 +157,4 @@ instance (GFieldId field f, GFieldId field g) => GFieldId field (f :+: g) where
     case (gfieldId' @field (Proxy :: Proxy f), gfieldId' @field (Proxy :: Proxy g)) of
       ((Nothing, _), a1) -> a1
       (a0@(Just _, _), _) -> a0
+

--- a/hasktorch/src/Torch/Typed/NamedTensor.hs
+++ b/hasktorch/src/Torch/Typed/NamedTensor.hs
@@ -23,28 +23,26 @@ module Torch.Typed.NamedTensor where
 
 import Data.Default.Class
 import Data.Kind
-import Data.Proxy
-import Data.Vector.Sized (Vector)
 import Data.Maybe (fromJust)
+import Data.Vector.Sized (Vector)
 import qualified Data.Vector.Sized as V
 import GHC.Exts
 import GHC.Generics
 import GHC.TypeLits
 import qualified Torch.DType as D
 import qualified Torch.Device as D
-import qualified Torch.Functional as F
+import Torch.Lens
 import qualified Torch.Tensor as D
 import Torch.Typed.Factories
 import Torch.Typed.Functional
 import Torch.Typed.Tensor
-import Torch.Lens
 
 class NamedTensorLike a where
   type ToNestedList a :: Type
   toNestedList :: a -> ToNestedList a
   asNamedTensor :: a -> NamedTensor '( 'D.CPU, 0) (ToDType a) (ToShape a)
   fromNestedList :: ToNestedList a -> a
-  fromNamedTensor :: NamedTensor '( 'D.CPU, 0) (ToDType a) (ToShape a) -> a 
+  fromNamedTensor :: NamedTensor '( 'D.CPU, 0) (ToDType a) (ToShape a) -> a
 
 instance NamedTensorLike Bool where
   type ToNestedList Bool = Bool
@@ -79,18 +77,18 @@ instance (KnownNat n, D.TensorLike (ToNestedList a), NamedTensorLike a) => Named
   toNestedList v = fmap toNestedList (V.toList v)
   asNamedTensor v = fromUnnamed . UnsafeMkTensor . D.asTensor $ toNestedList v
   fromNestedList = fmap fromNestedList . fromJust . V.fromList
-  fromNamedTensor =  fromNestedList . D.asValue . toDynamic
+  fromNamedTensor = fromNestedList . D.asValue . toDynamic
 
 instance {-# OVERLAPS #-} (Coercible (vec n a) (Vector n a), KnownNat n, D.TensorLike (ToNestedList a), NamedTensorLike a) => NamedTensorLike (vec n a) where
   type ToNestedList (vec n a) = [ToNestedList a]
   toNestedList v = map (toNestedList @a) (V.toList (coerce v :: Vector n a))
   asNamedTensor v = fromUnnamed . UnsafeMkTensor . D.asTensor $ toNestedList v
   fromNestedList v = coerce (fmap fromNestedList . fromJust . V.fromList $ v :: Vector n a)
-  fromNamedTensor =  fromNestedList . D.asValue . toDynamic
+  fromNamedTensor = fromNestedList . D.asValue . toDynamic
 
 instance {-# OVERLAPS #-} (Generic (g a), Default (g a), HasTypes (g a) a, KnownNat (ToNat g), D.TensorLike (ToNestedList a), NamedTensorLike a) => NamedTensorLike (g a) where
   type ToNestedList (g a) = [ToNestedList a]
   toNestedList v = map (toNestedList @a) (flattenValues (types @a) v)
   asNamedTensor v = fromUnnamed . UnsafeMkTensor . D.asTensor $ toNestedList v
   fromNestedList v = replaceValues (types @a) def (fmap fromNestedList v)
-  fromNamedTensor =  fromNestedList . D.asValue . toDynamic
+  fromNamedTensor = fromNestedList . D.asValue . toDynamic

--- a/hasktorch/src/Torch/Typed/NamedTensor.hs
+++ b/hasktorch/src/Torch/Typed/NamedTensor.hs
@@ -1,0 +1,96 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
+{-# LANGUAGE NoStarIsType #-}
+
+module Torch.Typed.NamedTensor where
+
+import Data.Default.Class
+import Data.Kind
+import Data.Proxy
+import Data.Vector.Sized (Vector)
+import Data.Maybe (fromJust)
+import qualified Data.Vector.Sized as V
+import GHC.Exts
+import GHC.Generics
+import GHC.TypeLits
+import qualified Torch.DType as D
+import qualified Torch.Device as D
+import qualified Torch.Functional as F
+import qualified Torch.Tensor as D
+import Torch.Typed.Factories
+import Torch.Typed.Functional
+import Torch.Typed.Tensor
+import Torch.Lens
+
+class NamedTensorLike a where
+  type ToNestedList a :: Type
+  toNestedList :: a -> ToNestedList a
+  asNamedTensor :: a -> NamedTensor '( 'D.CPU, 0) (ToDType a) (ToShape a)
+  fromNestedList :: ToNestedList a -> a
+  fromNamedTensor :: NamedTensor '( 'D.CPU, 0) (ToDType a) (ToShape a) -> a 
+
+instance NamedTensorLike Bool where
+  type ToNestedList Bool = Bool
+  toNestedList = id
+  asNamedTensor = fromUnnamed . UnsafeMkTensor . D.asTensor
+  fromNestedList = id
+  fromNamedTensor = D.asValue . toDynamic
+
+instance NamedTensorLike Int where
+  type ToNestedList Int = Int
+  toNestedList = id
+  asNamedTensor = fromUnnamed . UnsafeMkTensor . D.asTensor
+  fromNestedList = id
+  fromNamedTensor = D.asValue . toDynamic
+
+instance NamedTensorLike Float where
+  type ToNestedList Float = Float
+  toNestedList = id
+  asNamedTensor = fromUnnamed . UnsafeMkTensor . D.asTensor
+  fromNestedList = id
+  fromNamedTensor = D.asValue . toDynamic
+
+instance NamedTensorLike Double where
+  type ToNestedList Double = Double
+  toNestedList = id
+  asNamedTensor = fromUnnamed . UnsafeMkTensor . D.asTensor
+  fromNestedList = id
+  fromNamedTensor = D.asValue . toDynamic
+
+instance (KnownNat n, D.TensorLike (ToNestedList a), NamedTensorLike a) => NamedTensorLike (Vector n a) where
+  type ToNestedList (Vector n a) = [ToNestedList a]
+  toNestedList v = fmap toNestedList (V.toList v)
+  asNamedTensor v = fromUnnamed . UnsafeMkTensor . D.asTensor $ toNestedList v
+  fromNestedList = fmap fromNestedList . fromJust . V.fromList
+  fromNamedTensor =  fromNestedList . D.asValue . toDynamic
+
+instance {-# OVERLAPS #-} (Coercible (vec n a) (Vector n a), KnownNat n, D.TensorLike (ToNestedList a), NamedTensorLike a) => NamedTensorLike (vec n a) where
+  type ToNestedList (vec n a) = [ToNestedList a]
+  toNestedList v = map (toNestedList @a) (V.toList (coerce v :: Vector n a))
+  asNamedTensor v = fromUnnamed . UnsafeMkTensor . D.asTensor $ toNestedList v
+  fromNestedList v = coerce (fmap fromNestedList . fromJust . V.fromList $ v :: Vector n a)
+  fromNamedTensor =  fromNestedList . D.asValue . toDynamic
+
+instance {-# OVERLAPS #-} (Generic (g a), Default (g a), HasTypes (g a) a, KnownNat (ToNat g), D.TensorLike (ToNestedList a), NamedTensorLike a) => NamedTensorLike (g a) where
+  type ToNestedList (g a) = [ToNestedList a]
+  toNestedList v = map (toNestedList @a) (flattenValues (types @a) v)
+  asNamedTensor v = fromUnnamed . UnsafeMkTensor . D.asTensor $ toNestedList v
+  fromNestedList v = replaceValues (types @a) def (fmap fromNestedList v)
+  fromNamedTensor =  fromNestedList . D.asValue . toDynamic

--- a/hasktorch/src/Torch/Typed/Tensor.hs
+++ b/hasktorch/src/Torch/Typed/Tensor.hs
@@ -716,48 +716,6 @@ type family FindDim (a :: Size) (shape :: Shape) :: Nat where
 data NamedTensor (device :: (D.DeviceType, Nat)) (dtype :: D.DType) (shape :: Shape) where
   FromTensor :: forall device dtype shape' shape. shape ~ ToNats shape' => Tensor device dtype shape -> NamedTensor device dtype shape'
 
-class NamedTensorLike a where
-  type ToNestedList a :: Type
-  toNestedList :: a -> ToNestedList a
-  asNamedTensor :: a -> NamedTensor '( 'D.CPU, 0) (ToDType a) (ToShape a)
-  fromNestedList :: ToNestedList a -> a
-  fromNamedTensor :: NamedTensor '( 'D.CPU, 0) (ToDType a) (ToShape a) -> a 
-
-instance NamedTensorLike Bool where
-  type ToNestedList Bool = Bool
-  toNestedList = id
-  asNamedTensor = fromUnnamed . UnsafeMkTensor . D.asTensor
-  fromNestedList = id
-  fromNamedTensor = D.asValue . toDynamic
-
-instance NamedTensorLike Int where
-  type ToNestedList Int = Int
-  toNestedList = id
-  asNamedTensor = fromUnnamed . UnsafeMkTensor . D.asTensor
-  fromNestedList = id
-  fromNamedTensor = D.asValue . toDynamic
-
-instance NamedTensorLike Float where
-  type ToNestedList Float = Float
-  toNestedList = id
-  asNamedTensor = fromUnnamed . UnsafeMkTensor . D.asTensor
-  fromNestedList = id
-  fromNamedTensor = D.asValue . toDynamic
-
-instance NamedTensorLike Double where
-  type ToNestedList Double = Double
-  toNestedList = id
-  asNamedTensor = fromUnnamed . UnsafeMkTensor . D.asTensor
-  fromNestedList = id
-  fromNamedTensor = D.asValue . toDynamic
-
-instance (KnownNat n, D.TensorLike (ToNestedList a), NamedTensorLike a) => NamedTensorLike (Vector n a) where
-  type ToNestedList (Vector n a) = [ToNestedList a]
-  toNestedList v = fmap toNestedList (V.toList v)
-  asNamedTensor v = fromUnnamed . UnsafeMkTensor . D.asTensor $ toNestedList v
-  fromNestedList = fmap fromNestedList . fromJust . V.fromList
-  fromNamedTensor =  fromNestedList . D.asValue . toDynamic
-
 instance Unnamed (NamedTensor device dtype shape) where
   type UTShape (NamedTensor device dtype shape) = ToNats shape
   type UTDevice (NamedTensor device dtype shape) = device

--- a/hasktorch/src/Torch/Typed/Tensor.hs
+++ b/hasktorch/src/Torch/Typed/Tensor.hs
@@ -790,3 +790,4 @@ type family ReplaceDevice'' (tensor :: t) (device :: (D.DeviceType, Nat)) :: t w
 type family ReplaceDType'' (tensor :: t) (dtype :: D.DType) :: t where
   ReplaceDType'' (Tensor device dtype0 shape) dtype1 = Tensor device dtype1 shape
   ReplaceDType'' (NamedTensor device dtype0 shape) dtype1 = NamedTensor device dtype1 shape
+

--- a/hasktorch/test/Torch/Typed/NamedTensorSpec.hs
+++ b/hasktorch/test/Torch/Typed/NamedTensorSpec.hs
@@ -20,6 +20,7 @@
 {-# LANGUAGE UndecidableSuperClasses #-}
 {-# LANGUAGE NoStarIsType #-}
 {-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE DeriveAnyClass #-}
 
 module Torch.Typed.NamedTensorSpec (spec) where
 
@@ -42,7 +43,7 @@ import Torch.Typed.Factories
 import Torch.Typed.Functional
 import Torch.Typed.Lens
 import Torch.Typed.Tensor
-import Torch.Lens (Lens, Lens', Traversal, Traversal', flattenValues)
+import Torch.Lens
 
 newtype Batch (n::Nat) a = Batch (Vector n a) deriving (Show, Eq, Generic)
 newtype Height (n::Nat) a = Height (Vector n a) deriving (Show, Eq, Generic)
@@ -53,7 +54,7 @@ data RGB a = RGB
     g :: a,
     b :: a
   }
-  deriving (Show, Eq, Generic)
+  deriving (Show, Eq, Generic, Default)
 
 data YCoCg a = YCoCg
   { y :: a,
@@ -64,21 +65,22 @@ data YCoCg a = YCoCg
 
 data RGBA a = RGBA a a a a deriving (Show, Eq, Generic)
 
-instance (Coercible (vec n a) (Vector n a), KnownNat n, D.TensorLike (ToNestedList a), NamedTensorLike a) => NamedTensorLike (vec n a) where
+instance {-# OVERLAPS #-} (Coercible (vec n a) (Vector n a), KnownNat n, D.TensorLike (ToNestedList a), NamedTensorLike a) => NamedTensorLike (vec n a) where
   type ToNestedList (vec n a) = [ToNestedList a]
   toNestedList v = map (toNestedList @a) (V.toList (coerce v :: Vector n a))
   asNamedTensor v = fromUnnamed . UnsafeMkTensor . D.asTensor $ toNestedList v
   fromNestedList v = coerce (fmap fromNestedList . fromJust . V.fromList $ v :: Vector n a)
   fromNamedTensor =  fromNestedList . D.asValue . toDynamic
 
-instance (D.TensorLike (ToNestedList a), NamedTensorLike a) => NamedTensorLike (RGB a) where
-  type ToNestedList (RGB a) = [ToNestedList a]
-  toNestedList (RGB r g b) = map toNestedList [r,g,b]
+instance HasTypes Float Float where
+  types_ = id
+
+instance {-# OVERLAPS #-} (Generic (g a), Default (g a), HasTypes (g a) a, KnownNat (ToNat g), D.TensorLike (ToNestedList a), NamedTensorLike a) => NamedTensorLike (g a) where
+  type ToNestedList (g a) = [ToNestedList a]
+  toNestedList v = map (toNestedList @a) (flattenValues (types @a) v)
   asNamedTensor v = fromUnnamed . UnsafeMkTensor . D.asTensor $ toNestedList v
-  fromNestedList v =
-    let [r,g,b] = fmap fromNestedList v
-    in RGB r g b
-  fromNamedTensor = fromNestedList . D.asValue . toDynamic
+  fromNestedList v = replaceValues (types @a) def (fmap fromNestedList v)
+  fromNamedTensor =  fromNestedList . D.asValue . toDynamic
 
 testFieldLens :: HasField "r" shape => Lens' (NamedTensor '(D.CPU, 0) 'D.Float shape) (NamedTensor '(D.CPU, 0) 'D.Float (DropField "r" shape))
 testFieldLens = field @"r"

--- a/hasktorch/test/Torch/Typed/NamedTensorSpec.hs
+++ b/hasktorch/test/Torch/Typed/NamedTensorSpec.hs
@@ -64,27 +64,12 @@ data YCoCg a = YCoCg
 
 data RGBA a = RGBA a a a a deriving (Show, Eq, Generic)
 
-instance (KnownNat n, D.TensorLike (ToNestedList a), NamedTensorLike a) => NamedTensorLike (Batch n a) where
-  type ToNestedList (Batch n a) = [ToNestedList a]
-  toNestedList (Batch v) = map toNestedList (V.toList v)
+instance (Coercible (vec n a) (Vector n a), KnownNat n, D.TensorLike (ToNestedList a), NamedTensorLike a) => NamedTensorLike (vec n a) where
+  type ToNestedList (vec n a) = [ToNestedList a]
+  toNestedList v = map (toNestedList @a) (V.toList (coerce v :: Vector n a))
   asNamedTensor v = fromUnnamed . UnsafeMkTensor . D.asTensor $ toNestedList v
-  fromNestedList = Batch . fmap fromNestedList . fromJust . V.fromList
+  fromNestedList v = coerce (fmap fromNestedList . fromJust . V.fromList $ v :: Vector n a)
   fromNamedTensor =  fromNestedList . D.asValue . toDynamic
-
-instance (KnownNat n, D.TensorLike (ToNestedList a), NamedTensorLike a) => NamedTensorLike (Height n a) where
-  type ToNestedList (Height n a) = [ToNestedList a]
-  toNestedList (Height v) = map toNestedList (V.toList v)
-  asNamedTensor v = fromUnnamed . UnsafeMkTensor . D.asTensor $ toNestedList v
-  fromNestedList = Height . fmap fromNestedList . fromJust . V.fromList
-  fromNamedTensor = fromNestedList . D.asValue . toDynamic
-
-
-instance (KnownNat n, D.TensorLike (ToNestedList a), NamedTensorLike a) => NamedTensorLike (Width n a) where
-  type ToNestedList (Width n a) = [ToNestedList a]
-  toNestedList (Width v) = map toNestedList (V.toList v)
-  asNamedTensor v = fromUnnamed . UnsafeMkTensor . D.asTensor $ toNestedList v
-  fromNestedList = Width . fmap fromNestedList . fromJust . V.fromList
-  fromNamedTensor = fromNestedList . D.asValue . toDynamic
 
 instance (D.TensorLike (ToNestedList a), NamedTensorLike a) => NamedTensorLike (RGB a) where
   type ToNestedList (RGB a) = [ToNestedList a]

--- a/hasktorch/test/Torch/Typed/NamedTensorSpec.hs
+++ b/hasktorch/test/Torch/Typed/NamedTensorSpec.hs
@@ -191,3 +191,8 @@ spec = do
           v1 = meanNamedDim @(Vector 3) t :: NamedTensor '(D.CPU, 0) 'D.Float '[Vector 2, Vector 4, RGB]
       checkDynamicTensorAttributes' v0
       checkDynamicTensorAttributes' v1
+    it "shape and dtype" $ do
+      let t :: NamedTensor '(D.CPU, 0) 'D.Float '[Vector 2, Vector 3, Vector 4, RGB]
+          t = def
+      shape t `shouldBe` [2,3,4,3]
+      dtype t `shouldBe` D.Float

--- a/hasktorch/test/Torch/Typed/NamedTensorSpec.hs
+++ b/hasktorch/test/Torch/Typed/NamedTensorSpec.hs
@@ -178,9 +178,16 @@ spec = do
       fieldId @"g" (Proxy :: Proxy (RGB ())) `shouldBe` Just 1
       fieldId @"b" (Proxy :: Proxy (RGB ())) `shouldBe` Just 2
       fieldId @"y" (Proxy :: Proxy (RGB ())) `shouldBe` Nothing
-    it "sort by a name" $ do
+    it "sort" $ do
       let t :: NamedTensor '(D.CPU, 0) 'D.Float '[Vector 2, Vector 3, Vector 4, RGB]
           t = def
-          (v, idx) = sortNamedDim @RGB t True
+          (v, idx) = sortNamedDim @RGB True t
       checkDynamicTensorAttributes' v
       checkDynamicTensorAttributes' idx
+    it "mean" $ do
+      let t :: NamedTensor '(D.CPU, 0) 'D.Float '[Vector 2, Vector 3, Vector 4, RGB]
+          t = def
+          v0 = meanNamedDim @RGB t :: NamedTensor '(D.CPU, 0) 'D.Float '[Vector 2, Vector 3, Vector 4]
+          v1 = meanNamedDim @(Vector 3) t :: NamedTensor '(D.CPU, 0) 'D.Float '[Vector 2, Vector 4, RGB]
+      checkDynamicTensorAttributes' v0
+      checkDynamicTensorAttributes' v1

--- a/hasktorch/test/Torch/Typed/NamedTensorSpec.hs
+++ b/hasktorch/test/Torch/Typed/NamedTensorSpec.hs
@@ -19,6 +19,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE UndecidableSuperClasses #-}
 {-# LANGUAGE NoStarIsType #-}
+{-# LANGUAGE OverloadedLists #-}
 
 module Torch.Typed.NamedTensorSpec (spec) where
 
@@ -26,6 +27,7 @@ import Data.Default.Class
 import Data.Kind
 import Data.Proxy
 import Data.Vector.Sized (Vector)
+import Data.Maybe (fromJust)
 import qualified Data.Vector.Sized as V
 import GHC.Exts
 import GHC.Generics
@@ -37,8 +39,13 @@ import qualified Torch.Device as D
 import qualified Torch.Functional as F
 import qualified Torch.Tensor as D
 import Torch.Typed.Factories
+import Torch.Typed.Functional
 import Torch.Typed.Lens
 import Torch.Typed.Tensor
+
+newtype Batch (n::Nat) a = Batch (Vector n a) deriving (Show, Eq, Generic)
+newtype Height (n::Nat) a = Height (Vector n a) deriving (Show, Eq, Generic)
+newtype Width (n::Nat) a = Width (Vector n a) deriving (Show, Eq, Generic)
 
 data RGB a = RGB
   { r :: a,
@@ -55,6 +62,37 @@ data YCoCg a = YCoCg
   deriving (Show, Eq, Generic)
 
 data RGBA a = RGBA a a a a deriving (Show, Eq, Generic)
+
+instance (KnownNat n, D.TensorLike (ToNestedList a), NamedTensorLike a) => NamedTensorLike (Batch n a) where
+  type ToNestedList (Batch n a) = [ToNestedList a]
+  toNestedList (Batch v) = map toNestedList (V.toList v)
+  asNamedTensor v = fromUnnamed . UnsafeMkTensor . D.asTensor $ toNestedList v
+  fromNestedList = Batch . fmap fromNestedList . fromJust . V.fromList
+  fromNamedTensor =  fromNestedList . D.asValue . toDynamic
+
+instance (KnownNat n, D.TensorLike (ToNestedList a), NamedTensorLike a) => NamedTensorLike (Height n a) where
+  type ToNestedList (Height n a) = [ToNestedList a]
+  toNestedList (Height v) = map toNestedList (V.toList v)
+  asNamedTensor v = fromUnnamed . UnsafeMkTensor . D.asTensor $ toNestedList v
+  fromNestedList = Height . fmap fromNestedList . fromJust . V.fromList
+  fromNamedTensor = fromNestedList . D.asValue . toDynamic
+
+
+instance (KnownNat n, D.TensorLike (ToNestedList a), NamedTensorLike a) => NamedTensorLike (Width n a) where
+  type ToNestedList (Width n a) = [ToNestedList a]
+  toNestedList (Width v) = map toNestedList (V.toList v)
+  asNamedTensor v = fromUnnamed . UnsafeMkTensor . D.asTensor $ toNestedList v
+  fromNestedList = Width . fmap fromNestedList . fromJust . V.fromList
+  fromNamedTensor = fromNestedList . D.asValue . toDynamic
+
+instance (D.TensorLike (ToNestedList a), NamedTensorLike a) => NamedTensorLike (RGB a) where
+  type ToNestedList (RGB a) = [ToNestedList a]
+  toNestedList (RGB r g b) = map toNestedList [r,g,b]
+  asNamedTensor v = fromUnnamed . UnsafeMkTensor . D.asTensor $ toNestedList v
+  fromNestedList v =
+    let [r,g,b] = fmap fromNestedList v
+    in RGB r g b
+  fromNamedTensor = fromNestedList . D.asValue . toDynamic
 
 testFieldLens :: HasField "r" shape => Lens' (NamedTensor '(D.CPU, 0) 'D.Float shape) (NamedTensor '(D.CPU, 0) 'D.Float (DropField "r" shape))
 testFieldLens = field @"r"
@@ -76,6 +114,9 @@ testCountField2 = id
 
 testCountField3 :: Proxy (ToNat RGBA) -> Proxy 4
 testCountField3 = id
+
+testCountField4 :: Proxy (ToNat (Batch n)) -> Proxy n
+testCountField4 = id
 
 toYCoCG :: (KnownNat n, KnownDType dtype, KnownDevice device) => NamedTensor device dtype [Vector n, RGB] -> NamedTensor device dtype [Vector n, YCoCg]
 toYCoCG rgb =
@@ -105,13 +146,24 @@ checkDynamicTensorAttributes' t = do
 spec :: Spec
 spec = do
   describe "NamedTensor" $ do
-    it "create" $ do
+    it "create by Typed Tensor" $ do
       let t :: Tensor '(D.CPU, 0) 'D.Float '[2, 3]
           t = ones
           t2 :: NamedTensor '(D.CPU, 0) 'D.Float '[Vector 2, RGB]
           t2 = fromUnnamed t
+          t3 :: NamedTensor '(D.CPU, 0) 'D.Float '[Batch 2, RGB]
+          t3 = fromUnnamed t
       print t2
       checkDynamicTensorAttributes' t2
+      checkDynamicTensorAttributes' t3
+    it "create by default class" $ do
+      let t :: NamedTensor '(D.CPU, 0) 'D.Float '[Batch 2, Height 3, Width 4, RGB]
+          t = def
+      checkDynamicTensorAttributes' t
+    it "create by NamedTensorLike" $ do
+      let t :: NamedTensor '(D.CPU, 0) 'D.Float '[Batch 1, Height 1, Width 1, RGB]
+          t = asNamedTensor $ Batch (V.singleton (Height (V.singleton (Width (V.singleton (RGB { r = 0 :: Float, g = 1, b = 2 }))))))
+      checkDynamicTensorAttributes' t
     it "check a shape of lens" $ do
       let t :: NamedTensor '(D.CPU, 0) 'D.Float '[Vector 2, Vector 3, Vector 4, RGB]
           t = def
@@ -120,9 +172,15 @@ spec = do
       print $ shape t2
       checkDynamicTensorAttributes' t
       checkDynamicTensorAttributes' t2
-    it "check fieldids" $ do
+    it "get fieldids" $ do
       let v = RGB () () ()
       fieldId @"r" (Proxy :: Proxy (RGB ())) `shouldBe` Just 0
       fieldId @"g" (Proxy :: Proxy (RGB ())) `shouldBe` Just 1
       fieldId @"b" (Proxy :: Proxy (RGB ())) `shouldBe` Just 2
       fieldId @"y" (Proxy :: Proxy (RGB ())) `shouldBe` Nothing
+    it "sort by a name" $ do
+      let t :: NamedTensor '(D.CPU, 0) 'D.Float '[Vector 2, Vector 3, Vector 4, RGB]
+          t = def
+          (v, idx) = sortNamedDim @RGB t True
+      checkDynamicTensorAttributes' v
+      checkDynamicTensorAttributes' idx

--- a/hasktorch/test/Torch/Typed/NamedTensorSpec.hs
+++ b/hasktorch/test/Torch/Typed/NamedTensorSpec.hs
@@ -42,6 +42,7 @@ import Torch.Typed.Factories
 import Torch.Typed.Functional
 import Torch.Typed.Lens
 import Torch.Typed.Tensor
+import Torch.Lens (Lens, Lens', Traversal, Traversal', flattenValues)
 
 newtype Batch (n::Nat) a = Batch (Vector n a) deriving (Show, Eq, Generic)
 newtype Height (n::Nat) a = Height (Vector n a) deriving (Show, Eq, Generic)
@@ -99,6 +100,9 @@ testFieldLens = field @"r"
 
 testFieldLens2 :: Lens' (NamedTensor '(D.CPU, 0) 'D.Float '[Vector n, RGB]) (NamedTensor '(D.CPU, 0) 'D.Float '[Vector n])
 testFieldLens2 = field @"r"
+
+testNamedLens :: Traversal' (NamedTensor '(D.CPU, 0) 'D.Float '[Vector n, RGB]) (NamedTensor '(D.CPU, 0) 'D.Float '[Vector n])
+testNamedLens = name @RGB
 
 testDropField :: Proxy (DropField "r" '[Vector 2, RGB]) -> Proxy '[Vector 2]
 testDropField = id
@@ -196,3 +200,9 @@ spec = do
           t = def
       shape t `shouldBe` [2,3,4,3]
       dtype t `shouldBe` D.Float
+    it "named index" $ do
+      let t :: NamedTensor '(D.CPU, 0) 'D.Float '[Vector 2, Vector 3, Vector 4, RGB]
+          t = def
+          t2 = flattenValues (name @(Vector 3)) t
+      map shape t2 `shouldBe` [[2,4,3],[2,4,3],[2,4,3]]
+      map dtype t2 `shouldBe` [D.Float,D.Float,D.Float]

--- a/hasktorch/test/Torch/Typed/NamedTensorSpec.hs
+++ b/hasktorch/test/Torch/Typed/NamedTensorSpec.hs
@@ -46,9 +46,9 @@ import Torch.Typed.NamedTensor
 import Torch.Typed.Tensor
 import Torch.Lens
 
-newtype Batch (n::Nat) a = Batch (Vector n a) deriving (Show, Eq)
-newtype Height (n::Nat) a = Height (Vector n a) deriving (Show, Eq)
-newtype Width (n::Nat) a = Width (Vector n a) deriving (Show, Eq)
+newtype Batch (n::Nat) a = Batch (Vector n a) deriving (Show, Eq, Generic)
+newtype Height (n::Nat) a = Height (Vector n a) deriving (Show, Eq, Generic)
+newtype Width (n::Nat) a = Width (Vector n a) deriving (Show, Eq, Generic)
 
 data RGB a = RGB
   { r :: a,
@@ -75,6 +75,9 @@ testFieldLens2 = field @"r"
 
 testNamedLens :: Traversal' (NamedTensor '(D.CPU, 0) 'D.Float '[Vector n, RGB]) (NamedTensor '(D.CPU, 0) 'D.Float '[Vector n])
 testNamedLens = name @RGB
+
+testNamedLens2 :: Traversal' (NamedTensor '(D.CPU, 0) 'D.Float '[Vector 3, RGB, Vector 4]) (NamedTensor '(D.CPU, 0) 'D.Float '[Vector 3,Vector 4])
+testNamedLens2 = name @RGB
 
 testDropField :: Proxy (DropField "r" '[Vector 2, RGB]) -> Proxy '[Vector 2]
 testDropField = id


### PR DESCRIPTION
This PR improves the implementation of typed namedtensor.

The original functions of namedtensor are below.
http://nlp.seas.harvard.edu/NamedTensor
Some features have not been implemented yet.

- [x] Assigning Names
- [x] Accessors and Reduction
- [ ] Broadcasting and Contraction
- [ ] Shifting Dimensions
- [ ] Ban Indexing
- [ ] Private Dimensions

The features of typed named tensors are below.

- [x] Identifies algebraic data types with named tensors.
- [x] Conversion between typed-tensor and values not using tensor. This is implemented by NamedTensorLike.
- [x] Lens to access data on a tensor using fields of algebraic data type.
- [x] Generics for NamedTensorLike
- [x] Lens for named dimension. I think it is like unbind-function.
