### PR TITLE
updated authors to `hasktorch contributor team` instead of `austin huang`

### DIFF
--- a/examples/examples.cabal
+++ b/examples/examples.cabal
@@ -5,7 +5,7 @@ synopsis:            examples for the new version of hasktorch
 -- description:
 homepage:            https://github.com/hasktorch/hasktorch#readme
 license:             BSD-3-Clause
-author:              Austin Huang
+author:              Hasktorch Contributor Team
 maintainer:          hasktorch@gmail.com
 copyright:           2019 Austin Huang
 category:            Machine Learning

--- a/hasktorch/hasktorch.cabal
+++ b/hasktorch/hasktorch.cabal
@@ -4,7 +4,7 @@ synopsis:            Functional differentiable programming in Haskell
 -- description:
 homepage:            https://github.com/hasktorch/hasktorch#readme
 license:             BSD3
-author:              Austin Huang
+author:              Hasktorch Contributor Team
 maintainer:          hasktorch@gmail.com
 copyright:           2019 Austin Huang
 category:            Codegen


### PR DESCRIPTION
Mainly for attribution on the tutorial page https://hasktorch.github.io/tutorial/index.html 