### PR TITLE
Add `all`, `any` reduction functions

### DIFF
--- a/experimental/gradually-typed/doctests.hs
+++ b/experimental/gradually-typed/doctests.hs
@@ -2,12 +2,13 @@ module Main where
 
 import Build_doctests (flags, module_sources, pkgs)
 import Data.Foldable (traverse_)
-import System.Environment (lookupEnv)
+import System.Environment (lookupEnv, setEnv)
 import Test.DocTest (doctest)
 
 main :: IO ()
 main = do
   libDir <- lookupEnv "NIX_GHC_LIBDIR"
+  setEnv "HASKTORCH_DEBUG" "0"
 
   let args =
         concat

--- a/experimental/gradually-typed/hasktorch-gradually-typed.cabal
+++ b/experimental/gradually-typed/hasktorch-gradually-typed.cabal
@@ -140,6 +140,7 @@ test-suite spec
   hs-source-dirs:      test
   main-is:             Spec.hs
   other-modules:       TensorSpec
+                     , TransformerSpec
   default-language:    Haskell2010
   ghc-options:         -Wall -fplugin GHC.TypeLits.Normalise -fplugin GHC.TypeLits.KnownNat.Solver -fplugin GHC.TypeLits.Extra.Solver -fconstraint-solver-iterations=0
   build-depends:       base >= 4.7 && < 5

--- a/experimental/gradually-typed/src/Torch/GraduallyTyped/NN/Dropout.hs
+++ b/experimental/gradually-typed/src/Torch/GraduallyTyped/NN/Dropout.hs
@@ -4,7 +4,9 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -52,4 +54,4 @@ instance
     output
     generatorOutput
   where
-  forward (Dropout _p) input g = pure $ (unsafeCoerce :: (input, g) -> (output, generatorOutput)) (input, g)
+  forward (Dropout _p) input g = pure $ (unsafeCoerce @(input, generator) @(output, generatorOutput)) (input, g)

--- a/experimental/gradually-typed/src/Torch/GraduallyTyped/NN/Transformer/Stack.hs
+++ b/experimental/gradually-typed/src/Torch/GraduallyTyped/NN/Transformer/Stack.hs
@@ -7,7 +7,6 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverlappingInstances #-}
 {-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RecordWildCards #-}

--- a/experimental/gradually-typed/src/Torch/GraduallyTyped/Tensor/MathOperations/Reduction.hs
+++ b/experimental/gradually-typed/src/Torch/GraduallyTyped/Tensor/MathOperations/Reduction.hs
@@ -22,6 +22,7 @@ import Data.Singletons (SingI (..), SingKind (..))
 import Foreign.ForeignPtr (ForeignPtr)
 import GHC.TypeLits (Nat, Symbol, TypeError)
 import System.IO.Unsafe (unsafePerformIO)
+import Torch.GraduallyTyped.DType (DType (..), DataType (..))
 import Torch.GraduallyTyped.Prelude (forgetIsChecked)
 import Torch.GraduallyTyped.Shape.Class (ReplaceDimSizeImplF)
 import Torch.GraduallyTyped.Shape.Type (By (..), Dim (..), Name (..), SSelectDim, SSelectDims, SelectDim (..), SelectDims (..), Shape (..), Size (..))
@@ -74,7 +75,7 @@ type family BoolReductionF (reduction :: Symbol) (selectDim :: SelectDim (By Sym
 all ::
   forall requiresGradient layout device dataType shape.
   Tensor requiresGradient layout device dataType shape ->
-  Tensor requiresGradient layout device dataType ('Shape '[])
+  Tensor requiresGradient layout device ('DataType 'Bool) ('Shape '[])
 all = unsafePerformIO . cast1 ATen.all_t
 
 -- | Reduces each row of the input tensor in the selected dimension to True if all elements in the row evaluate to True and False otherwise.
@@ -101,7 +102,7 @@ sAllDim ::
   MonadThrow m =>
   SSelectDim selectDim ->
   Tensor gradient layout device dataType shape ->
-  m (Tensor gradient layout device dataType (BoolReductionF "all" selectDim shape))
+  m (Tensor gradient layout device ('DataType 'Bool) (BoolReductionF "all" selectDim shape))
 sAllDim by tensor = unsafeThrowableIO $ case forgetIsChecked $ fromSing by of
   ByName name ->
     cast3
@@ -134,7 +135,7 @@ allDim ::
   forall selectDim gradient layout device dataType shape.
   SingI selectDim =>
   Tensor gradient layout device dataType shape ->
-  Tensor gradient layout device dataType (BoolReductionF "all" selectDim shape)
+  Tensor gradient layout device ('DataType 'Bool) (BoolReductionF "all" selectDim shape)
 allDim = unsafePerformIO . sAllDim (sing @selectDim)
 
 -- | Tests if any element in input evaluates to True.
@@ -153,7 +154,7 @@ allDim = unsafePerformIO . sAllDim (sing @selectDim)
 any ::
   forall requiresGradient layout device dataType shape.
   Tensor requiresGradient layout device dataType shape ->
-  Tensor requiresGradient layout device dataType ('Shape '[])
+  Tensor requiresGradient layout device ('DataType 'Bool) ('Shape '[])
 any = unsafePerformIO . cast1 ATen.any_t
 
 -- | Reduces each row of the input tensor in the selected dimension to True if any element in the row evaluates to True and False otherwise.
@@ -180,7 +181,7 @@ sAnyDim ::
   MonadThrow m =>
   SSelectDim selectDim ->
   Tensor gradient layout device dataType shape ->
-  m (Tensor gradient layout device dataType (BoolReductionF "any" selectDim shape))
+  m (Tensor gradient layout device ('DataType 'Bool) (BoolReductionF "any" selectDim shape))
 sAnyDim by tensor = unsafeThrowableIO $
   case forgetIsChecked $ fromSing by of
     ByName name ->
@@ -214,7 +215,7 @@ anyDim ::
   forall selectDim gradient layout device dataType shape.
   SingI selectDim =>
   Tensor gradient layout device dataType shape ->
-  Tensor gradient layout device dataType (BoolReductionF "any" selectDim shape)
+  Tensor gradient layout device ('DataType 'Bool) (BoolReductionF "any" selectDim shape)
 anyDim = unsafePerformIO . sAnyDim (sing @selectDim)
 
 type family MeanSelectDimsF (bys :: [By Symbol Nat]) (dims :: [Dim (Name Symbol) (Size Nat)]) :: [Dim (Name Symbol) (Size Nat)] where

--- a/experimental/gradually-typed/src/Torch/GraduallyTyped/Tensor/MathOperations/Reduction.hs
+++ b/experimental/gradually-typed/src/Torch/GraduallyTyped/Tensor/MathOperations/Reduction.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -12,6 +13,7 @@
 
 module Torch.GraduallyTyped.Tensor.MathOperations.Reduction where
 
+import Control.Monad.Catch (MonadThrow)
 import Control.Monad.State (execState, modify)
 import Data.Bifunctor (Bifunctor (first), second)
 import Data.Foldable (for_)
@@ -20,26 +22,25 @@ import Data.Singletons (SingI (..), SingKind (..))
 import Foreign.ForeignPtr (ForeignPtr)
 import GHC.TypeLits (Nat, Symbol, TypeError)
 import System.IO.Unsafe (unsafePerformIO)
-import Torch.GraduallyTyped.DType (DType (..), DataType (..))
 import Torch.GraduallyTyped.Prelude (forgetIsChecked)
 import Torch.GraduallyTyped.Shape.Class (ReplaceDimSizeImplF)
-import Torch.GraduallyTyped.Shape.Type (By (..), Dim (..), Name (..), SSelectDims, SelectDims (..), Shape (..), Size (..))
+import Torch.GraduallyTyped.Shape.Type (By (..), Dim (..), Name (..), SSelectDim, SSelectDims, SelectDim (..), SelectDims (..), Shape (..), Size (..))
 import Torch.GraduallyTyped.Tensor.Type (Tensor)
 import Torch.Internal.Cast (cast1, cast3)
-import qualified Torch.Internal.Cast as ATen
 import Torch.Internal.Class (Castable (cast), uncast)
+import Torch.Internal.GC (unsafeThrowableIO)
 import qualified Torch.Internal.Managed.Native as ATen
 import qualified Torch.Internal.Type as ATen (Tensor)
 import Type.Errors.Pretty (type (%), type (<>))
+import Prelude hiding (all, any)
 
-allT ::
-  forall requiresGradient layout device shape.
-  Tensor requiresGradient layout device ('DataType 'Bool) shape ->
-  Tensor requiresGradient layout device ('DataType 'Bool) ('Shape '[])
-allT t = unsafePerformIO $ ATen.cast1 ATen.all_t t
+-- $setup
+-- >>> import Data.Singletons.Prelude.List (SList (..))
+-- >>> import Torch.GraduallyTyped
+-- >>> import Prelude hiding (all, any)
 
-type MeanErrorMessage (by :: By Symbol Nat) (dims :: [Dim (Name Symbol) (Size Nat)]) =
-  "Cannot apply mean on the dimension matching"
+type ReductionErrorMessage (reduction :: Symbol) (by :: By Symbol Nat) (dims :: [Dim (Name Symbol) (Size Nat)]) =
+  "Cannot apply '" <> reduction <> "' on the dimension matching"
     % ""
     % "    '" <> by <> "'"
     % ""
@@ -48,65 +49,267 @@ type MeanErrorMessage (by :: By Symbol Nat) (dims :: [Dim (Name Symbol) (Size Na
     % "    '" <> dims <> "'."
     % ""
 
-type family MeanCheckF (by :: By Symbol Nat) (dims :: [Dim (Name Symbol) (Size Nat)]) (result :: Maybe [Dim (Name Symbol) (Size Nat)]) :: [Dim (Name Symbol) (Size Nat)] where
-  MeanCheckF by dims 'Nothing = TypeError (MeanErrorMessage by dims)
-  MeanCheckF _ _ ('Just dims') = dims'
+type family ReductionCheckF (reduction :: Symbol) (by :: By Symbol Nat) (dims :: [Dim (Name Symbol) (Size Nat)]) (result :: Maybe [Dim (Name Symbol) (Size Nat)]) :: [Dim (Name Symbol) (Size Nat)] where
+  ReductionCheckF reduction by dims 'Nothing = TypeError (ReductionErrorMessage reduction by dims)
+  ReductionCheckF _ _ _ ('Just dims') = dims'
+
+type family BoolReductionF (reduction :: Symbol) (selectDim :: SelectDim (By Symbol Nat)) (shape :: Shape [Dim (Name Symbol) (Size Nat)]) :: Shape [Dim (Name Symbol) (Size Nat)] where
+  BoolReductionF _ 'UncheckedSelectDim _ = 'UncheckedShape
+  BoolReductionF _ _ 'UncheckedShape = 'UncheckedShape
+  BoolReductionF reduction ('SelectDim by) ('Shape dims) = 'Shape (ReductionCheckF reduction by dims (ReplaceDimSizeImplF by dims ('Size 1)))
+
+-- | Tests if all element in input evaluates to True.
+--
+-- >>> g <- sMkGenerator (SDevice SCPU) 0
+-- >>> shape = SShape $ SName @"*" :&: SSize @2 :|: SName @"*" :&: SSize @4 :|: SNil
+-- >>> (t, _) = sRandn (SGradient SWithoutGradient) (SLayout SDense) (SDevice SCPU) (SDataType SFloat) shape g
+-- >>> :type all $ bool t
+-- all $ bool t
+--   :: Tensor
+--        ('Gradient 'WithoutGradient)
+--        ('Layout 'Dense)
+--        ('Device 'CPU)
+--        ('DataType 'Bool)
+--        ('Shape '[])
+all ::
+  forall requiresGradient layout device dataType shape.
+  Tensor requiresGradient layout device dataType shape ->
+  Tensor requiresGradient layout device dataType ('Shape '[])
+all = unsafePerformIO . cast1 ATen.all_t
+
+-- | Reduces each row of the input tensor in the selected dimension to True if all elements in the row evaluate to True and False otherwise.
+-- For a version that accepts non-singleton parameters see 'allDim'.
+--
+-- >>> g <- sMkGenerator (SDevice SCPU) 0
+-- >>> shape = SShape $ SName @"*" :&: SSize @2 :|: SName @"*" :&: SSize @4 :|: SNil
+-- >>> (t, _) = sRandn (SGradient SWithoutGradient) (SLayout SDense) (SDevice SCPU) (SDataType SFloat) shape g
+-- >>> t' <- sAllDim (SSelectDim (SByIndex @1)) $ bool t
+-- >>> :type t'
+-- t'
+--   :: Tensor
+--        ('Gradient 'WithoutGradient)
+--        ('Layout 'Dense)
+--        ('Device 'CPU)
+--        ('DataType 'Bool)
+--        ('Shape '[ 'Dim ('Name "*") ('Size 2), 'Dim ('Name "*") ('Size 1)])
+--
+-- >>> sAllDim (SUncheckedSelectDim (ByIndex 3)) t
+-- ...
+-- *** Exception: HasktorchException "Exception: Dimension out of range (expected to be in range of [-2, 1], but got 3)...
+sAllDim ::
+  forall selectDim gradient layout device dataType shape m.
+  MonadThrow m =>
+  SSelectDim selectDim ->
+  Tensor gradient layout device dataType shape ->
+  m (Tensor gradient layout device dataType (BoolReductionF "all" selectDim shape))
+sAllDim by tensor = unsafeThrowableIO $ case forgetIsChecked $ fromSing by of
+  ByName name ->
+    cast3
+      ATen.all_tnb
+      tensor
+      name
+      True -- keepDim
+  ByIndex index ->
+    cast3
+      ATen.all_tlb
+      tensor
+      (fromInteger index :: Int)
+      True -- keepDim
+
+-- | Reduces each row of the input tensor in the selected dimension to True if all elements in the row evaluate to True and False otherwise.
+-- For a version that accepts singleton parameters see 'sAllDim'.
+--
+-- >>> g <- sMkGenerator (SDevice SCPU) 0
+-- >>> type Shape' = 'Shape '[ 'Dim ('Name "*") ('Size 2), 'Dim ('Name "*") ('Size 4) ]
+-- >>> (t, _) = randn @('Gradient 'WithoutGradient) @('Layout 'Dense) @('Device 'CPU) @('DataType 'Float) @Shape' g
+-- >>> :type allDim @('SelectDim ('ByIndex 1)) $ bool t
+-- allDim @('SelectDim ('ByIndex 1)) $ bool t
+--   :: Tensor
+--        ('Gradient 'WithoutGradient)
+--        ('Layout 'Dense)
+--        ('Device 'CPU)
+--        ('DataType 'Bool)
+--        ('Shape '[ 'Dim ('Name "*") ('Size 2), 'Dim ('Name "*") ('Size 1)])
+allDim ::
+  forall selectDim gradient layout device dataType shape.
+  SingI selectDim =>
+  Tensor gradient layout device dataType shape ->
+  Tensor gradient layout device dataType (BoolReductionF "all" selectDim shape)
+allDim = unsafePerformIO . sAllDim (sing @selectDim)
+
+-- | Tests if any element in input evaluates to True.
+--
+-- >>> g <- sMkGenerator (SDevice SCPU) 0
+-- >>> shape = SShape $ SName @"*" :&: SSize @2 :|: SName @"*" :&: SSize @4 :|: SNil
+-- >>> (t, _) = sRandn (SGradient SWithoutGradient) (SLayout SDense) (SDevice SCPU) (SDataType SFloat) shape g
+-- >>> :type any $ bool t
+-- any $ bool t
+--   :: Tensor
+--        ('Gradient 'WithoutGradient)
+--        ('Layout 'Dense)
+--        ('Device 'CPU)
+--        ('DataType 'Bool)
+--        ('Shape '[])
+any ::
+  forall requiresGradient layout device dataType shape.
+  Tensor requiresGradient layout device dataType shape ->
+  Tensor requiresGradient layout device dataType ('Shape '[])
+any = unsafePerformIO . cast1 ATen.any_t
+
+-- | Reduces each row of the input tensor in the selected dimension to True if any element in the row evaluates to True and False otherwise.
+-- For a version that accepts non-singleton parameters see 'anyDim'.
+--
+-- >>> g <- sMkGenerator (SDevice SCPU) 0
+-- >>> shape = SShape $ SName @"*" :&: SSize @2 :|: SName @"*" :&: SSize @4 :|: SNil
+-- >>> (t, _) = sRandn (SGradient SWithoutGradient) (SLayout SDense) (SDevice SCPU) (SDataType SFloat) shape g
+-- >>> t' <- sAnyDim (SSelectDim (SByIndex @1)) $ bool t
+-- >>> :type t'
+-- t'
+--   :: Tensor
+--        ('Gradient 'WithoutGradient)
+--        ('Layout 'Dense)
+--        ('Device 'CPU)
+--        ('DataType 'Bool)
+--        ('Shape '[ 'Dim ('Name "*") ('Size 2), 'Dim ('Name "*") ('Size 1)])
+--
+-- >>> sAnyDim (SUncheckedSelectDim (ByIndex 3)) t
+-- ...
+-- *** Exception: HasktorchException "Exception: Dimension out of range (expected to be in range of [-2, 1], but got 3)...
+sAnyDim ::
+  forall selectDim gradient layout device shape dataType m.
+  MonadThrow m =>
+  SSelectDim selectDim ->
+  Tensor gradient layout device dataType shape ->
+  m (Tensor gradient layout device dataType (BoolReductionF "any" selectDim shape))
+sAnyDim by tensor = unsafeThrowableIO $
+  case forgetIsChecked $ fromSing by of
+    ByName name ->
+      cast3
+        ATen.any_tnb
+        tensor
+        name
+        True -- keepDim
+    ByIndex index ->
+      cast3
+        ATen.any_tlb
+        tensor
+        (fromInteger index :: Int)
+        True -- keepDim
+
+-- | Reduces each row of the input tensor in the selected dimension to True if any element in the row evaluates to True and False otherwise.
+-- For a version that accepts singleton parameters see 'sAnyDim'.
+--
+-- >>> g <- sMkGenerator (SDevice SCPU) 0
+-- >>> type Shape' = 'Shape '[ 'Dim ('Name "*") ('Size 2), 'Dim ('Name "*") ('Size 4) ]
+-- >>> (t, _) = randn @('Gradient 'WithoutGradient) @('Layout 'Dense) @('Device 'CPU) @('DataType 'Float) @Shape' g
+-- >>> :type anyDim @('SelectDim ('ByIndex 1)) $ bool t
+-- anyDim @('SelectDim ('ByIndex 1)) $ bool t
+--   :: Tensor
+--        ('Gradient 'WithoutGradient)
+--        ('Layout 'Dense)
+--        ('Device 'CPU)
+--        ('DataType 'Bool)
+--        ('Shape '[ 'Dim ('Name "*") ('Size 2), 'Dim ('Name "*") ('Size 1)])
+anyDim ::
+  forall selectDim gradient layout device dataType shape.
+  SingI selectDim =>
+  Tensor gradient layout device dataType shape ->
+  Tensor gradient layout device dataType (BoolReductionF "any" selectDim shape)
+anyDim = unsafePerformIO . sAnyDim (sing @selectDim)
 
 type family MeanSelectDimsF (bys :: [By Symbol Nat]) (dims :: [Dim (Name Symbol) (Size Nat)]) :: [Dim (Name Symbol) (Size Nat)] where
   MeanSelectDimsF '[] dims = dims
-  MeanSelectDimsF (by ': bys) dims = MeanSelectDimsF bys (MeanCheckF by dims (ReplaceDimSizeImplF by dims ('Size 1)))
+  MeanSelectDimsF (by ': bys) dims = MeanSelectDimsF bys (ReductionCheckF "mean" by dims (ReplaceDimSizeImplF by dims ('Size 1)))
 
 type family MeanF (selectDims :: SelectDims [By Symbol Nat]) (shape :: Shape [Dim (Name Symbol) (Size Nat)]) :: Shape [Dim (Name Symbol) (Size Nat)] where
   MeanF 'UncheckedSelectDims _ = 'UncheckedShape
   MeanF _ 'UncheckedShape = 'UncheckedShape
   MeanF ('SelectDims bys) ('Shape dims) = 'Shape (MeanSelectDimsF bys dims)
 
-sMeanDim ::
-  forall selectDims gradient layout device dataType shape.
+-- | Reduces the mean value over each row of the input tensor in the dimensions selected by 'selectDims'.
+-- For a version that accepts non-singleton parameters see 'meanDim'.
+--
+-- >>> g <- sMkGenerator (SDevice SCPU) 0
+-- >>> shape = SShape $ SName @"batch" :&: SSize @8 :|: SName @"width" :&: SSize @224 :|: SName @"height" :&: SSize @224 :|: SNil
+-- >>> (t, _) = sRandn (SGradient SWithoutGradient) (SLayout SDense) (SDevice SCPU) (SDataType SFloat) shape g
+-- >>> t' <- sMeanDims (SSelectDims $ SCons (SByName @"width") $ SCons (SByName @"height") SNil) t
+-- >>> :type t'
+-- t'
+--   :: Tensor
+--        ('Gradient 'WithoutGradient)
+--        ('Layout 'Dense)
+--        ('Device 'CPU)
+--        ('DataType 'Float)
+--        ('Shape
+--           '[ 'Dim ('Name "batch") ('Size 8), 'Dim ('Name "width") ('Size 1),
+--              'Dim ('Name "height") ('Size 1)])
+--
+-- >>> sMeanDims (SUncheckedSelectDims [ByName "feature"]) t
+-- ...
+-- *** Exception: HasktorchException "Exception: Name 'feature' not found in Tensor['batch', 'width', 'height']...
+sMeanDims ::
+  forall selectDims gradient layout device dataType shape m.
+  MonadThrow m =>
   SSelectDims selectDims ->
   Tensor gradient layout device dataType shape ->
-  Tensor gradient layout device dataType (MeanF selectDims shape)
-sMeanDim bys tensor =
+  m (Tensor gradient layout device dataType (MeanF selectDims shape))
+sMeanDims bys tensor =
   let bys' = forgetIsChecked $ fromSing bys
       (names, indexes) = flip execState (Set.empty, Set.empty) $ do
         for_ bys' $ \by -> do
           case by of
             ByName name -> modify . first $ Set.insert name
             ByIndex index -> modify . second $ Set.insert index
-   in unsafePerformIO $ do
+   in unsafeThrowableIO $ do
         case (names, indexes) of
-          (names, indexes)
-            | Set.null names && Set.null indexes ->
+          (names', indexes')
+            | Set.null names' && Set.null indexes' ->
               do
                 t :: ForeignPtr ATen.Tensor <- cast tensor pure
                 uncast t pure
-            | Set.null names ->
-              cast1 (meanIndexes indexes) tensor
-            | Set.null indexes ->
-              cast1 (meanNames names) tensor
+            | Set.null names' ->
+              cast1 (meanIndexes indexes') tensor
+            | Set.null indexes' ->
+              cast1 (meanNames names') tensor
             | otherwise ->
               do
-                t' :: ForeignPtr ATen.Tensor <- cast1 (meanIndexes indexes) tensor
-                cast1 (meanNames names) t'
+                t' :: ForeignPtr ATen.Tensor <- cast1 (meanIndexes indexes') tensor
+                cast1 (meanNames names') t'
   where
     meanNames :: Set.Set String -> ForeignPtr ATen.Tensor -> IO (ForeignPtr ATen.Tensor)
-    meanNames names tensor =
+    meanNames names tensor' =
       cast3
         ATen.mean_tNb
-        tensor
+        tensor'
         (Set.toList names)
         True -- keepDim
     meanIndexes :: Set.Set Integer -> ForeignPtr ATen.Tensor -> IO (ForeignPtr ATen.Tensor)
-    meanIndexes indexes tensor =
+    meanIndexes indexes tensor' =
       cast3
         ATen.mean_tlb
-        tensor
+        tensor'
         (Set.toList indexes)
         True -- keepDim
 
-meanDim ::
+-- | Reduce the mean value over each row of the input tensor in the dimensions selected by 'selectDims'.
+-- For a version that accepts singleton parameters see 'sMeanDim'.
+--
+-- >>> g <- sMkGenerator (SDevice SCPU) 0
+-- >>> type Shape' = 'Shape '[ 'Dim ('Name "batch") ('Size 8), 'Dim ('Name "feature") ('Size 4) ]
+-- >>> (t, _) = randn @('Gradient 'WithoutGradient) @('Layout 'Dense) @('Device 'CPU) @('DataType 'Float) @Shape' g
+-- >>> :type meanDims @('SelectDims '[ 'ByName "feature" ]) t
+-- meanDims @('SelectDims '[ 'ByName "feature" ]) t
+--   :: Tensor
+--        ('Gradient 'WithoutGradient)
+--        ('Layout 'Dense)
+--        ('Device 'CPU)
+--        ('DataType 'Float)
+--        ('Shape
+--           '[ 'Dim ('Name "batch") ('Size 8),
+--              'Dim ('Name "feature") ('Size 1)])
+meanDims ::
   forall selectDims gradient layout device dataType shape.
   SingI selectDims =>
   Tensor gradient layout device dataType shape ->
   Tensor gradient layout device dataType (MeanF selectDims shape)
-meanDim = sMeanDim (sing @selectDims)
+meanDims = unsafePerformIO . sMeanDims (sing @selectDims)

--- a/experimental/gradually-typed/test/TensorSpec.hs
+++ b/experimental/gradually-typed/test/TensorSpec.hs
@@ -14,6 +14,8 @@ import Test.Hspec
 import Test.Hspec.Hedgehog (MonadGen, assert, forAll, hedgehog, (===))
 import qualified Test.QuickCheck as QC
 import Torch.GraduallyTyped
+import Prelude hiding (all)
+import qualified Prelude as P
 
 toCPUTensor ::
   (TensorLike a dType dims, MonadThrow m) =>
@@ -109,21 +111,21 @@ spec = describe "TensorLike" $ do
         xs :: [Float] <- forAll $ Gen.list (Range.linear 0 1000) genReal
         t <- toCPUTensor xs
         let xs' = fromTensor t
-        assert $ all (uncurry (~~)) $ zip xs' xs
+        assert $ P.all (uncurry (~~)) $ zip xs' xs
 
     it "[Double]" $
       hedgehog $ do
         xs :: [Double] <- forAll $ Gen.list (Range.linear 0 1000) genReal
         t <- toCPUTensor xs
         let xs' = fromTensor t
-        assert $ all (uncurry (~~)) $ zip xs' xs
+        assert $ P.all (uncurry (~~)) $ zip xs' xs
 
     it "(Vector Float)" $
       hedgehog $ do
         xs :: V.Vector Double <- (V.fromList <$>) <$> forAll $ Gen.list (Range.linear 0 1000) genReal
         t <- toCPUTensor xs
         let xs' = fromTensor t
-        assert $ all (uncurry (~~)) $ V.zip xs' xs
+        assert $ P.all (uncurry (~~)) $ V.zip xs' xs
 
     it "Tensor" $ do
       let t =
@@ -134,7 +136,7 @@ spec = describe "TensorLike" $ do
               @('DataType 'Int64)
               @('Shape '[ 'Dim ('Name "*") ('Size 4), 'Dim ('Name "*") ('Size 8)])
       t' <- toTensor @('Gradient 'WithoutGradient) @('Layout 'Dense) @('Device 'CPU) t
-      fromTensor (allT $ t' ==. t) `shouldBe` True
+      fromTensor (all $ t' ==. t) `shouldBe` True
       let t'' =
             fromTensor
               @( Tensor
@@ -145,7 +147,7 @@ spec = describe "TensorLike" $ do
                    ('Shape '[ 'Dim ('Name "*") ('Size 4), 'Dim ('Name "*") ('Size 8)])
                )
               t'
-      fromTensor (allT $ t'' ==. t) `shouldBe` True
+      fromTensor (all $ t'' ==. t) `shouldBe` True
 
   it "dims ([[]] :: [[[Int]]]) = 1x0x0" $ do
     x <- toCPUTensor @[[[Int]]] [[]]

--- a/experimental/gradually-typed/test/TensorSpec.hs
+++ b/experimental/gradually-typed/test/TensorSpec.hs
@@ -136,7 +136,8 @@ spec = describe "TensorLike" $ do
               @('DataType 'Int64)
               @('Shape '[ 'Dim ('Name "*") ('Size 4), 'Dim ('Name "*") ('Size 8)])
       t' <- toTensor @('Gradient 'WithoutGradient) @('Layout 'Dense) @('Device 'CPU) t
-      fromTensor (all $ t' ==. t) `shouldBe` True
+      all' <- all $ t' ==. t
+      fromTensor all' `shouldBe` True
       let t'' =
             fromTensor
               @( Tensor
@@ -147,7 +148,8 @@ spec = describe "TensorLike" $ do
                    ('Shape '[ 'Dim ('Name "*") ('Size 4), 'Dim ('Name "*") ('Size 8)])
                )
               t'
-      fromTensor (all $ t'' ==. t) `shouldBe` True
+      all'' <- all $ t'' ==. t
+      fromTensor all'' `shouldBe` True
 
   it "dims ([[]] :: [[[Int]]]) = 1x0x0" $ do
     x <- toCPUTensor @[[[Int]]] [[]]


### PR DESCRIPTION
TODO:

- [ ] Fix `ReplaceDimSizeImplF`, so that we get a type error when `selectDim` does not match a dimension.

EDIT: This looks like a bug in GHC: https://gitlab.haskell.org/ghc/ghc/-/issues/13775