### PR TITLE
Add python-style slice operator

### DIFF
--- a/examples/vae/Main.hs
+++ b/examples/vae/Main.hs
@@ -116,7 +116,7 @@ main = do
     trained <- foldLoop init numIters $ \vaeState i -> do
       let startIndex = mod (batchSize * i) nSamples
           endIndex = Prelude.min (startIndex + batchSize) nSamples
-          input = slice 0 startIndex endIndex 1 dat -- size should be [batchSize, dataDim]
+          input = sliceDim 0 startIndex endIndex 1 dat -- size should be [batchSize, dataDim]
       output <- model vaeState input
       let (reconX, muVal, logvarVal) = (squeezeAll $ recon output, mu output, logvar output )
           loss = vaeLoss reconX input muVal logvarVal

--- a/hasktorch/hasktorch.cabal
+++ b/hasktorch/hasktorch.cabal
@@ -91,6 +91,7 @@ library
                     , Torch.Data.Dataset
                     , Torch.Data.CsvDatastream
                     , Torch.Tutorial
+                    , Torch.Index
 
  other-modules:       Paths_hasktorch
  hs-source-dirs:      src
@@ -130,6 +131,8 @@ library
                     , containers
                     , inline-c
                     , vector-sized
+                    , template-haskell
+                    , megaparsec
 
  default-extensions:  Strict
                     , StrictData
@@ -173,6 +176,7 @@ test-suite spec
                     , Torch.Distributions.ConstraintsSpec
                     , Torch.Distributions.BernoulliSpec
                     , Torch.Distributions.CategoricalSpec
+                    , IndexSpec
   default-language: Haskell2010
   ghc-options:         -fplugin GHC.TypeLits.Normalise -fplugin GHC.TypeLits.KnownNat.Solver -fplugin GHC.TypeLits.Extra.Solver -fconstraint-solver-iterations=0
   build-depends:      base >= 4.7 && < 5

--- a/hasktorch/src/Torch.hs
+++ b/hasktorch/src/Torch.hs
@@ -14,7 +14,8 @@ module Torch
     module Torch.TensorFactories,
     module Torch.TensorOptions,
     module Torch.Serialize,
-    module Torch.Script
+    module Torch.Script,
+    module Torch.Index
   )
 where
 
@@ -33,3 +34,4 @@ import Torch.TensorFactories
 import Torch.TensorOptions
 import Torch.Serialize
 import Torch.Script
+import Torch.Index

--- a/hasktorch/src/Torch/Index.hs
+++ b/hasktorch/src/Torch/Index.hs
@@ -70,6 +70,11 @@ parseSlice str =
           v <- lexm decimal
           pure $ LitE (IntegerL (-v))
       )
+      <|>
+      ( do
+          v <- lexm $ between (char '{') (char '}') (some alphaNumChar)
+          pure $ VarE (mkName v)
+      ) 
     slice =
       try ( do
           a <- number

--- a/hasktorch/src/Torch/Index.hs
+++ b/hasktorch/src/Torch/Index.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Torch.Index
-  ( pySlice
+  ( slice
   ) where
 
 import Torch.Tensor
@@ -28,7 +28,7 @@ lexm = lexeme sc
 
 parseSlice :: String -> Q [Exp]
 parseSlice str =
-  case M.runParser parse' "pySlice" str of
+  case M.runParser parse' "slice" str of
     Left e -> fail $ show e
     Right v -> return v
     
@@ -124,12 +124,12 @@ parseSlice str =
           pure $ AppE (ConE 'Slice) (ConE '())
           )
 
-pySlice :: QuasiQuoter
-pySlice = QuasiQuoter
+slice :: QuasiQuoter
+slice = QuasiQuoter
   { quoteExp = parseSlice >=> qconcat
-  , quotePat = error "quotePat is not implemented for pySlice."
-  , quoteDec = error "quoteDec is not implemented for pySlice."
-  , quoteType = error "quoteType is not implemented for pySlice."
+  , quotePat = error "quotePat is not implemented for slice."
+  , quoteDec = error "quoteDec is not implemented for slice."
+  , quoteType = error "quoteType is not implemented for slice."
   }
   where
     qconcat :: [Exp] -> Q Exp

--- a/hasktorch/src/Torch/Index.hs
+++ b/hasktorch/src/Torch/Index.hs
@@ -60,7 +60,16 @@ parseSlice str =
           pure $ ConE 'False
       )
     number :: Parser Exp 
-    number = lexm decimal >>= \v -> pure $ LitE (IntegerL v)
+    number =
+      ( do
+          v <- lexm decimal
+          pure $ LitE (IntegerL v)
+      ) <|>
+      ( do
+          _ <- lexm $ string "-"
+          v <- lexm decimal
+          pure $ LitE (IntegerL (-v))
+      )
     slice =
       try ( do
           a <- number

--- a/hasktorch/src/Torch/Index.hs
+++ b/hasktorch/src/Torch/Index.hs
@@ -1,0 +1,137 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Torch.Index
+  ( pySlice
+  ) where
+
+import Torch.Tensor
+import Language.Haskell.TH.Quote (QuasiQuoter (..))
+import Language.Haskell.TH.Syntax hiding (Unsafe)
+import Language.Haskell.TH.Lib
+import Text.Megaparsec as M
+import Text.Megaparsec.Char.Lexer 
+import Text.Megaparsec.Char hiding (space)
+import Data.Void
+import Control.Monad ((>=>))
+
+type Parser = Parsec Void String
+
+sc :: Parser ()
+sc = space space1 empty empty
+
+lexm :: Parser a -> Parser a
+lexm = lexeme sc
+
+parseSlice :: String -> Q [Exp]
+parseSlice str =
+  case M.runParser parse' "pySlice" str of
+    Left e -> fail $ show e
+    Right v -> return v
+    
+  where
+    parse' :: Parser [Exp]
+    parse' = (sc >> (try slice <|> try bool <|> try other <|> number)) `sepBy` char ','
+    other :: Parser Exp
+    other =
+      ( do
+          _ <- lexm $ string ("None" :: Tokens String)
+          pure $ ConE 'None
+      ) <|>
+      ( do
+          _ <- lexm $ string ("Ellipsis" :: Tokens String)
+          pure $ ConE 'Ellipsis
+      ) <|>
+      ( do
+          _ <- lexm $ string ("..." :: Tokens String)
+          pure $ ConE 'Ellipsis
+      )
+    bool :: Parser Exp
+    bool =
+      ( do
+          _ <- lexm $ string "True"
+          pure $ ConE 'True
+      ) <|>
+      ( do
+          _ <- lexm $ string "False"
+          pure $ ConE 'False
+      )
+    number :: Parser Exp 
+    number = lexm decimal >>= \v -> pure $ LitE (IntegerL v)
+    slice =
+      try ( do
+          a <- number
+          lexm $ string ":"
+          b <- number
+          lexm $ string ":"
+          c <- number
+          pure $ AppE (ConE 'Slice) (TupE [Just a,Just b,Just c])
+        ) <|>
+      try ( do
+          lexm $ string ":"
+          b <- number
+          lexm $ string ":"
+          c <- number
+          pure $ AppE (ConE 'Slice) (TupE [Just (ConE 'None),Just b,Just c])
+        ) <|>
+      try ( do
+          a <- number
+          lexm $ string "::"
+          c <- number
+          pure $ AppE (ConE 'Slice) (TupE [Just a,Just (ConE 'None),Just c])
+        ) <|>
+      try ( do
+          a <- number
+          lexm $ string ":"
+          b <- number
+          pure $ AppE (ConE 'Slice) (TupE [Just a,Just b])
+        ) <|>
+      try ( do
+          lexm $ string "::"
+          c <- number
+          pure $ AppE (ConE 'Slice) (TupE [Just (ConE 'None),Just (ConE 'None),Just c])
+        ) <|>
+      try ( do
+          lexm $ string ":"
+          b <- number
+          lexm $ string ":"
+          pure $ AppE (ConE 'Slice) (TupE [Just (ConE 'None),Just b])
+        ) <|>
+      try ( do
+          lexm $ string ":"
+          b <- number
+          pure $ AppE (ConE 'Slice) (TupE [Just (ConE 'None),Just b])
+        ) <|>
+      try ( do
+          a <- number
+          lexm $ string "::"
+          pure $ AppE (ConE 'Slice) (TupE [Just a,Just (ConE 'None)])
+        ) <|>
+      try ( do
+          a <- number
+          lexm $ string ":"
+          pure $ AppE (ConE 'Slice) (TupE [Just a,Just (ConE 'None)])
+        ) <|>
+      try ( do
+          _ <- lexm $ string "::"
+          pure $ AppE (ConE 'Slice) (ConE '())
+        ) <|>
+          ( do
+          _ <- lexm $ string ":"
+          pure $ AppE (ConE 'Slice) (ConE '())
+          )
+
+pySlice :: QuasiQuoter
+pySlice = QuasiQuoter
+  { quoteExp = parseSlice >=> qconcat
+  , quotePat = error "quotePat is not implemented for pySlice."
+  , quoteDec = error "quoteDec is not implemented for pySlice."
+  , quoteType = error "quoteType is not implemented for pySlice."
+  }
+  where
+    qconcat :: [Exp] -> Q Exp
+    qconcat [exp] = pure exp
+    qconcat exps = pure $ TupE $ map Just exps

--- a/hasktorch/src/Torch/Tensor.hs
+++ b/hasktorch/src/Torch/Tensor.hs
@@ -11,6 +11,7 @@
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE RankNTypes #-}
 
 module Torch.Tensor where
 
@@ -384,7 +385,7 @@ data None = None
 data Ellipsis = Ellipsis
   deriving (Show, Eq)
 
-data Slice a = Slice a
+newtype Slice a = Slice a
   deriving (Show, Eq)
 
 instance Castable RawTensorIndex (ForeignPtr ATen.TensorIndex) where
@@ -393,6 +394,9 @@ instance Castable RawTensorIndex (ForeignPtr ATen.TensorIndex) where
 
 class TensorIndex a where
   pushIndex :: [RawTensorIndex] -> a -> [RawTensorIndex]
+  toLens :: a -> Lens' Tensor Tensor
+  default toLens :: a -> Lens' Tensor Tensor
+  toLens idx func s = maskedFill s idx <$> func (s ! idx)
 
 instance {-# OVERLAPS #-} TensorIndex None where
   pushIndex vec _ = unsafePerformIO $ do

--- a/hasktorch/src/Torch/Tensor.hs
+++ b/hasktorch/src/Torch/Tensor.hs
@@ -272,7 +272,7 @@ indexSelect' ::
 indexSelect' dim indexList t = unsafePerformIO $ (cast3 ATen.index_select_tlt) t dim (asTensor indexList)
 
 -- | Slices the input tensor along the selected dimension at the given range.
-slice ::
+sliceDim ::
   -- | dim
   Int ->
   -- | start
@@ -284,7 +284,7 @@ slice ::
   -- | input
   Tensor ->
   Tensor
-slice _dim _start _end _step _self = unsafePerformIO $ (cast5 ATen.slice_tllll) _self _dim _start _end _step
+sliceDim _dim _start _end _step _self = unsafePerformIO $ (cast5 ATen.slice_tllll) _self _dim _start _end _step
 
 isContiguous ::
   Tensor ->

--- a/hasktorch/src/Torch/Tutorial.hs
+++ b/hasktorch/src/Torch/Tutorial.hs
@@ -149,7 +149,7 @@ Some operations transform a tensor:
 >>> Torch.relu (asTensor ([-1.0, -0.5, 0.5, 1] :: [Float]))
 Tensor Float [4] [ 0.0000,  0.0000,  0.5000   ,  1.0000   ]
 
-'Torch.Tensor.select' slices out a selection by specifying a dimension and index:
+'Torch.Tensor.selectDim' slices out a selection by specifying a dimension and index:
 
 >>> let x = asTensor [[[1, 2, 3]], [[4, 5, 6]], [[7, 8, 9]], [[10, 11, 12]]]
 >>> shape x

--- a/hasktorch/test/IndexSpec.hs
+++ b/hasktorch/test/IndexSpec.hs
@@ -57,6 +57,9 @@ spec = do
       [slice|1,2,3|] `shouldBe` (1, 2, 3)
     it "1 , 2, 3" $ do
       [slice|1 , 2, 3|] `shouldBe` (1, 2, 3)
+    it "1 , 2, 3" $ do
+      let i = 1
+      [slice|{i} , 2, 3|] `shouldBe` (1, 2, 3)
   describe "indexing" $ do
     it "pick up a value" $ do
       let x = asTensor ([[[0,1,2],[3,4,5]],[[6,7,8],[9,10,11]]] :: [[[Int]]])

--- a/hasktorch/test/IndexSpec.hs
+++ b/hasktorch/test/IndexSpec.hs
@@ -16,51 +16,51 @@ import Torch.TensorFactories
 
 spec :: Spec
 spec = do
-  describe "pySlice" $ do
+  describe "slice" $ do
     it "None" $ do
-      [pySlice|None|] `shouldBe` None
+      [slice|None|] `shouldBe` None
     it "Ellipsis" $ do
-      [pySlice|Ellipsis|] `shouldBe` Ellipsis
+      [slice|Ellipsis|] `shouldBe` Ellipsis
     it "..." $ do
-      [pySlice|...|] `shouldBe` Ellipsis
+      [slice|...|] `shouldBe` Ellipsis
     it "123" $ do
-      [pySlice|123|] `shouldBe` 123
+      [slice|123|] `shouldBe` 123
     it "True" $ do
-      [pySlice|True|] `shouldBe` True
+      [slice|True|] `shouldBe` True
     it "False" $ do
-      [pySlice|False|] `shouldBe` False
+      [slice|False|] `shouldBe` False
     it ":" $ do
-      [pySlice|:|] `shouldBe` Slice ()
+      [slice|:|] `shouldBe` Slice ()
     it "::" $ do
-      [pySlice|::|] `shouldBe` Slice ()
+      [slice|::|] `shouldBe` Slice ()
     it "1:" $ do
-      [pySlice|1:|] `shouldBe` Slice (1, None)
+      [slice|1:|] `shouldBe` Slice (1, None)
     it "1::" $ do
-      [pySlice|1::|] `shouldBe` Slice (1, None)
+      [slice|1::|] `shouldBe` Slice (1, None)
     it ":3" $ do
-      [pySlice|:3|] `shouldBe` Slice (None, 3)
+      [slice|:3|] `shouldBe` Slice (None, 3)
     it ":3:" $ do
-      [pySlice|:3:|] `shouldBe` Slice (None, 3)
+      [slice|:3:|] `shouldBe` Slice (None, 3)
     it "::2" $ do
-      [pySlice|::2|] `shouldBe` Slice (None, None, 2)
+      [slice|::2|] `shouldBe` Slice (None, None, 2)
     it "1:3" $ do
-      [pySlice|1:3|] `shouldBe` Slice (1, 3)
+      [slice|1:3|] `shouldBe` Slice (1, 3)
     it "1::2" $ do
-      [pySlice|1::2|] `shouldBe` Slice (1, None, 2)
+      [slice|1::2|] `shouldBe` Slice (1, None, 2)
     it ":3:2" $ do
-      [pySlice|:3:2|] `shouldBe` Slice (None, 3, 2)
+      [slice|:3:2|] `shouldBe` Slice (None, 3, 2)
     it "1:3:2" $ do
-      [pySlice|1:3:2|] `shouldBe` Slice (1, 3, 2)
+      [slice|1:3:2|] `shouldBe` Slice (1, 3, 2)
     it "1,2,3" $ do
-      [pySlice|1,2,3|] `shouldBe` (1, 2, 3)
+      [slice|1,2,3|] `shouldBe` (1, 2, 3)
     it "1 , 2, 3" $ do
-      [pySlice|1 , 2, 3|] `shouldBe` (1, 2, 3)
+      [slice|1 , 2, 3|] `shouldBe` (1, 2, 3)
   describe "indexing" $ do
     it "pick up a value" $ do
       let x = asTensor ([[[0,1,2],[3,4,5]],[[6,7,8],[9,10,11]]] :: [[[Int]]])
-          r = x ! [pySlice|1,0,2|]
+          r = x ! [slice|1,0,2|]
       (dtype &&& shape &&& asValue) r `shouldBe` (Int64, ([], 8 :: Int))
     it "intercalate" $ do
       let x = zeros' [6]
-          i = [pySlice|0::2|]
+          i = [slice|0::2|]
       (dtype &&& shape &&& asValue) (maskedFill x i (arange' 1 4 1)) `shouldBe` (Float, ([6], [1,0,2,0,3,0] :: [Float]))

--- a/hasktorch/test/IndexSpec.hs
+++ b/hasktorch/test/IndexSpec.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE ExtendedDefaultRules #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+
+module IndexSpec (spec) where
+
+import Test.Hspec
+import Test.QuickCheck
+import Torch.Tensor
+import Torch.Index
+import Control.Arrow                  ( (&&&) )
+import Torch.DType
+import Torch.TensorFactories
+
+spec :: Spec
+spec = do
+  describe "pySlice" $ do
+    it "None" $ do
+      [pySlice|None|] `shouldBe` None
+    it "Ellipsis" $ do
+      [pySlice|Ellipsis|] `shouldBe` Ellipsis
+    it "..." $ do
+      [pySlice|...|] `shouldBe` Ellipsis
+    it "123" $ do
+      [pySlice|123|] `shouldBe` 123
+    it "True" $ do
+      [pySlice|True|] `shouldBe` True
+    it "False" $ do
+      [pySlice|False|] `shouldBe` False
+    it ":" $ do
+      [pySlice|:|] `shouldBe` Slice ()
+    it "::" $ do
+      [pySlice|::|] `shouldBe` Slice ()
+    it "1:" $ do
+      [pySlice|1:|] `shouldBe` Slice (1, None)
+    it "1::" $ do
+      [pySlice|1::|] `shouldBe` Slice (1, None)
+    it ":3" $ do
+      [pySlice|:3|] `shouldBe` Slice (None, 3)
+    it ":3:" $ do
+      [pySlice|:3:|] `shouldBe` Slice (None, 3)
+    it "::2" $ do
+      [pySlice|::2|] `shouldBe` Slice (None, None, 2)
+    it "1:3" $ do
+      [pySlice|1:3|] `shouldBe` Slice (1, 3)
+    it "1::2" $ do
+      [pySlice|1::2|] `shouldBe` Slice (1, None, 2)
+    it ":3:2" $ do
+      [pySlice|:3:2|] `shouldBe` Slice (None, 3, 2)
+    it "1:3:2" $ do
+      [pySlice|1:3:2|] `shouldBe` Slice (1, 3, 2)
+    it "1,2,3" $ do
+      [pySlice|1,2,3|] `shouldBe` (1, 2, 3)
+    it "1 , 2, 3" $ do
+      [pySlice|1 , 2, 3|] `shouldBe` (1, 2, 3)
+  describe "indexing" $ do
+    it "pick up a value" $ do
+      let x = asTensor ([[[0,1,2],[3,4,5]],[[6,7,8],[9,10,11]]] :: [[[Int]]])
+          r = x ! [pySlice|1,0,2|]
+      (dtype &&& shape &&& asValue) r `shouldBe` (Int64, ([], 8 :: Int))
+    it "intercalate" $ do
+      let x = zeros' [6]
+          i = [pySlice|0::2|]
+      (dtype &&& shape &&& asValue) (maskedFill x i (arange' 1 4 1)) `shouldBe` (Float, ([6], [1,0,2,0,3,0] :: [Float]))

--- a/hasktorch/test/IndexSpec.hs
+++ b/hasktorch/test/IndexSpec.hs
@@ -25,6 +25,8 @@ spec = do
       [slice|...|] `shouldBe` Ellipsis
     it "123" $ do
       [slice|123|] `shouldBe` 123
+    it "-123" $ do
+      [slice|-123|] `shouldBe` -123
     it "True" $ do
       [slice|True|] `shouldBe` True
     it "False" $ do

--- a/hasktorch/test/IndexSpec.hs
+++ b/hasktorch/test/IndexSpec.hs
@@ -66,3 +66,7 @@ spec = do
       let x = zeros' [6]
           i = [slice|0::2|]
       (dtype &&& shape &&& asValue) (maskedFill x i (arange' 1 4 1)) `shouldBe` (Float, ([6], [1,0,2,0,3,0] :: [Float]))
+    it "negative index" $ do
+      let x = arange' 1 5 1
+          i = [slice|-1|]
+      (dtype &&& shape &&& asValue) (x ! i) `shouldBe` (Float, ([], 4 :: Float))


### PR DESCRIPTION
This PR adds the slice operator of python-style with ~~`pySlice`~~ `slice` quote.

When you get values in python looks like this,

```python
tensor[0,0:3]
```

hasktorch uses ~~pySlice~~ slice to get the value with `!`  and ~~`pySlice`~~ `slice` as follows:

```
tensor ! [slice|0,0:3|]
```


