### PR TITLE
Add a HasForward instance of ScriptModule

### DIFF
--- a/examples/load-torchscript/Main.hs
+++ b/examples/load-torchscript/Main.hs
@@ -8,6 +8,7 @@ module Main where
 import Control.Monad (foldM)
 import System.Environment (getArgs)
 import Torch.Script
+import Torch.NN
 import Torch.Vision
 import Torch
 import qualified Codec.Picture as I
@@ -37,7 +38,7 @@ main = do
     Right (img_,_) -> do
       let img' = centerCrop 224 224 img_
           img'' = toType Float $ hwc2chw $ normalize $ divScalar (255.0::Float) $ toType Float $ fromDynImage $ I.ImageRGB8 img'
-      case (Torch.Script.forward model [IVTensor img'']) of
+      case (forward model [IVTensor img'']) of
         IVTensor v'' -> do
           let (scores',idxs') = topK 5 (Dim 1) True True $ softmax (Dim 1) v''
               scores = asValue scores' :: [[Float]]

--- a/hasktorch/src/Torch/Script.hs
+++ b/hasktorch/src/Torch/Script.hs
@@ -162,26 +162,12 @@ load WithRequiredGrad file = do
 load' :: FilePath -> IO RawModule
 load' = cast1 LibTorch.load
 
-forwardIO ::
-  -- | module
-  ScriptModule ->
-  -- | inputs
-  [IValue] ->
-  -- | output
-  IO IValue
-forwardIO = cast2 forward'
-  where
-    forward' :: ScriptModule -> [RawIValue] -> IO RawIValue
-    forward' = cast2 LibTorch.forward
-
-forward ::
-  -- | module
-  ScriptModule ->
-  -- | inputs
-  [IValue] ->
-  -- | output
-  IValue
-forward module' = unsafePerformIO . forwardIO module'
+instance HasForward ScriptModule [IValue] IValue where
+  forward module' = unsafePerformIO . forwardStoch module'
+  forwardStoch = cast2 forward'
+    where
+      forward' :: ScriptModule -> [RawIValue] -> IO RawIValue
+      forward' = cast2 LibTorch.forward
 
 registerParameter :: RawModule -> String -> Tensor -> Bool -> IO ()
 registerParameter = cast4 LibTorch.registerParameter

--- a/hasktorch/test/ScriptSpec.hs
+++ b/hasktorch/test/ScriptSpec.hs
@@ -12,6 +12,7 @@ import Test.Hspec
 import Torch hiding (forward)
 import Torch.Script
 import Torch.Autograd
+import Torch.NN
 import GHC.Generics
 import Control.Exception.Safe (catch,throwIO)
 import Language.C.Inline.Cpp.Exceptions (CppException(..))


### PR DESCRIPTION
At first, this pr removes ScriptModule's forward function to avoid forward function collisions.
Then it adds the instance of HasForward for ScriptModule.