### PR TITLE
Bump libtorch to 1.9

### DIFF
--- a/.github/workflows/cabal-macos.yaml
+++ b/.github/workflows/cabal-macos.yaml
@@ -18,7 +18,7 @@ jobs:
         brew install ghc@8.10 || true
         brew install cabal-install || true
         brew tap hasktorch/libtorch-prebuild https://github.com/hasktorch/homebrew-libtorch-prebuild || true
-        brew install libtorch-prebuild@1.8.1 || true
+        brew install libtorch-prebuild@1.9 || true
         #pushd deps/ ; ./get-deps.sh -a cpu -c ;popd
     - name: Build
       run: |

--- a/.github/workflows/stack-macos.yaml
+++ b/.github/workflows/stack-macos.yaml
@@ -20,7 +20,7 @@ jobs:
         clang --version
         stack --version
         brew tap hasktorch/libtorch-prebuild https://github.com/hasktorch/homebrew-libtorch-prebuild || true
-        brew install libtorch-prebuild@1.8.1 || true
+        brew install libtorch-prebuild@1.9 || true
         #pushd deps/ ; ./get-deps.sh -a cpu -c ;popd
     - name: Cache .stack
       id: cache-stack

--- a/codegen/codegen.cabal
+++ b/codegen/codegen.cabal
@@ -1,5 +1,5 @@
 name:                codegen
-version:             1.8.0.0
+version:             1.9.0.0
 synopsis:            parse torch yaml spec files, generate code
 -- description:
 homepage:            https://github.com/hasktorch/hasktorch#readme

--- a/codegen/src/ParseDeclarations.hs
+++ b/codegen/src/ParseDeclarations.hs
@@ -14,7 +14,6 @@ import qualified ParseFunctionSig as S
 {- Declarations.yaml -}
 {- --A example--
 - name: _th_set_
-  matches_jit_signature: false
   schema_string: ''
   method_prefix_derived: ''
   arguments:
@@ -69,7 +68,6 @@ data Mode
 
 data Declaration = Declaration
   { name :: String
-  , matches_jit_signature :: Bool
   , schema_string :: String
 --  , method_prefix_derived :: String
   , arguments :: [Type]

--- a/codegen/src/RenderClass.hs
+++ b/codegen/src/RenderClass.hs
@@ -19,7 +19,6 @@ import qualified ParseDeclarations as D
 import qualified ParseClass as PC
 import qualified ParseFunctionSig as P
 import RenderCommon
-import qualified RenderDeclarations as RD
 
 renderImport :: Bool -> PC.CppClassSpec -> Text -> Text
 renderImport is_managed _ unmanagedModuleName =  if is_managed then  [st|

--- a/codegen/src/RenderDeclarations.hs
+++ b/codegen/src/RenderDeclarations.hs
@@ -28,7 +28,10 @@ addFunctionWithDefaultArguments dl = map (\args -> dl{D.arguments = args}) genAr
     genArgsWithDefault [] = []
     genArgsWithDefault (x:xs) | D.default' x /= Nothing = (x:xs) : genArgsWithDefault xs
                               | otherwise = [(x:xs)]
-    genArgsWithDefault' = map reverse $ genArgsWithDefault (reverse $ D.arguments dl)
+    genArgsWithDefault' =
+      case D.arguments dl of
+        [] -> [[]]
+        xs -> map reverse $ genArgsWithDefault (reverse xs)
 
 
 toFunction :: D.Declaration -> P.Function
@@ -70,6 +73,7 @@ decodeAndCodeGen basedir fileName = do
 
       let nativeFunctions = filter (\a -> D.mode a == D.Native && "namespace" `elem` (D.method_of a)) fns
           nativeFunctions' = split' 16 nativeFunctions
+      
       forM_ (zip [0..] nativeFunctions') $ \(i::Int,funcs') -> do
         createDirectoryIfMissing True (basedir <> "/Torch/Internal/Unmanaged/Native")
         createDirectoryIfMissing True (basedir <> "/Torch/Internal/Managed/Native")

--- a/deps/get-deps.sh
+++ b/deps/get-deps.sh
@@ -11,7 +11,7 @@ USE_NIGHTLY=0
 USE_BINARY_FOR_CI=0
 COMPUTE_ARCH=cpu
 SKIP_DOWNLOAD=0
-VERSION=1.8.1
+VERSION=1.9.0
 
 if ! command -v unzip &> /dev/null
 then

--- a/experimental/gradually-typed/hasktorch-gradually-typed.cabal
+++ b/experimental/gradually-typed/hasktorch-gradually-typed.cabal
@@ -108,7 +108,7 @@ library
   ghc-options:         -Wall -fplugin GHC.TypeLits.Normalise -fplugin GHC.TypeLits.KnownNat.Solver -fplugin GHC.TypeLits.Extra.Solver -fconstraint-solver-iterations=0
   build-depends:       base >= 4.7 && < 5
                      , hasktorch
-                     , libtorch-ffi == 1.8.*
+                     , libtorch-ffi == 1.9.*
                      , ghc-typelits-extra
                      , ghc-typelits-knownnat
                      , ghc-typelits-natnormalise
@@ -170,7 +170,7 @@ test-suite doctests
   build-depends:       base >= 4.7 && < 5
                      , doctest >=0.16.0.1 && <0.17
                      , hasktorch
-                     , libtorch-ffi == 1.8.*
+                     , libtorch-ffi == 1.9.*
                      , ghc-typelits-extra
                      , ghc-typelits-knownnat
                      , ghc-typelits-natnormalise

--- a/hasktorch/hasktorch.cabal
+++ b/hasktorch/hasktorch.cabal
@@ -99,7 +99,7 @@ library
  ghc-options:         -fplugin GHC.TypeLits.Normalise -fplugin GHC.TypeLits.KnownNat.Solver -fplugin GHC.TypeLits.Extra.Solver -fconstraint-solver-iterations=0
  build-depends:       async
                     , base >= 4.7 && < 5
-                    , libtorch-ffi == 1.8.*
+                    , libtorch-ffi == 1.9.*
                     , finite-typelits
                     , ghc-typelits-extra
                     , ghc-typelits-knownnat
@@ -215,7 +215,7 @@ test-suite doctests
   build-depends:      doctest >=0.16.0.1 && <0.17
                     , async
                     , base >= 4.7 && < 5
-                    , libtorch-ffi == 1.8.*
+                    , libtorch-ffi == 1.9.*
                     , finite-typelits
                     , ghc-typelits-extra
                     , ghc-typelits-knownnat

--- a/hasktorch/src/Torch.hs
+++ b/hasktorch/src/Torch.hs
@@ -13,7 +13,6 @@ module Torch
     module Torch.Tensor,
     module Torch.TensorFactories,
     module Torch.TensorOptions,
-    module Torch.Serialize,
     module Torch.Script,
     module Torch.Index
   )
@@ -32,6 +31,5 @@ import Torch.Serialize
 import Torch.Tensor
 import Torch.TensorFactories
 import Torch.TensorOptions
-import Torch.Serialize
 import Torch.Script
 import Torch.Index

--- a/hasktorch/src/Torch/Functional/Internal.hs
+++ b/hasktorch/src/Torch/Functional/Internal.hs
@@ -482,13 +482,6 @@ chunk
   -> [Tensor]
 chunk _self _chunks _dim = unsafePerformIO $ (cast3 ATen.chunk_tll) _self _chunks _dim
 
--- tensor_split_tll
---   :: Tensor -- ^ self
---   -> [Int] -- ^ indices
---   -> Int -- ^ dim
---   -> [Tensor]
--- tensor_split_tll _self _indices _dim = unsafePerformIO $ (cast3 ATen.tensor_split_tll) _self _indices _dim
-
 tensor_split_ttl
   :: Tensor -- ^ self
   -> Tensor -- ^ tensor_indices_or_sections
@@ -496,31 +489,57 @@ tensor_split_ttl
   -> [Tensor]
 tensor_split_ttl _self _tensor_indices_or_sections _dim = unsafePerformIO $ (cast3 ATen.tensor_split_ttl) _self _tensor_indices_or_sections _dim
 
-clamp
+clamp_tss
   :: Tensor -- ^ self
   -> Float -- ^ min
   -> Float -- ^ max
   -> Tensor
-clamp _self _min _max = unsafePerformIO $ (cast3 ATen.clamp_tss) _self _min _max
+clamp_tss _self _min _max = unsafePerformIO $ (cast3 ATen.clamp_tss) _self _min _max
 
-clamp_max
+clamp_ttt
+  :: Tensor -- ^ self
+  -> Tensor -- ^ min
+  -> Tensor -- ^ max
+  -> Tensor
+clamp_ttt _self _min _max = unsafePerformIO $ (cast3 ATen.clamp_ttt) _self _min _max
+
+clamp_max_ts
   :: Tensor -- ^ self
   -> Float -- ^ max
   -> Tensor
-clamp_max _self _max = unsafePerformIO $ (cast2 ATen.clamp_max_ts) _self _max
+clamp_max_ts _self _max = unsafePerformIO $ (cast2 ATen.clamp_max_ts) _self _max
 
-clamp_min
+clamp_max_tt
+  :: Tensor -- ^ self
+  -> Tensor -- ^ max
+  -> Tensor
+clamp_max_tt _self _max = unsafePerformIO $ (cast2 ATen.clamp_max_tt) _self _max
+
+clamp_min_ts
   :: Tensor -- ^ self
   -> Float -- ^ min
   -> Tensor
-clamp_min _self _min = unsafePerformIO $ (cast2 ATen.clamp_min_ts) _self _min
+clamp_min_ts _self _min = unsafePerformIO $ (cast2 ATen.clamp_min_ts) _self _min
 
-clip
+clamp_min_tt
+  :: Tensor -- ^ self
+  -> Tensor -- ^ min
+  -> Tensor
+clamp_min_tt _self _min = unsafePerformIO $ (cast2 ATen.clamp_min_tt) _self _min
+
+clip_tss
   :: Tensor -- ^ self
   -> Float -- ^ min
   -> Float -- ^ max
   -> Tensor
-clip _self _min _max = unsafePerformIO $ (cast3 ATen.clip_tss) _self _min _max
+clip_tss _self _min _max = unsafePerformIO $ (cast3 ATen.clip_tss) _self _min _max
+
+clip_ttt
+  :: Tensor -- ^ self
+  -> Tensor -- ^ min
+  -> Tensor -- ^ max
+  -> Tensor
+clip_ttt _self _min _max = unsafePerformIO $ (cast3 ATen.clip_ttt) _self _min _max
 
 cudnn_is_acceptable
   :: Tensor -- ^ self
@@ -586,7 +605,7 @@ convolution_backward_overrideable
   -> (Tensor,Tensor,Tensor)
 convolution_backward_overrideable _grad_output _input _weight _stride _padding _dilation _transposed _output_padding _groups _output_mask = unsafePerformIO $ (cast10 ATen.convolution_backward_overrideable_tttlllblla) _grad_output _input _weight _stride _padding _dilation _transposed _output_padding _groups _output_mask
 
-conv1d
+conv1d_tttllll
   :: Tensor -- ^ input
   -> Tensor -- ^ weight
   -> Tensor -- ^ bias
@@ -595,7 +614,7 @@ conv1d
   -> Int -- ^ dilation
   -> Int -- ^ groups
   -> Tensor
-conv1d _input _weight _bias _stride _padding _dilation _groups = unsafePerformIO $ (cast7 ATen.conv1d_tttllll) _input _weight _bias _stride _padding _dilation _groups
+conv1d_tttllll _input _weight _bias _stride _padding _dilation _groups = unsafePerformIO $ (cast7 ATen.conv1d_tttllll) _input _weight _bias _stride _padding _dilation _groups
 
 conv2d
   :: Tensor -- ^ input
@@ -608,7 +627,7 @@ conv2d
   -> Tensor
 conv2d _input _weight _bias _stride _padding _dilation _groups = unsafePerformIO $ (cast7 ATen.conv2d_tttllll) _input _weight _bias _stride _padding _dilation _groups
 
-conv3d
+conv3d_tttllll
   :: Tensor -- ^ input
   -> Tensor -- ^ weight
   -> Tensor -- ^ bias
@@ -617,7 +636,40 @@ conv3d
   -> (Int,Int,Int) -- ^ dilation
   -> Int -- ^ groups
   -> Tensor
-conv3d _input _weight _bias _stride _padding _dilation _groups = unsafePerformIO $ (cast7 ATen.conv3d_tttllll) _input _weight _bias _stride _padding _dilation _groups
+conv3d_tttllll _input _weight _bias _stride _padding _dilation _groups = unsafePerformIO $ (cast7 ATen.conv3d_tttllll) _input _weight _bias _stride _padding _dilation _groups
+
+conv1d_tttlsll
+  :: Tensor -- ^ input
+  -> Tensor -- ^ weight
+  -> Tensor -- ^ bias
+  -> Int -- ^ stride
+  -> String -- ^ padding
+  -> Int -- ^ dilation
+  -> Int -- ^ groups
+  -> Tensor
+conv1d_tttlsll _input _weight _bias _stride _padding _dilation _groups = unsafePerformIO $ (cast7 ATen.conv1d_tttlsll) _input _weight _bias _stride _padding _dilation _groups
+
+conv2d_tttlsll
+  :: Tensor -- ^ input
+  -> Tensor -- ^ weight
+  -> Tensor -- ^ bias
+  -> (Int,Int) -- ^ stride
+  -> String -- ^ padding
+  -> (Int,Int) -- ^ dilation
+  -> Int -- ^ groups
+  -> Tensor
+conv2d_tttlsll _input _weight _bias _stride _padding _dilation _groups = unsafePerformIO $ (cast7 ATen.conv2d_tttlsll) _input _weight _bias _stride _padding _dilation _groups
+
+conv3d_tttlsll
+  :: Tensor -- ^ input
+  -> Tensor -- ^ weight
+  -> Tensor -- ^ bias
+  -> (Int,Int,Int) -- ^ stride
+  -> String -- ^ padding
+  -> (Int,Int,Int) -- ^ dilation
+  -> Int -- ^ groups
+  -> Tensor
+conv3d_tttlsll _input _weight _bias _stride _padding _dilation _groups = unsafePerformIO $ (cast7 ATen.conv3d_tttlsll) _input _weight _bias _stride _padding _dilation _groups
 
 conv_tbc
   :: Tensor -- ^ self
@@ -681,12 +733,6 @@ cosine_embedding_loss
   -> Int -- ^ reduction
   -> Tensor
 cosine_embedding_loss _input1 _input2 _target _margin _reduction = unsafePerformIO $ (cast5 ATen.cosine_embedding_loss_tttdl) _input1 _input2 _target _margin _reduction
-
-count_nonzero_tl
-  :: Tensor -- ^ self
-  -> [Int] -- ^ dim
-  -> Tensor
-count_nonzero_tl _self _dim = unsafePerformIO $ (cast2 ATen.count_nonzero_tl) _self _dim
 
 cudnn_affine_grid_generator
   :: Tensor -- ^ theta
@@ -843,6 +889,30 @@ cudnn_convolution_transpose_backward_weight
   -> Tensor
 cudnn_convolution_transpose_backward_weight _weight_size _grad_output _self _padding _stride _dilation _groups _benchmark _deterministic _allow_tf32 = unsafePerformIO $ (cast10 ATen.cudnn_convolution_transpose_backward_weight_lttllllbbb) _weight_size _grad_output _self _padding _stride _dilation _groups _benchmark _deterministic _allow_tf32
 
+cudnn_convolution_relu
+  :: Tensor -- ^ self
+  -> Tensor -- ^ weight
+  -> Tensor -- ^ bias
+  -> [Int] -- ^ stride
+  -> [Int] -- ^ padding
+  -> [Int] -- ^ dilation
+  -> Int -- ^ groups
+  -> Tensor
+cudnn_convolution_relu _self _weight _bias _stride _padding _dilation _groups = unsafePerformIO $ (cast7 ATen.cudnn_convolution_relu_tttllll) _self _weight _bias _stride _padding _dilation _groups
+
+cudnn_convolution_add_relu
+  :: Tensor -- ^ self
+  -> Tensor -- ^ weight
+  -> Tensor -- ^ z
+  -> Float -- ^ alpha
+  -> Tensor -- ^ bias
+  -> [Int] -- ^ stride
+  -> [Int] -- ^ padding
+  -> [Int] -- ^ dilation
+  -> Int -- ^ groups
+  -> Tensor
+cudnn_convolution_add_relu _self _weight _z _alpha _bias _stride _padding _dilation _groups = unsafePerformIO $ (cast9 ATen.cudnn_convolution_add_relu_tttstllll) _self _weight _z _alpha _bias _stride _padding _dilation _groups
+
 cudnn_grid_sampler
   :: Tensor -- ^ self
   -> Tensor -- ^ grid
@@ -963,6 +1033,14 @@ diff
   -> Tensor
 diff _self _n _dim _prepend _append = unsafePerformIO $ (cast5 ATen.diff_tlltt) _self _n _dim _prepend _append
 
+gradient_tsll
+  :: Tensor -- ^ self
+  -> Float -- ^ spacing
+  -> Int -- ^ dim
+  -> Int -- ^ edge_order
+  -> [Tensor]
+gradient_tsll _self _spacing _dim _edge_order = unsafePerformIO $ (cast4 ATen.gradient_tsll) _self _spacing _dim _edge_order
+
 div
   :: Tensor -- ^ self
   -> Tensor -- ^ other
@@ -1059,7 +1137,7 @@ row_stack
   -> Tensor
 row_stack _tensors = unsafePerformIO $ (cast1 ATen.row_stack_l) _tensors
 
-embedding_bag
+embedding_bag_tttblbtb
   :: Tensor -- ^ weight
   -> Tensor -- ^ indices
   -> Tensor -- ^ offsets
@@ -1069,7 +1147,20 @@ embedding_bag
   -> Tensor -- ^ per_sample_weights
   -> Bool -- ^ include_last_offset
   -> (Tensor,Tensor,Tensor,Tensor)
-embedding_bag _weight _indices _offsets _scale_grad_by_freq _mode _sparse _per_sample_weights _include_last_offset = unsafePerformIO $ (cast8 ATen.embedding_bag_tttblbtb) _weight _indices _offsets _scale_grad_by_freq _mode _sparse _per_sample_weights _include_last_offset
+embedding_bag_tttblbtb _weight _indices _offsets _scale_grad_by_freq _mode _sparse _per_sample_weights _include_last_offset = unsafePerformIO $ (cast8 ATen.embedding_bag_tttblbtb) _weight _indices _offsets _scale_grad_by_freq _mode _sparse _per_sample_weights _include_last_offset
+
+embedding_bag_tttblbtbl
+  :: Tensor -- ^ weight
+  -> Tensor -- ^ indices
+  -> Tensor -- ^ offsets
+  -> Bool -- ^ scale_grad_by_freq
+  -> Int -- ^ mode
+  -> Bool -- ^ sparse
+  -> Tensor -- ^ per_sample_weights
+  -> Bool -- ^ include_last_offset
+  -> Int -- ^ padding_idx
+  -> (Tensor,Tensor,Tensor,Tensor)
+embedding_bag_tttblbtbl _weight _indices _offsets _scale_grad_by_freq _mode _sparse _per_sample_weights _include_last_offset _padding_idx = unsafePerformIO $ (cast9 ATen.embedding_bag_tttblbtbl) _weight _indices _offsets _scale_grad_by_freq _mode _sparse _per_sample_weights _include_last_offset _padding_idx
 
 empty_quantized
   :: [Int] -- ^ size
@@ -1223,11 +1314,11 @@ native_group_norm
   -> (Tensor,Tensor,Tensor)
 native_group_norm _input _weight _bias _N _C _HxW _group _eps = unsafePerformIO $ (cast8 ATen.native_group_norm_tttlllld) _input _weight _bias _N _C _HxW _group _eps
 
--- index
---   :: Tensor -- ^ self
---   -> [Tensor] -- ^ indices
---   -> Tensor
--- index _self _indices = unsafePerformIO $ (cast2 ATen.index_tl) _self _indices
+index
+  :: Tensor -- ^ self
+  -> [Tensor] -- ^ indices
+  -> Tensor
+index _self _indices = unsafePerformIO $ (cast2 ATen.index_tl) _self _indices
 
 indexCopy
   :: Tensor -- ^ self
@@ -1245,13 +1336,13 @@ indexCopyWithDimname
   -> Tensor
 indexCopyWithDimname _self _dim _index _source = unsafePerformIO $ (cast4 ATen.index_copy_tntt) _self _dim _index _source
 
--- index_put
---   :: Tensor -- ^ self
---   -> [Tensor] -- ^ indices
---   -> Tensor -- ^ values
---   -> Bool -- ^ accumulate
---   -> Tensor
--- index_put _self _indices _values _accumulate = unsafePerformIO $ (cast4 ATen.index_put_tltb) _self _indices _values _accumulate
+index_put
+  :: Tensor -- ^ self
+  -> [Tensor] -- ^ indices
+  -> Tensor -- ^ values
+  -> Bool -- ^ accumulate
+  -> Tensor
+index_put _self _indices _values _accumulate = unsafePerformIO $ (cast4 ATen.index_put_tltb) _self _indices _values _accumulate
 
 instance_norm
   :: Tensor -- ^ input
@@ -2126,8 +2217,9 @@ batch_norm_backward_elemt
   -> Tensor -- ^ weight
   -> Tensor -- ^ mean_dy
   -> Tensor -- ^ mean_dy_xmu
+  -> Tensor -- ^ count
   -> Tensor
-batch_norm_backward_elemt _grad_out _input _mean _invstd _weight _mean_dy _mean_dy_xmu = unsafePerformIO $ (cast7 ATen.batch_norm_backward_elemt_ttttttt) _grad_out _input _mean _invstd _weight _mean_dy _mean_dy_xmu
+batch_norm_backward_elemt _grad_out _input _mean _invstd _weight _mean_dy _mean_dy_xmu _count = unsafePerformIO $ (cast8 ATen.batch_norm_backward_elemt_tttttttt) _grad_out _input _mean _invstd _weight _mean_dy _mean_dy_xmu _count
 
 batch_norm_update_stats
   :: Tensor -- ^ input
@@ -2136,6 +2228,10 @@ batch_norm_update_stats
   -> Double -- ^ momentum
   -> (Tensor,Tensor)
 batch_norm_update_stats _input _running_mean _running_var _momentum = unsafePerformIO $ (cast4 ATen.batch_norm_update_stats_tttd) _input _running_mean _running_var _momentum
+
+is_vulkan_available
+  :: Bool
+is_vulkan_available  = unsafePerformIO $ (cast0 ATen.is_vulkan_available) 
 
 pairwise_distance
   :: Tensor -- ^ x1
@@ -2168,19 +2264,11 @@ cosine_similarity
   -> Tensor
 cosine_similarity _x1 _x2 _dim _eps = unsafePerformIO $ (cast4 ATen.cosine_similarity_ttld) _x1 _x2 _dim _eps
 
-movedim_tll
+permute
   :: Tensor -- ^ self
-  -> [Int] -- ^ source
-  -> [Int] -- ^ destination
+  -> [Int] -- ^ dims
   -> Tensor
-movedim_tll _self _source _destination = unsafePerformIO $ (cast3 ATen.movedim_tll) _self _source _destination
-
-moveaxis_tll
-  :: Tensor -- ^ self
-  -> [Int] -- ^ source
-  -> [Int] -- ^ destination
-  -> Tensor
-moveaxis_tll _self _source _destination = unsafePerformIO $ (cast3 ATen.moveaxis_tll) _self _source _destination
+permute _self _dims = unsafePerformIO $ (cast2 ATen.permute_tl) _self _dims
 
 pixel_shuffle
   :: Tensor -- ^ self
@@ -2281,6 +2369,11 @@ relu
   -> Tensor
 relu _self = unsafePerformIO $ (cast1 ATen.relu_t) _self
 
+relu6
+  :: Tensor -- ^ self
+  -> Tensor
+relu6 _self = unsafePerformIO $ (cast1 ATen.relu6_t) _self
+
 prelu
   :: Tensor -- ^ self
   -> Tensor -- ^ weight
@@ -2332,6 +2425,11 @@ silu
   :: Tensor -- ^ self
   -> Tensor
 silu _self = unsafePerformIO $ (cast1 ATen.silu_t) _self
+
+mish
+  :: Tensor -- ^ self
+  -> Tensor
+mish _self = unsafePerformIO $ (cast1 ATen.mish_t) _self
 
 sigmoid
   :: Tensor -- ^ self
@@ -2578,6 +2676,14 @@ stdDim
   -> Tensor
 stdDim _self _dim _unbiased _keepdim = unsafePerformIO $ (cast4 ATen.std_tlbb) _self _dim _unbiased _keepdim
 
+std_tllb
+  :: Tensor -- ^ self
+  -> Int -- ^ dim
+  -> Int -- ^ correction
+  -> Bool -- ^ keepdim
+  -> Tensor
+std_tllb _self _dim _correction _keepdim = unsafePerformIO $ (cast4 ATen.std_tllb) _self _dim _correction _keepdim
+
 stdMeanAll
   :: Tensor -- ^ self
   -> Bool -- ^ unbiased
@@ -2592,6 +2698,14 @@ stdMeanDim
   -> (Tensor,Tensor)
 stdMeanDim _self _dim _unbiased _keepdim = unsafePerformIO $ (cast4 ATen.std_mean_tlbb) _self _dim _unbiased _keepdim
 
+std_mean_tllb
+  :: Tensor -- ^ self
+  -> Int -- ^ dim
+  -> Int -- ^ correction
+  -> Bool -- ^ keepdim
+  -> (Tensor,Tensor)
+std_mean_tllb _self _dim _correction _keepdim = unsafePerformIO $ (cast4 ATen.std_mean_tllb) _self _dim _correction _keepdim
+
 stdMeanWithDimnames
   :: Tensor -- ^ self
   -> [Dimname] -- ^ dim
@@ -2600,6 +2714,14 @@ stdMeanWithDimnames
   -> (Tensor,Tensor)
 stdMeanWithDimnames _self _dim _unbiased _keepdim = unsafePerformIO $ (cast4 ATen.std_mean_tNbb) _self _dim _unbiased _keepdim
 
+std_mean_tNlb
+  :: Tensor -- ^ self
+  -> [Dimname] -- ^ dim
+  -> Int -- ^ correction
+  -> Bool -- ^ keepdim
+  -> (Tensor,Tensor)
+std_mean_tNlb _self _dim _correction _keepdim = unsafePerformIO $ (cast4 ATen.std_mean_tNlb) _self _dim _correction _keepdim
+
 stdWithDimnames
   :: Tensor -- ^ self
   -> [Dimname] -- ^ dim
@@ -2607,6 +2729,14 @@ stdWithDimnames
   -> Bool -- ^ keepdim
   -> Tensor
 stdWithDimnames _self _dim _unbiased _keepdim = unsafePerformIO $ (cast4 ATen.std_tNbb) _self _dim _unbiased _keepdim
+
+std_tNlb
+  :: Tensor -- ^ self
+  -> [Dimname] -- ^ dim
+  -> Int -- ^ correction
+  -> Bool -- ^ keepdim
+  -> Tensor
+std_tNlb _self _dim _correction _keepdim = unsafePerformIO $ (cast4 ATen.std_tNlb) _self _dim _correction _keepdim
 
 prodAll
   :: Tensor -- ^ self
@@ -2804,6 +2934,14 @@ varDim
   -> Tensor
 varDim _self _dim _unbiased _keepdim = unsafePerformIO $ (cast4 ATen.var_tlbb) _self _dim _unbiased _keepdim
 
+var_tllb
+  :: Tensor -- ^ self
+  -> Int -- ^ dim
+  -> Int -- ^ correction
+  -> Bool -- ^ keepdim
+  -> Tensor
+var_tllb _self _dim _correction _keepdim = unsafePerformIO $ (cast4 ATen.var_tllb) _self _dim _correction _keepdim
+
 varWithDimnames
   :: Tensor -- ^ self
   -> [Dimname] -- ^ dim
@@ -2811,6 +2949,14 @@ varWithDimnames
   -> Bool -- ^ keepdim
   -> Tensor
 varWithDimnames _self _dim _unbiased _keepdim = unsafePerformIO $ (cast4 ATen.var_tNbb) _self _dim _unbiased _keepdim
+
+var_tNlb
+  :: Tensor -- ^ self
+  -> [Dimname] -- ^ dim
+  -> Int -- ^ correction
+  -> Bool -- ^ keepdim
+  -> Tensor
+var_tNlb _self _dim _correction _keepdim = unsafePerformIO $ (cast4 ATen.var_tNlb) _self _dim _correction _keepdim
 
 varMean
   :: Tensor -- ^ self
@@ -2826,6 +2972,14 @@ varMeanDim
   -> (Tensor,Tensor)
 varMeanDim _self _dim _unbiased _keepdim = unsafePerformIO $ (cast4 ATen.var_mean_tlbb) _self _dim _unbiased _keepdim
 
+var_mean_tllb
+  :: Tensor -- ^ self
+  -> Int -- ^ dim
+  -> Int -- ^ correction
+  -> Bool -- ^ keepdim
+  -> (Tensor,Tensor)
+var_mean_tllb _self _dim _correction _keepdim = unsafePerformIO $ (cast4 ATen.var_mean_tllb) _self _dim _correction _keepdim
+
 varMeanWithDimnames
   :: Tensor -- ^ self
   -> [Dimname] -- ^ dim
@@ -2833,6 +2987,14 @@ varMeanWithDimnames
   -> Bool -- ^ keepdim
   -> (Tensor,Tensor)
 varMeanWithDimnames _self _dim _unbiased _keepdim = unsafePerformIO $ (cast4 ATen.var_mean_tNbb) _self _dim _unbiased _keepdim
+
+var_mean_tNlb
+  :: Tensor -- ^ self
+  -> [Dimname] -- ^ dim
+  -> Int -- ^ correction
+  -> Bool -- ^ keepdim
+  -> (Tensor,Tensor)
+var_mean_tNlb _self _dim _correction _keepdim = unsafePerformIO $ (cast4 ATen.var_mean_tNlb) _self _dim _correction _keepdim
 
 where'
   :: Tensor -- ^ condition
@@ -2936,6 +3098,11 @@ norm_tsNb
   -> Tensor
 norm_tsNb _self _p _dim _keepdim = unsafePerformIO $ (cast4 ATen.norm_tsNb) _self _p _dim _keepdim
 
+frexp
+  :: Tensor -- ^ self
+  -> (Tensor,Tensor)
+frexp _self = unsafePerformIO $ (cast1 ATen.frexp_t) _self
+
 frobeniusNormAll
   :: Tensor -- ^ self
   -> Tensor
@@ -2966,6 +3133,11 @@ clone
   -> ATen.MemoryFormat -- ^ memory_format
   -> Tensor
 clone _self _memory_format = unsafePerformIO $ (cast2 ATen.clone_tM) _self _memory_format
+
+positive
+  :: Tensor -- ^ self
+  -> Tensor
+positive _self = unsafePerformIO $ (cast1 ATen.positive_t) _self
 
 sub
   :: Tensor -- ^ self
@@ -3462,6 +3634,14 @@ masked_scatter
   -> Tensor
 masked_scatter _self _mask _source = unsafePerformIO $ (cast3 ATen.masked_scatter_ttt) _self _mask _source
 
+put
+  :: Tensor -- ^ self
+  -> Tensor -- ^ index
+  -> Tensor -- ^ source
+  -> Bool -- ^ accumulate
+  -> Tensor
+put _self _index _source _accumulate = unsafePerformIO $ (cast4 ATen.put_tttb) _self _index _source _accumulate
+
 indexAdd
   :: Tensor -- ^ self
   -> Int -- ^ dim
@@ -3470,13 +3650,23 @@ indexAdd
   -> Tensor
 indexAdd _self _dim _index _source = unsafePerformIO $ (cast4 ATen.index_add_tltt) _self _dim _index _source
 
-indexAddWithDimname
+index_add_tltts
+  :: Tensor -- ^ self
+  -> Int -- ^ dim
+  -> Tensor -- ^ index
+  -> Tensor -- ^ source
+  -> Float -- ^ alpha
+  -> Tensor
+index_add_tltts _self _dim _index _source _alpha = unsafePerformIO $ (cast5 ATen.index_add_tltts) _self _dim _index _source _alpha
+
+index_add_tntts
   :: Tensor -- ^ self
   -> Dimname -- ^ dim
   -> Tensor -- ^ index
   -> Tensor -- ^ source
+  -> Float -- ^ alpha
   -> Tensor
-indexAddWithDimname _self _dim _index _source = unsafePerformIO $ (cast4 ATen.index_add_tntt) _self _dim _index _source
+index_add_tntts _self _dim _index _source _alpha = unsafePerformIO $ (cast5 ATen.index_add_tntts) _self _dim _index _source _alpha
 
 indexFillScalar
   :: Tensor -- ^ self
@@ -3771,6 +3961,13 @@ take
   -> Tensor
 take _self _index = unsafePerformIO $ (cast2 ATen.take_tt) _self _index
 
+take_along_dim
+  :: Tensor -- ^ self
+  -> Tensor -- ^ indices
+  -> Int -- ^ dim
+  -> Tensor
+take_along_dim _self _indices _dim = unsafePerformIO $ (cast3 ATen.take_along_dim_ttl) _self _indices _dim
+
 indexSelect
   :: Tensor -- ^ self
   -> Int -- ^ dim
@@ -3832,6 +4029,15 @@ addcdiv
   -> Float -- ^ value
   -> Tensor
 addcdiv _self _tensor1 _tensor2 _value = unsafePerformIO $ (cast4 ATen.addcdiv_ttts) _self _tensor1 _tensor2 _value
+
+cross_entropy_loss
+  :: Tensor -- ^ self
+  -> Tensor -- ^ target
+  -> Tensor -- ^ weight
+  -> Int -- ^ reduction
+  -> Int -- ^ ignore_index
+  -> Tensor
+cross_entropy_loss _self _target _weight _reduction _ignore_index = unsafePerformIO $ (cast5 ATen.cross_entropy_loss_tttll) _self _target _weight _reduction _ignore_index
 
 lstsq
   :: Tensor -- ^ self
@@ -3939,6 +4145,14 @@ lu_solve
   -> Tensor -- ^ LU_pivots
   -> Tensor
 lu_solve _self _LU_data _LU_pivots = unsafePerformIO $ (cast3 ATen.lu_solve_ttt) _self _LU_data _LU_pivots
+
+lu_unpack
+  :: Tensor -- ^ LU_data
+  -> Tensor -- ^ LU_pivots
+  -> Bool -- ^ unpack_data
+  -> Bool -- ^ unpack_pivots
+  -> (Tensor,Tensor,Tensor)
+lu_unpack _LU_data _LU_pivots _unpack_data _unpack_pivots = unsafePerformIO $ (cast4 ATen.lu_unpack_ttbb) _LU_data _LU_pivots _unpack_data _unpack_pivots
 
 lgamma
   :: Tensor -- ^ self
@@ -4137,6 +4351,42 @@ nanquantile_ttlb
   -> Tensor
 nanquantile_ttlb _self _q _dim _keepdim = unsafePerformIO $ (cast4 ATen.nanquantile_ttlb) _self _q _dim _keepdim
 
+quantile_tdlbs
+  :: Tensor -- ^ self
+  -> Double -- ^ q
+  -> Int -- ^ dim
+  -> Bool -- ^ keepdim
+  -> String -- ^ interpolation
+  -> Tensor
+quantile_tdlbs _self _q _dim _keepdim _interpolation = unsafePerformIO $ (cast5 ATen.quantile_tdlbs) _self _q _dim _keepdim _interpolation
+
+quantile_ttlbs
+  :: Tensor -- ^ self
+  -> Tensor -- ^ q
+  -> Int -- ^ dim
+  -> Bool -- ^ keepdim
+  -> String -- ^ interpolation
+  -> Tensor
+quantile_ttlbs _self _q _dim _keepdim _interpolation = unsafePerformIO $ (cast5 ATen.quantile_ttlbs) _self _q _dim _keepdim _interpolation
+
+nanquantile_tdlbs
+  :: Tensor -- ^ self
+  -> Double -- ^ q
+  -> Int -- ^ dim
+  -> Bool -- ^ keepdim
+  -> String -- ^ interpolation
+  -> Tensor
+nanquantile_tdlbs _self _q _dim _keepdim _interpolation = unsafePerformIO $ (cast5 ATen.nanquantile_tdlbs) _self _q _dim _keepdim _interpolation
+
+nanquantile_ttlbs
+  :: Tensor -- ^ self
+  -> Tensor -- ^ q
+  -> Int -- ^ dim
+  -> Bool -- ^ keepdim
+  -> String -- ^ interpolation
+  -> Tensor
+nanquantile_ttlbs _self _q _dim _keepdim _interpolation = unsafePerformIO $ (cast5 ATen.nanquantile_ttlbs) _self _q _dim _keepdim _interpolation
+
 sort
   :: Tensor -- ^ self
   -> Int -- ^ dim
@@ -4144,12 +4394,28 @@ sort
   -> (Tensor,Tensor)
 sort _self _dim _descending = unsafePerformIO $ (cast3 ATen.sort_tlb) _self _dim _descending
 
+sort_tblb
+  :: Tensor -- ^ self
+  -> Bool -- ^ stable
+  -> Int -- ^ dim
+  -> Bool -- ^ descending
+  -> (Tensor,Tensor)
+sort_tblb _self _stable _dim _descending = unsafePerformIO $ (cast4 ATen.sort_tblb) _self _stable _dim _descending
+
 sortWithDimname
   :: Tensor -- ^ self
   -> Dimname -- ^ dim
   -> Bool -- ^ descending
   -> (Tensor,Tensor)
 sortWithDimname _self _dim _descending = unsafePerformIO $ (cast3 ATen.sort_tnb) _self _dim _descending
+
+sort_tbnb
+  :: Tensor -- ^ self
+  -> Bool -- ^ stable
+  -> Dimname -- ^ dim
+  -> Bool -- ^ descending
+  -> (Tensor,Tensor)
+sort_tbnb _self _stable _dim _descending = unsafePerformIO $ (cast4 ATen.sort_tbnb) _self _stable _dim _descending
 
 msort
   :: Tensor -- ^ self
@@ -4314,6 +4580,15 @@ multilabel_margin_loss_forward
   -> (Tensor,Tensor)
 multilabel_margin_loss_forward _self _target _reduction = unsafePerformIO $ (cast3 ATen.multilabel_margin_loss_forward_ttl) _self _target _reduction
 
+nll_loss_nd
+  :: Tensor -- ^ self
+  -> Tensor -- ^ target
+  -> Tensor -- ^ weight
+  -> Int -- ^ reduction
+  -> Int -- ^ ignore_index
+  -> Tensor
+nll_loss_nd _self _target _weight _reduction _ignore_index = unsafePerformIO $ (cast5 ATen.nll_loss_nd_tttll) _self _target _weight _reduction _ignore_index
+
 nll_loss
   :: Tensor -- ^ self
   -> Tensor -- ^ target
@@ -4357,6 +4632,14 @@ smooth_l1_loss
   -> Double -- ^ beta
   -> Tensor
 smooth_l1_loss _self _target _reduction _beta = unsafePerformIO $ (cast4 ATen.smooth_l1_loss_ttld) _self _target _reduction _beta
+
+huber_loss
+  :: Tensor -- ^ self
+  -> Tensor -- ^ target
+  -> Int -- ^ reduction
+  -> Double -- ^ delta
+  -> Tensor
+huber_loss _self _target _reduction _delta = unsafePerformIO $ (cast4 ATen.huber_loss_ttld) _self _target _reduction _delta
 
 soft_margin_loss
   :: Tensor -- ^ self
@@ -4723,6 +5006,17 @@ thnn_conv_depthwise2d_forward
   -> Tensor
 thnn_conv_depthwise2d_forward _self _weight _kernel_size _bias _stride _padding _dilation = unsafePerformIO $ (cast7 ATen.thnn_conv_depthwise2d_forward_ttltlll) _self _weight _kernel_size _bias _stride _padding _dilation
 
+conv_depthwise3d
+  :: Tensor -- ^ self
+  -> Tensor -- ^ weight
+  -> (Int,Int,Int) -- ^ kernel_size
+  -> Tensor -- ^ bias
+  -> (Int,Int,Int) -- ^ stride
+  -> (Int,Int,Int) -- ^ padding
+  -> (Int,Int,Int) -- ^ dilation
+  -> Tensor
+conv_depthwise3d _self _weight _kernel_size _bias _stride _padding _dilation = unsafePerformIO $ (cast7 ATen.conv_depthwise3d_ttltlll) _self _weight _kernel_size _bias _stride _padding _dilation
+
 slow_conv3d
   :: Tensor -- ^ self
   -> Tensor -- ^ weight
@@ -4808,6 +5102,75 @@ isneginf
   :: Tensor -- ^ self
   -> Tensor
 isneginf _self = unsafePerformIO $ (cast1 ATen.isneginf_t) _self
+
+special_entr
+  :: Tensor -- ^ self
+  -> Tensor
+special_entr _self = unsafePerformIO $ (cast1 ATen.special_entr_t) _self
+
+special_expm1
+  :: Tensor -- ^ self
+  -> Tensor
+special_expm1 _self = unsafePerformIO $ (cast1 ATen.special_expm1_t) _self
+
+special_exp2
+  :: Tensor -- ^ self
+  -> Tensor
+special_exp2 _self = unsafePerformIO $ (cast1 ATen.special_exp2_t) _self
+
+special_gammaln
+  :: Tensor -- ^ self
+  -> Tensor
+special_gammaln _self = unsafePerformIO $ (cast1 ATen.special_gammaln_t) _self
+
+special_erf
+  :: Tensor -- ^ self
+  -> Tensor
+special_erf _self = unsafePerformIO $ (cast1 ATen.special_erf_t) _self
+
+special_erfc
+  :: Tensor -- ^ self
+  -> Tensor
+special_erfc _self = unsafePerformIO $ (cast1 ATen.special_erfc_t) _self
+
+special_erfinv
+  :: Tensor -- ^ self
+  -> Tensor
+special_erfinv _self = unsafePerformIO $ (cast1 ATen.special_erfinv_t) _self
+
+special_xlog1py_tt
+  :: Tensor -- ^ self
+  -> Tensor -- ^ other
+  -> Tensor
+special_xlog1py_tt _self _other = unsafePerformIO $ (cast2 ATen.special_xlog1py_tt) _self _other
+
+special_xlog1py_st
+  :: Float -- ^ self
+  -> Tensor -- ^ other
+  -> Tensor
+special_xlog1py_st _self _other = unsafePerformIO $ (cast2 ATen.special_xlog1py_st) _self _other
+
+special_xlog1py_ts
+  :: Tensor -- ^ self
+  -> Float -- ^ other
+  -> Tensor
+special_xlog1py_ts _self _other = unsafePerformIO $ (cast2 ATen.special_xlog1py_ts) _self _other
+
+special_i0e
+  :: Tensor -- ^ self
+  -> Tensor
+special_i0e _self = unsafePerformIO $ (cast1 ATen.special_i0e_t) _self
+
+special_logit
+  :: Tensor -- ^ self
+  -> Double -- ^ eps
+  -> Tensor
+special_logit _self _eps = unsafePerformIO $ (cast2 ATen.special_logit_td) _self _eps
+
+special_expit
+  :: Tensor -- ^ self
+  -> Tensor
+special_expit _self = unsafePerformIO $ (cast1 ATen.special_expit_t) _self
 
 fft_fft
   :: Tensor -- ^ self
@@ -4933,6 +5296,12 @@ fft_ifftshift
   -> Tensor
 fft_ifftshift _self _dim = unsafePerformIO $ (cast2 ATen.fft_ifftshift_tl) _self _dim
 
+linalg_cholesky_ex
+  :: Tensor -- ^ self
+  -> Bool -- ^ check_errors
+  -> (Tensor,Tensor)
+linalg_cholesky_ex _self _check_errors = unsafePerformIO $ (cast2 ATen.linalg_cholesky_ex_tb) _self _check_errors
+
 linalg_cholesky
   :: Tensor -- ^ self
   -> Tensor
@@ -4948,10 +5317,28 @@ det
   -> Tensor
 det _self = unsafePerformIO $ (cast1 ATen.det_t) _self
 
+linalg_lstsq
+  :: Tensor -- ^ self
+  -> Tensor -- ^ b
+  -> Double -- ^ rcond
+  -> String -- ^ driver
+  -> (Tensor,Tensor,Tensor,Tensor)
+linalg_lstsq _self _b _rcond _driver = unsafePerformIO $ (cast4 ATen.linalg_lstsq_ttds) _self _b _rcond _driver
+
 linalg_slogdet
   :: Tensor -- ^ self
   -> (Tensor,Tensor)
 linalg_slogdet _self = unsafePerformIO $ (cast1 ATen.linalg_slogdet_t) _self
+
+linalg_eig
+  :: Tensor -- ^ self
+  -> (Tensor,Tensor)
+linalg_eig _self = unsafePerformIO $ (cast1 ATen.linalg_eig_t) _self
+
+linalg_eigvals
+  :: Tensor -- ^ self
+  -> Tensor
+linalg_eigvals _self = unsafePerformIO $ (cast1 ATen.linalg_eigvals_t) _self
 
 linalg_eigh
   :: Tensor -- ^ self
@@ -4964,6 +5351,18 @@ linalg_eigvalsh
   -> String -- ^ UPLO
   -> Tensor
 linalg_eigvalsh _self _UPLO = unsafePerformIO $ (cast2 ATen.linalg_eigvalsh_ts) _self _UPLO
+
+linalg_householder_product
+  :: Tensor -- ^ input
+  -> Tensor -- ^ tau
+  -> Tensor
+linalg_householder_product _input _tau = unsafePerformIO $ (cast2 ATen.linalg_householder_product_tt) _input _tau
+
+linalg_inv_ex
+  :: Tensor -- ^ self
+  -> Bool -- ^ check_errors
+  -> (Tensor,Tensor)
+linalg_inv_ex _self _check_errors = unsafePerformIO $ (cast2 ATen.linalg_inv_ex_tb) _self _check_errors
 
 linalg_inv
   :: Tensor -- ^ self
@@ -4988,27 +5387,25 @@ ger
   -> Tensor
 ger _self _vec2 = unsafePerformIO $ (cast2 ATen.ger_tt) _self _vec2
 
--- linalg_norm_tslbs
---   :: Tensor -- ^ self
---   -> String -- ^ ord
---   -> Int -- ^ dim
---   -> Bool -- ^ keepdim
---   -> DType -- ^ dtype
---   -> Tensor
--- linalg_norm_tslbs _self _ord _dim _keepdim _dtype = unsafePerformIO $ (cast5 ATen.linalg_norm_tslbs) _self _ord _dim _keepdim _dtype
+linalg_vector_norm
+  :: Tensor -- ^ self
+  -> Float -- ^ ord
+  -> Int -- ^ dim
+  -> Bool -- ^ keepdim
+  -> DType -- ^ dtype
+  -> Tensor
+linalg_vector_norm _self _ord _dim _keepdim _dtype = unsafePerformIO $ (cast5 ATen.linalg_vector_norm_tslbs) _self _ord _dim _keepdim _dtype
 
 linalg_svd
   :: Tensor -- ^ self
   -> Bool -- ^ full_matrices
-  -> Bool -- ^ compute_uv
   -> (Tensor,Tensor,Tensor)
-linalg_svd _self _full_matrices _compute_uv = unsafePerformIO $ (cast3 ATen.linalg_svd_tbb) _self _full_matrices _compute_uv
+linalg_svd _self _full_matrices = unsafePerformIO $ (cast2 ATen.linalg_svd_tb) _self _full_matrices
 
--- linalg_cond_ts
---   :: Tensor -- ^ self
---   -> String -- ^ p
---   -> Tensor
--- linalg_cond_ts _self _p = unsafePerformIO $ (cast2 ATen.linalg_cond_ts) _self _p
+linalg_svdvals
+  :: Tensor -- ^ input
+  -> Tensor
+linalg_svdvals _input = unsafePerformIO $ (cast1 ATen.linalg_svdvals_t) _input
 
 linalg_pinv_tdb
   :: Tensor -- ^ self
@@ -5049,10 +5446,57 @@ linalg_qr
   -> (Tensor,Tensor)
 linalg_qr _self _mode = unsafePerformIO $ (cast2 ATen.linalg_qr_ts) _self _mode
 
-linalg_matrix_rank
+linalg_matrix_power
+  :: Tensor -- ^ self
+  -> Int -- ^ n
+  -> Tensor
+linalg_matrix_power _self _n = unsafePerformIO $ (cast2 ATen.linalg_matrix_power_tl) _self _n
+
+linalg_matrix_rank_tdb
   :: Tensor -- ^ self
   -> Double -- ^ tol
   -> Bool -- ^ hermitian
   -> Tensor
-linalg_matrix_rank _self _tol _hermitian = unsafePerformIO $ (cast3 ATen.linalg_matrix_rank_tdb) _self _tol _hermitian
+linalg_matrix_rank_tdb _self _tol _hermitian = unsafePerformIO $ (cast3 ATen.linalg_matrix_rank_tdb) _self _tol _hermitian
+
+linalg_matrix_rank_ttb
+  :: Tensor -- ^ input
+  -> Tensor -- ^ tol
+  -> Bool -- ^ hermitian
+  -> Tensor
+linalg_matrix_rank_ttb _input _tol _hermitian = unsafePerformIO $ (cast3 ATen.linalg_matrix_rank_ttb) _input _tol _hermitian
+
+linalg_multi_dot
+  :: [Tensor] -- ^ tensors
+  -> Tensor
+linalg_multi_dot _tensors = unsafePerformIO $ (cast1 ATen.linalg_multi_dot_l) _tensors
+
+segment_reduce
+  :: Tensor -- ^ data
+  -> String -- ^ reduce
+  -> Tensor -- ^ lengths
+  -> Tensor -- ^ indices
+  -> Int -- ^ axis
+  -> Bool -- ^ unsafe
+  -> Float -- ^ initial
+  -> Tensor
+segment_reduce _data _reduce _lengths _indices _axis _unsafe _initial = unsafePerformIO $ (cast7 ATen.segment_reduce_tsttlbs) _data _reduce _lengths _indices _axis _unsafe _initial
+
+pad_sequence
+  :: [Tensor] -- ^ sequences
+  -> Bool -- ^ batch_first
+  -> Double -- ^ padding_value
+  -> Tensor
+pad_sequence _sequences _batch_first _padding_value = unsafePerformIO $ (cast3 ATen.pad_sequence_lbd) _sequences _batch_first _padding_value
+
+flatten_dense_tensors
+  :: [Tensor] -- ^ tensors
+  -> Tensor
+flatten_dense_tensors _tensors = unsafePerformIO $ (cast1 ATen.flatten_dense_tensors_l) _tensors
+
+unflatten_dense_tensors
+  :: Tensor -- ^ flat
+  -> [Tensor] -- ^ tensors
+  -> [Tensor]
+unflatten_dense_tensors _flat _tensors = unsafePerformIO $ (cast2 ATen.unflatten_dense_tensors_tl) _flat _tensors
 

--- a/hasktorch/src/Torch/Script.hs
+++ b/hasktorch/src/Torch/Script.hs
@@ -290,14 +290,12 @@ dumpToStr ::
   Bool ->
   -- | print_param_values
   Bool ->
-  -- | level
-  Int ->
   -- | ouput
   IO String
-dumpToStr = cast5 LibTorch.dumpToStr
+dumpToStr = cast4 LibTorch.dumpToStr
 
 dumpToStr' :: ScriptModule -> IO String
-dumpToStr' obj = dumpToStr obj True True True 0
+dumpToStr' obj = dumpToStr obj True True True
 
 runMethod ::
   -- | module

--- a/hasktorch/src/Torch/Typed/Functional.hs
+++ b/hasktorch/src/Torch/Typed/Functional.hs
@@ -980,9 +980,21 @@ type family SymeigDTypeIsValid (device :: (D.DeviceType, Nat)) (dtype :: D.DType
   SymeigDTypeIsValid '(deviceType, _) dtype = UnsupportedDTypeForDevice deviceType dtype
 
 -- | symeig
---
+-- Warning:
+-- torch.symeig is deprecated in favor of torch.linalg.eigh and will be removed in a future PyTorch release.
+-- The default behavior has changed from using the upper triangular portion of the matrix by default to using the lower triangular portion.
+-- L, _ = torch.symeig(A, upper=upper)
+-- should be replaced with
+-- L = torch.linalg.eigvalsh(A, UPLO='U' if upper else 'L')
+-- and
+-- L, V = torch.symeig(A, eigenvectors=True)
+-- should be replaced with
+-- L, V = torch.linalg.eigh(A, UPLO='U' if upper else 'L') (function operator())
+-- 
 -- >>> t <- rand :: IO (CPUTensor 'D.Float '[3,2,2])
 -- >>> (eigenVals,eigenVecs) = symeig Upper t
+-- >>> dtype &&& shape $ eigenVals -- Skip warning
+-- ...
 -- >>> dtype &&& shape $ eigenVals
 -- (Float,[3,2])
 -- >>> :t eigenVals
@@ -1067,8 +1079,21 @@ type family EigDTypeIsValid (device :: (D.DeviceType, Nat)) (dtype :: D.DType) :
   EigDTypeIsValid '(deviceType, _) dtype = UnsupportedDTypeForDevice deviceType dtype
 
 -- | eig
+-- Warning:
+-- torch.eig is deprecated in favor of torch.linalg.eig and will be removed in a future PyTorch release.
+-- torch.linalg.eig returns complex tensors of dtype cfloat or cdouble rather than real tensors mimicking complex tensors.
+-- L, _ = torch.eig(A)
+-- should be replaced with
+-- L_complex = torch.linalg.eigvals(A)
+-- and
+-- L, V = torch.eig(A, eigenvectors=True)
+-- should be replaced with
+-- L_complex, V_complex = torch.linalg.eig(A) (function operator())
+--
 -- >>> t <- rand :: IO (CPUTensor 'D.Float '[3,3])
 -- >>> (eigenVals,eigenVecs) = eig @EnableEigenVectors t
+-- >>> dtype &&& shape $ eigenVals -- Skip warning
+-- ...
 -- >>> dtype &&& shape $ eigenVals
 -- (Float,[3,2])
 -- >>> :t eigenVals
@@ -1200,9 +1225,20 @@ type family CholeskyDTypeIsValid (device :: (D.DeviceType, Nat)) (dtype :: D.DTy
 -- TODO: cholesky can throw if the input is not positive-definite.
 -- Computes the Cholesky decomposition of a symmetric positive-definite matrix.
 -- The operation supports batching.
+-- 
+-- Warning:
+-- torch.cholesky is deprecated in favor of torch.linalg.cholesky and will be removed in a future PyTorch release.
+-- L = torch.cholesky(A)
+-- should be replaced with
+-- L = torch.linalg.cholesky(A)
+-- and
+-- U = torch.cholesky(A, upper=True)
+-- should be replaced with
+-- U = torch.linalg.cholesky(A.transpose(-2, -1).conj()).transpose(-2, -1).conj() (function operator())
 --
 -- >>> t <- rand :: IO (CPUTensor 'D.Float '[2,2])
--- >>> u = cholesky Upper (t `matmul` transpose2D t)
+-- >>> u = cholesky Upper (t `matmul` transpose2D t) -- Skip warning
+-- ...
 -- >>> dtype &&& shape $ u
 -- (Float,[2,2])
 -- >>> :t u
@@ -1300,10 +1336,20 @@ type family SolveDTypeIsValid (device :: (D.DeviceType, Nat)) (dtype :: D.DType)
 -- `a` has to be a positive semidefinite matrix.
 -- The operation supports batching.
 --
+-- Warning:
+-- torch.solve is deprecated in favor of torch.linalg.solveand will be removed in a future PyTorch release.
+-- torch.linalg.solve has its arguments reversed and does not return the LU factorization.
+-- To get the LU factorization see torch.lu, which can be used with torch.lu_solve or torch.lu_unpack.
+-- X = torch.solve(B, A).solution
+-- should be replaced with
+-- X = torch.linalg.solve(A, B) (function operator())
+--
 -- >>> t <- rand :: IO (CPUTensor 'D.Float '[10,10])
 -- >>> a = t `matmul` transpose2D t
 -- >>> b <- rand :: IO (CPUTensor 'D.Float '[10,3])
 -- >>> (c,lu) = solve b a
+-- >>> dtype &&& shape $ c -- Skip warning
+-- ...
 -- >>> dtype &&& shape $ c
 -- (Float,[10,3])
 -- >>> dtype &&& shape $ lu
@@ -3470,7 +3516,8 @@ maxPool1d input =
 -- | maxPool2d
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
 --
--- >>> t = maxPool2d @'(1,1) @'(1,1) @'(0,0) (ones :: CPUTensor 'D.Float '[1,3,4,5])
+-- >>> t = maxPool2d @'(1,1) @'(1,1) @'(0,0) (ones :: CPUTensor 'D.Float '[1,3,4,5]) -- Skip warning
+-- ...
 -- >>> shape t
 -- [1,3,4,5]
 -- >>> :t t

--- a/libtorch-ffi/csrc/hasktorch_finializer.cpp
+++ b/libtorch-ffi/csrc/hasktorch_finializer.cpp
@@ -181,6 +181,14 @@ void delete_stream(c10::Stream* object){
   delete object;
 }
 
+void delete_arrayrefscalar(at::ArrayRef<at::Scalar>* object){
+  delete object;
+}
+
+void delete_vectorscalar(std::vector<at::Scalar>* object){
+  delete object;
+}
+
 std::map<void*,int> objectAge;
 std::map<void*,int> prevObjectAge;
 
@@ -296,6 +304,10 @@ showObject(int flag, void* ptr, void* fptr){
     std::cout << age << ":" << "optimizer" << ":" << std::hex << (ptr) << std::dec << std::endl;
   }else if(fptr == (void*)delete_stream){
     std::cout << age << ":" << "stream" << ":" << std::hex << (ptr) << std::dec << std::endl;
+  }else if(fptr == (void*)delete_arrayrefscalar){
+    std::cout << age << ":" << "at::ArrayRef<at::Scalar>" << ":" << std::hex << (ptr) << std::dec << std::endl;
+  }else if(fptr == (void*)delete_vectorscalar){
+    std::cout << age << ":" << "std::vector<at::Scalar>" << ":" << std::hex << (ptr) << std::dec << std::endl;
   }
 }
 

--- a/libtorch-ffi/csrc/hasktorch_finializer.h
+++ b/libtorch-ffi/csrc/hasktorch_finializer.h
@@ -103,5 +103,9 @@ extern "C" {
   void delete_optimizer(torch::optim::Optimizer* ptr);
 
   void delete_stream(c10::Stream* ptr);
+
+  void delete_arrayrefscalar(at::ArrayRef<at::Scalar>* ptr);
+
+  void delete_vectorscalar(std::vector<at::Scalar>* ptr);
 #include "hasktorch_dump.h"
 };

--- a/libtorch-ffi/libtorch-ffi.cabal
+++ b/libtorch-ffi/libtorch-ffi.cabal
@@ -1,7 +1,7 @@
 cabal-version:       3.0
 name:                libtorch-ffi
-version:             1.8.0.0
--- The prefix(1.8) of this version("1.8.0.0") is the same as libtorch's one.
+version:             1.9.0.0
+-- The prefix(1.9) of this version("1.9.0.0") is the same as libtorch's one.
 synopsis:            test out alternative options for ffi interface to libtorch 1.x
 -- description:
 homepage:            https://github.com/hasktorch/hasktorch#readme

--- a/libtorch-ffi/src/Torch/Internal/Managed/Native/Native0.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Native/Native0.hs
@@ -127,6 +127,11 @@ align_tensors_l
   -> IO (ForeignPtr TensorList)
 align_tensors_l = cast1 Unmanaged.align_tensors_l
 
+_assert_async_t
+  :: ForeignPtr Tensor
+  -> IO (())
+_assert_async_t = cast1 Unmanaged._assert_async_t
+
 _use_cudnn_ctc_loss_ttlll
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
@@ -146,6 +151,10 @@ _cudnn_ctc_loss_ttlllbb
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
 _cudnn_ctc_loss_ttlllbb = cast7 Unmanaged._cudnn_ctc_loss_ttlllbb
+
+_use_cudnn_rnn_flatten_weight
+  :: IO (CBool)
+_use_cudnn_rnn_flatten_weight = cast0 Unmanaged._use_cudnn_rnn_flatten_weight
 
 _cudnn_rnn_flatten_weight_lllllllbb
   :: ForeignPtr TensorList
@@ -664,33 +673,6 @@ addmv_out_tttt
   -> IO (ForeignPtr Tensor)
 addmv_out_tttt = cast4 Unmanaged.addmv_out_tttt
 
-_addmv_impl__ttttss
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Scalar
-  -> ForeignPtr Scalar
-  -> IO (ForeignPtr Tensor)
-_addmv_impl__ttttss = cast6 Unmanaged._addmv_impl__ttttss
-
-_addmv_impl__tttts
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Scalar
-  -> IO (ForeignPtr Tensor)
-_addmv_impl__tttts = cast5 Unmanaged._addmv_impl__tttts
-
-_addmv_impl__tttt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-_addmv_impl__tttt = cast4 Unmanaged._addmv_impl__tttt
-
 addr_tttss
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
@@ -1193,4 +1175,113 @@ arcsin__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
 arcsin__t = cast1 Unmanaged.arcsin__t
+
+arcsin_out_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+arcsin_out_tt = cast2 Unmanaged.arcsin_out_tt
+
+atan_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+atan_t = cast1 Unmanaged.atan_t
+
+atan__t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+atan__t = cast1 Unmanaged.atan__t
+
+atan_out_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+atan_out_tt = cast2 Unmanaged.atan_out_tt
+
+arctan_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+arctan_t = cast1 Unmanaged.arctan_t
+
+arctan__t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+arctan__t = cast1 Unmanaged.arctan__t
+
+arctan_out_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+arctan_out_tt = cast2 Unmanaged.arctan_out_tt
+
+atleast_1d_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+atleast_1d_t = cast1 Unmanaged.atleast_1d_t
+
+atleast_1d_l
+  :: ForeignPtr TensorList
+  -> IO (ForeignPtr TensorList)
+atleast_1d_l = cast1 Unmanaged.atleast_1d_l
+
+atleast_2d_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+atleast_2d_t = cast1 Unmanaged.atleast_2d_t
+
+atleast_2d_l
+  :: ForeignPtr TensorList
+  -> IO (ForeignPtr TensorList)
+atleast_2d_l = cast1 Unmanaged.atleast_2d_l
+
+atleast_3d_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+atleast_3d_t = cast1 Unmanaged.atleast_3d_t
+
+atleast_3d_l
+  :: ForeignPtr TensorList
+  -> IO (ForeignPtr TensorList)
+atleast_3d_l = cast1 Unmanaged.atleast_3d_l
+
+baddbmm_tttss
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+baddbmm_tttss = cast5 Unmanaged.baddbmm_tttss
+
+baddbmm_ttts
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+baddbmm_ttts = cast4 Unmanaged.baddbmm_ttts
+
+baddbmm_ttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+baddbmm_ttt = cast3 Unmanaged.baddbmm_ttt
+
+_baddbmm_mkl__tttss
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+_baddbmm_mkl__tttss = cast5 Unmanaged._baddbmm_mkl__tttss
+
+_baddbmm_mkl__ttts
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+_baddbmm_mkl__ttts = cast4 Unmanaged._baddbmm_mkl__ttts
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Native/Native1.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Native/Native1.hs
@@ -21,115 +21,6 @@ import Torch.Internal.Objects
 import qualified Torch.Internal.Unmanaged.Native.Native1 as Unmanaged
 
 
-arcsin_out_tt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-arcsin_out_tt = cast2 Unmanaged.arcsin_out_tt
-
-atan_t
-  :: ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-atan_t = cast1 Unmanaged.atan_t
-
-atan__t
-  :: ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-atan__t = cast1 Unmanaged.atan__t
-
-atan_out_tt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-atan_out_tt = cast2 Unmanaged.atan_out_tt
-
-arctan_t
-  :: ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-arctan_t = cast1 Unmanaged.arctan_t
-
-arctan__t
-  :: ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-arctan__t = cast1 Unmanaged.arctan__t
-
-arctan_out_tt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-arctan_out_tt = cast2 Unmanaged.arctan_out_tt
-
-atleast_1d_t
-  :: ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-atleast_1d_t = cast1 Unmanaged.atleast_1d_t
-
-atleast_1d_l
-  :: ForeignPtr TensorList
-  -> IO (ForeignPtr TensorList)
-atleast_1d_l = cast1 Unmanaged.atleast_1d_l
-
-atleast_2d_t
-  :: ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-atleast_2d_t = cast1 Unmanaged.atleast_2d_t
-
-atleast_2d_l
-  :: ForeignPtr TensorList
-  -> IO (ForeignPtr TensorList)
-atleast_2d_l = cast1 Unmanaged.atleast_2d_l
-
-atleast_3d_t
-  :: ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-atleast_3d_t = cast1 Unmanaged.atleast_3d_t
-
-atleast_3d_l
-  :: ForeignPtr TensorList
-  -> IO (ForeignPtr TensorList)
-atleast_3d_l = cast1 Unmanaged.atleast_3d_l
-
-baddbmm_tttss
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Scalar
-  -> ForeignPtr Scalar
-  -> IO (ForeignPtr Tensor)
-baddbmm_tttss = cast5 Unmanaged.baddbmm_tttss
-
-baddbmm_ttts
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Scalar
-  -> IO (ForeignPtr Tensor)
-baddbmm_ttts = cast4 Unmanaged.baddbmm_ttts
-
-baddbmm_ttt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-baddbmm_ttt = cast3 Unmanaged.baddbmm_ttt
-
-_baddbmm_mkl__tttss
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Scalar
-  -> ForeignPtr Scalar
-  -> IO (ForeignPtr Tensor)
-_baddbmm_mkl__tttss = cast5 Unmanaged._baddbmm_mkl__tttss
-
-_baddbmm_mkl__ttts
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Scalar
-  -> IO (ForeignPtr Tensor)
-_baddbmm_mkl__ttts = cast4 Unmanaged._baddbmm_mkl__ttts
-
 _baddbmm_mkl__ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
@@ -476,12 +367,6 @@ bitwise_not_out_tt
   -> IO (ForeignPtr Tensor)
 bitwise_not_out_tt = cast2 Unmanaged.bitwise_not_out_tt
 
-copysign_tt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-copysign_tt = cast2 Unmanaged.copysign_tt
-
 copysign_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
@@ -489,11 +374,24 @@ copysign_out_ttt
   -> IO (ForeignPtr Tensor)
 copysign_out_ttt = cast3 Unmanaged.copysign_out_ttt
 
+copysign_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+copysign_tt = cast2 Unmanaged.copysign_tt
+
 copysign_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
 copysign_ts = cast2 Unmanaged.copysign_ts
+
+copysign_out_tts
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+copysign_out_tts = cast3 Unmanaged.copysign_out_tts
 
 logical_not_t
   :: ForeignPtr Tensor
@@ -684,6 +582,12 @@ chain_matmul_l
   -> IO (ForeignPtr Tensor)
 chain_matmul_l = cast1 Unmanaged.chain_matmul_l
 
+chain_matmul_out_tl
+  :: ForeignPtr Tensor
+  -> ForeignPtr TensorList
+  -> IO (ForeignPtr Tensor)
+chain_matmul_out_tl = cast2 Unmanaged.chain_matmul_out_tl
+
 unsafe_chunk_tll
   :: ForeignPtr Tensor
   -> Int64
@@ -754,6 +658,19 @@ clamp_t
   -> IO (ForeignPtr Tensor)
 clamp_t = cast1 Unmanaged.clamp_t
 
+clamp_ttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+clamp_ttt = cast3 Unmanaged.clamp_ttt
+
+clamp_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+clamp_tt = cast2 Unmanaged.clamp_tt
+
 clamp__tss
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
@@ -771,6 +688,19 @@ clamp__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
 clamp__t = cast1 Unmanaged.clamp__t
+
+clamp__ttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+clamp__ttt = cast3 Unmanaged.clamp__ttt
+
+clamp__tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+clamp__tt = cast2 Unmanaged.clamp__tt
 
 clamp_out_ttss
   :: ForeignPtr Tensor
@@ -793,17 +723,44 @@ clamp_out_tt
   -> IO (ForeignPtr Tensor)
 clamp_out_tt = cast2 Unmanaged.clamp_out_tt
 
+clamp_out_tttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+clamp_out_tttt = cast4 Unmanaged.clamp_out_tttt
+
+clamp_out_ttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+clamp_out_ttt = cast3 Unmanaged.clamp_out_ttt
+
 clamp_max_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
 clamp_max_ts = cast2 Unmanaged.clamp_max_ts
 
+clamp_max_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+clamp_max_tt = cast2 Unmanaged.clamp_max_tt
+
 clamp_max__ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
 clamp_max__ts = cast2 Unmanaged.clamp_max__ts
+
+clamp_max__tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+clamp_max__tt = cast2 Unmanaged.clamp_max__tt
 
 clamp_max_out_tts
   :: ForeignPtr Tensor
@@ -812,11 +769,24 @@ clamp_max_out_tts
   -> IO (ForeignPtr Tensor)
 clamp_max_out_tts = cast3 Unmanaged.clamp_max_out_tts
 
+clamp_max_out_ttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+clamp_max_out_ttt = cast3 Unmanaged.clamp_max_out_ttt
+
 clamp_min_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
 clamp_min_ts = cast2 Unmanaged.clamp_min_ts
+
+clamp_min_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+clamp_min_tt = cast2 Unmanaged.clamp_min_tt
 
 clamp_min__ts
   :: ForeignPtr Tensor
@@ -824,12 +794,25 @@ clamp_min__ts
   -> IO (ForeignPtr Tensor)
 clamp_min__ts = cast2 Unmanaged.clamp_min__ts
 
+clamp_min__tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+clamp_min__tt = cast2 Unmanaged.clamp_min__tt
+
 clamp_min_out_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
 clamp_min_out_tts = cast3 Unmanaged.clamp_min_out_tts
+
+clamp_min_out_ttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+clamp_min_out_ttt = cast3 Unmanaged.clamp_min_out_ttt
 
 clip_tss
   :: ForeignPtr Tensor
@@ -849,6 +832,19 @@ clip_t
   -> IO (ForeignPtr Tensor)
 clip_t = cast1 Unmanaged.clip_t
 
+clip_ttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+clip_ttt = cast3 Unmanaged.clip_ttt
+
+clip_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+clip_tt = cast2 Unmanaged.clip_tt
+
 clip__tss
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
@@ -866,6 +862,19 @@ clip__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
 clip__t = cast1 Unmanaged.clip__t
+
+clip__ttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+clip__ttt = cast3 Unmanaged.clip__ttt
+
+clip__tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+clip__tt = cast2 Unmanaged.clip__tt
 
 clip_out_ttss
   :: ForeignPtr Tensor
@@ -887,6 +896,21 @@ clip_out_tt
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
 clip_out_tt = cast2 Unmanaged.clip_out_tt
+
+clip_out_tttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+clip_out_tttt = cast4 Unmanaged.clip_out_tttt
+
+clip_out_ttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+clip_out_ttt = cast3 Unmanaged.clip_out_ttt
 
 cudnn_is_acceptable_t
   :: ForeignPtr Tensor
@@ -1004,6 +1028,17 @@ _convolution_tttlllbllbbb
   -> CBool
   -> IO (ForeignPtr Tensor)
 _convolution_tttlllbllbbb = cast12 Unmanaged._convolution_tttlllbllbbb
+
+_convolution_mode_tttlsll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr StdString
+  -> ForeignPtr IntArray
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+_convolution_mode_tttlsll = cast7 Unmanaged._convolution_mode_tttlsll
 
 _convolution_nogroup_tttlllbl
   :: ForeignPtr Tensor
@@ -1191,6 +1226,96 @@ conv3d_tt
   -> IO (ForeignPtr Tensor)
 conv3d_tt = cast2 Unmanaged.conv3d_tt
 
+conv1d_tttlsll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr StdString
+  -> ForeignPtr IntArray
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+conv1d_tttlsll = cast7 Unmanaged.conv1d_tttlsll
+
+conv1d_tttlsl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr StdString
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+conv1d_tttlsl = cast6 Unmanaged.conv1d_tttlsl
+
+conv1d_tttls
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr StdString
+  -> IO (ForeignPtr Tensor)
+conv1d_tttls = cast5 Unmanaged.conv1d_tttls
+
+conv2d_tttlsll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr StdString
+  -> ForeignPtr IntArray
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+conv2d_tttlsll = cast7 Unmanaged.conv2d_tttlsll
+
+conv2d_tttlsl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr StdString
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+conv2d_tttlsl = cast6 Unmanaged.conv2d_tttlsl
+
+conv2d_tttls
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr StdString
+  -> IO (ForeignPtr Tensor)
+conv2d_tttls = cast5 Unmanaged.conv2d_tttls
+
+conv3d_tttlsll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr StdString
+  -> ForeignPtr IntArray
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+conv3d_tttlsll = cast7 Unmanaged.conv3d_tttlsll
+
+conv3d_tttlsl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr StdString
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+conv3d_tttlsl = cast6 Unmanaged.conv3d_tttlsl
+
+conv3d_tttls
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr StdString
+  -> IO (ForeignPtr Tensor)
+conv3d_tttls = cast5 Unmanaged.conv3d_tttls
+
 conv_tbc_tttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
@@ -1198,95 +1323,4 @@ conv_tbc_tttl
   -> Int64
   -> IO (ForeignPtr Tensor)
 conv_tbc_tttl = cast4 Unmanaged.conv_tbc_tttl
-
-conv_tbc_ttt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-conv_tbc_ttt = cast3 Unmanaged.conv_tbc_ttt
-
-conv_tbc_backward_ttttl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> Int64
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-conv_tbc_backward_ttttl = cast5 Unmanaged.conv_tbc_backward_ttttl
-
-conv_transpose1d_tttlllll
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> Int64
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-conv_transpose1d_tttlllll = cast8 Unmanaged.conv_transpose1d_tttlllll
-
-conv_transpose1d_tttllll
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> Int64
-  -> IO (ForeignPtr Tensor)
-conv_transpose1d_tttllll = cast7 Unmanaged.conv_transpose1d_tttllll
-
-conv_transpose1d_tttlll
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-conv_transpose1d_tttlll = cast6 Unmanaged.conv_transpose1d_tttlll
-
-conv_transpose1d_tttll
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-conv_transpose1d_tttll = cast5 Unmanaged.conv_transpose1d_tttll
-
-conv_transpose1d_tttl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-conv_transpose1d_tttl = cast4 Unmanaged.conv_transpose1d_tttl
-
-conv_transpose1d_ttt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-conv_transpose1d_ttt = cast3 Unmanaged.conv_transpose1d_ttt
-
-conv_transpose1d_tt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-conv_transpose1d_tt = cast2 Unmanaged.conv_transpose1d_tt
-
-conv_transpose2d_tttlllll
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> Int64
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-conv_transpose2d_tttlllll = cast8 Unmanaged.conv_transpose2d_tttlllll
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Native/Native10.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Native/Native10.hs
@@ -21,238 +21,6 @@ import Torch.Internal.Objects
 import qualified Torch.Internal.Unmanaged.Native.Native10 as Unmanaged
 
 
-symeig_out_tttbb
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> CBool
-  -> CBool
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-symeig_out_tttbb = cast5 Unmanaged.symeig_out_tttbb
-
-symeig_out_tttb
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> CBool
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-symeig_out_tttb = cast4 Unmanaged.symeig_out_tttb
-
-symeig_out_ttt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-symeig_out_ttt = cast3 Unmanaged.symeig_out_ttt
-
-symeig_tbb
-  :: ForeignPtr Tensor
-  -> CBool
-  -> CBool
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-symeig_tbb = cast3 Unmanaged.symeig_tbb
-
-symeig_tb
-  :: ForeignPtr Tensor
-  -> CBool
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-symeig_tb = cast2 Unmanaged.symeig_tb
-
-symeig_t
-  :: ForeignPtr Tensor
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-symeig_t = cast1 Unmanaged.symeig_t
-
-_symeig_helper_tbb
-  :: ForeignPtr Tensor
-  -> CBool
-  -> CBool
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-_symeig_helper_tbb = cast3 Unmanaged._symeig_helper_tbb
-
-eig_out_tttb
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> CBool
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-eig_out_tttb = cast4 Unmanaged.eig_out_tttb
-
-eig_out_ttt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-eig_out_ttt = cast3 Unmanaged.eig_out_ttt
-
-eig_tb
-  :: ForeignPtr Tensor
-  -> CBool
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-eig_tb = cast2 Unmanaged.eig_tb
-
-eig_t
-  :: ForeignPtr Tensor
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-eig_t = cast1 Unmanaged.eig_t
-
-svd_out_ttttbb
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> CBool
-  -> CBool
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-svd_out_ttttbb = cast6 Unmanaged.svd_out_ttttbb
-
-svd_out_ttttb
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> CBool
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-svd_out_ttttb = cast5 Unmanaged.svd_out_ttttb
-
-svd_out_tttt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-svd_out_tttt = cast4 Unmanaged.svd_out_tttt
-
-svd_tbb
-  :: ForeignPtr Tensor
-  -> CBool
-  -> CBool
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-svd_tbb = cast3 Unmanaged.svd_tbb
-
-svd_tb
-  :: ForeignPtr Tensor
-  -> CBool
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-svd_tb = cast2 Unmanaged.svd_tb
-
-svd_t
-  :: ForeignPtr Tensor
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-svd_t = cast1 Unmanaged.svd_t
-
-_svd_helper_tbb
-  :: ForeignPtr Tensor
-  -> CBool
-  -> CBool
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-_svd_helper_tbb = cast3 Unmanaged._svd_helper_tbb
-
-swapaxes_tll
-  :: ForeignPtr Tensor
-  -> Int64
-  -> Int64
-  -> IO (ForeignPtr Tensor)
-swapaxes_tll = cast3 Unmanaged.swapaxes_tll
-
-swapdims_tll
-  :: ForeignPtr Tensor
-  -> Int64
-  -> Int64
-  -> IO (ForeignPtr Tensor)
-swapdims_tll = cast3 Unmanaged.swapdims_tll
-
-cholesky_out_ttb
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> CBool
-  -> IO (ForeignPtr Tensor)
-cholesky_out_ttb = cast3 Unmanaged.cholesky_out_ttb
-
-cholesky_out_tt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-cholesky_out_tt = cast2 Unmanaged.cholesky_out_tt
-
-cholesky_tb
-  :: ForeignPtr Tensor
-  -> CBool
-  -> IO (ForeignPtr Tensor)
-cholesky_tb = cast2 Unmanaged.cholesky_tb
-
-cholesky_t
-  :: ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-cholesky_t = cast1 Unmanaged.cholesky_t
-
-_cholesky_helper_tb
-  :: ForeignPtr Tensor
-  -> CBool
-  -> IO (ForeignPtr Tensor)
-_cholesky_helper_tb = cast2 Unmanaged._cholesky_helper_tb
-
-cholesky_solve_out_tttb
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> CBool
-  -> IO (ForeignPtr Tensor)
-cholesky_solve_out_tttb = cast4 Unmanaged.cholesky_solve_out_tttb
-
-cholesky_solve_out_ttt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-cholesky_solve_out_ttt = cast3 Unmanaged.cholesky_solve_out_ttt
-
-cholesky_solve_ttb
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> CBool
-  -> IO (ForeignPtr Tensor)
-cholesky_solve_ttb = cast3 Unmanaged.cholesky_solve_ttb
-
-cholesky_solve_tt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-cholesky_solve_tt = cast2 Unmanaged.cholesky_solve_tt
-
-_cholesky_solve_helper_ttb
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> CBool
-  -> IO (ForeignPtr Tensor)
-_cholesky_solve_helper_ttb = cast3 Unmanaged._cholesky_solve_helper_ttb
-
-solve_tt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-solve_tt = cast2 Unmanaged.solve_tt
-
-solve_out_tttt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-solve_out_tttt = cast4 Unmanaged.solve_out_tttt
-
-_solve_helper_tt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-_solve_helper_tt = cast2 Unmanaged._solve_helper_tt
-
-cholesky_inverse_tb
-  :: ForeignPtr Tensor
-  -> CBool
-  -> IO (ForeignPtr Tensor)
-cholesky_inverse_tb = cast2 Unmanaged.cholesky_inverse_tb
-
 cholesky_inverse_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
@@ -309,18 +77,18 @@ geqrf_t
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
 geqrf_t = cast1 Unmanaged.geqrf_t
 
+orgqr_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+orgqr_tt = cast2 Unmanaged.orgqr_tt
+
 orgqr_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
 orgqr_out_ttt = cast3 Unmanaged.orgqr_out_ttt
-
-orgqr_tt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-orgqr_tt = cast2 Unmanaged.orgqr_tt
 
 ormqr_out_ttttbb
   :: ForeignPtr Tensor
@@ -406,12 +174,56 @@ lu_solve_ttt
   -> IO (ForeignPtr Tensor)
 lu_solve_ttt = cast3 Unmanaged.lu_solve_ttt
 
-_lu_solve_helper_ttt
+lu_unpack_ttbb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> CBool
+  -> CBool
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
+lu_unpack_ttbb = cast4 Unmanaged.lu_unpack_ttbb
+
+lu_unpack_ttb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> CBool
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
+lu_unpack_ttb = cast3 Unmanaged.lu_unpack_ttb
+
+lu_unpack_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
+lu_unpack_tt = cast2 Unmanaged.lu_unpack_tt
+
+lu_unpack_out_tttttbb
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-_lu_solve_helper_ttt = cast3 Unmanaged._lu_solve_helper_ttt
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> CBool
+  -> CBool
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
+lu_unpack_out_tttttbb = cast7 Unmanaged.lu_unpack_out_tttttbb
+
+lu_unpack_out_tttttb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> CBool
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
+lu_unpack_out_tttttb = cast6 Unmanaged.lu_unpack_out_tttttb
+
+lu_unpack_out_ttttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
+lu_unpack_out_ttttt = cast5 Unmanaged.lu_unpack_out_ttttt
 
 multinomial_out_ttlbG
   :: ForeignPtr Tensor
@@ -1026,6 +838,82 @@ nanquantile_tt
   -> IO (ForeignPtr Tensor)
 nanquantile_tt = cast2 Unmanaged.nanquantile_tt
 
+quantile_out_ttdlbs
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> CDouble
+  -> Int64
+  -> CBool
+  -> ForeignPtr StdString
+  -> IO (ForeignPtr Tensor)
+quantile_out_ttdlbs = cast6 Unmanaged.quantile_out_ttdlbs
+
+quantile_tdlbs
+  :: ForeignPtr Tensor
+  -> CDouble
+  -> Int64
+  -> CBool
+  -> ForeignPtr StdString
+  -> IO (ForeignPtr Tensor)
+quantile_tdlbs = cast5 Unmanaged.quantile_tdlbs
+
+quantile_out_tttlbs
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> CBool
+  -> ForeignPtr StdString
+  -> IO (ForeignPtr Tensor)
+quantile_out_tttlbs = cast6 Unmanaged.quantile_out_tttlbs
+
+quantile_ttlbs
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> CBool
+  -> ForeignPtr StdString
+  -> IO (ForeignPtr Tensor)
+quantile_ttlbs = cast5 Unmanaged.quantile_ttlbs
+
+nanquantile_out_ttdlbs
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> CDouble
+  -> Int64
+  -> CBool
+  -> ForeignPtr StdString
+  -> IO (ForeignPtr Tensor)
+nanquantile_out_ttdlbs = cast6 Unmanaged.nanquantile_out_ttdlbs
+
+nanquantile_tdlbs
+  :: ForeignPtr Tensor
+  -> CDouble
+  -> Int64
+  -> CBool
+  -> ForeignPtr StdString
+  -> IO (ForeignPtr Tensor)
+nanquantile_tdlbs = cast5 Unmanaged.nanquantile_tdlbs
+
+nanquantile_out_tttlbs
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> CBool
+  -> ForeignPtr StdString
+  -> IO (ForeignPtr Tensor)
+nanquantile_out_tttlbs = cast6 Unmanaged.nanquantile_out_tttlbs
+
+nanquantile_ttlbs
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> CBool
+  -> ForeignPtr StdString
+  -> IO (ForeignPtr Tensor)
+nanquantile_ttlbs = cast5 Unmanaged.nanquantile_ttlbs
+
 sort_out_tttlb
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
@@ -1050,6 +938,24 @@ sort_out_ttt
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
 sort_out_ttt = cast3 Unmanaged.sort_out_ttt
 
+sort_out_tttblb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> CBool
+  -> Int64
+  -> CBool
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+sort_out_tttblb = cast6 Unmanaged.sort_out_tttblb
+
+sort_out_tttb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> CBool
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+sort_out_tttb = cast4 Unmanaged.sort_out_tttb
+
 sort_tlb
   :: ForeignPtr Tensor
   -> Int64
@@ -1068,6 +974,27 @@ sort_t
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
 sort_t = cast1 Unmanaged.sort_t
 
+sort_tblb
+  :: ForeignPtr Tensor
+  -> CBool
+  -> Int64
+  -> CBool
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+sort_tblb = cast4 Unmanaged.sort_tblb
+
+sort_tbl
+  :: ForeignPtr Tensor
+  -> CBool
+  -> Int64
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+sort_tbl = cast3 Unmanaged.sort_tbl
+
+sort_tb
+  :: ForeignPtr Tensor
+  -> CBool
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+sort_tb = cast2 Unmanaged.sort_tb
+
 sort_out_tttnb
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
@@ -1085,6 +1012,25 @@ sort_out_tttn
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
 sort_out_tttn = cast4 Unmanaged.sort_out_tttn
 
+sort_out_tttbnb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> CBool
+  -> ForeignPtr Dimname
+  -> CBool
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+sort_out_tttbnb = cast6 Unmanaged.sort_out_tttbnb
+
+sort_out_tttbn
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> CBool
+  -> ForeignPtr Dimname
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+sort_out_tttbn = cast5 Unmanaged.sort_out_tttbn
+
 sort_tnb
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
@@ -1097,6 +1043,21 @@ sort_tn
   -> ForeignPtr Dimname
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
 sort_tn = cast2 Unmanaged.sort_tn
+
+sort_tbnb
+  :: ForeignPtr Tensor
+  -> CBool
+  -> ForeignPtr Dimname
+  -> CBool
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+sort_tbnb = cast4 Unmanaged.sort_tbnb
+
+sort_tbn
+  :: ForeignPtr Tensor
+  -> CBool
+  -> ForeignPtr Dimname
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+sort_tbn = cast3 Unmanaged.sort_tbn
 
 msort_out_tt
   :: ForeignPtr Tensor
@@ -1207,4 +1168,191 @@ topk_tl
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
 topk_tl = cast2 Unmanaged.topk_tl
+
+all_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+all_t = cast1 Unmanaged.all_t
+
+any_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+any_t = cast1 Unmanaged.any_t
+
+renorm_out_ttsls
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> Int64
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+renorm_out_ttsls = cast5 Unmanaged.renorm_out_ttsls
+
+renorm_tsls
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> Int64
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+renorm_tsls = cast4 Unmanaged.renorm_tsls
+
+unfold_backward_tllll
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> Int64
+  -> Int64
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+unfold_backward_tllll = cast5 Unmanaged.unfold_backward_tllll
+
+equal_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (CBool)
+equal_tt = cast2 Unmanaged.equal_tt
+
+pow_out_ttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+pow_out_ttt = cast3 Unmanaged.pow_out_ttt
+
+pow_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+pow_tt = cast2 Unmanaged.pow_tt
+
+pow_out_tst
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+pow_out_tst = cast3 Unmanaged.pow_out_tst
+
+pow_st
+  :: ForeignPtr Scalar
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+pow_st = cast2 Unmanaged.pow_st
+
+pow_out_tts
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+pow_out_tts = cast3 Unmanaged.pow_out_tts
+
+pow_ts
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+pow_ts = cast2 Unmanaged.pow_ts
+
+float_power_out_ttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+float_power_out_ttt = cast3 Unmanaged.float_power_out_ttt
+
+float_power_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+float_power_tt = cast2 Unmanaged.float_power_tt
+
+float_power_out_tst
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+float_power_out_tst = cast3 Unmanaged.float_power_out_tst
+
+float_power_st
+  :: ForeignPtr Scalar
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+float_power_st = cast2 Unmanaged.float_power_st
+
+float_power_out_tts
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+float_power_out_tts = cast3 Unmanaged.float_power_out_tts
+
+float_power_ts
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+float_power_ts = cast2 Unmanaged.float_power_ts
+
+normal_out_ttdG
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> CDouble
+  -> ForeignPtr Generator
+  -> IO (ForeignPtr Tensor)
+normal_out_ttdG = cast4 Unmanaged.normal_out_ttdG
+
+normal_out_ttd
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> CDouble
+  -> IO (ForeignPtr Tensor)
+normal_out_ttd = cast3 Unmanaged.normal_out_ttd
+
+normal_out_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+normal_out_tt = cast2 Unmanaged.normal_out_tt
+
+normal_tdG
+  :: ForeignPtr Tensor
+  -> CDouble
+  -> ForeignPtr Generator
+  -> IO (ForeignPtr Tensor)
+normal_tdG = cast3 Unmanaged.normal_tdG
+
+normal_td
+  :: ForeignPtr Tensor
+  -> CDouble
+  -> IO (ForeignPtr Tensor)
+normal_td = cast2 Unmanaged.normal_td
+
+normal_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+normal_t = cast1 Unmanaged.normal_t
+
+normal_out_tdtG
+  :: ForeignPtr Tensor
+  -> CDouble
+  -> ForeignPtr Tensor
+  -> ForeignPtr Generator
+  -> IO (ForeignPtr Tensor)
+normal_out_tdtG = cast4 Unmanaged.normal_out_tdtG
+
+normal_out_tdt
+  :: ForeignPtr Tensor
+  -> CDouble
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+normal_out_tdt = cast3 Unmanaged.normal_out_tdt
+
+normal_dtG
+  :: CDouble
+  -> ForeignPtr Tensor
+  -> ForeignPtr Generator
+  -> IO (ForeignPtr Tensor)
+normal_dtG = cast3 Unmanaged.normal_dtG
+
+normal_dt
+  :: CDouble
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+normal_dt = cast2 Unmanaged.normal_dt
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Native/Native10.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Native/Native10.hs
@@ -982,12 +982,12 @@ sort_tblb
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
 sort_tblb = cast4 Unmanaged.sort_tblb
 
-sort_tbl
-  :: ForeignPtr Tensor
-  -> CBool
-  -> Int64
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-sort_tbl = cast3 Unmanaged.sort_tbl
+-- sort_tbl
+--   :: ForeignPtr Tensor
+--   -> CBool
+--   -> Int64
+--   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+-- sort_tbl = cast3 Unmanaged.sort_tbl
 
 sort_tb
   :: ForeignPtr Tensor

--- a/libtorch-ffi/src/Torch/Internal/Managed/Native/Native11.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Native/Native11.hs
@@ -21,193 +21,6 @@ import Torch.Internal.Objects
 import qualified Torch.Internal.Unmanaged.Native.Native11 as Unmanaged
 
 
-all_t
-  :: ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-all_t = cast1 Unmanaged.all_t
-
-any_t
-  :: ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-any_t = cast1 Unmanaged.any_t
-
-renorm_out_ttsls
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Scalar
-  -> Int64
-  -> ForeignPtr Scalar
-  -> IO (ForeignPtr Tensor)
-renorm_out_ttsls = cast5 Unmanaged.renorm_out_ttsls
-
-renorm_tsls
-  :: ForeignPtr Tensor
-  -> ForeignPtr Scalar
-  -> Int64
-  -> ForeignPtr Scalar
-  -> IO (ForeignPtr Tensor)
-renorm_tsls = cast4 Unmanaged.renorm_tsls
-
-unfold_backward_tllll
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> Int64
-  -> Int64
-  -> Int64
-  -> IO (ForeignPtr Tensor)
-unfold_backward_tllll = cast5 Unmanaged.unfold_backward_tllll
-
-equal_tt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (CBool)
-equal_tt = cast2 Unmanaged.equal_tt
-
-pow_out_ttt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-pow_out_ttt = cast3 Unmanaged.pow_out_ttt
-
-pow_tt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-pow_tt = cast2 Unmanaged.pow_tt
-
-pow_out_tst
-  :: ForeignPtr Tensor
-  -> ForeignPtr Scalar
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-pow_out_tst = cast3 Unmanaged.pow_out_tst
-
-pow_st
-  :: ForeignPtr Scalar
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-pow_st = cast2 Unmanaged.pow_st
-
-pow_out_tts
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Scalar
-  -> IO (ForeignPtr Tensor)
-pow_out_tts = cast3 Unmanaged.pow_out_tts
-
-pow_ts
-  :: ForeignPtr Tensor
-  -> ForeignPtr Scalar
-  -> IO (ForeignPtr Tensor)
-pow_ts = cast2 Unmanaged.pow_ts
-
-float_power_out_ttt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-float_power_out_ttt = cast3 Unmanaged.float_power_out_ttt
-
-float_power_tt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-float_power_tt = cast2 Unmanaged.float_power_tt
-
-float_power_out_tst
-  :: ForeignPtr Tensor
-  -> ForeignPtr Scalar
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-float_power_out_tst = cast3 Unmanaged.float_power_out_tst
-
-float_power_st
-  :: ForeignPtr Scalar
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-float_power_st = cast2 Unmanaged.float_power_st
-
-float_power_out_tts
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Scalar
-  -> IO (ForeignPtr Tensor)
-float_power_out_tts = cast3 Unmanaged.float_power_out_tts
-
-float_power_ts
-  :: ForeignPtr Tensor
-  -> ForeignPtr Scalar
-  -> IO (ForeignPtr Tensor)
-float_power_ts = cast2 Unmanaged.float_power_ts
-
-normal_out_ttdG
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> CDouble
-  -> ForeignPtr Generator
-  -> IO (ForeignPtr Tensor)
-normal_out_ttdG = cast4 Unmanaged.normal_out_ttdG
-
-normal_out_ttd
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> CDouble
-  -> IO (ForeignPtr Tensor)
-normal_out_ttd = cast3 Unmanaged.normal_out_ttd
-
-normal_out_tt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-normal_out_tt = cast2 Unmanaged.normal_out_tt
-
-normal_tdG
-  :: ForeignPtr Tensor
-  -> CDouble
-  -> ForeignPtr Generator
-  -> IO (ForeignPtr Tensor)
-normal_tdG = cast3 Unmanaged.normal_tdG
-
-normal_td
-  :: ForeignPtr Tensor
-  -> CDouble
-  -> IO (ForeignPtr Tensor)
-normal_td = cast2 Unmanaged.normal_td
-
-normal_t
-  :: ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-normal_t = cast1 Unmanaged.normal_t
-
-normal_out_tdtG
-  :: ForeignPtr Tensor
-  -> CDouble
-  -> ForeignPtr Tensor
-  -> ForeignPtr Generator
-  -> IO (ForeignPtr Tensor)
-normal_out_tdtG = cast4 Unmanaged.normal_out_tdtG
-
-normal_out_tdt
-  :: ForeignPtr Tensor
-  -> CDouble
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-normal_out_tdt = cast3 Unmanaged.normal_out_tdt
-
-normal_dtG
-  :: CDouble
-  -> ForeignPtr Tensor
-  -> ForeignPtr Generator
-  -> IO (ForeignPtr Tensor)
-normal_dtG = cast3 Unmanaged.normal_dtG
-
-normal_dt
-  :: CDouble
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-normal_dt = cast2 Unmanaged.normal_dt
-
 normal_out_tttG
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
@@ -316,28 +129,6 @@ _cumprod_out_ttl
   -> IO (ForeignPtr Tensor)
 _cumprod_out_ttl = cast3 Unmanaged._cumprod_out_ttl
 
-_var_tb
-  :: ForeignPtr Tensor
-  -> CBool
-  -> IO (ForeignPtr Tensor)
-_var_tb = cast2 Unmanaged._var_tb
-
-_var_t
-  :: ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-_var_t = cast1 Unmanaged._var_t
-
-_std_tb
-  :: ForeignPtr Tensor
-  -> CBool
-  -> IO (ForeignPtr Tensor)
-_std_tb = cast2 Unmanaged._std_tb
-
-_std_t
-  :: ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-_std_t = cast1 Unmanaged._std_t
-
 _amp_foreach_non_finite_check_and_unscale__ltt
   :: ForeignPtr TensorList
   -> ForeignPtr Tensor
@@ -345,7 +136,7 @@ _amp_foreach_non_finite_check_and_unscale__ltt
   -> IO (())
 _amp_foreach_non_finite_check_and_unscale__ltt = cast3 Unmanaged._amp_foreach_non_finite_check_and_unscale__ltt
 
-_amp_update_scale_tttddl
+_amp_update_scale__tttddl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
@@ -353,7 +144,7 @@ _amp_update_scale_tttddl
   -> CDouble
   -> Int64
   -> IO (ForeignPtr Tensor)
-_amp_update_scale_tttddl = cast6 Unmanaged._amp_update_scale_tttddl
+_amp_update_scale__tttddl = cast6 Unmanaged._amp_update_scale__tttddl
 
 _cat_ll
   :: ForeignPtr TensorList
@@ -503,53 +294,53 @@ _foreach_div__ll
   -> IO (())
 _foreach_div__ll = cast2 Unmanaged._foreach_div__ll
 
-_foreach_add_la
+_foreach_add_lA
   :: ForeignPtr TensorList
-  -> ForeignPtr (StdVector CDouble)
+  -> ForeignPtr (StdVector Scalar)
   -> IO (ForeignPtr TensorList)
-_foreach_add_la = cast2 Unmanaged._foreach_add_la
+_foreach_add_lA = cast2 Unmanaged._foreach_add_lA
 
-_foreach_add__la
+_foreach_add__lA
   :: ForeignPtr TensorList
-  -> ForeignPtr (StdVector CDouble)
+  -> ForeignPtr (StdVector Scalar)
   -> IO (())
-_foreach_add__la = cast2 Unmanaged._foreach_add__la
+_foreach_add__lA = cast2 Unmanaged._foreach_add__lA
 
-_foreach_sub_la
+_foreach_sub_lA
   :: ForeignPtr TensorList
-  -> ForeignPtr (StdVector CDouble)
+  -> ForeignPtr (StdVector Scalar)
   -> IO (ForeignPtr TensorList)
-_foreach_sub_la = cast2 Unmanaged._foreach_sub_la
+_foreach_sub_lA = cast2 Unmanaged._foreach_sub_lA
 
-_foreach_sub__la
+_foreach_sub__lA
   :: ForeignPtr TensorList
-  -> ForeignPtr (StdVector CDouble)
+  -> ForeignPtr (StdVector Scalar)
   -> IO (())
-_foreach_sub__la = cast2 Unmanaged._foreach_sub__la
+_foreach_sub__lA = cast2 Unmanaged._foreach_sub__lA
 
-_foreach_div_la
+_foreach_div_lA
   :: ForeignPtr TensorList
-  -> ForeignPtr (StdVector CDouble)
+  -> ForeignPtr (StdVector Scalar)
   -> IO (ForeignPtr TensorList)
-_foreach_div_la = cast2 Unmanaged._foreach_div_la
+_foreach_div_lA = cast2 Unmanaged._foreach_div_lA
 
-_foreach_div__la
+_foreach_div__lA
   :: ForeignPtr TensorList
-  -> ForeignPtr (StdVector CDouble)
+  -> ForeignPtr (StdVector Scalar)
   -> IO (())
-_foreach_div__la = cast2 Unmanaged._foreach_div__la
+_foreach_div__lA = cast2 Unmanaged._foreach_div__lA
 
-_foreach_mul_la
+_foreach_mul_lA
   :: ForeignPtr TensorList
-  -> ForeignPtr (StdVector CDouble)
+  -> ForeignPtr (StdVector Scalar)
   -> IO (ForeignPtr TensorList)
-_foreach_mul_la = cast2 Unmanaged._foreach_mul_la
+_foreach_mul_lA = cast2 Unmanaged._foreach_mul_lA
 
-_foreach_mul__la
+_foreach_mul__lA
   :: ForeignPtr TensorList
-  -> ForeignPtr (StdVector CDouble)
+  -> ForeignPtr (StdVector Scalar)
   -> IO (())
-_foreach_mul__la = cast2 Unmanaged._foreach_mul__la
+_foreach_mul__lA = cast2 Unmanaged._foreach_mul__lA
 
 _foreach_exp_l
   :: ForeignPtr TensorList
@@ -866,21 +657,21 @@ _foreach_addcmul__lll
   -> IO (())
 _foreach_addcmul__lll = cast3 Unmanaged._foreach_addcmul__lll
 
-_foreach_addcdiv__llla
+_foreach_addcdiv__lllA
   :: ForeignPtr TensorList
   -> ForeignPtr TensorList
   -> ForeignPtr TensorList
-  -> ForeignPtr (StdVector CDouble)
+  -> ForeignPtr (StdVector Scalar)
   -> IO (())
-_foreach_addcdiv__llla = cast4 Unmanaged._foreach_addcdiv__llla
+_foreach_addcdiv__lllA = cast4 Unmanaged._foreach_addcdiv__lllA
 
-_foreach_addcmul__llla
+_foreach_addcmul__lllA
   :: ForeignPtr TensorList
   -> ForeignPtr TensorList
   -> ForeignPtr TensorList
-  -> ForeignPtr (StdVector CDouble)
+  -> ForeignPtr (StdVector Scalar)
   -> IO (())
-_foreach_addcmul__llla = cast4 Unmanaged._foreach_addcmul__llla
+_foreach_addcmul__lllA = cast4 Unmanaged._foreach_addcmul__lllA
 
 _foreach_addcdiv_llls
   :: ForeignPtr TensorList
@@ -912,21 +703,21 @@ _foreach_addcmul_lll
   -> IO (ForeignPtr TensorList)
 _foreach_addcmul_lll = cast3 Unmanaged._foreach_addcmul_lll
 
-_foreach_addcdiv_llla
+_foreach_addcdiv_lllA
   :: ForeignPtr TensorList
   -> ForeignPtr TensorList
   -> ForeignPtr TensorList
-  -> ForeignPtr (StdVector CDouble)
+  -> ForeignPtr (StdVector Scalar)
   -> IO (ForeignPtr TensorList)
-_foreach_addcdiv_llla = cast4 Unmanaged._foreach_addcdiv_llla
+_foreach_addcdiv_lllA = cast4 Unmanaged._foreach_addcdiv_lllA
 
-_foreach_addcmul_llla
+_foreach_addcmul_lllA
   :: ForeignPtr TensorList
   -> ForeignPtr TensorList
   -> ForeignPtr TensorList
-  -> ForeignPtr (StdVector CDouble)
+  -> ForeignPtr (StdVector Scalar)
   -> IO (ForeignPtr TensorList)
-_foreach_addcmul_llla = cast4 Unmanaged._foreach_addcmul_llla
+_foreach_addcmul_lllA = cast4 Unmanaged._foreach_addcmul_lllA
 
 _foreach_maximum_ll
   :: ForeignPtr TensorList
@@ -939,48 +730,6 @@ _foreach_minimum_ll
   -> ForeignPtr TensorList
   -> IO (ForeignPtr TensorList)
 _foreach_minimum_ll = cast2 Unmanaged._foreach_minimum_ll
-
-_mode_tlb
-  :: ForeignPtr Tensor
-  -> Int64
-  -> CBool
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-_mode_tlb = cast3 Unmanaged._mode_tlb
-
-_mode_tl
-  :: ForeignPtr Tensor
-  -> Int64
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-_mode_tl = cast2 Unmanaged._mode_tl
-
-_mode_t
-  :: ForeignPtr Tensor
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-_mode_t = cast1 Unmanaged._mode_t
-
-_mode_out_tttlb
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> Int64
-  -> CBool
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-_mode_out_tttlb = cast5 Unmanaged._mode_out_tttlb
-
-_mode_out_tttl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> Int64
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-_mode_out_tttl = cast4 Unmanaged._mode_out_tttl
-
-_mode_out_ttt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-_mode_out_ttt = cast3 Unmanaged._mode_out_ttt
 
 bucketize_ttbb
   :: ForeignPtr Tensor
@@ -1092,4 +841,463 @@ searchsorted_out_ttt
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
 searchsorted_out_ttt = cast3 Unmanaged.searchsorted_out_ttt
+
+searchsorted_tsbb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> CBool
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+searchsorted_tsbb = cast4 Unmanaged.searchsorted_tsbb
+
+searchsorted_tsb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+searchsorted_tsb = cast3 Unmanaged.searchsorted_tsb
+
+searchsorted_ts
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+searchsorted_ts = cast2 Unmanaged.searchsorted_ts
+
+mse_loss_out_tttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+mse_loss_out_tttl = cast4 Unmanaged.mse_loss_out_tttl
+
+mse_loss_out_ttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+mse_loss_out_ttt = cast3 Unmanaged.mse_loss_out_ttt
+
+mse_loss_ttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+mse_loss_ttl = cast3 Unmanaged.mse_loss_ttl
+
+mse_loss_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+mse_loss_tt = cast2 Unmanaged.mse_loss_tt
+
+mse_loss_backward_out_ttttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+mse_loss_backward_out_ttttl = cast5 Unmanaged.mse_loss_backward_out_ttttl
+
+mse_loss_backward_tttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+mse_loss_backward_tttl = cast4 Unmanaged.mse_loss_backward_tttl
+
+l1_loss_out_tttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+l1_loss_out_tttl = cast4 Unmanaged.l1_loss_out_tttl
+
+l1_loss_out_ttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+l1_loss_out_ttt = cast3 Unmanaged.l1_loss_out_ttt
+
+l1_loss_ttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+l1_loss_ttl = cast3 Unmanaged.l1_loss_ttl
+
+l1_loss_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+l1_loss_tt = cast2 Unmanaged.l1_loss_tt
+
+l1_loss_backward_out_ttttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+l1_loss_backward_out_ttttl = cast5 Unmanaged.l1_loss_backward_out_ttttl
+
+l1_loss_backward_tttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+l1_loss_backward_tttl = cast4 Unmanaged.l1_loss_backward_tttl
+
+multi_margin_loss_out_tttsstl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr Scalar
+  -> ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+multi_margin_loss_out_tttsstl = cast7 Unmanaged.multi_margin_loss_out_tttsstl
+
+multi_margin_loss_out_tttsst
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr Scalar
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+multi_margin_loss_out_tttsst = cast6 Unmanaged.multi_margin_loss_out_tttsst
+
+multi_margin_loss_out_tttss
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+multi_margin_loss_out_tttss = cast5 Unmanaged.multi_margin_loss_out_tttss
+
+multi_margin_loss_out_ttts
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+multi_margin_loss_out_ttts = cast4 Unmanaged.multi_margin_loss_out_ttts
+
+multi_margin_loss_out_ttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+multi_margin_loss_out_ttt = cast3 Unmanaged.multi_margin_loss_out_ttt
+
+multi_margin_loss_ttsstl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr Scalar
+  -> ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+multi_margin_loss_ttsstl = cast6 Unmanaged.multi_margin_loss_ttsstl
+
+multi_margin_loss_ttsst
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr Scalar
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+multi_margin_loss_ttsst = cast5 Unmanaged.multi_margin_loss_ttsst
+
+multi_margin_loss_ttss
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+multi_margin_loss_ttss = cast4 Unmanaged.multi_margin_loss_ttss
+
+multi_margin_loss_tts
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+multi_margin_loss_tts = cast3 Unmanaged.multi_margin_loss_tts
+
+multi_margin_loss_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+multi_margin_loss_tt = cast2 Unmanaged.multi_margin_loss_tt
+
+multi_margin_loss_backward_out_ttttsstl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr Scalar
+  -> ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+multi_margin_loss_backward_out_ttttsstl = cast8 Unmanaged.multi_margin_loss_backward_out_ttttsstl
+
+multi_margin_loss_backward_out_ttttsst
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr Scalar
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+multi_margin_loss_backward_out_ttttsst = cast7 Unmanaged.multi_margin_loss_backward_out_ttttsst
+
+multi_margin_loss_backward_out_ttttss
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+multi_margin_loss_backward_out_ttttss = cast6 Unmanaged.multi_margin_loss_backward_out_ttttss
+
+multi_margin_loss_backward_tttsstl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr Scalar
+  -> ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+multi_margin_loss_backward_tttsstl = cast7 Unmanaged.multi_margin_loss_backward_tttsstl
+
+multi_margin_loss_backward_tttsst
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr Scalar
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+multi_margin_loss_backward_tttsst = cast6 Unmanaged.multi_margin_loss_backward_tttsst
+
+multi_margin_loss_backward_tttss
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+multi_margin_loss_backward_tttss = cast5 Unmanaged.multi_margin_loss_backward_tttss
+
+multilabel_margin_loss_out_tttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+multilabel_margin_loss_out_tttl = cast4 Unmanaged.multilabel_margin_loss_out_tttl
+
+multilabel_margin_loss_out_ttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+multilabel_margin_loss_out_ttt = cast3 Unmanaged.multilabel_margin_loss_out_ttt
+
+multilabel_margin_loss_ttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+multilabel_margin_loss_ttl = cast3 Unmanaged.multilabel_margin_loss_ttl
+
+multilabel_margin_loss_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+multilabel_margin_loss_tt = cast2 Unmanaged.multilabel_margin_loss_tt
+
+multilabel_margin_loss_forward_out_ttttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+multilabel_margin_loss_forward_out_ttttl = cast5 Unmanaged.multilabel_margin_loss_forward_out_ttttl
+
+multilabel_margin_loss_forward_ttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+multilabel_margin_loss_forward_ttl = cast3 Unmanaged.multilabel_margin_loss_forward_ttl
+
+multilabel_margin_loss_backward_out_ttttlt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+multilabel_margin_loss_backward_out_ttttlt = cast6 Unmanaged.multilabel_margin_loss_backward_out_ttttlt
+
+multilabel_margin_loss_backward_tttlt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+multilabel_margin_loss_backward_tttlt = cast5 Unmanaged.multilabel_margin_loss_backward_tttlt
+
+nll_loss_out_ttttll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+nll_loss_out_ttttll = cast6 Unmanaged.nll_loss_out_ttttll
+
+nll_loss_out_ttttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+nll_loss_out_ttttl = cast5 Unmanaged.nll_loss_out_ttttl
+
+nll_loss_out_tttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+nll_loss_out_tttt = cast4 Unmanaged.nll_loss_out_tttt
+
+nll_loss_out_ttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+nll_loss_out_ttt = cast3 Unmanaged.nll_loss_out_ttt
+
+nll_loss_nd_tttll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+nll_loss_nd_tttll = cast5 Unmanaged.nll_loss_nd_tttll
+
+nll_loss_nd_tttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+nll_loss_nd_tttl = cast4 Unmanaged.nll_loss_nd_tttl
+
+nll_loss_nd_ttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+nll_loss_nd_ttt = cast3 Unmanaged.nll_loss_nd_ttt
+
+nll_loss_nd_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+nll_loss_nd_tt = cast2 Unmanaged.nll_loss_nd_tt
+
+nll_loss_tttll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+nll_loss_tttll = cast5 Unmanaged.nll_loss_tttll
+
+nll_loss_tttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+nll_loss_tttl = cast4 Unmanaged.nll_loss_tttl
+
+nll_loss_ttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+nll_loss_ttt = cast3 Unmanaged.nll_loss_ttt
+
+nll_loss_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+nll_loss_tt = cast2 Unmanaged.nll_loss_tt
+
+nll_loss_forward_out_tttttll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> Int64
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+nll_loss_forward_out_tttttll = cast7 Unmanaged.nll_loss_forward_out_tttttll
+
+nll_loss_forward_tttll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> Int64
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+nll_loss_forward_tttll = cast5 Unmanaged.nll_loss_forward_tttll
+
+nll_loss_backward_out_tttttllt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> Int64
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+nll_loss_backward_out_tttttllt = cast8 Unmanaged.nll_loss_backward_out_tttttllt
+
+nll_loss_backward_ttttllt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> Int64
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+nll_loss_backward_ttttllt = cast7 Unmanaged.nll_loss_backward_ttttllt
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Native/Native12.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Native/Native12.hs
@@ -21,435 +21,6 @@ import Torch.Internal.Objects
 import qualified Torch.Internal.Unmanaged.Native.Native12 as Unmanaged
 
 
-searchsorted_tsbb
-  :: ForeignPtr Tensor
-  -> ForeignPtr Scalar
-  -> CBool
-  -> CBool
-  -> IO (ForeignPtr Tensor)
-searchsorted_tsbb = cast4 Unmanaged.searchsorted_tsbb
-
-searchsorted_tsb
-  :: ForeignPtr Tensor
-  -> ForeignPtr Scalar
-  -> CBool
-  -> IO (ForeignPtr Tensor)
-searchsorted_tsb = cast3 Unmanaged.searchsorted_tsb
-
-searchsorted_ts
-  :: ForeignPtr Tensor
-  -> ForeignPtr Scalar
-  -> IO (ForeignPtr Tensor)
-searchsorted_ts = cast2 Unmanaged.searchsorted_ts
-
-mse_loss_out_tttl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> Int64
-  -> IO (ForeignPtr Tensor)
-mse_loss_out_tttl = cast4 Unmanaged.mse_loss_out_tttl
-
-mse_loss_out_ttt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-mse_loss_out_ttt = cast3 Unmanaged.mse_loss_out_ttt
-
-mse_loss_ttl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> Int64
-  -> IO (ForeignPtr Tensor)
-mse_loss_ttl = cast3 Unmanaged.mse_loss_ttl
-
-mse_loss_tt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-mse_loss_tt = cast2 Unmanaged.mse_loss_tt
-
-mse_loss_backward_out_ttttl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> Int64
-  -> IO (ForeignPtr Tensor)
-mse_loss_backward_out_ttttl = cast5 Unmanaged.mse_loss_backward_out_ttttl
-
-mse_loss_backward_tttl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> Int64
-  -> IO (ForeignPtr Tensor)
-mse_loss_backward_tttl = cast4 Unmanaged.mse_loss_backward_tttl
-
-l1_loss_out_tttl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> Int64
-  -> IO (ForeignPtr Tensor)
-l1_loss_out_tttl = cast4 Unmanaged.l1_loss_out_tttl
-
-l1_loss_out_ttt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-l1_loss_out_ttt = cast3 Unmanaged.l1_loss_out_ttt
-
-l1_loss_ttl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> Int64
-  -> IO (ForeignPtr Tensor)
-l1_loss_ttl = cast3 Unmanaged.l1_loss_ttl
-
-l1_loss_tt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-l1_loss_tt = cast2 Unmanaged.l1_loss_tt
-
-l1_loss_backward_out_ttttl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> Int64
-  -> IO (ForeignPtr Tensor)
-l1_loss_backward_out_ttttl = cast5 Unmanaged.l1_loss_backward_out_ttttl
-
-l1_loss_backward_tttl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> Int64
-  -> IO (ForeignPtr Tensor)
-l1_loss_backward_tttl = cast4 Unmanaged.l1_loss_backward_tttl
-
-multi_margin_loss_out_tttsstl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Scalar
-  -> ForeignPtr Scalar
-  -> ForeignPtr Tensor
-  -> Int64
-  -> IO (ForeignPtr Tensor)
-multi_margin_loss_out_tttsstl = cast7 Unmanaged.multi_margin_loss_out_tttsstl
-
-multi_margin_loss_out_tttsst
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Scalar
-  -> ForeignPtr Scalar
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-multi_margin_loss_out_tttsst = cast6 Unmanaged.multi_margin_loss_out_tttsst
-
-multi_margin_loss_out_tttss
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Scalar
-  -> ForeignPtr Scalar
-  -> IO (ForeignPtr Tensor)
-multi_margin_loss_out_tttss = cast5 Unmanaged.multi_margin_loss_out_tttss
-
-multi_margin_loss_out_ttts
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Scalar
-  -> IO (ForeignPtr Tensor)
-multi_margin_loss_out_ttts = cast4 Unmanaged.multi_margin_loss_out_ttts
-
-multi_margin_loss_out_ttt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-multi_margin_loss_out_ttt = cast3 Unmanaged.multi_margin_loss_out_ttt
-
-multi_margin_loss_ttsstl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Scalar
-  -> ForeignPtr Scalar
-  -> ForeignPtr Tensor
-  -> Int64
-  -> IO (ForeignPtr Tensor)
-multi_margin_loss_ttsstl = cast6 Unmanaged.multi_margin_loss_ttsstl
-
-multi_margin_loss_ttsst
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Scalar
-  -> ForeignPtr Scalar
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-multi_margin_loss_ttsst = cast5 Unmanaged.multi_margin_loss_ttsst
-
-multi_margin_loss_ttss
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Scalar
-  -> ForeignPtr Scalar
-  -> IO (ForeignPtr Tensor)
-multi_margin_loss_ttss = cast4 Unmanaged.multi_margin_loss_ttss
-
-multi_margin_loss_tts
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Scalar
-  -> IO (ForeignPtr Tensor)
-multi_margin_loss_tts = cast3 Unmanaged.multi_margin_loss_tts
-
-multi_margin_loss_tt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-multi_margin_loss_tt = cast2 Unmanaged.multi_margin_loss_tt
-
-multi_margin_loss_backward_out_ttttsstl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Scalar
-  -> ForeignPtr Scalar
-  -> ForeignPtr Tensor
-  -> Int64
-  -> IO (ForeignPtr Tensor)
-multi_margin_loss_backward_out_ttttsstl = cast8 Unmanaged.multi_margin_loss_backward_out_ttttsstl
-
-multi_margin_loss_backward_out_ttttsst
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Scalar
-  -> ForeignPtr Scalar
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-multi_margin_loss_backward_out_ttttsst = cast7 Unmanaged.multi_margin_loss_backward_out_ttttsst
-
-multi_margin_loss_backward_out_ttttss
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Scalar
-  -> ForeignPtr Scalar
-  -> IO (ForeignPtr Tensor)
-multi_margin_loss_backward_out_ttttss = cast6 Unmanaged.multi_margin_loss_backward_out_ttttss
-
-multi_margin_loss_backward_tttsstl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Scalar
-  -> ForeignPtr Scalar
-  -> ForeignPtr Tensor
-  -> Int64
-  -> IO (ForeignPtr Tensor)
-multi_margin_loss_backward_tttsstl = cast7 Unmanaged.multi_margin_loss_backward_tttsstl
-
-multi_margin_loss_backward_tttsst
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Scalar
-  -> ForeignPtr Scalar
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-multi_margin_loss_backward_tttsst = cast6 Unmanaged.multi_margin_loss_backward_tttsst
-
-multi_margin_loss_backward_tttss
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Scalar
-  -> ForeignPtr Scalar
-  -> IO (ForeignPtr Tensor)
-multi_margin_loss_backward_tttss = cast5 Unmanaged.multi_margin_loss_backward_tttss
-
-multilabel_margin_loss_out_tttl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> Int64
-  -> IO (ForeignPtr Tensor)
-multilabel_margin_loss_out_tttl = cast4 Unmanaged.multilabel_margin_loss_out_tttl
-
-multilabel_margin_loss_out_ttt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-multilabel_margin_loss_out_ttt = cast3 Unmanaged.multilabel_margin_loss_out_ttt
-
-multilabel_margin_loss_ttl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> Int64
-  -> IO (ForeignPtr Tensor)
-multilabel_margin_loss_ttl = cast3 Unmanaged.multilabel_margin_loss_ttl
-
-multilabel_margin_loss_tt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-multilabel_margin_loss_tt = cast2 Unmanaged.multilabel_margin_loss_tt
-
-multilabel_margin_loss_forward_out_ttttl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> Int64
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-multilabel_margin_loss_forward_out_ttttl = cast5 Unmanaged.multilabel_margin_loss_forward_out_ttttl
-
-multilabel_margin_loss_forward_ttl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> Int64
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-multilabel_margin_loss_forward_ttl = cast3 Unmanaged.multilabel_margin_loss_forward_ttl
-
-multilabel_margin_loss_backward_out_ttttlt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> Int64
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-multilabel_margin_loss_backward_out_ttttlt = cast6 Unmanaged.multilabel_margin_loss_backward_out_ttttlt
-
-multilabel_margin_loss_backward_tttlt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> Int64
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-multilabel_margin_loss_backward_tttlt = cast5 Unmanaged.multilabel_margin_loss_backward_tttlt
-
-nll_loss_out_ttttll
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> Int64
-  -> Int64
-  -> IO (ForeignPtr Tensor)
-nll_loss_out_ttttll = cast6 Unmanaged.nll_loss_out_ttttll
-
-nll_loss_out_ttttl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> Int64
-  -> IO (ForeignPtr Tensor)
-nll_loss_out_ttttl = cast5 Unmanaged.nll_loss_out_ttttl
-
-nll_loss_out_tttt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-nll_loss_out_tttt = cast4 Unmanaged.nll_loss_out_tttt
-
-nll_loss_out_ttt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-nll_loss_out_ttt = cast3 Unmanaged.nll_loss_out_ttt
-
-nll_loss_tttll
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> Int64
-  -> Int64
-  -> IO (ForeignPtr Tensor)
-nll_loss_tttll = cast5 Unmanaged.nll_loss_tttll
-
-nll_loss_tttl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> Int64
-  -> IO (ForeignPtr Tensor)
-nll_loss_tttl = cast4 Unmanaged.nll_loss_tttl
-
-nll_loss_ttt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-nll_loss_ttt = cast3 Unmanaged.nll_loss_ttt
-
-nll_loss_tt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-nll_loss_tt = cast2 Unmanaged.nll_loss_tt
-
-nll_loss_forward_out_tttttll
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> Int64
-  -> Int64
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-nll_loss_forward_out_tttttll = cast7 Unmanaged.nll_loss_forward_out_tttttll
-
-nll_loss_forward_tttll
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> Int64
-  -> Int64
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-nll_loss_forward_tttll = cast5 Unmanaged.nll_loss_forward_tttll
-
-nll_loss_backward_out_tttttllt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> Int64
-  -> Int64
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-nll_loss_backward_out_tttttllt = cast8 Unmanaged.nll_loss_backward_out_tttttllt
-
-nll_loss_backward_ttttllt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> Int64
-  -> Int64
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-nll_loss_backward_ttttllt = cast7 Unmanaged.nll_loss_backward_ttttllt
-
 nll_loss2d_out_ttttll
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
@@ -620,6 +191,70 @@ smooth_l1_loss_backward_tttld
   -> CDouble
   -> IO (ForeignPtr Tensor)
 smooth_l1_loss_backward_tttld = cast5 Unmanaged.smooth_l1_loss_backward_tttld
+
+huber_loss_out_tttld
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> CDouble
+  -> IO (ForeignPtr Tensor)
+huber_loss_out_tttld = cast5 Unmanaged.huber_loss_out_tttld
+
+huber_loss_out_tttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+huber_loss_out_tttl = cast4 Unmanaged.huber_loss_out_tttl
+
+huber_loss_out_ttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+huber_loss_out_ttt = cast3 Unmanaged.huber_loss_out_ttt
+
+huber_loss_ttld
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> CDouble
+  -> IO (ForeignPtr Tensor)
+huber_loss_ttld = cast4 Unmanaged.huber_loss_ttld
+
+huber_loss_ttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+huber_loss_ttl = cast3 Unmanaged.huber_loss_ttl
+
+huber_loss_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+huber_loss_tt = cast2 Unmanaged.huber_loss_tt
+
+huber_loss_backward_out_ttttld
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> CDouble
+  -> IO (ForeignPtr Tensor)
+huber_loss_backward_out_ttttld = cast6 Unmanaged.huber_loss_backward_out_ttttld
+
+huber_loss_backward_tttld
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> CDouble
+  -> IO (ForeignPtr Tensor)
+huber_loss_backward_tttld = cast5 Unmanaged.huber_loss_backward_tttld
 
 soft_margin_loss_out_tttl
   :: ForeignPtr Tensor
@@ -1248,6 +883,12 @@ mkldnn_adaptive_avg_pool2d_tl
   -> IO (ForeignPtr Tensor)
 mkldnn_adaptive_avg_pool2d_tl = cast2 Unmanaged.mkldnn_adaptive_avg_pool2d_tl
 
+mkldnn_adaptive_avg_pool2d_backward_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+mkldnn_adaptive_avg_pool2d_backward_tt = cast2 Unmanaged.mkldnn_adaptive_avg_pool2d_backward_tt
+
 _adaptive_avg_pool2d_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
@@ -1273,6 +914,12 @@ adaptive_avg_pool3d_tl
   -> IO (ForeignPtr Tensor)
 adaptive_avg_pool3d_tl = cast2 Unmanaged.adaptive_avg_pool3d_tl
 
+_adaptive_avg_pool3d_tl
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+_adaptive_avg_pool3d_tl = cast2 Unmanaged._adaptive_avg_pool3d_tl
+
 adaptive_avg_pool3d_backward_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
@@ -1280,11 +927,11 @@ adaptive_avg_pool3d_backward_out_ttt
   -> IO (ForeignPtr Tensor)
 adaptive_avg_pool3d_backward_out_ttt = cast3 Unmanaged.adaptive_avg_pool3d_backward_out_ttt
 
-adaptive_avg_pool3d_backward_tt
+_adaptive_avg_pool3d_backward_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-adaptive_avg_pool3d_backward_tt = cast2 Unmanaged.adaptive_avg_pool3d_backward_tt
+_adaptive_avg_pool3d_backward_tt = cast2 Unmanaged._adaptive_avg_pool3d_backward_tt
 
 adaptive_max_pool2d_out_tttl
   :: ForeignPtr Tensor
@@ -1328,4 +975,551 @@ adaptive_max_pool3d_tl
   -> ForeignPtr IntArray
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
 adaptive_max_pool3d_tl = cast2 Unmanaged.adaptive_max_pool3d_tl
+
+adaptive_max_pool3d_backward_out_tttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+adaptive_max_pool3d_backward_out_tttt = cast4 Unmanaged.adaptive_max_pool3d_backward_out_tttt
+
+adaptive_max_pool3d_backward_ttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+adaptive_max_pool3d_backward_ttt = cast3 Unmanaged.adaptive_max_pool3d_backward_ttt
+
+avg_pool2d_out_ttlllbbl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> CBool
+  -> CBool
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+avg_pool2d_out_ttlllbbl = cast8 Unmanaged.avg_pool2d_out_ttlllbbl
+
+avg_pool2d_out_ttlllbb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> CBool
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+avg_pool2d_out_ttlllbb = cast7 Unmanaged.avg_pool2d_out_ttlllbb
+
+avg_pool2d_out_ttlllb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+avg_pool2d_out_ttlllb = cast6 Unmanaged.avg_pool2d_out_ttlllb
+
+avg_pool2d_out_ttlll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+avg_pool2d_out_ttlll = cast5 Unmanaged.avg_pool2d_out_ttlll
+
+avg_pool2d_out_ttll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+avg_pool2d_out_ttll = cast4 Unmanaged.avg_pool2d_out_ttll
+
+avg_pool2d_out_ttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+avg_pool2d_out_ttl = cast3 Unmanaged.avg_pool2d_out_ttl
+
+avg_pool2d_tlllbbl
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> CBool
+  -> CBool
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+avg_pool2d_tlllbbl = cast7 Unmanaged.avg_pool2d_tlllbbl
+
+avg_pool2d_tlllbb
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> CBool
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+avg_pool2d_tlllbb = cast6 Unmanaged.avg_pool2d_tlllbb
+
+avg_pool2d_tlllb
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+avg_pool2d_tlllb = cast5 Unmanaged.avg_pool2d_tlllb
+
+avg_pool2d_tlll
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+avg_pool2d_tlll = cast4 Unmanaged.avg_pool2d_tlll
+
+avg_pool2d_tll
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+avg_pool2d_tll = cast3 Unmanaged.avg_pool2d_tll
+
+avg_pool2d_tl
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+avg_pool2d_tl = cast2 Unmanaged.avg_pool2d_tl
+
+avg_pool2d_backward_out_tttlllbbl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> CBool
+  -> CBool
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+avg_pool2d_backward_out_tttlllbbl = cast9 Unmanaged.avg_pool2d_backward_out_tttlllbbl
+
+avg_pool2d_backward_ttlllbbl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> CBool
+  -> CBool
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+avg_pool2d_backward_ttlllbbl = cast8 Unmanaged.avg_pool2d_backward_ttlllbbl
+
+avg_pool3d_out_ttlllbbl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> CBool
+  -> CBool
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+avg_pool3d_out_ttlllbbl = cast8 Unmanaged.avg_pool3d_out_ttlllbbl
+
+avg_pool3d_out_ttlllbb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> CBool
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+avg_pool3d_out_ttlllbb = cast7 Unmanaged.avg_pool3d_out_ttlllbb
+
+avg_pool3d_out_ttlllb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+avg_pool3d_out_ttlllb = cast6 Unmanaged.avg_pool3d_out_ttlllb
+
+avg_pool3d_out_ttlll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+avg_pool3d_out_ttlll = cast5 Unmanaged.avg_pool3d_out_ttlll
+
+avg_pool3d_out_ttll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+avg_pool3d_out_ttll = cast4 Unmanaged.avg_pool3d_out_ttll
+
+avg_pool3d_out_ttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+avg_pool3d_out_ttl = cast3 Unmanaged.avg_pool3d_out_ttl
+
+avg_pool3d_tlllbbl
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> CBool
+  -> CBool
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+avg_pool3d_tlllbbl = cast7 Unmanaged.avg_pool3d_tlllbbl
+
+avg_pool3d_tlllbb
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> CBool
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+avg_pool3d_tlllbb = cast6 Unmanaged.avg_pool3d_tlllbb
+
+avg_pool3d_tlllb
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+avg_pool3d_tlllb = cast5 Unmanaged.avg_pool3d_tlllb
+
+avg_pool3d_tlll
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+avg_pool3d_tlll = cast4 Unmanaged.avg_pool3d_tlll
+
+avg_pool3d_tll
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+avg_pool3d_tll = cast3 Unmanaged.avg_pool3d_tll
+
+avg_pool3d_tl
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+avg_pool3d_tl = cast2 Unmanaged.avg_pool3d_tl
+
+avg_pool3d_backward_out_tttlllbbl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> CBool
+  -> CBool
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+avg_pool3d_backward_out_tttlllbbl = cast9 Unmanaged.avg_pool3d_backward_out_tttlllbbl
+
+avg_pool3d_backward_ttlllbbl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> CBool
+  -> CBool
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+avg_pool3d_backward_ttlllbbl = cast8 Unmanaged.avg_pool3d_backward_ttlllbbl
+
+fractional_max_pool2d_out_tttllt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+fractional_max_pool2d_out_tttllt = cast6 Unmanaged.fractional_max_pool2d_out_tttllt
+
+fractional_max_pool2d_tllt
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+fractional_max_pool2d_tllt = cast4 Unmanaged.fractional_max_pool2d_tllt
+
+fractional_max_pool2d_backward_out_tttllt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+fractional_max_pool2d_backward_out_tttllt = cast6 Unmanaged.fractional_max_pool2d_backward_out_tttllt
+
+fractional_max_pool2d_backward_ttllt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+fractional_max_pool2d_backward_ttllt = cast5 Unmanaged.fractional_max_pool2d_backward_ttllt
+
+fractional_max_pool3d_out_tttllt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+fractional_max_pool3d_out_tttllt = cast6 Unmanaged.fractional_max_pool3d_out_tttllt
+
+fractional_max_pool3d_tllt
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+fractional_max_pool3d_tllt = cast4 Unmanaged.fractional_max_pool3d_tllt
+
+fractional_max_pool3d_backward_out_tttllt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+fractional_max_pool3d_backward_out_tttllt = cast6 Unmanaged.fractional_max_pool3d_backward_out_tttllt
+
+fractional_max_pool3d_backward_ttllt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+fractional_max_pool3d_backward_ttllt = cast5 Unmanaged.fractional_max_pool3d_backward_ttllt
+
+max_pool2d_with_indices_out_tttllllb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> CBool
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+max_pool2d_with_indices_out_tttllllb = cast8 Unmanaged.max_pool2d_with_indices_out_tttllllb
+
+max_pool2d_with_indices_out_tttllll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+max_pool2d_with_indices_out_tttllll = cast7 Unmanaged.max_pool2d_with_indices_out_tttllll
+
+max_pool2d_with_indices_out_tttlll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+max_pool2d_with_indices_out_tttlll = cast6 Unmanaged.max_pool2d_with_indices_out_tttlll
+
+max_pool2d_with_indices_out_tttll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+max_pool2d_with_indices_out_tttll = cast5 Unmanaged.max_pool2d_with_indices_out_tttll
+
+max_pool2d_with_indices_out_tttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+max_pool2d_with_indices_out_tttl = cast4 Unmanaged.max_pool2d_with_indices_out_tttl
+
+max_pool2d_with_indices_tllllb
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> CBool
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+max_pool2d_with_indices_tllllb = cast6 Unmanaged.max_pool2d_with_indices_tllllb
+
+max_pool2d_with_indices_tllll
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+max_pool2d_with_indices_tllll = cast5 Unmanaged.max_pool2d_with_indices_tllll
+
+max_pool2d_with_indices_tlll
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+max_pool2d_with_indices_tlll = cast4 Unmanaged.max_pool2d_with_indices_tlll
+
+max_pool2d_with_indices_tll
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+max_pool2d_with_indices_tll = cast3 Unmanaged.max_pool2d_with_indices_tll
+
+max_pool2d_with_indices_tl
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+max_pool2d_with_indices_tl = cast2 Unmanaged.max_pool2d_with_indices_tl
+
+max_pool2d_with_indices_backward_out_tttllllbt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> CBool
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+max_pool2d_with_indices_backward_out_tttllllbt = cast9 Unmanaged.max_pool2d_with_indices_backward_out_tttllllbt
+
+max_pool2d_with_indices_backward_ttllllbt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> CBool
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+max_pool2d_with_indices_backward_ttllllbt = cast8 Unmanaged.max_pool2d_with_indices_backward_ttllllbt
+
+max_pool3d_with_indices_out_tttllllb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> CBool
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+max_pool3d_with_indices_out_tttllllb = cast8 Unmanaged.max_pool3d_with_indices_out_tttllllb
+
+max_pool3d_with_indices_out_tttllll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+max_pool3d_with_indices_out_tttllll = cast7 Unmanaged.max_pool3d_with_indices_out_tttllll
+
+max_pool3d_with_indices_out_tttlll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+max_pool3d_with_indices_out_tttlll = cast6 Unmanaged.max_pool3d_with_indices_out_tttlll
+
+max_pool3d_with_indices_out_tttll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+max_pool3d_with_indices_out_tttll = cast5 Unmanaged.max_pool3d_with_indices_out_tttll
+
+max_pool3d_with_indices_out_tttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+max_pool3d_with_indices_out_tttl = cast4 Unmanaged.max_pool3d_with_indices_out_tttl
+
+max_pool3d_with_indices_tllllb
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> CBool
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+max_pool3d_with_indices_tllllb = cast6 Unmanaged.max_pool3d_with_indices_tllllb
+
+max_pool3d_with_indices_tllll
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+max_pool3d_with_indices_tllll = cast5 Unmanaged.max_pool3d_with_indices_tllll
+
+max_pool3d_with_indices_tlll
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+max_pool3d_with_indices_tlll = cast4 Unmanaged.max_pool3d_with_indices_tlll
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Native/Native13.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Native/Native13.hs
@@ -21,553 +21,6 @@ import Torch.Internal.Objects
 import qualified Torch.Internal.Unmanaged.Native.Native13 as Unmanaged
 
 
-adaptive_max_pool3d_backward_out_tttt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-adaptive_max_pool3d_backward_out_tttt = cast4 Unmanaged.adaptive_max_pool3d_backward_out_tttt
-
-adaptive_max_pool3d_backward_ttt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-adaptive_max_pool3d_backward_ttt = cast3 Unmanaged.adaptive_max_pool3d_backward_ttt
-
-avg_pool2d_out_ttlllbbl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> CBool
-  -> CBool
-  -> Int64
-  -> IO (ForeignPtr Tensor)
-avg_pool2d_out_ttlllbbl = cast8 Unmanaged.avg_pool2d_out_ttlllbbl
-
-avg_pool2d_out_ttlllbb
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> CBool
-  -> CBool
-  -> IO (ForeignPtr Tensor)
-avg_pool2d_out_ttlllbb = cast7 Unmanaged.avg_pool2d_out_ttlllbb
-
-avg_pool2d_out_ttlllb
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> CBool
-  -> IO (ForeignPtr Tensor)
-avg_pool2d_out_ttlllb = cast6 Unmanaged.avg_pool2d_out_ttlllb
-
-avg_pool2d_out_ttlll
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-avg_pool2d_out_ttlll = cast5 Unmanaged.avg_pool2d_out_ttlll
-
-avg_pool2d_out_ttll
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-avg_pool2d_out_ttll = cast4 Unmanaged.avg_pool2d_out_ttll
-
-avg_pool2d_out_ttl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-avg_pool2d_out_ttl = cast3 Unmanaged.avg_pool2d_out_ttl
-
-avg_pool2d_tlllbbl
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> CBool
-  -> CBool
-  -> Int64
-  -> IO (ForeignPtr Tensor)
-avg_pool2d_tlllbbl = cast7 Unmanaged.avg_pool2d_tlllbbl
-
-avg_pool2d_tlllbb
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> CBool
-  -> CBool
-  -> IO (ForeignPtr Tensor)
-avg_pool2d_tlllbb = cast6 Unmanaged.avg_pool2d_tlllbb
-
-avg_pool2d_tlllb
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> CBool
-  -> IO (ForeignPtr Tensor)
-avg_pool2d_tlllb = cast5 Unmanaged.avg_pool2d_tlllb
-
-avg_pool2d_tlll
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-avg_pool2d_tlll = cast4 Unmanaged.avg_pool2d_tlll
-
-avg_pool2d_tll
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-avg_pool2d_tll = cast3 Unmanaged.avg_pool2d_tll
-
-avg_pool2d_tl
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-avg_pool2d_tl = cast2 Unmanaged.avg_pool2d_tl
-
-avg_pool2d_backward_out_tttlllbbl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> CBool
-  -> CBool
-  -> Int64
-  -> IO (ForeignPtr Tensor)
-avg_pool2d_backward_out_tttlllbbl = cast9 Unmanaged.avg_pool2d_backward_out_tttlllbbl
-
-avg_pool2d_backward_ttlllbbl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> CBool
-  -> CBool
-  -> Int64
-  -> IO (ForeignPtr Tensor)
-avg_pool2d_backward_ttlllbbl = cast8 Unmanaged.avg_pool2d_backward_ttlllbbl
-
-avg_pool3d_out_ttlllbbl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> CBool
-  -> CBool
-  -> Int64
-  -> IO (ForeignPtr Tensor)
-avg_pool3d_out_ttlllbbl = cast8 Unmanaged.avg_pool3d_out_ttlllbbl
-
-avg_pool3d_out_ttlllbb
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> CBool
-  -> CBool
-  -> IO (ForeignPtr Tensor)
-avg_pool3d_out_ttlllbb = cast7 Unmanaged.avg_pool3d_out_ttlllbb
-
-avg_pool3d_out_ttlllb
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> CBool
-  -> IO (ForeignPtr Tensor)
-avg_pool3d_out_ttlllb = cast6 Unmanaged.avg_pool3d_out_ttlllb
-
-avg_pool3d_out_ttlll
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-avg_pool3d_out_ttlll = cast5 Unmanaged.avg_pool3d_out_ttlll
-
-avg_pool3d_out_ttll
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-avg_pool3d_out_ttll = cast4 Unmanaged.avg_pool3d_out_ttll
-
-avg_pool3d_out_ttl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-avg_pool3d_out_ttl = cast3 Unmanaged.avg_pool3d_out_ttl
-
-avg_pool3d_tlllbbl
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> CBool
-  -> CBool
-  -> Int64
-  -> IO (ForeignPtr Tensor)
-avg_pool3d_tlllbbl = cast7 Unmanaged.avg_pool3d_tlllbbl
-
-avg_pool3d_tlllbb
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> CBool
-  -> CBool
-  -> IO (ForeignPtr Tensor)
-avg_pool3d_tlllbb = cast6 Unmanaged.avg_pool3d_tlllbb
-
-avg_pool3d_tlllb
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> CBool
-  -> IO (ForeignPtr Tensor)
-avg_pool3d_tlllb = cast5 Unmanaged.avg_pool3d_tlllb
-
-avg_pool3d_tlll
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-avg_pool3d_tlll = cast4 Unmanaged.avg_pool3d_tlll
-
-avg_pool3d_tll
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-avg_pool3d_tll = cast3 Unmanaged.avg_pool3d_tll
-
-avg_pool3d_tl
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-avg_pool3d_tl = cast2 Unmanaged.avg_pool3d_tl
-
-avg_pool3d_backward_out_tttlllbbl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> CBool
-  -> CBool
-  -> Int64
-  -> IO (ForeignPtr Tensor)
-avg_pool3d_backward_out_tttlllbbl = cast9 Unmanaged.avg_pool3d_backward_out_tttlllbbl
-
-avg_pool3d_backward_ttlllbbl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> CBool
-  -> CBool
-  -> Int64
-  -> IO (ForeignPtr Tensor)
-avg_pool3d_backward_ttlllbbl = cast8 Unmanaged.avg_pool3d_backward_ttlllbbl
-
-fractional_max_pool2d_out_tttllt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-fractional_max_pool2d_out_tttllt = cast6 Unmanaged.fractional_max_pool2d_out_tttllt
-
-fractional_max_pool2d_tllt
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-fractional_max_pool2d_tllt = cast4 Unmanaged.fractional_max_pool2d_tllt
-
-fractional_max_pool2d_backward_out_tttllt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-fractional_max_pool2d_backward_out_tttllt = cast6 Unmanaged.fractional_max_pool2d_backward_out_tttllt
-
-fractional_max_pool2d_backward_ttllt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-fractional_max_pool2d_backward_ttllt = cast5 Unmanaged.fractional_max_pool2d_backward_ttllt
-
-fractional_max_pool3d_out_tttllt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-fractional_max_pool3d_out_tttllt = cast6 Unmanaged.fractional_max_pool3d_out_tttllt
-
-fractional_max_pool3d_tllt
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-fractional_max_pool3d_tllt = cast4 Unmanaged.fractional_max_pool3d_tllt
-
-fractional_max_pool3d_backward_out_tttllt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-fractional_max_pool3d_backward_out_tttllt = cast6 Unmanaged.fractional_max_pool3d_backward_out_tttllt
-
-fractional_max_pool3d_backward_ttllt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-fractional_max_pool3d_backward_ttllt = cast5 Unmanaged.fractional_max_pool3d_backward_ttllt
-
-max_pool2d_with_indices_out_tttllllb
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> CBool
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_pool2d_with_indices_out_tttllllb = cast8 Unmanaged.max_pool2d_with_indices_out_tttllllb
-
-max_pool2d_with_indices_out_tttllll
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_pool2d_with_indices_out_tttllll = cast7 Unmanaged.max_pool2d_with_indices_out_tttllll
-
-max_pool2d_with_indices_out_tttlll
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_pool2d_with_indices_out_tttlll = cast6 Unmanaged.max_pool2d_with_indices_out_tttlll
-
-max_pool2d_with_indices_out_tttll
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_pool2d_with_indices_out_tttll = cast5 Unmanaged.max_pool2d_with_indices_out_tttll
-
-max_pool2d_with_indices_out_tttl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_pool2d_with_indices_out_tttl = cast4 Unmanaged.max_pool2d_with_indices_out_tttl
-
-max_pool2d_with_indices_tllllb
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> CBool
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_pool2d_with_indices_tllllb = cast6 Unmanaged.max_pool2d_with_indices_tllllb
-
-max_pool2d_with_indices_tllll
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_pool2d_with_indices_tllll = cast5 Unmanaged.max_pool2d_with_indices_tllll
-
-max_pool2d_with_indices_tlll
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_pool2d_with_indices_tlll = cast4 Unmanaged.max_pool2d_with_indices_tlll
-
-max_pool2d_with_indices_tll
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_pool2d_with_indices_tll = cast3 Unmanaged.max_pool2d_with_indices_tll
-
-max_pool2d_with_indices_tl
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_pool2d_with_indices_tl = cast2 Unmanaged.max_pool2d_with_indices_tl
-
-max_pool2d_with_indices_backward_out_tttllllbt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> CBool
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-max_pool2d_with_indices_backward_out_tttllllbt = cast9 Unmanaged.max_pool2d_with_indices_backward_out_tttllllbt
-
-max_pool2d_with_indices_backward_ttllllbt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> CBool
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-max_pool2d_with_indices_backward_ttllllbt = cast8 Unmanaged.max_pool2d_with_indices_backward_ttllllbt
-
-max_pool3d_with_indices_out_tttllllb
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> CBool
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_pool3d_with_indices_out_tttllllb = cast8 Unmanaged.max_pool3d_with_indices_out_tttllllb
-
-max_pool3d_with_indices_out_tttllll
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_pool3d_with_indices_out_tttllll = cast7 Unmanaged.max_pool3d_with_indices_out_tttllll
-
-max_pool3d_with_indices_out_tttlll
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_pool3d_with_indices_out_tttlll = cast6 Unmanaged.max_pool3d_with_indices_out_tttlll
-
-max_pool3d_with_indices_out_tttll
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_pool3d_with_indices_out_tttll = cast5 Unmanaged.max_pool3d_with_indices_out_tttll
-
-max_pool3d_with_indices_out_tttl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_pool3d_with_indices_out_tttl = cast4 Unmanaged.max_pool3d_with_indices_out_tttl
-
-max_pool3d_with_indices_tllllb
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> CBool
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_pool3d_with_indices_tllllb = cast6 Unmanaged.max_pool3d_with_indices_tllllb
-
-max_pool3d_with_indices_tllll
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_pool3d_with_indices_tllll = cast5 Unmanaged.max_pool3d_with_indices_tllll
-
-max_pool3d_with_indices_tlll
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_pool3d_with_indices_tlll = cast4 Unmanaged.max_pool3d_with_indices_tlll
-
 max_pool3d_with_indices_tll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
@@ -948,14 +401,6 @@ upsample_linear1d_out_ttlb
   -> IO (ForeignPtr Tensor)
 upsample_linear1d_out_ttlb = cast4 Unmanaged.upsample_linear1d_out_ttlb
 
--- upsample_linear1d_tlbd
---   :: ForeignPtr Tensor
---   -> ForeignPtr IntArray
---   -> CBool
---   -> CDouble
---   -> IO (ForeignPtr Tensor)
--- upsample_linear1d_tlbd = cast4 Unmanaged.upsample_linear1d_tlbd
-
 upsample_linear1d_tlb
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
@@ -981,15 +426,6 @@ upsample_linear1d_backward_out_ttllb
   -> CBool
   -> IO (ForeignPtr Tensor)
 upsample_linear1d_backward_out_ttllb = cast5 Unmanaged.upsample_linear1d_backward_out_ttllb
-
--- upsample_linear1d_backward_tllbd
---   :: ForeignPtr Tensor
---   -> ForeignPtr IntArray
---   -> ForeignPtr IntArray
---   -> CBool
---   -> CDouble
---   -> IO (ForeignPtr Tensor)
--- upsample_linear1d_backward_tllbd = cast5 Unmanaged.upsample_linear1d_backward_tllbd
 
 upsample_linear1d_backward_tllb
   :: ForeignPtr Tensor
@@ -1034,14 +470,6 @@ upsample_bilinear2d_tlbdd
   -> CDouble
   -> IO (ForeignPtr Tensor)
 upsample_bilinear2d_tlbdd = cast5 Unmanaged.upsample_bilinear2d_tlbdd
-
--- upsample_bilinear2d_tlbd
---   :: ForeignPtr Tensor
---   -> ForeignPtr IntArray
---   -> CBool
---   -> CDouble
---   -> IO (ForeignPtr Tensor)
--- upsample_bilinear2d_tlbd = cast4 Unmanaged.upsample_bilinear2d_tlbd
 
 upsample_bilinear2d_tlb
   :: ForeignPtr Tensor
@@ -1090,15 +518,6 @@ upsample_bilinear2d_backward_tllbdd
   -> IO (ForeignPtr Tensor)
 upsample_bilinear2d_backward_tllbdd = cast6 Unmanaged.upsample_bilinear2d_backward_tllbdd
 
--- upsample_bilinear2d_backward_tllbd
---   :: ForeignPtr Tensor
---   -> ForeignPtr IntArray
---   -> ForeignPtr IntArray
---   -> CBool
---   -> CDouble
---   -> IO (ForeignPtr Tensor)
--- upsample_bilinear2d_backward_tllbd = cast5 Unmanaged.upsample_bilinear2d_backward_tllbd
-
 upsample_bilinear2d_backward_tllb
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
@@ -1142,14 +561,6 @@ upsample_bicubic2d_tlbdd
   -> CDouble
   -> IO (ForeignPtr Tensor)
 upsample_bicubic2d_tlbdd = cast5 Unmanaged.upsample_bicubic2d_tlbdd
-
--- upsample_bicubic2d_tlbd
---   :: ForeignPtr Tensor
---   -> ForeignPtr IntArray
---   -> CBool
---   -> CDouble
---   -> IO (ForeignPtr Tensor)
--- upsample_bicubic2d_tlbd = cast4 Unmanaged.upsample_bicubic2d_tlbd
 
 upsample_bicubic2d_tlb
   :: ForeignPtr Tensor
@@ -1197,15 +608,6 @@ upsample_bicubic2d_backward_tllbdd
   -> CDouble
   -> IO (ForeignPtr Tensor)
 upsample_bicubic2d_backward_tllbdd = cast6 Unmanaged.upsample_bicubic2d_backward_tllbdd
-
--- upsample_bicubic2d_backward_tllbd
---   :: ForeignPtr Tensor
---   -> ForeignPtr IntArray
---   -> ForeignPtr IntArray
---   -> CBool
---   -> CDouble
---   -> IO (ForeignPtr Tensor)
--- upsample_bicubic2d_backward_tllbd = cast5 Unmanaged.upsample_bicubic2d_backward_tllbd
 
 upsample_bicubic2d_backward_tllb
   :: ForeignPtr Tensor
@@ -1271,14 +673,6 @@ upsample_trilinear3d_tlbdd
   -> CDouble
   -> IO (ForeignPtr Tensor)
 upsample_trilinear3d_tlbdd = cast5 Unmanaged.upsample_trilinear3d_tlbdd
-
--- upsample_trilinear3d_tlbd
---   :: ForeignPtr Tensor
---   -> ForeignPtr IntArray
---   -> CBool
---   -> CDouble
---   -> IO (ForeignPtr Tensor)
--- upsample_trilinear3d_tlbd = cast4 Unmanaged.upsample_trilinear3d_tlbd
 
 upsample_trilinear3d_tlb
   :: ForeignPtr Tensor
@@ -1350,15 +744,6 @@ upsample_trilinear3d_backward_tllbdd
   -> IO (ForeignPtr Tensor)
 upsample_trilinear3d_backward_tllbdd = cast6 Unmanaged.upsample_trilinear3d_backward_tllbdd
 
--- upsample_trilinear3d_backward_tllbd
---   :: ForeignPtr Tensor
---   -> ForeignPtr IntArray
---   -> ForeignPtr IntArray
---   -> CBool
---   -> CDouble
---   -> IO (ForeignPtr Tensor)
--- upsample_trilinear3d_backward_tllbd = cast5 Unmanaged.upsample_trilinear3d_backward_tllbd
-
 upsample_trilinear3d_backward_tllb
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
@@ -1382,13 +767,6 @@ upsample_nearest1d_out_ttl
   -> IO (ForeignPtr Tensor)
 upsample_nearest1d_out_ttl = cast3 Unmanaged.upsample_nearest1d_out_ttl
 
--- upsample_nearest1d_tld
---   :: ForeignPtr Tensor
---   -> ForeignPtr IntArray
---   -> CDouble
---   -> IO (ForeignPtr Tensor)
--- upsample_nearest1d_tld = cast3 Unmanaged.upsample_nearest1d_tld
-
 upsample_nearest1d_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
@@ -1411,14 +789,6 @@ upsample_nearest1d_backward_out_ttll
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
 upsample_nearest1d_backward_out_ttll = cast4 Unmanaged.upsample_nearest1d_backward_out_ttll
-
--- upsample_nearest1d_backward_tlld
---   :: ForeignPtr Tensor
---   -> ForeignPtr IntArray
---   -> ForeignPtr IntArray
---   -> CDouble
---   -> IO (ForeignPtr Tensor)
--- upsample_nearest1d_backward_tlld = cast4 Unmanaged.upsample_nearest1d_backward_tlld
 
 upsample_nearest1d_backward_tll
   :: ForeignPtr Tensor
@@ -1458,13 +828,6 @@ upsample_nearest2d_tldd
   -> CDouble
   -> IO (ForeignPtr Tensor)
 upsample_nearest2d_tldd = cast4 Unmanaged.upsample_nearest2d_tldd
-
--- upsample_nearest2d_tld
---   :: ForeignPtr Tensor
---   -> ForeignPtr IntArray
---   -> CDouble
---   -> IO (ForeignPtr Tensor)
--- upsample_nearest2d_tld = cast3 Unmanaged.upsample_nearest2d_tld
 
 upsample_nearest2d_tl
   :: ForeignPtr Tensor
@@ -1508,14 +871,6 @@ upsample_nearest2d_backward_tlldd
   -> IO (ForeignPtr Tensor)
 upsample_nearest2d_backward_tlldd = cast5 Unmanaged.upsample_nearest2d_backward_tlldd
 
--- upsample_nearest2d_backward_tlld
---   :: ForeignPtr Tensor
---   -> ForeignPtr IntArray
---   -> ForeignPtr IntArray
---   -> CDouble
---   -> IO (ForeignPtr Tensor)
--- upsample_nearest2d_backward_tlld = cast4 Unmanaged.upsample_nearest2d_backward_tlld
-
 upsample_nearest2d_backward_tll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
@@ -1532,4 +887,714 @@ upsample_nearest3d_out_ttlddd
   -> CDouble
   -> IO (ForeignPtr Tensor)
 upsample_nearest3d_out_ttlddd = cast6 Unmanaged.upsample_nearest3d_out_ttlddd
+
+upsample_nearest3d_out_ttldd
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> CDouble
+  -> CDouble
+  -> IO (ForeignPtr Tensor)
+upsample_nearest3d_out_ttldd = cast5 Unmanaged.upsample_nearest3d_out_ttldd
+
+upsample_nearest3d_out_ttld
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> CDouble
+  -> IO (ForeignPtr Tensor)
+upsample_nearest3d_out_ttld = cast4 Unmanaged.upsample_nearest3d_out_ttld
+
+upsample_nearest3d_out_ttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+upsample_nearest3d_out_ttl = cast3 Unmanaged.upsample_nearest3d_out_ttl
+
+upsample_nearest3d_tlddd
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> CDouble
+  -> CDouble
+  -> CDouble
+  -> IO (ForeignPtr Tensor)
+upsample_nearest3d_tlddd = cast5 Unmanaged.upsample_nearest3d_tlddd
+
+upsample_nearest3d_tldd
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> CDouble
+  -> CDouble
+  -> IO (ForeignPtr Tensor)
+upsample_nearest3d_tldd = cast4 Unmanaged.upsample_nearest3d_tldd
+
+upsample_nearest3d_tl
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+upsample_nearest3d_tl = cast2 Unmanaged.upsample_nearest3d_tl
+
+upsample_nearest3d_backward_out_ttllddd
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> CDouble
+  -> CDouble
+  -> CDouble
+  -> IO (ForeignPtr Tensor)
+upsample_nearest3d_backward_out_ttllddd = cast7 Unmanaged.upsample_nearest3d_backward_out_ttllddd
+
+upsample_nearest3d_backward_out_ttlldd
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> CDouble
+  -> CDouble
+  -> IO (ForeignPtr Tensor)
+upsample_nearest3d_backward_out_ttlldd = cast6 Unmanaged.upsample_nearest3d_backward_out_ttlldd
+
+upsample_nearest3d_backward_out_ttlld
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> CDouble
+  -> IO (ForeignPtr Tensor)
+upsample_nearest3d_backward_out_ttlld = cast5 Unmanaged.upsample_nearest3d_backward_out_ttlld
+
+upsample_nearest3d_backward_out_ttll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+upsample_nearest3d_backward_out_ttll = cast4 Unmanaged.upsample_nearest3d_backward_out_ttll
+
+upsample_nearest3d_backward_tllddd
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> CDouble
+  -> CDouble
+  -> CDouble
+  -> IO (ForeignPtr Tensor)
+upsample_nearest3d_backward_tllddd = cast6 Unmanaged.upsample_nearest3d_backward_tllddd
+
+upsample_nearest3d_backward_tlldd
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> CDouble
+  -> CDouble
+  -> IO (ForeignPtr Tensor)
+upsample_nearest3d_backward_tlldd = cast5 Unmanaged.upsample_nearest3d_backward_tlldd
+
+upsample_nearest3d_backward_tll
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+upsample_nearest3d_backward_tll = cast3 Unmanaged.upsample_nearest3d_backward_tll
+
+sigmoid_backward_out_ttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+sigmoid_backward_out_ttt = cast3 Unmanaged.sigmoid_backward_out_ttt
+
+sigmoid_backward_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+sigmoid_backward_tt = cast2 Unmanaged.sigmoid_backward_tt
+
+logit_backward_out_tttd
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> CDouble
+  -> IO (ForeignPtr Tensor)
+logit_backward_out_tttd = cast4 Unmanaged.logit_backward_out_tttd
+
+logit_backward_out_ttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+logit_backward_out_ttt = cast3 Unmanaged.logit_backward_out_ttt
+
+logit_backward_ttd
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> CDouble
+  -> IO (ForeignPtr Tensor)
+logit_backward_ttd = cast3 Unmanaged.logit_backward_ttd
+
+logit_backward_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+logit_backward_tt = cast2 Unmanaged.logit_backward_tt
+
+tanh_backward_out_ttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tanh_backward_out_ttt = cast3 Unmanaged.tanh_backward_out_ttt
+
+tanh_backward_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tanh_backward_tt = cast2 Unmanaged.tanh_backward_tt
+
+slow_conv_transpose2d_out_tttltllll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+slow_conv_transpose2d_out_tttltllll = cast9 Unmanaged.slow_conv_transpose2d_out_tttltllll
+
+slow_conv_transpose2d_out_tttltlll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+slow_conv_transpose2d_out_tttltlll = cast8 Unmanaged.slow_conv_transpose2d_out_tttltlll
+
+slow_conv_transpose2d_out_tttltll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+slow_conv_transpose2d_out_tttltll = cast7 Unmanaged.slow_conv_transpose2d_out_tttltll
+
+slow_conv_transpose2d_out_tttltl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+slow_conv_transpose2d_out_tttltl = cast6 Unmanaged.slow_conv_transpose2d_out_tttltl
+
+slow_conv_transpose2d_out_tttlt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+slow_conv_transpose2d_out_tttlt = cast5 Unmanaged.slow_conv_transpose2d_out_tttlt
+
+slow_conv_transpose2d_out_tttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+slow_conv_transpose2d_out_tttl = cast4 Unmanaged.slow_conv_transpose2d_out_tttl
+
+slow_conv_transpose2d_ttltllll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+slow_conv_transpose2d_ttltllll = cast8 Unmanaged.slow_conv_transpose2d_ttltllll
+
+slow_conv_transpose2d_ttltlll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+slow_conv_transpose2d_ttltlll = cast7 Unmanaged.slow_conv_transpose2d_ttltlll
+
+slow_conv_transpose2d_ttltll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+slow_conv_transpose2d_ttltll = cast6 Unmanaged.slow_conv_transpose2d_ttltll
+
+slow_conv_transpose2d_ttltl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+slow_conv_transpose2d_ttltl = cast5 Unmanaged.slow_conv_transpose2d_ttltl
+
+slow_conv_transpose2d_ttlt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+slow_conv_transpose2d_ttlt = cast4 Unmanaged.slow_conv_transpose2d_ttlt
+
+slow_conv_transpose2d_ttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+slow_conv_transpose2d_ttl = cast3 Unmanaged.slow_conv_transpose2d_ttl
+
+slow_conv_transpose2d_backward_out_ttttttllllltt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
+slow_conv_transpose2d_backward_out_ttttttllllltt = cast13 Unmanaged.slow_conv_transpose2d_backward_out_ttttttllllltt
+
+slow_conv_transpose2d_backward_tttllllltta
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr (StdArray '(CBool,3))
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
+slow_conv_transpose2d_backward_tttllllltta = cast11 Unmanaged.slow_conv_transpose2d_backward_tttllllltta
+
+slow_conv_transpose3d_out_tttltllll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+slow_conv_transpose3d_out_tttltllll = cast9 Unmanaged.slow_conv_transpose3d_out_tttltllll
+
+slow_conv_transpose3d_out_tttltlll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+slow_conv_transpose3d_out_tttltlll = cast8 Unmanaged.slow_conv_transpose3d_out_tttltlll
+
+slow_conv_transpose3d_out_tttltll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+slow_conv_transpose3d_out_tttltll = cast7 Unmanaged.slow_conv_transpose3d_out_tttltll
+
+slow_conv_transpose3d_out_tttltl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+slow_conv_transpose3d_out_tttltl = cast6 Unmanaged.slow_conv_transpose3d_out_tttltl
+
+slow_conv_transpose3d_out_tttlt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+slow_conv_transpose3d_out_tttlt = cast5 Unmanaged.slow_conv_transpose3d_out_tttlt
+
+slow_conv_transpose3d_out_tttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+slow_conv_transpose3d_out_tttl = cast4 Unmanaged.slow_conv_transpose3d_out_tttl
+
+slow_conv_transpose3d_ttltllll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+slow_conv_transpose3d_ttltllll = cast8 Unmanaged.slow_conv_transpose3d_ttltllll
+
+slow_conv_transpose3d_ttltlll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+slow_conv_transpose3d_ttltlll = cast7 Unmanaged.slow_conv_transpose3d_ttltlll
+
+slow_conv_transpose3d_ttltll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+slow_conv_transpose3d_ttltll = cast6 Unmanaged.slow_conv_transpose3d_ttltll
+
+slow_conv_transpose3d_ttltl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+slow_conv_transpose3d_ttltl = cast5 Unmanaged.slow_conv_transpose3d_ttltl
+
+slow_conv_transpose3d_ttlt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+slow_conv_transpose3d_ttlt = cast4 Unmanaged.slow_conv_transpose3d_ttlt
+
+slow_conv_transpose3d_ttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+slow_conv_transpose3d_ttl = cast3 Unmanaged.slow_conv_transpose3d_ttl
+
+slow_conv_transpose3d_backward_out_ttttttllllltt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
+slow_conv_transpose3d_backward_out_ttttttllllltt = cast13 Unmanaged.slow_conv_transpose3d_backward_out_ttttttllllltt
+
+slow_conv_transpose3d_backward_tttllllltta
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr (StdArray '(CBool,3))
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
+slow_conv_transpose3d_backward_tttllllltta = cast11 Unmanaged.slow_conv_transpose3d_backward_tttllllltta
+
+thnn_conv2d_out_tttltll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+thnn_conv2d_out_tttltll = cast7 Unmanaged.thnn_conv2d_out_tttltll
+
+thnn_conv2d_out_tttltl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+thnn_conv2d_out_tttltl = cast6 Unmanaged.thnn_conv2d_out_tttltl
+
+thnn_conv2d_out_tttlt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+thnn_conv2d_out_tttlt = cast5 Unmanaged.thnn_conv2d_out_tttlt
+
+thnn_conv2d_out_tttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+thnn_conv2d_out_tttl = cast4 Unmanaged.thnn_conv2d_out_tttl
+
+thnn_conv2d_ttltll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+thnn_conv2d_ttltll = cast6 Unmanaged.thnn_conv2d_ttltll
+
+thnn_conv2d_ttltl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+thnn_conv2d_ttltl = cast5 Unmanaged.thnn_conv2d_ttltl
+
+thnn_conv2d_ttlt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+thnn_conv2d_ttlt = cast4 Unmanaged.thnn_conv2d_ttlt
+
+thnn_conv2d_ttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+thnn_conv2d_ttl = cast3 Unmanaged.thnn_conv2d_ttl
+
+thnn_conv2d_forward_out_tttttltll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
+thnn_conv2d_forward_out_tttttltll = cast9 Unmanaged.thnn_conv2d_forward_out_tttttltll
+
+thnn_conv2d_forward_ttltll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
+thnn_conv2d_forward_ttltll = cast6 Unmanaged.thnn_conv2d_forward_ttltll
+
+thnn_conv2d_backward_out_ttttttllltt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
+thnn_conv2d_backward_out_ttttttllltt = cast11 Unmanaged.thnn_conv2d_backward_out_ttttttllltt
+
+thnn_conv2d_backward_tttllltta
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr (StdArray '(CBool,3))
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
+thnn_conv2d_backward_tttllltta = cast9 Unmanaged.thnn_conv2d_backward_tttllltta
+
+thnn_conv_depthwise2d_out_tttltlll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+thnn_conv_depthwise2d_out_tttltlll = cast8 Unmanaged.thnn_conv_depthwise2d_out_tttltlll
+
+thnn_conv_depthwise2d_out_tttltll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+thnn_conv_depthwise2d_out_tttltll = cast7 Unmanaged.thnn_conv_depthwise2d_out_tttltll
+
+thnn_conv_depthwise2d_out_tttltl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+thnn_conv_depthwise2d_out_tttltl = cast6 Unmanaged.thnn_conv_depthwise2d_out_tttltl
+
+thnn_conv_depthwise2d_out_tttlt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+thnn_conv_depthwise2d_out_tttlt = cast5 Unmanaged.thnn_conv_depthwise2d_out_tttlt
+
+thnn_conv_depthwise2d_out_tttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+thnn_conv_depthwise2d_out_tttl = cast4 Unmanaged.thnn_conv_depthwise2d_out_tttl
+
+thnn_conv_depthwise2d_ttltlll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+thnn_conv_depthwise2d_ttltlll = cast7 Unmanaged.thnn_conv_depthwise2d_ttltlll
+
+thnn_conv_depthwise2d_ttltll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+thnn_conv_depthwise2d_ttltll = cast6 Unmanaged.thnn_conv_depthwise2d_ttltll
+
+thnn_conv_depthwise2d_ttltl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+thnn_conv_depthwise2d_ttltl = cast5 Unmanaged.thnn_conv_depthwise2d_ttltl
+
+thnn_conv_depthwise2d_ttlt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+thnn_conv_depthwise2d_ttlt = cast4 Unmanaged.thnn_conv_depthwise2d_ttlt
+
+thnn_conv_depthwise2d_ttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+thnn_conv_depthwise2d_ttl = cast3 Unmanaged.thnn_conv_depthwise2d_ttl
+
+thnn_conv_depthwise2d_forward_out_tttltlll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+thnn_conv_depthwise2d_forward_out_tttltlll = cast8 Unmanaged.thnn_conv_depthwise2d_forward_out_tttltlll
+
+thnn_conv_depthwise2d_forward_ttltlll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+thnn_conv_depthwise2d_forward_ttltlll = cast7 Unmanaged.thnn_conv_depthwise2d_forward_ttltlll
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Native/Native14.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Native/Native14.hs
@@ -21,731 +21,6 @@ import Torch.Internal.Objects
 import qualified Torch.Internal.Unmanaged.Native.Native14 as Unmanaged
 
 
-upsample_nearest3d_out_ttldd
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> CDouble
-  -> CDouble
-  -> IO (ForeignPtr Tensor)
-upsample_nearest3d_out_ttldd = cast5 Unmanaged.upsample_nearest3d_out_ttldd
-
-upsample_nearest3d_out_ttld
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> CDouble
-  -> IO (ForeignPtr Tensor)
-upsample_nearest3d_out_ttld = cast4 Unmanaged.upsample_nearest3d_out_ttld
-
-upsample_nearest3d_out_ttl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-upsample_nearest3d_out_ttl = cast3 Unmanaged.upsample_nearest3d_out_ttl
-
-upsample_nearest3d_tlddd
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> CDouble
-  -> CDouble
-  -> CDouble
-  -> IO (ForeignPtr Tensor)
-upsample_nearest3d_tlddd = cast5 Unmanaged.upsample_nearest3d_tlddd
-
-upsample_nearest3d_tldd
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> CDouble
-  -> CDouble
-  -> IO (ForeignPtr Tensor)
-upsample_nearest3d_tldd = cast4 Unmanaged.upsample_nearest3d_tldd
-
--- upsample_nearest3d_tld
---   :: ForeignPtr Tensor
---   -> ForeignPtr IntArray
---   -> CDouble
---   -> IO (ForeignPtr Tensor)
--- upsample_nearest3d_tld = cast3 Unmanaged.upsample_nearest3d_tld
-
-upsample_nearest3d_tl
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-upsample_nearest3d_tl = cast2 Unmanaged.upsample_nearest3d_tl
-
-upsample_nearest3d_backward_out_ttllddd
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> CDouble
-  -> CDouble
-  -> CDouble
-  -> IO (ForeignPtr Tensor)
-upsample_nearest3d_backward_out_ttllddd = cast7 Unmanaged.upsample_nearest3d_backward_out_ttllddd
-
-upsample_nearest3d_backward_out_ttlldd
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> CDouble
-  -> CDouble
-  -> IO (ForeignPtr Tensor)
-upsample_nearest3d_backward_out_ttlldd = cast6 Unmanaged.upsample_nearest3d_backward_out_ttlldd
-
-upsample_nearest3d_backward_out_ttlld
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> CDouble
-  -> IO (ForeignPtr Tensor)
-upsample_nearest3d_backward_out_ttlld = cast5 Unmanaged.upsample_nearest3d_backward_out_ttlld
-
-upsample_nearest3d_backward_out_ttll
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-upsample_nearest3d_backward_out_ttll = cast4 Unmanaged.upsample_nearest3d_backward_out_ttll
-
-upsample_nearest3d_backward_tllddd
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> CDouble
-  -> CDouble
-  -> CDouble
-  -> IO (ForeignPtr Tensor)
-upsample_nearest3d_backward_tllddd = cast6 Unmanaged.upsample_nearest3d_backward_tllddd
-
-upsample_nearest3d_backward_tlldd
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> CDouble
-  -> CDouble
-  -> IO (ForeignPtr Tensor)
-upsample_nearest3d_backward_tlldd = cast5 Unmanaged.upsample_nearest3d_backward_tlldd
-
--- upsample_nearest3d_backward_tlld
---   :: ForeignPtr Tensor
---   -> ForeignPtr IntArray
---   -> ForeignPtr IntArray
---   -> CDouble
---   -> IO (ForeignPtr Tensor)
--- upsample_nearest3d_backward_tlld = cast4 Unmanaged.upsample_nearest3d_backward_tlld
-
-upsample_nearest3d_backward_tll
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-upsample_nearest3d_backward_tll = cast3 Unmanaged.upsample_nearest3d_backward_tll
-
-sigmoid_backward_out_ttt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-sigmoid_backward_out_ttt = cast3 Unmanaged.sigmoid_backward_out_ttt
-
-sigmoid_backward_tt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-sigmoid_backward_tt = cast2 Unmanaged.sigmoid_backward_tt
-
-logit_backward_out_tttd
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> CDouble
-  -> IO (ForeignPtr Tensor)
-logit_backward_out_tttd = cast4 Unmanaged.logit_backward_out_tttd
-
-logit_backward_out_ttt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-logit_backward_out_ttt = cast3 Unmanaged.logit_backward_out_ttt
-
-logit_backward_ttd
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> CDouble
-  -> IO (ForeignPtr Tensor)
-logit_backward_ttd = cast3 Unmanaged.logit_backward_ttd
-
-logit_backward_tt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-logit_backward_tt = cast2 Unmanaged.logit_backward_tt
-
-tanh_backward_out_ttt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-tanh_backward_out_ttt = cast3 Unmanaged.tanh_backward_out_ttt
-
-tanh_backward_tt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-tanh_backward_tt = cast2 Unmanaged.tanh_backward_tt
-
-slow_conv_transpose2d_out_tttltllll
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-slow_conv_transpose2d_out_tttltllll = cast9 Unmanaged.slow_conv_transpose2d_out_tttltllll
-
-slow_conv_transpose2d_out_tttltlll
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-slow_conv_transpose2d_out_tttltlll = cast8 Unmanaged.slow_conv_transpose2d_out_tttltlll
-
-slow_conv_transpose2d_out_tttltll
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-slow_conv_transpose2d_out_tttltll = cast7 Unmanaged.slow_conv_transpose2d_out_tttltll
-
-slow_conv_transpose2d_out_tttltl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-slow_conv_transpose2d_out_tttltl = cast6 Unmanaged.slow_conv_transpose2d_out_tttltl
-
-slow_conv_transpose2d_out_tttlt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-slow_conv_transpose2d_out_tttlt = cast5 Unmanaged.slow_conv_transpose2d_out_tttlt
-
-slow_conv_transpose2d_out_tttl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-slow_conv_transpose2d_out_tttl = cast4 Unmanaged.slow_conv_transpose2d_out_tttl
-
-slow_conv_transpose2d_ttltllll
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-slow_conv_transpose2d_ttltllll = cast8 Unmanaged.slow_conv_transpose2d_ttltllll
-
-slow_conv_transpose2d_ttltlll
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-slow_conv_transpose2d_ttltlll = cast7 Unmanaged.slow_conv_transpose2d_ttltlll
-
-slow_conv_transpose2d_ttltll
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-slow_conv_transpose2d_ttltll = cast6 Unmanaged.slow_conv_transpose2d_ttltll
-
-slow_conv_transpose2d_ttltl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-slow_conv_transpose2d_ttltl = cast5 Unmanaged.slow_conv_transpose2d_ttltl
-
-slow_conv_transpose2d_ttlt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-slow_conv_transpose2d_ttlt = cast4 Unmanaged.slow_conv_transpose2d_ttlt
-
-slow_conv_transpose2d_ttl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-slow_conv_transpose2d_ttl = cast3 Unmanaged.slow_conv_transpose2d_ttl
-
-slow_conv_transpose2d_backward_out_ttttttllllltt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-slow_conv_transpose2d_backward_out_ttttttllllltt = cast13 Unmanaged.slow_conv_transpose2d_backward_out_ttttttllllltt
-
-slow_conv_transpose2d_backward_tttllllltta
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr (StdArray '(CBool,3))
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-slow_conv_transpose2d_backward_tttllllltta = cast11 Unmanaged.slow_conv_transpose2d_backward_tttllllltta
-
-slow_conv_transpose3d_out_tttltllll
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-slow_conv_transpose3d_out_tttltllll = cast9 Unmanaged.slow_conv_transpose3d_out_tttltllll
-
-slow_conv_transpose3d_out_tttltlll
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-slow_conv_transpose3d_out_tttltlll = cast8 Unmanaged.slow_conv_transpose3d_out_tttltlll
-
-slow_conv_transpose3d_out_tttltll
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-slow_conv_transpose3d_out_tttltll = cast7 Unmanaged.slow_conv_transpose3d_out_tttltll
-
-slow_conv_transpose3d_out_tttltl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-slow_conv_transpose3d_out_tttltl = cast6 Unmanaged.slow_conv_transpose3d_out_tttltl
-
-slow_conv_transpose3d_out_tttlt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-slow_conv_transpose3d_out_tttlt = cast5 Unmanaged.slow_conv_transpose3d_out_tttlt
-
-slow_conv_transpose3d_out_tttl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-slow_conv_transpose3d_out_tttl = cast4 Unmanaged.slow_conv_transpose3d_out_tttl
-
-slow_conv_transpose3d_ttltllll
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-slow_conv_transpose3d_ttltllll = cast8 Unmanaged.slow_conv_transpose3d_ttltllll
-
-slow_conv_transpose3d_ttltlll
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-slow_conv_transpose3d_ttltlll = cast7 Unmanaged.slow_conv_transpose3d_ttltlll
-
-slow_conv_transpose3d_ttltll
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-slow_conv_transpose3d_ttltll = cast6 Unmanaged.slow_conv_transpose3d_ttltll
-
-slow_conv_transpose3d_ttltl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-slow_conv_transpose3d_ttltl = cast5 Unmanaged.slow_conv_transpose3d_ttltl
-
-slow_conv_transpose3d_ttlt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-slow_conv_transpose3d_ttlt = cast4 Unmanaged.slow_conv_transpose3d_ttlt
-
-slow_conv_transpose3d_ttl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-slow_conv_transpose3d_ttl = cast3 Unmanaged.slow_conv_transpose3d_ttl
-
-slow_conv_transpose3d_backward_out_ttttttllllltt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-slow_conv_transpose3d_backward_out_ttttttllllltt = cast13 Unmanaged.slow_conv_transpose3d_backward_out_ttttttllllltt
-
-slow_conv_transpose3d_backward_tttllllltta
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr (StdArray '(CBool,3))
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-slow_conv_transpose3d_backward_tttllllltta = cast11 Unmanaged.slow_conv_transpose3d_backward_tttllllltta
-
-thnn_conv2d_out_tttltll
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-thnn_conv2d_out_tttltll = cast7 Unmanaged.thnn_conv2d_out_tttltll
-
-thnn_conv2d_out_tttltl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-thnn_conv2d_out_tttltl = cast6 Unmanaged.thnn_conv2d_out_tttltl
-
-thnn_conv2d_out_tttlt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-thnn_conv2d_out_tttlt = cast5 Unmanaged.thnn_conv2d_out_tttlt
-
-thnn_conv2d_out_tttl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-thnn_conv2d_out_tttl = cast4 Unmanaged.thnn_conv2d_out_tttl
-
-thnn_conv2d_ttltll
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-thnn_conv2d_ttltll = cast6 Unmanaged.thnn_conv2d_ttltll
-
-thnn_conv2d_ttltl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-thnn_conv2d_ttltl = cast5 Unmanaged.thnn_conv2d_ttltl
-
-thnn_conv2d_ttlt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-thnn_conv2d_ttlt = cast4 Unmanaged.thnn_conv2d_ttlt
-
-thnn_conv2d_ttl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-thnn_conv2d_ttl = cast3 Unmanaged.thnn_conv2d_ttl
-
-thnn_conv2d_forward_out_tttttltll
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-thnn_conv2d_forward_out_tttttltll = cast9 Unmanaged.thnn_conv2d_forward_out_tttttltll
-
-thnn_conv2d_forward_ttltll
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-thnn_conv2d_forward_ttltll = cast6 Unmanaged.thnn_conv2d_forward_ttltll
-
-thnn_conv2d_backward_out_ttttttllltt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-thnn_conv2d_backward_out_ttttttllltt = cast11 Unmanaged.thnn_conv2d_backward_out_ttttttllltt
-
-thnn_conv2d_backward_tttllltta
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr (StdArray '(CBool,3))
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-thnn_conv2d_backward_tttllltta = cast9 Unmanaged.thnn_conv2d_backward_tttllltta
-
-thnn_conv_depthwise2d_out_tttltlll
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-thnn_conv_depthwise2d_out_tttltlll = cast8 Unmanaged.thnn_conv_depthwise2d_out_tttltlll
-
-thnn_conv_depthwise2d_out_tttltll
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-thnn_conv_depthwise2d_out_tttltll = cast7 Unmanaged.thnn_conv_depthwise2d_out_tttltll
-
-thnn_conv_depthwise2d_out_tttltl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-thnn_conv_depthwise2d_out_tttltl = cast6 Unmanaged.thnn_conv_depthwise2d_out_tttltl
-
-thnn_conv_depthwise2d_out_tttlt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-thnn_conv_depthwise2d_out_tttlt = cast5 Unmanaged.thnn_conv_depthwise2d_out_tttlt
-
-thnn_conv_depthwise2d_out_tttl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-thnn_conv_depthwise2d_out_tttl = cast4 Unmanaged.thnn_conv_depthwise2d_out_tttl
-
-thnn_conv_depthwise2d_ttltlll
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-thnn_conv_depthwise2d_ttltlll = cast7 Unmanaged.thnn_conv_depthwise2d_ttltlll
-
-thnn_conv_depthwise2d_ttltll
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-thnn_conv_depthwise2d_ttltll = cast6 Unmanaged.thnn_conv_depthwise2d_ttltll
-
-thnn_conv_depthwise2d_ttltl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-thnn_conv_depthwise2d_ttltl = cast5 Unmanaged.thnn_conv_depthwise2d_ttltl
-
-thnn_conv_depthwise2d_ttlt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-thnn_conv_depthwise2d_ttlt = cast4 Unmanaged.thnn_conv_depthwise2d_ttlt
-
-thnn_conv_depthwise2d_ttl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-thnn_conv_depthwise2d_ttl = cast3 Unmanaged.thnn_conv_depthwise2d_ttl
-
-thnn_conv_depthwise2d_forward_out_tttltlll
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-thnn_conv_depthwise2d_forward_out_tttltlll = cast8 Unmanaged.thnn_conv_depthwise2d_forward_out_tttltlll
-
-thnn_conv_depthwise2d_forward_ttltlll
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-thnn_conv_depthwise2d_forward_ttltlll = cast7 Unmanaged.thnn_conv_depthwise2d_forward_ttltlll
-
 thnn_conv_depthwise2d_backward_out_tttttllll
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
@@ -770,6 +45,43 @@ thnn_conv_depthwise2d_backward_tttlllla
   -> ForeignPtr (StdArray '(CBool,2))
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
 thnn_conv_depthwise2d_backward_tttlllla = cast8 Unmanaged.thnn_conv_depthwise2d_backward_tttlllla
+
+conv_depthwise3d_ttltlll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+conv_depthwise3d_ttltlll = cast7 Unmanaged.conv_depthwise3d_ttltlll
+
+conv_depthwise3d_backward_out_ttttttllll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
+conv_depthwise3d_backward_out_ttttttllll = cast10 Unmanaged.conv_depthwise3d_backward_out_ttttttllll
+
+conv_depthwise3d_backward_tttlllla
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr (StdArray '(CBool,3))
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
+conv_depthwise3d_backward_tttlllla = cast8 Unmanaged.conv_depthwise3d_backward_tttlllla
 
 slow_conv3d_out_tttltll
   :: ForeignPtr Tensor
@@ -1145,6 +457,168 @@ _remove_batch_dim_tlll
   -> Int64
   -> IO (ForeignPtr Tensor)
 _remove_batch_dim_tlll = cast4 Unmanaged._remove_batch_dim_tlll
+
+special_entr_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+special_entr_t = cast1 Unmanaged.special_entr_t
+
+special_entr_out_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+special_entr_out_tt = cast2 Unmanaged.special_entr_out_tt
+
+special_expm1_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+special_expm1_t = cast1 Unmanaged.special_expm1_t
+
+special_expm1_out_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+special_expm1_out_tt = cast2 Unmanaged.special_expm1_out_tt
+
+special_exp2_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+special_exp2_t = cast1 Unmanaged.special_exp2_t
+
+special_exp2_out_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+special_exp2_out_tt = cast2 Unmanaged.special_exp2_out_tt
+
+special_gammaln_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+special_gammaln_t = cast1 Unmanaged.special_gammaln_t
+
+special_gammaln_out_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+special_gammaln_out_tt = cast2 Unmanaged.special_gammaln_out_tt
+
+special_erf_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+special_erf_t = cast1 Unmanaged.special_erf_t
+
+special_erf_out_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+special_erf_out_tt = cast2 Unmanaged.special_erf_out_tt
+
+special_erfc_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+special_erfc_t = cast1 Unmanaged.special_erfc_t
+
+special_erfc_out_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+special_erfc_out_tt = cast2 Unmanaged.special_erfc_out_tt
+
+special_erfinv_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+special_erfinv_t = cast1 Unmanaged.special_erfinv_t
+
+special_erfinv_out_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+special_erfinv_out_tt = cast2 Unmanaged.special_erfinv_out_tt
+
+special_xlog1py_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+special_xlog1py_tt = cast2 Unmanaged.special_xlog1py_tt
+
+special_xlog1py_st
+  :: ForeignPtr Scalar
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+special_xlog1py_st = cast2 Unmanaged.special_xlog1py_st
+
+special_xlog1py_ts
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+special_xlog1py_ts = cast2 Unmanaged.special_xlog1py_ts
+
+special_xlog1py_out_ttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+special_xlog1py_out_ttt = cast3 Unmanaged.special_xlog1py_out_ttt
+
+special_xlog1py_out_tst
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+special_xlog1py_out_tst = cast3 Unmanaged.special_xlog1py_out_tst
+
+special_xlog1py_out_tts
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+special_xlog1py_out_tts = cast3 Unmanaged.special_xlog1py_out_tts
+
+special_i0e_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+special_i0e_t = cast1 Unmanaged.special_i0e_t
+
+special_i0e_out_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+special_i0e_out_tt = cast2 Unmanaged.special_i0e_out_tt
+
+special_logit_td
+  :: ForeignPtr Tensor
+  -> CDouble
+  -> IO (ForeignPtr Tensor)
+special_logit_td = cast2 Unmanaged.special_logit_td
+
+special_logit_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+special_logit_t = cast1 Unmanaged.special_logit_t
+
+special_logit_out_ttd
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> CDouble
+  -> IO (ForeignPtr Tensor)
+special_logit_out_ttd = cast3 Unmanaged.special_logit_out_ttd
+
+special_logit_out_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+special_logit_out_tt = cast2 Unmanaged.special_logit_out_tt
+
+special_expit_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+special_expit_t = cast1 Unmanaged.special_expit_t
+
+special_expit_out_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+special_expit_out_tt = cast2 Unmanaged.special_expit_out_tt
 
 fft_fft_tlls
   :: ForeignPtr Tensor
@@ -1524,4 +998,427 @@ fft_fft2_out_ttll
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
 fft_fft2_out_ttll = cast4 Unmanaged.fft_fft2_out_ttll
+
+fft_fft2_out_ttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+fft_fft2_out_ttl = cast3 Unmanaged.fft_fft2_out_ttl
+
+fft_fft2_out_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+fft_fft2_out_tt = cast2 Unmanaged.fft_fft2_out_tt
+
+fft_ifft2_tlls
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr StdString
+  -> IO (ForeignPtr Tensor)
+fft_ifft2_tlls = cast4 Unmanaged.fft_ifft2_tlls
+
+fft_ifft2_tll
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+fft_ifft2_tll = cast3 Unmanaged.fft_ifft2_tll
+
+fft_ifft2_tl
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+fft_ifft2_tl = cast2 Unmanaged.fft_ifft2_tl
+
+fft_ifft2_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+fft_ifft2_t = cast1 Unmanaged.fft_ifft2_t
+
+fft_ifft2_out_ttlls
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr StdString
+  -> IO (ForeignPtr Tensor)
+fft_ifft2_out_ttlls = cast5 Unmanaged.fft_ifft2_out_ttlls
+
+fft_ifft2_out_ttll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+fft_ifft2_out_ttll = cast4 Unmanaged.fft_ifft2_out_ttll
+
+fft_ifft2_out_ttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+fft_ifft2_out_ttl = cast3 Unmanaged.fft_ifft2_out_ttl
+
+fft_ifft2_out_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+fft_ifft2_out_tt = cast2 Unmanaged.fft_ifft2_out_tt
+
+fft_rfft2_tlls
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr StdString
+  -> IO (ForeignPtr Tensor)
+fft_rfft2_tlls = cast4 Unmanaged.fft_rfft2_tlls
+
+fft_rfft2_tll
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+fft_rfft2_tll = cast3 Unmanaged.fft_rfft2_tll
+
+fft_rfft2_tl
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+fft_rfft2_tl = cast2 Unmanaged.fft_rfft2_tl
+
+fft_rfft2_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+fft_rfft2_t = cast1 Unmanaged.fft_rfft2_t
+
+fft_rfft2_out_ttlls
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr StdString
+  -> IO (ForeignPtr Tensor)
+fft_rfft2_out_ttlls = cast5 Unmanaged.fft_rfft2_out_ttlls
+
+fft_rfft2_out_ttll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+fft_rfft2_out_ttll = cast4 Unmanaged.fft_rfft2_out_ttll
+
+fft_rfft2_out_ttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+fft_rfft2_out_ttl = cast3 Unmanaged.fft_rfft2_out_ttl
+
+fft_rfft2_out_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+fft_rfft2_out_tt = cast2 Unmanaged.fft_rfft2_out_tt
+
+fft_irfft2_tlls
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr StdString
+  -> IO (ForeignPtr Tensor)
+fft_irfft2_tlls = cast4 Unmanaged.fft_irfft2_tlls
+
+fft_irfft2_tll
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+fft_irfft2_tll = cast3 Unmanaged.fft_irfft2_tll
+
+fft_irfft2_tl
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+fft_irfft2_tl = cast2 Unmanaged.fft_irfft2_tl
+
+fft_irfft2_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+fft_irfft2_t = cast1 Unmanaged.fft_irfft2_t
+
+fft_irfft2_out_ttlls
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr StdString
+  -> IO (ForeignPtr Tensor)
+fft_irfft2_out_ttlls = cast5 Unmanaged.fft_irfft2_out_ttlls
+
+fft_irfft2_out_ttll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+fft_irfft2_out_ttll = cast4 Unmanaged.fft_irfft2_out_ttll
+
+fft_irfft2_out_ttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+fft_irfft2_out_ttl = cast3 Unmanaged.fft_irfft2_out_ttl
+
+fft_irfft2_out_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+fft_irfft2_out_tt = cast2 Unmanaged.fft_irfft2_out_tt
+
+fft_fftn_tlls
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr StdString
+  -> IO (ForeignPtr Tensor)
+fft_fftn_tlls = cast4 Unmanaged.fft_fftn_tlls
+
+fft_fftn_tll
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+fft_fftn_tll = cast3 Unmanaged.fft_fftn_tll
+
+fft_fftn_tl
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+fft_fftn_tl = cast2 Unmanaged.fft_fftn_tl
+
+fft_fftn_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+fft_fftn_t = cast1 Unmanaged.fft_fftn_t
+
+fft_fftn_out_ttlls
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr StdString
+  -> IO (ForeignPtr Tensor)
+fft_fftn_out_ttlls = cast5 Unmanaged.fft_fftn_out_ttlls
+
+fft_fftn_out_ttll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+fft_fftn_out_ttll = cast4 Unmanaged.fft_fftn_out_ttll
+
+fft_fftn_out_ttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+fft_fftn_out_ttl = cast3 Unmanaged.fft_fftn_out_ttl
+
+fft_fftn_out_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+fft_fftn_out_tt = cast2 Unmanaged.fft_fftn_out_tt
+
+fft_ifftn_tlls
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr StdString
+  -> IO (ForeignPtr Tensor)
+fft_ifftn_tlls = cast4 Unmanaged.fft_ifftn_tlls
+
+fft_ifftn_tll
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+fft_ifftn_tll = cast3 Unmanaged.fft_ifftn_tll
+
+fft_ifftn_tl
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+fft_ifftn_tl = cast2 Unmanaged.fft_ifftn_tl
+
+fft_ifftn_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+fft_ifftn_t = cast1 Unmanaged.fft_ifftn_t
+
+fft_ifftn_out_ttlls
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr StdString
+  -> IO (ForeignPtr Tensor)
+fft_ifftn_out_ttlls = cast5 Unmanaged.fft_ifftn_out_ttlls
+
+fft_ifftn_out_ttll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+fft_ifftn_out_ttll = cast4 Unmanaged.fft_ifftn_out_ttll
+
+fft_ifftn_out_ttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+fft_ifftn_out_ttl = cast3 Unmanaged.fft_ifftn_out_ttl
+
+fft_ifftn_out_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+fft_ifftn_out_tt = cast2 Unmanaged.fft_ifftn_out_tt
+
+fft_rfftn_tlls
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr StdString
+  -> IO (ForeignPtr Tensor)
+fft_rfftn_tlls = cast4 Unmanaged.fft_rfftn_tlls
+
+fft_rfftn_tll
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+fft_rfftn_tll = cast3 Unmanaged.fft_rfftn_tll
+
+fft_rfftn_tl
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+fft_rfftn_tl = cast2 Unmanaged.fft_rfftn_tl
+
+fft_rfftn_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+fft_rfftn_t = cast1 Unmanaged.fft_rfftn_t
+
+fft_rfftn_out_ttlls
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr StdString
+  -> IO (ForeignPtr Tensor)
+fft_rfftn_out_ttlls = cast5 Unmanaged.fft_rfftn_out_ttlls
+
+fft_rfftn_out_ttll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+fft_rfftn_out_ttll = cast4 Unmanaged.fft_rfftn_out_ttll
+
+fft_rfftn_out_ttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+fft_rfftn_out_ttl = cast3 Unmanaged.fft_rfftn_out_ttl
+
+fft_rfftn_out_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+fft_rfftn_out_tt = cast2 Unmanaged.fft_rfftn_out_tt
+
+fft_irfftn_tlls
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr StdString
+  -> IO (ForeignPtr Tensor)
+fft_irfftn_tlls = cast4 Unmanaged.fft_irfftn_tlls
+
+fft_irfftn_tll
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+fft_irfftn_tll = cast3 Unmanaged.fft_irfftn_tll
+
+fft_irfftn_tl
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+fft_irfftn_tl = cast2 Unmanaged.fft_irfftn_tl
+
+fft_irfftn_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+fft_irfftn_t = cast1 Unmanaged.fft_irfftn_t
+
+fft_irfftn_out_ttlls
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr StdString
+  -> IO (ForeignPtr Tensor)
+fft_irfftn_out_ttlls = cast5 Unmanaged.fft_irfftn_out_ttlls
+
+fft_irfftn_out_ttll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+fft_irfftn_out_ttll = cast4 Unmanaged.fft_irfftn_out_ttll
+
+fft_irfftn_out_ttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+fft_irfftn_out_ttl = cast3 Unmanaged.fft_irfftn_out_ttl
+
+fft_irfftn_out_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+fft_irfftn_out_tt = cast2 Unmanaged.fft_irfftn_out_tt
+
+fft_fftfreq_ldo
+  :: Int64
+  -> CDouble
+  -> ForeignPtr TensorOptions
+  -> IO (ForeignPtr Tensor)
+fft_fftfreq_ldo = cast3 Unmanaged.fft_fftfreq_ldo
+
+fft_fftfreq_ld
+  :: Int64
+  -> CDouble
+  -> IO (ForeignPtr Tensor)
+fft_fftfreq_ld = cast2 Unmanaged.fft_fftfreq_ld
+
+fft_fftfreq_l
+  :: Int64
+  -> IO (ForeignPtr Tensor)
+fft_fftfreq_l = cast1 Unmanaged.fft_fftfreq_l
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Native/Native15.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Native/Native15.hs
@@ -21,429 +21,6 @@ import Torch.Internal.Objects
 import qualified Torch.Internal.Unmanaged.Native.Native15 as Unmanaged
 
 
-fft_fft2_out_ttl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-fft_fft2_out_ttl = cast3 Unmanaged.fft_fft2_out_ttl
-
-fft_fft2_out_tt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-fft_fft2_out_tt = cast2 Unmanaged.fft_fft2_out_tt
-
-fft_ifft2_tlls
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr StdString
-  -> IO (ForeignPtr Tensor)
-fft_ifft2_tlls = cast4 Unmanaged.fft_ifft2_tlls
-
-fft_ifft2_tll
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-fft_ifft2_tll = cast3 Unmanaged.fft_ifft2_tll
-
-fft_ifft2_tl
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-fft_ifft2_tl = cast2 Unmanaged.fft_ifft2_tl
-
-fft_ifft2_t
-  :: ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-fft_ifft2_t = cast1 Unmanaged.fft_ifft2_t
-
-fft_ifft2_out_ttlls
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr StdString
-  -> IO (ForeignPtr Tensor)
-fft_ifft2_out_ttlls = cast5 Unmanaged.fft_ifft2_out_ttlls
-
-fft_ifft2_out_ttll
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-fft_ifft2_out_ttll = cast4 Unmanaged.fft_ifft2_out_ttll
-
-fft_ifft2_out_ttl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-fft_ifft2_out_ttl = cast3 Unmanaged.fft_ifft2_out_ttl
-
-fft_ifft2_out_tt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-fft_ifft2_out_tt = cast2 Unmanaged.fft_ifft2_out_tt
-
-fft_rfft2_tlls
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr StdString
-  -> IO (ForeignPtr Tensor)
-fft_rfft2_tlls = cast4 Unmanaged.fft_rfft2_tlls
-
-fft_rfft2_tll
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-fft_rfft2_tll = cast3 Unmanaged.fft_rfft2_tll
-
-fft_rfft2_tl
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-fft_rfft2_tl = cast2 Unmanaged.fft_rfft2_tl
-
-fft_rfft2_t
-  :: ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-fft_rfft2_t = cast1 Unmanaged.fft_rfft2_t
-
-fft_rfft2_out_ttlls
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr StdString
-  -> IO (ForeignPtr Tensor)
-fft_rfft2_out_ttlls = cast5 Unmanaged.fft_rfft2_out_ttlls
-
-fft_rfft2_out_ttll
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-fft_rfft2_out_ttll = cast4 Unmanaged.fft_rfft2_out_ttll
-
-fft_rfft2_out_ttl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-fft_rfft2_out_ttl = cast3 Unmanaged.fft_rfft2_out_ttl
-
-fft_rfft2_out_tt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-fft_rfft2_out_tt = cast2 Unmanaged.fft_rfft2_out_tt
-
-fft_irfft2_tlls
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr StdString
-  -> IO (ForeignPtr Tensor)
-fft_irfft2_tlls = cast4 Unmanaged.fft_irfft2_tlls
-
-fft_irfft2_tll
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-fft_irfft2_tll = cast3 Unmanaged.fft_irfft2_tll
-
-fft_irfft2_tl
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-fft_irfft2_tl = cast2 Unmanaged.fft_irfft2_tl
-
-fft_irfft2_t
-  :: ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-fft_irfft2_t = cast1 Unmanaged.fft_irfft2_t
-
-fft_irfft2_out_ttlls
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr StdString
-  -> IO (ForeignPtr Tensor)
-fft_irfft2_out_ttlls = cast5 Unmanaged.fft_irfft2_out_ttlls
-
-fft_irfft2_out_ttll
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-fft_irfft2_out_ttll = cast4 Unmanaged.fft_irfft2_out_ttll
-
-fft_irfft2_out_ttl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-fft_irfft2_out_ttl = cast3 Unmanaged.fft_irfft2_out_ttl
-
-fft_irfft2_out_tt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-fft_irfft2_out_tt = cast2 Unmanaged.fft_irfft2_out_tt
-
-fft_fftn_tlls
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr StdString
-  -> IO (ForeignPtr Tensor)
-fft_fftn_tlls = cast4 Unmanaged.fft_fftn_tlls
-
-fft_fftn_tll
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-fft_fftn_tll = cast3 Unmanaged.fft_fftn_tll
-
-fft_fftn_tl
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-fft_fftn_tl = cast2 Unmanaged.fft_fftn_tl
-
-fft_fftn_t
-  :: ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-fft_fftn_t = cast1 Unmanaged.fft_fftn_t
-
-fft_fftn_out_ttlls
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr StdString
-  -> IO (ForeignPtr Tensor)
-fft_fftn_out_ttlls = cast5 Unmanaged.fft_fftn_out_ttlls
-
-fft_fftn_out_ttll
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-fft_fftn_out_ttll = cast4 Unmanaged.fft_fftn_out_ttll
-
-fft_fftn_out_ttl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-fft_fftn_out_ttl = cast3 Unmanaged.fft_fftn_out_ttl
-
-fft_fftn_out_tt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-fft_fftn_out_tt = cast2 Unmanaged.fft_fftn_out_tt
-
-fft_ifftn_tlls
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr StdString
-  -> IO (ForeignPtr Tensor)
-fft_ifftn_tlls = cast4 Unmanaged.fft_ifftn_tlls
-
-fft_ifftn_tll
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-fft_ifftn_tll = cast3 Unmanaged.fft_ifftn_tll
-
-fft_ifftn_tl
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-fft_ifftn_tl = cast2 Unmanaged.fft_ifftn_tl
-
-fft_ifftn_t
-  :: ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-fft_ifftn_t = cast1 Unmanaged.fft_ifftn_t
-
-fft_ifftn_out_ttlls
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr StdString
-  -> IO (ForeignPtr Tensor)
-fft_ifftn_out_ttlls = cast5 Unmanaged.fft_ifftn_out_ttlls
-
-fft_ifftn_out_ttll
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-fft_ifftn_out_ttll = cast4 Unmanaged.fft_ifftn_out_ttll
-
-fft_ifftn_out_ttl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-fft_ifftn_out_ttl = cast3 Unmanaged.fft_ifftn_out_ttl
-
-fft_ifftn_out_tt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-fft_ifftn_out_tt = cast2 Unmanaged.fft_ifftn_out_tt
-
-fft_rfftn_tlls
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr StdString
-  -> IO (ForeignPtr Tensor)
-fft_rfftn_tlls = cast4 Unmanaged.fft_rfftn_tlls
-
-fft_rfftn_tll
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-fft_rfftn_tll = cast3 Unmanaged.fft_rfftn_tll
-
-fft_rfftn_tl
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-fft_rfftn_tl = cast2 Unmanaged.fft_rfftn_tl
-
-fft_rfftn_t
-  :: ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-fft_rfftn_t = cast1 Unmanaged.fft_rfftn_t
-
-fft_rfftn_out_ttlls
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr StdString
-  -> IO (ForeignPtr Tensor)
-fft_rfftn_out_ttlls = cast5 Unmanaged.fft_rfftn_out_ttlls
-
-fft_rfftn_out_ttll
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-fft_rfftn_out_ttll = cast4 Unmanaged.fft_rfftn_out_ttll
-
-fft_rfftn_out_ttl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-fft_rfftn_out_ttl = cast3 Unmanaged.fft_rfftn_out_ttl
-
-fft_rfftn_out_tt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-fft_rfftn_out_tt = cast2 Unmanaged.fft_rfftn_out_tt
-
-fft_irfftn_tlls
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr StdString
-  -> IO (ForeignPtr Tensor)
-fft_irfftn_tlls = cast4 Unmanaged.fft_irfftn_tlls
-
-fft_irfftn_tll
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-fft_irfftn_tll = cast3 Unmanaged.fft_irfftn_tll
-
-fft_irfftn_tl
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-fft_irfftn_tl = cast2 Unmanaged.fft_irfftn_tl
-
-fft_irfftn_t
-  :: ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-fft_irfftn_t = cast1 Unmanaged.fft_irfftn_t
-
-fft_irfftn_out_ttlls
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> ForeignPtr StdString
-  -> IO (ForeignPtr Tensor)
-fft_irfftn_out_ttlls = cast5 Unmanaged.fft_irfftn_out_ttlls
-
-fft_irfftn_out_ttll
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-fft_irfftn_out_ttll = cast4 Unmanaged.fft_irfftn_out_ttll
-
-fft_irfftn_out_ttl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-fft_irfftn_out_ttl = cast3 Unmanaged.fft_irfftn_out_ttl
-
-fft_irfftn_out_tt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-fft_irfftn_out_tt = cast2 Unmanaged.fft_irfftn_out_tt
-
-fft_fftfreq_ldo
-  :: Int64
-  -> CDouble
-  -> ForeignPtr TensorOptions
-  -> IO (ForeignPtr Tensor)
-fft_fftfreq_ldo = cast3 Unmanaged.fft_fftfreq_ldo
-
-fft_fftfreq_ld
-  :: Int64
-  -> CDouble
-  -> IO (ForeignPtr Tensor)
-fft_fftfreq_ld = cast2 Unmanaged.fft_fftfreq_ld
-
-fft_fftfreq_l
-  :: Int64
-  -> IO (ForeignPtr Tensor)
-fft_fftfreq_l = cast1 Unmanaged.fft_fftfreq_l
-
 fft_fftfreq_out_tld
   :: ForeignPtr Tensor
   -> Int64
@@ -510,6 +87,32 @@ fft_ifftshift_t
   -> IO (ForeignPtr Tensor)
 fft_ifftshift_t = cast1 Unmanaged.fft_ifftshift_t
 
+linalg_cholesky_ex_tb
+  :: ForeignPtr Tensor
+  -> CBool
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+linalg_cholesky_ex_tb = cast2 Unmanaged.linalg_cholesky_ex_tb
+
+linalg_cholesky_ex_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+linalg_cholesky_ex_t = cast1 Unmanaged.linalg_cholesky_ex_t
+
+linalg_cholesky_ex_out_tttb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> CBool
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+linalg_cholesky_ex_out_tttb = cast4 Unmanaged.linalg_cholesky_ex_out_tttb
+
+linalg_cholesky_ex_out_ttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+linalg_cholesky_ex_out_ttt = cast3 Unmanaged.linalg_cholesky_ex_out_ttt
+
 linalg_cholesky_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
@@ -526,10 +129,70 @@ linalg_det_t
   -> IO (ForeignPtr Tensor)
 linalg_det_t = cast1 Unmanaged.linalg_det_t
 
+linalg_det_out_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+linalg_det_out_tt = cast2 Unmanaged.linalg_det_out_tt
+
 det_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
 det_t = cast1 Unmanaged.det_t
+
+linalg_lstsq_ttds
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> CDouble
+  -> ForeignPtr StdString
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
+linalg_lstsq_ttds = cast4 Unmanaged.linalg_lstsq_ttds
+
+linalg_lstsq_ttd
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> CDouble
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
+linalg_lstsq_ttd = cast3 Unmanaged.linalg_lstsq_ttd
+
+linalg_lstsq_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
+linalg_lstsq_tt = cast2 Unmanaged.linalg_lstsq_tt
+
+linalg_lstsq_out_ttttttds
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> CDouble
+  -> ForeignPtr StdString
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
+linalg_lstsq_out_ttttttds = cast8 Unmanaged.linalg_lstsq_out_ttttttds
+
+linalg_lstsq_out_ttttttd
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> CDouble
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
+linalg_lstsq_out_ttttttd = cast7 Unmanaged.linalg_lstsq_out_ttttttd
+
+linalg_lstsq_out_tttttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
+linalg_lstsq_out_tttttt = cast6 Unmanaged.linalg_lstsq_out_tttttt
 
 linalg_slogdet_t
   :: ForeignPtr Tensor
@@ -543,12 +206,28 @@ linalg_slogdet_out_ttt
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
 linalg_slogdet_out_ttt = cast3 Unmanaged.linalg_slogdet_out_ttt
 
-_syevd_helper_tbs
+linalg_eig_t
   :: ForeignPtr Tensor
-  -> CBool
-  -> ForeignPtr StdString
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-_syevd_helper_tbs = cast3 Unmanaged._syevd_helper_tbs
+linalg_eig_t = cast1 Unmanaged.linalg_eig_t
+
+linalg_eig_out_ttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+linalg_eig_out_ttt = cast3 Unmanaged.linalg_eig_out_ttt
+
+linalg_eigvals_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+linalg_eigvals_t = cast1 Unmanaged.linalg_eigvals_t
+
+linalg_eigvals_out_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+linalg_eigvals_out_tt = cast2 Unmanaged.linalg_eigvals_out_tt
 
 linalg_eigh_ts
   :: ForeignPtr Tensor
@@ -600,12 +279,51 @@ linalg_eigvalsh_out_tt
   -> IO (ForeignPtr Tensor)
 linalg_eigvalsh_out_tt = cast2 Unmanaged.linalg_eigvalsh_out_tt
 
+linalg_householder_product_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+linalg_householder_product_tt = cast2 Unmanaged.linalg_householder_product_tt
+
+linalg_householder_product_out_ttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+linalg_householder_product_out_ttt = cast3 Unmanaged.linalg_householder_product_out_ttt
+
 _linalg_inv_out_helper__ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
 _linalg_inv_out_helper__ttt = cast3 Unmanaged._linalg_inv_out_helper__ttt
+
+linalg_inv_ex_tb
+  :: ForeignPtr Tensor
+  -> CBool
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+linalg_inv_ex_tb = cast2 Unmanaged.linalg_inv_ex_tb
+
+linalg_inv_ex_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+linalg_inv_ex_t = cast1 Unmanaged.linalg_inv_ex_t
+
+linalg_inv_ex_out_tttb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> CBool
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+linalg_inv_ex_out_tttb = cast4 Unmanaged.linalg_inv_ex_out_tttb
+
+linalg_inv_ex_out_ttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+linalg_inv_ex_out_ttt = cast3 Unmanaged.linalg_inv_ex_out_ttt
 
 linalg_inv_t
   :: ForeignPtr Tensor
@@ -732,15 +450,155 @@ linalg_norm_out_tt
   -> IO (ForeignPtr Tensor)
 linalg_norm_out_tt = cast2 Unmanaged.linalg_norm_out_tt
 
-linalg_svd_out_ttttbb
+linalg_vector_norm_tslbs
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr IntArray
+  -> CBool
+  -> ScalarType
+  -> IO (ForeignPtr Tensor)
+linalg_vector_norm_tslbs = cast5 Unmanaged.linalg_vector_norm_tslbs
+
+linalg_vector_norm_tslb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr IntArray
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+linalg_vector_norm_tslb = cast4 Unmanaged.linalg_vector_norm_tslb
+
+linalg_vector_norm_tsl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+linalg_vector_norm_tsl = cast3 Unmanaged.linalg_vector_norm_tsl
+
+linalg_vector_norm_ts
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+linalg_vector_norm_ts = cast2 Unmanaged.linalg_vector_norm_ts
+
+linalg_vector_norm_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+linalg_vector_norm_t = cast1 Unmanaged.linalg_vector_norm_t
+
+linalg_vector_norm_out_ttslbs
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr IntArray
   -> CBool
+  -> ScalarType
+  -> IO (ForeignPtr Tensor)
+linalg_vector_norm_out_ttslbs = cast6 Unmanaged.linalg_vector_norm_out_ttslbs
+
+linalg_vector_norm_out_ttslb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr IntArray
   -> CBool
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-linalg_svd_out_ttttbb = cast6 Unmanaged.linalg_svd_out_ttttbb
+  -> IO (ForeignPtr Tensor)
+linalg_vector_norm_out_ttslb = cast5 Unmanaged.linalg_vector_norm_out_ttslb
+
+linalg_vector_norm_out_ttsl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+linalg_vector_norm_out_ttsl = cast4 Unmanaged.linalg_vector_norm_out_ttsl
+
+linalg_vector_norm_out_tts
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+linalg_vector_norm_out_tts = cast3 Unmanaged.linalg_vector_norm_out_tts
+
+linalg_vector_norm_out_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+linalg_vector_norm_out_tt = cast2 Unmanaged.linalg_vector_norm_out_tt
+
+linalg_matrix_norm_tslbs
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr IntArray
+  -> CBool
+  -> ScalarType
+  -> IO (ForeignPtr Tensor)
+linalg_matrix_norm_tslbs = cast5 Unmanaged.linalg_matrix_norm_tslbs
+
+linalg_matrix_norm_tslb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr IntArray
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+linalg_matrix_norm_tslb = cast4 Unmanaged.linalg_matrix_norm_tslb
+
+linalg_matrix_norm_tsl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+linalg_matrix_norm_tsl = cast3 Unmanaged.linalg_matrix_norm_tsl
+
+linalg_matrix_norm_ts
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+linalg_matrix_norm_ts = cast2 Unmanaged.linalg_matrix_norm_ts
+
+linalg_matrix_norm_out_ttslbs
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr IntArray
+  -> CBool
+  -> ScalarType
+  -> IO (ForeignPtr Tensor)
+linalg_matrix_norm_out_ttslbs = cast6 Unmanaged.linalg_matrix_norm_out_ttslbs
+
+linalg_matrix_norm_out_ttslb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr IntArray
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+linalg_matrix_norm_out_ttslb = cast5 Unmanaged.linalg_matrix_norm_out_ttslb
+
+linalg_matrix_norm_out_ttsl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+linalg_matrix_norm_out_ttsl = cast4 Unmanaged.linalg_matrix_norm_out_ttsl
+
+linalg_matrix_norm_out_tts
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+linalg_matrix_norm_out_tts = cast3 Unmanaged.linalg_matrix_norm_out_tts
+
+linalg_matrix_norm_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+linalg_matrix_norm_t = cast1 Unmanaged.linalg_matrix_norm_t
+
+linalg_matrix_norm_out_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+linalg_matrix_norm_out_tt = cast2 Unmanaged.linalg_matrix_norm_out_tt
 
 linalg_svd_out_ttttb
   :: ForeignPtr Tensor
@@ -759,13 +617,6 @@ linalg_svd_out_tttt
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
 linalg_svd_out_tttt = cast4 Unmanaged.linalg_svd_out_tttt
 
-linalg_svd_tbb
-  :: ForeignPtr Tensor
-  -> CBool
-  -> CBool
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-linalg_svd_tbb = cast3 Unmanaged.linalg_svd_tbb
-
 linalg_svd_tb
   :: ForeignPtr Tensor
   -> CBool
@@ -776,6 +627,17 @@ linalg_svd_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
 linalg_svd_t = cast1 Unmanaged.linalg_svd_t
+
+linalg_svdvals_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+linalg_svdvals_t = cast1 Unmanaged.linalg_svdvals_t
+
+linalg_svdvals_out_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+linalg_svdvals_out_tt = cast2 Unmanaged.linalg_svdvals_out_tt
 
 linalg_cond_ts
   :: ForeignPtr Tensor
@@ -972,6 +834,19 @@ _linalg_qr_helper_ts
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
 _linalg_qr_helper_ts = cast2 Unmanaged._linalg_qr_helper_ts
 
+linalg_matrix_power_tl
+  :: ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+linalg_matrix_power_tl = cast2 Unmanaged.linalg_matrix_power_tl
+
+linalg_matrix_power_out_ttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+linalg_matrix_power_out_ttl = cast3 Unmanaged.linalg_matrix_power_out_ttl
+
 linalg_matrix_rank_tdb
   :: ForeignPtr Tensor
   -> CDouble
@@ -1010,6 +885,45 @@ linalg_matrix_rank_out_tt
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
 linalg_matrix_rank_out_tt = cast2 Unmanaged.linalg_matrix_rank_out_tt
+
+linalg_matrix_rank_ttb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+linalg_matrix_rank_ttb = cast3 Unmanaged.linalg_matrix_rank_ttb
+
+linalg_matrix_rank_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+linalg_matrix_rank_tt = cast2 Unmanaged.linalg_matrix_rank_tt
+
+linalg_matrix_rank_out_tttb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+linalg_matrix_rank_out_tttb = cast4 Unmanaged.linalg_matrix_rank_out_tttb
+
+linalg_matrix_rank_out_ttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+linalg_matrix_rank_out_ttt = cast3 Unmanaged.linalg_matrix_rank_out_ttt
+
+linalg_multi_dot_l
+  :: ForeignPtr TensorList
+  -> IO (ForeignPtr Tensor)
+linalg_multi_dot_l = cast1 Unmanaged.linalg_multi_dot_l
+
+linalg_multi_dot_out_tl
+  :: ForeignPtr Tensor
+  -> ForeignPtr TensorList
+  -> IO (ForeignPtr Tensor)
+linalg_multi_dot_out_tl = cast2 Unmanaged.linalg_multi_dot_out_tl
 
 _test_serialization_subcmul_tts
   :: ForeignPtr Tensor
@@ -1084,4 +998,99 @@ _test_ambiguous_defaults_tls
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
 _test_ambiguous_defaults_tls = cast3 Unmanaged._test_ambiguous_defaults_tls
+
+segment_reduce_tsttlbs
+  :: ForeignPtr Tensor
+  -> ForeignPtr StdString
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> CBool
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+segment_reduce_tsttlbs = cast7 Unmanaged.segment_reduce_tsttlbs
+
+segment_reduce_tsttlb
+  :: ForeignPtr Tensor
+  -> ForeignPtr StdString
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+segment_reduce_tsttlb = cast6 Unmanaged.segment_reduce_tsttlb
+
+segment_reduce_tsttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr StdString
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+segment_reduce_tsttl = cast5 Unmanaged.segment_reduce_tsttl
+
+segment_reduce_tstt
+  :: ForeignPtr Tensor
+  -> ForeignPtr StdString
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+segment_reduce_tstt = cast4 Unmanaged.segment_reduce_tstt
+
+segment_reduce_tst
+  :: ForeignPtr Tensor
+  -> ForeignPtr StdString
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+segment_reduce_tst = cast3 Unmanaged.segment_reduce_tst
+
+segment_reduce_ts
+  :: ForeignPtr Tensor
+  -> ForeignPtr StdString
+  -> IO (ForeignPtr Tensor)
+segment_reduce_ts = cast2 Unmanaged.segment_reduce_ts
+
+segment_reduce_backward_tttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+segment_reduce_backward_tttt = cast4 Unmanaged.segment_reduce_backward_tttt
+
+segment_reduce_backward_ttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+segment_reduce_backward_ttt = cast3 Unmanaged.segment_reduce_backward_ttt
+
+pad_sequence_lbd
+  :: ForeignPtr TensorList
+  -> CBool
+  -> CDouble
+  -> IO (ForeignPtr Tensor)
+pad_sequence_lbd = cast3 Unmanaged.pad_sequence_lbd
+
+pad_sequence_lb
+  :: ForeignPtr TensorList
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+pad_sequence_lb = cast2 Unmanaged.pad_sequence_lb
+
+pad_sequence_l
+  :: ForeignPtr TensorList
+  -> IO (ForeignPtr Tensor)
+pad_sequence_l = cast1 Unmanaged.pad_sequence_l
+
+flatten_dense_tensors_l
+  :: ForeignPtr TensorList
+  -> IO (ForeignPtr Tensor)
+flatten_dense_tensors_l = cast1 Unmanaged.flatten_dense_tensors_l
+
+unflatten_dense_tensors_tl
+  :: ForeignPtr Tensor
+  -> ForeignPtr TensorList
+  -> IO (ForeignPtr TensorList)
+unflatten_dense_tensors_tl = cast2 Unmanaged.unflatten_dense_tensors_tl
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Native/Native2.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Native/Native2.hs
@@ -21,6 +21,97 @@ import Torch.Internal.Objects
 import qualified Torch.Internal.Unmanaged.Native.Native2 as Unmanaged
 
 
+conv_tbc_ttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+conv_tbc_ttt = cast3 Unmanaged.conv_tbc_ttt
+
+conv_tbc_backward_ttttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
+conv_tbc_backward_ttttl = cast5 Unmanaged.conv_tbc_backward_ttttl
+
+conv_transpose1d_tttlllll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> Int64
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+conv_transpose1d_tttlllll = cast8 Unmanaged.conv_transpose1d_tttlllll
+
+conv_transpose1d_tttllll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+conv_transpose1d_tttllll = cast7 Unmanaged.conv_transpose1d_tttllll
+
+conv_transpose1d_tttlll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+conv_transpose1d_tttlll = cast6 Unmanaged.conv_transpose1d_tttlll
+
+conv_transpose1d_tttll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+conv_transpose1d_tttll = cast5 Unmanaged.conv_transpose1d_tttll
+
+conv_transpose1d_tttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+conv_transpose1d_tttl = cast4 Unmanaged.conv_transpose1d_tttl
+
+conv_transpose1d_ttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+conv_transpose1d_ttt = cast3 Unmanaged.conv_transpose1d_ttt
+
+conv_transpose1d_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+conv_transpose1d_tt = cast2 Unmanaged.conv_transpose1d_tt
+
+conv_transpose2d_tttlllll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> Int64
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+conv_transpose2d_tttlllll = cast8 Unmanaged.conv_transpose2d_tttlllll
+
 conv_transpose2d_tttllll
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
@@ -423,6 +514,30 @@ cudnn_convolution_transpose_backward_weight_lttllllbbb
   -> IO (ForeignPtr Tensor)
 cudnn_convolution_transpose_backward_weight_lttllllbbb = cast10 Unmanaged.cudnn_convolution_transpose_backward_weight_lttllllbbb
 
+cudnn_convolution_relu_tttllll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+cudnn_convolution_relu_tttllll = cast7 Unmanaged.cudnn_convolution_relu_tttllll
+
+cudnn_convolution_add_relu_tttstllll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+cudnn_convolution_add_relu_tttstllll = cast9 Unmanaged.cudnn_convolution_add_relu_tttstllll
+
 cudnn_grid_sampler_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
@@ -572,12 +687,13 @@ cumprod_out_ttn
   -> IO (ForeignPtr Tensor)
 cumprod_out_ttn = cast3 Unmanaged.cumprod_out_ttn
 
-cumprod_backward_ttl
+cumprod_backward_ttlt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
+  -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-cumprod_backward_ttl = cast3 Unmanaged.cumprod_backward_ttl
+cumprod_backward_ttlt = cast4 Unmanaged.cumprod_backward_ttlt
 
 cumsum_tls
   :: ForeignPtr Tensor
@@ -927,6 +1043,45 @@ diff_out_tt
   -> IO (ForeignPtr Tensor)
 diff_out_tt = cast2 Unmanaged.diff_out_tt
 
+gradient_tsll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> Int64
+  -> Int64
+  -> IO (ForeignPtr TensorList)
+gradient_tsll = cast4 Unmanaged.gradient_tsll
+
+gradient_tsl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> Int64
+  -> IO (ForeignPtr TensorList)
+gradient_tsl = cast3 Unmanaged.gradient_tsl
+
+gradient_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr TensorList)
+gradient_t = cast1 Unmanaged.gradient_t
+
+gradient_tll
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> Int64
+  -> IO (ForeignPtr TensorList)
+gradient_tll = cast3 Unmanaged.gradient_tll
+
+gradient_tl
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr TensorList)
+gradient_tl = cast2 Unmanaged.gradient_tl
+
+gradient_tA
+  :: ForeignPtr Tensor
+  -> ForeignPtr (StdVector Scalar)
+  -> IO (ForeignPtr TensorList)
+gradient_tA = cast2 Unmanaged.gradient_tA
+
 div_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
@@ -1126,6 +1281,19 @@ embedding_sparse_backward_ttllb
   -> IO (ForeignPtr Tensor)
 embedding_sparse_backward_ttllb = cast5 Unmanaged.embedding_sparse_backward_ttllb
 
+_embedding_bag_forward_only_tttblbtbl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> CBool
+  -> Int64
+  -> CBool
+  -> ForeignPtr Tensor
+  -> CBool
+  -> Int64
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
+_embedding_bag_forward_only_tttblbtbl = cast9 Unmanaged._embedding_bag_forward_only_tttblbtbl
+
 _embedding_bag_forward_only_tttblbtb
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
@@ -1258,6 +1426,32 @@ embedding_bag_ttt
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
 embedding_bag_ttt = cast3 Unmanaged.embedding_bag_ttt
 
+embedding_bag_tttblbtbl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> CBool
+  -> Int64
+  -> CBool
+  -> ForeignPtr Tensor
+  -> CBool
+  -> Int64
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
+embedding_bag_tttblbtbl = cast9 Unmanaged.embedding_bag_tttblbtbl
+
+_embedding_bag_tttblbtbl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> CBool
+  -> Int64
+  -> CBool
+  -> ForeignPtr Tensor
+  -> CBool
+  -> Int64
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
+_embedding_bag_tttblbtbl = cast9 Unmanaged._embedding_bag_tttblbtbl
+
 _embedding_bag_tttblbtb
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
@@ -1307,137 +1501,4 @@ _embedding_bag_tttb
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
 _embedding_bag_tttb = cast4 Unmanaged._embedding_bag_tttb
-
-_embedding_bag_ttt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
-_embedding_bag_ttt = cast3 Unmanaged._embedding_bag_ttt
-
-_embedding_bag_backward_ttttttlblbt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> Int64
-  -> CBool
-  -> Int64
-  -> CBool
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-_embedding_bag_backward_ttttttlblbt = cast11 Unmanaged._embedding_bag_backward_ttttttlblbt
-
-_embedding_bag_sparse_backward_tttttlblt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> Int64
-  -> CBool
-  -> Int64
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-_embedding_bag_sparse_backward_tttttlblt = cast9 Unmanaged._embedding_bag_sparse_backward_tttttlblt
-
-_embedding_bag_dense_backward_ttttttlblt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> Int64
-  -> CBool
-  -> Int64
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-_embedding_bag_dense_backward_ttttttlblt = cast10 Unmanaged._embedding_bag_dense_backward_ttttttlblt
-
-_embedding_bag_per_sample_weights_backward_tttttl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> Int64
-  -> IO (ForeignPtr Tensor)
-_embedding_bag_per_sample_weights_backward_tttttl = cast6 Unmanaged._embedding_bag_per_sample_weights_backward_tttttl
-
-empty_meta_loM
-  :: ForeignPtr IntArray
-  -> ForeignPtr TensorOptions
-  -> MemoryFormat
-  -> IO (ForeignPtr Tensor)
-empty_meta_loM = cast3 Unmanaged.empty_meta_loM
-
-empty_meta_lo
-  :: ForeignPtr IntArray
-  -> ForeignPtr TensorOptions
-  -> IO (ForeignPtr Tensor)
-empty_meta_lo = cast2 Unmanaged.empty_meta_lo
-
-empty_meta_l
-  :: ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-empty_meta_l = cast1 Unmanaged.empty_meta_l
-
-empty_lNoM
-  :: ForeignPtr IntArray
-  -> ForeignPtr DimnameList
-  -> ForeignPtr TensorOptions
-  -> MemoryFormat
-  -> IO (ForeignPtr Tensor)
-empty_lNoM = cast4 Unmanaged.empty_lNoM
-
-empty_lNo
-  :: ForeignPtr IntArray
-  -> ForeignPtr DimnameList
-  -> ForeignPtr TensorOptions
-  -> IO (ForeignPtr Tensor)
-empty_lNo = cast3 Unmanaged.empty_lNo
-
-empty_lN
-  :: ForeignPtr IntArray
-  -> ForeignPtr DimnameList
-  -> IO (ForeignPtr Tensor)
-empty_lN = cast2 Unmanaged.empty_lN
-
-empty_loM
-  :: ForeignPtr IntArray
-  -> ForeignPtr TensorOptions
-  -> MemoryFormat
-  -> IO (ForeignPtr Tensor)
-empty_loM = cast3 Unmanaged.empty_loM
-
-empty_lo
-  :: ForeignPtr IntArray
-  -> ForeignPtr TensorOptions
-  -> IO (ForeignPtr Tensor)
-empty_lo = cast2 Unmanaged.empty_lo
-
-empty_l
-  :: ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-empty_l = cast1 Unmanaged.empty_l
-
-_empty_affine_quantized_lodlM
-  :: ForeignPtr IntArray
-  -> ForeignPtr TensorOptions
-  -> CDouble
-  -> Int64
-  -> MemoryFormat
-  -> IO (ForeignPtr Tensor)
-_empty_affine_quantized_lodlM = cast5 Unmanaged._empty_affine_quantized_lodlM
-
-_empty_affine_quantized_lodl
-  :: ForeignPtr IntArray
-  -> ForeignPtr TensorOptions
-  -> CDouble
-  -> Int64
-  -> IO (ForeignPtr Tensor)
-_empty_affine_quantized_lodl = cast4 Unmanaged._empty_affine_quantized_lodl
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Native/Native3.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Native/Native3.hs
@@ -21,6 +21,175 @@ import Torch.Internal.Objects
 import qualified Torch.Internal.Unmanaged.Native.Native3 as Unmanaged
 
 
+_embedding_bag_ttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
+_embedding_bag_ttt = cast3 Unmanaged._embedding_bag_ttt
+
+_embedding_bag_backward_ttttttlblbtl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> CBool
+  -> Int64
+  -> CBool
+  -> ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+_embedding_bag_backward_ttttttlblbtl = cast12 Unmanaged._embedding_bag_backward_ttttttlblbtl
+
+_embedding_bag_backward_ttttttlblbt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> CBool
+  -> Int64
+  -> CBool
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+_embedding_bag_backward_ttttttlblbt = cast11 Unmanaged._embedding_bag_backward_ttttttlblbt
+
+_embedding_bag_sparse_backward_tttttlbltl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> CBool
+  -> Int64
+  -> ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+_embedding_bag_sparse_backward_tttttlbltl = cast10 Unmanaged._embedding_bag_sparse_backward_tttttlbltl
+
+_embedding_bag_sparse_backward_tttttlblt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> CBool
+  -> Int64
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+_embedding_bag_sparse_backward_tttttlblt = cast9 Unmanaged._embedding_bag_sparse_backward_tttttlblt
+
+_embedding_bag_dense_backward_tttttlbltl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> CBool
+  -> Int64
+  -> ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+_embedding_bag_dense_backward_tttttlbltl = cast10 Unmanaged._embedding_bag_dense_backward_tttttlbltl
+
+_embedding_bag_dense_backward_tttttlblt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> CBool
+  -> Int64
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+_embedding_bag_dense_backward_tttttlblt = cast9 Unmanaged._embedding_bag_dense_backward_tttttlblt
+
+_embedding_bag_per_sample_weights_backward_tttttll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+_embedding_bag_per_sample_weights_backward_tttttll = cast7 Unmanaged._embedding_bag_per_sample_weights_backward_tttttll
+
+_embedding_bag_per_sample_weights_backward_tttttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+_embedding_bag_per_sample_weights_backward_tttttl = cast6 Unmanaged._embedding_bag_per_sample_weights_backward_tttttl
+
+empty_lNoM
+  :: ForeignPtr IntArray
+  -> ForeignPtr DimnameList
+  -> ForeignPtr TensorOptions
+  -> MemoryFormat
+  -> IO (ForeignPtr Tensor)
+empty_lNoM = cast4 Unmanaged.empty_lNoM
+
+empty_lNo
+  :: ForeignPtr IntArray
+  -> ForeignPtr DimnameList
+  -> ForeignPtr TensorOptions
+  -> IO (ForeignPtr Tensor)
+empty_lNo = cast3 Unmanaged.empty_lNo
+
+empty_lN
+  :: ForeignPtr IntArray
+  -> ForeignPtr DimnameList
+  -> IO (ForeignPtr Tensor)
+empty_lN = cast2 Unmanaged.empty_lN
+
+empty_loM
+  :: ForeignPtr IntArray
+  -> ForeignPtr TensorOptions
+  -> MemoryFormat
+  -> IO (ForeignPtr Tensor)
+empty_loM = cast3 Unmanaged.empty_loM
+
+empty_lo
+  :: ForeignPtr IntArray
+  -> ForeignPtr TensorOptions
+  -> IO (ForeignPtr Tensor)
+empty_lo = cast2 Unmanaged.empty_lo
+
+empty_l
+  :: ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+empty_l = cast1 Unmanaged.empty_l
+
+_empty_affine_quantized_lodlM
+  :: ForeignPtr IntArray
+  -> ForeignPtr TensorOptions
+  -> CDouble
+  -> Int64
+  -> MemoryFormat
+  -> IO (ForeignPtr Tensor)
+_empty_affine_quantized_lodlM = cast5 Unmanaged._empty_affine_quantized_lodlM
+
+_empty_affine_quantized_lodl
+  :: ForeignPtr IntArray
+  -> ForeignPtr TensorOptions
+  -> CDouble
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+_empty_affine_quantized_lodl = cast4 Unmanaged._empty_affine_quantized_lodl
+
 _empty_affine_quantized_lod
   :: ForeignPtr IntArray
   -> ForeignPtr TensorOptions

--- a/libtorch-ffi/src/Torch/Internal/Managed/Native/Native4.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Native/Native4.hs
@@ -621,6 +621,13 @@ matrix_power_tl
   -> IO (ForeignPtr Tensor)
 matrix_power_tl = cast2 Unmanaged.matrix_power_tl
 
+matrix_power_out_ttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+matrix_power_out_ttl = cast3 Unmanaged.matrix_power_out_ttl
+
 matrix_exp_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
@@ -931,6 +938,56 @@ mkldnn_max_pool2d_tl
   -> IO (ForeignPtr Tensor)
 mkldnn_max_pool2d_tl = cast2 Unmanaged.mkldnn_max_pool2d_tl
 
+mkldnn_max_pool2d_backward_tttllllb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+mkldnn_max_pool2d_backward_tttllllb = cast8 Unmanaged.mkldnn_max_pool2d_backward_tttllllb
+
+mkldnn_max_pool2d_backward_tttllll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+mkldnn_max_pool2d_backward_tttllll = cast7 Unmanaged.mkldnn_max_pool2d_backward_tttllll
+
+mkldnn_max_pool2d_backward_tttlll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+mkldnn_max_pool2d_backward_tttlll = cast6 Unmanaged.mkldnn_max_pool2d_backward_tttlll
+
+mkldnn_max_pool2d_backward_tttll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+mkldnn_max_pool2d_backward_tttll = cast5 Unmanaged.mkldnn_max_pool2d_backward_tttll
+
+mkldnn_max_pool2d_backward_tttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+mkldnn_max_pool2d_backward_tttl = cast4 Unmanaged.mkldnn_max_pool2d_backward_tttl
+
 mkldnn_max_pool3d_tllllb
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
@@ -970,6 +1027,56 @@ mkldnn_max_pool3d_tl
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
 mkldnn_max_pool3d_tl = cast2 Unmanaged.mkldnn_max_pool3d_tl
+
+mkldnn_max_pool3d_backward_tttllllb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+mkldnn_max_pool3d_backward_tttllllb = cast8 Unmanaged.mkldnn_max_pool3d_backward_tttllllb
+
+mkldnn_max_pool3d_backward_tttllll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+mkldnn_max_pool3d_backward_tttllll = cast7 Unmanaged.mkldnn_max_pool3d_backward_tttllll
+
+mkldnn_max_pool3d_backward_tttlll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+mkldnn_max_pool3d_backward_tttlll = cast6 Unmanaged.mkldnn_max_pool3d_backward_tttlll
+
+mkldnn_max_pool3d_backward_tttll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+mkldnn_max_pool3d_backward_tttll = cast5 Unmanaged.mkldnn_max_pool3d_backward_tttll
+
+mkldnn_max_pool3d_backward_tttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+mkldnn_max_pool3d_backward_tttl = cast4 Unmanaged.mkldnn_max_pool3d_backward_tttl
 
 quantized_max_pool1d_tllllb
   :: ForeignPtr Tensor
@@ -1239,4 +1346,48 @@ median_tn
   -> ForeignPtr Dimname
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
 median_tn = cast2 Unmanaged.median_tn
+
+median_out_tttnb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Dimname
+  -> CBool
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+median_out_tttnb = cast5 Unmanaged.median_out_tttnb
+
+median_out_tttn
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Dimname
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+median_out_tttn = cast4 Unmanaged.median_out_tttn
+
+nanmedian_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+nanmedian_t = cast1 Unmanaged.nanmedian_t
+
+nanmedian_tlb
+  :: ForeignPtr Tensor
+  -> Int64
+  -> CBool
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+nanmedian_tlb = cast3 Unmanaged.nanmedian_tlb
+
+nanmedian_tl
+  :: ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+nanmedian_tl = cast2 Unmanaged.nanmedian_tl
+
+nanmedian_out_tttlb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> CBool
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+nanmedian_out_tttlb = cast5 Unmanaged.nanmedian_out_tttlb
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Native/Native5.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Native/Native5.hs
@@ -21,50 +21,6 @@ import Torch.Internal.Objects
 import qualified Torch.Internal.Unmanaged.Native.Native5 as Unmanaged
 
 
-median_out_tttnb
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Dimname
-  -> CBool
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-median_out_tttnb = cast5 Unmanaged.median_out_tttnb
-
-median_out_tttn
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Dimname
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-median_out_tttn = cast4 Unmanaged.median_out_tttn
-
-nanmedian_t
-  :: ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-nanmedian_t = cast1 Unmanaged.nanmedian_t
-
-nanmedian_tlb
-  :: ForeignPtr Tensor
-  -> Int64
-  -> CBool
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-nanmedian_tlb = cast3 Unmanaged.nanmedian_tlb
-
-nanmedian_tl
-  :: ForeignPtr Tensor
-  -> Int64
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-nanmedian_tl = cast2 Unmanaged.nanmedian_tl
-
-nanmedian_out_tttlb
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> Int64
-  -> CBool
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-nanmedian_out_tttlb = cast5 Unmanaged.nanmedian_out_tttlb
-
 nanmedian_out_tttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
@@ -506,11 +462,11 @@ _sparse_sparse_matmul_tt
   -> IO (ForeignPtr Tensor)
 _sparse_sparse_matmul_tt = cast2 Unmanaged._sparse_sparse_matmul_tt
 
-_sparse_matrix_mask_helper_tt
+_sparse_mask_helper_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_sparse_matrix_mask_helper_tt = cast2 Unmanaged._sparse_matrix_mask_helper_tt
+_sparse_mask_helper_tt = cast2 Unmanaged._sparse_mask_helper_tt
 
 mode_tlb
   :: ForeignPtr Tensor
@@ -778,7 +734,7 @@ batch_norm_backward_reduce_tttttbbb
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
 batch_norm_backward_reduce_tttttbbb = cast8 Unmanaged.batch_norm_backward_reduce_tttttbbb
 
-batch_norm_backward_elemt_ttttttt
+batch_norm_backward_elemt_tttttttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
@@ -786,8 +742,9 @@ batch_norm_backward_elemt_ttttttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-batch_norm_backward_elemt_ttttttt = cast7 Unmanaged.batch_norm_backward_elemt_ttttttt
+batch_norm_backward_elemt_tttttttt = cast8 Unmanaged.batch_norm_backward_elemt_tttttttt
 
 batch_norm_update_stats_tttd
   :: ForeignPtr Tensor
@@ -796,6 +753,14 @@ batch_norm_update_stats_tttd
   -> CDouble
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
 batch_norm_update_stats_tttd = cast4 Unmanaged.batch_norm_update_stats_tttd
+
+is_vulkan_available
+  :: IO (CBool)
+is_vulkan_available = cast0 Unmanaged.is_vulkan_available
+
+_nnpack_available
+  :: IO (CBool)
+_nnpack_available = cast0 Unmanaged._nnpack_available
 
 _nnpack_spatial_convolution_tttll
   :: ForeignPtr Tensor
@@ -1011,6 +976,12 @@ cosine_similarity_tt
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
 cosine_similarity_tt = cast2 Unmanaged.cosine_similarity_tt
+
+permute_tl
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+permute_tl = cast2 Unmanaged.permute_tl
 
 movedim_tll
   :: ForeignPtr Tensor
@@ -1379,4 +1350,112 @@ randn_lGN
   -> ForeignPtr DimnameList
   -> IO (ForeignPtr Tensor)
 randn_lGN = cast3 Unmanaged.randn_lGN
+
+randn_out_tl
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+randn_out_tl = cast2 Unmanaged.randn_out_tl
+
+randn_out_tlG
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr Generator
+  -> IO (ForeignPtr Tensor)
+randn_out_tlG = cast3 Unmanaged.randn_out_tlG
+
+randn_like_toM
+  :: ForeignPtr Tensor
+  -> ForeignPtr TensorOptions
+  -> MemoryFormat
+  -> IO (ForeignPtr Tensor)
+randn_like_toM = cast3 Unmanaged.randn_like_toM
+
+randn_like_to
+  :: ForeignPtr Tensor
+  -> ForeignPtr TensorOptions
+  -> IO (ForeignPtr Tensor)
+randn_like_to = cast2 Unmanaged.randn_like_to
+
+randn_like_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+randn_like_t = cast1 Unmanaged.randn_like_t
+
+randperm_lo
+  :: Int64
+  -> ForeignPtr TensorOptions
+  -> IO (ForeignPtr Tensor)
+randperm_lo = cast2 Unmanaged.randperm_lo
+
+randperm_l
+  :: Int64
+  -> IO (ForeignPtr Tensor)
+randperm_l = cast1 Unmanaged.randperm_l
+
+randperm_lGo
+  :: Int64
+  -> ForeignPtr Generator
+  -> ForeignPtr TensorOptions
+  -> IO (ForeignPtr Tensor)
+randperm_lGo = cast3 Unmanaged.randperm_lGo
+
+randperm_lG
+  :: Int64
+  -> ForeignPtr Generator
+  -> IO (ForeignPtr Tensor)
+randperm_lG = cast2 Unmanaged.randperm_lG
+
+randperm_out_tl
+  :: ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+randperm_out_tl = cast2 Unmanaged.randperm_out_tl
+
+randperm_out_tlG
+  :: ForeignPtr Tensor
+  -> Int64
+  -> ForeignPtr Generator
+  -> IO (ForeignPtr Tensor)
+randperm_out_tlG = cast3 Unmanaged.randperm_out_tlG
+
+range_ssso
+  :: ForeignPtr Scalar
+  -> ForeignPtr Scalar
+  -> ForeignPtr Scalar
+  -> ForeignPtr TensorOptions
+  -> IO (ForeignPtr Tensor)
+range_ssso = cast4 Unmanaged.range_ssso
+
+range_sss
+  :: ForeignPtr Scalar
+  -> ForeignPtr Scalar
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+range_sss = cast3 Unmanaged.range_sss
+
+range_out_tsss
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr Scalar
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+range_out_tsss = cast4 Unmanaged.range_out_tsss
+
+range_out_tss
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+range_out_tss = cast3 Unmanaged.range_out_tss
+
+ravel_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+ravel_t = cast1 Unmanaged.ravel_t
+
+reciprocal_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+reciprocal_t = cast1 Unmanaged.reciprocal_t
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Native/Native6.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Native/Native6.hs
@@ -21,114 +21,6 @@ import Torch.Internal.Objects
 import qualified Torch.Internal.Unmanaged.Native.Native6 as Unmanaged
 
 
-randn_out_tl
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-randn_out_tl = cast2 Unmanaged.randn_out_tl
-
-randn_out_tlG
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr Generator
-  -> IO (ForeignPtr Tensor)
-randn_out_tlG = cast3 Unmanaged.randn_out_tlG
-
-randn_like_toM
-  :: ForeignPtr Tensor
-  -> ForeignPtr TensorOptions
-  -> MemoryFormat
-  -> IO (ForeignPtr Tensor)
-randn_like_toM = cast3 Unmanaged.randn_like_toM
-
-randn_like_to
-  :: ForeignPtr Tensor
-  -> ForeignPtr TensorOptions
-  -> IO (ForeignPtr Tensor)
-randn_like_to = cast2 Unmanaged.randn_like_to
-
-randn_like_t
-  :: ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-randn_like_t = cast1 Unmanaged.randn_like_t
-
-randperm_lo
-  :: Int64
-  -> ForeignPtr TensorOptions
-  -> IO (ForeignPtr Tensor)
-randperm_lo = cast2 Unmanaged.randperm_lo
-
-randperm_l
-  :: Int64
-  -> IO (ForeignPtr Tensor)
-randperm_l = cast1 Unmanaged.randperm_l
-
-randperm_lGo
-  :: Int64
-  -> ForeignPtr Generator
-  -> ForeignPtr TensorOptions
-  -> IO (ForeignPtr Tensor)
-randperm_lGo = cast3 Unmanaged.randperm_lGo
-
-randperm_lG
-  :: Int64
-  -> ForeignPtr Generator
-  -> IO (ForeignPtr Tensor)
-randperm_lG = cast2 Unmanaged.randperm_lG
-
-randperm_out_tl
-  :: ForeignPtr Tensor
-  -> Int64
-  -> IO (ForeignPtr Tensor)
-randperm_out_tl = cast2 Unmanaged.randperm_out_tl
-
-randperm_out_tlG
-  :: ForeignPtr Tensor
-  -> Int64
-  -> ForeignPtr Generator
-  -> IO (ForeignPtr Tensor)
-randperm_out_tlG = cast3 Unmanaged.randperm_out_tlG
-
-range_ssso
-  :: ForeignPtr Scalar
-  -> ForeignPtr Scalar
-  -> ForeignPtr Scalar
-  -> ForeignPtr TensorOptions
-  -> IO (ForeignPtr Tensor)
-range_ssso = cast4 Unmanaged.range_ssso
-
-range_sss
-  :: ForeignPtr Scalar
-  -> ForeignPtr Scalar
-  -> ForeignPtr Scalar
-  -> IO (ForeignPtr Tensor)
-range_sss = cast3 Unmanaged.range_sss
-
-range_out_tsss
-  :: ForeignPtr Tensor
-  -> ForeignPtr Scalar
-  -> ForeignPtr Scalar
-  -> ForeignPtr Scalar
-  -> IO (ForeignPtr Tensor)
-range_out_tsss = cast4 Unmanaged.range_out_tsss
-
-range_out_tss
-  :: ForeignPtr Tensor
-  -> ForeignPtr Scalar
-  -> ForeignPtr Scalar
-  -> IO (ForeignPtr Tensor)
-range_out_tss = cast3 Unmanaged.range_out_tss
-
-ravel_t
-  :: ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-ravel_t = cast1 Unmanaged.ravel_t
-
-reciprocal_t
-  :: ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-reciprocal_t = cast1 Unmanaged.reciprocal_t
-
 reciprocal__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
@@ -311,6 +203,16 @@ relu__t
   -> IO (ForeignPtr Tensor)
 relu__t = cast1 Unmanaged.relu__t
 
+relu6_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+relu6_t = cast1 Unmanaged.relu6_t
+
+relu6__t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+relu6__t = cast1 Unmanaged.relu6__t
+
 prelu_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
@@ -450,6 +352,28 @@ silu_backward_tt
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
 silu_backward_tt = cast2 Unmanaged.silu_backward_tt
+
+mish_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+mish_t = cast1 Unmanaged.mish_t
+
+mish__t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+mish__t = cast1 Unmanaged.mish__t
+
+mish_out_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+mish_out_tt = cast2 Unmanaged.mish_out_tt
+
+mish_backward_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+mish_backward_tt = cast2 Unmanaged.mish_backward_tt
 
 sigmoid_t
   :: ForeignPtr Tensor
@@ -720,6 +644,24 @@ split_with_sizes_tl
   -> ForeignPtr IntArray
   -> IO (ForeignPtr TensorList)
 split_with_sizes_tl = cast2 Unmanaged.split_with_sizes_tl
+
+hsplit_tl
+  :: ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr TensorList)
+hsplit_tl = cast2 Unmanaged.hsplit_tl
+
+vsplit_tl
+  :: ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr TensorList)
+vsplit_tl = cast2 Unmanaged.vsplit_tl
+
+dsplit_tl
+  :: ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr TensorList)
+dsplit_tl = cast2 Unmanaged.dsplit_tl
 
 squeeze_t
   :: ForeignPtr Tensor
@@ -1135,4 +1077,165 @@ sum_out_ttN
   -> ForeignPtr DimnameList
   -> IO (ForeignPtr Tensor)
 sum_out_ttN = cast3 Unmanaged.sum_out_ttN
+
+nansum_ts
+  :: ForeignPtr Tensor
+  -> ScalarType
+  -> IO (ForeignPtr Tensor)
+nansum_ts = cast2 Unmanaged.nansum_ts
+
+nansum_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+nansum_t = cast1 Unmanaged.nansum_t
+
+nansum_tlbs
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> CBool
+  -> ScalarType
+  -> IO (ForeignPtr Tensor)
+nansum_tlbs = cast4 Unmanaged.nansum_tlbs
+
+nansum_tlb
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+nansum_tlb = cast3 Unmanaged.nansum_tlb
+
+nansum_tl
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+nansum_tl = cast2 Unmanaged.nansum_tl
+
+nansum_out_ttlbs
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> CBool
+  -> ScalarType
+  -> IO (ForeignPtr Tensor)
+nansum_out_ttlbs = cast5 Unmanaged.nansum_out_ttlbs
+
+nansum_out_ttlb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+nansum_out_ttlb = cast4 Unmanaged.nansum_out_ttlb
+
+nansum_out_ttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+nansum_out_ttl = cast3 Unmanaged.nansum_out_ttl
+
+sqrt_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+sqrt_t = cast1 Unmanaged.sqrt_t
+
+sqrt__t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+sqrt__t = cast1 Unmanaged.sqrt__t
+
+sqrt_out_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+sqrt_out_tt = cast2 Unmanaged.sqrt_out_tt
+
+square_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+square_t = cast1 Unmanaged.square_t
+
+square__t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+square__t = cast1 Unmanaged.square__t
+
+square_out_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+square_out_tt = cast2 Unmanaged.square_out_tt
+
+std_tb
+  :: ForeignPtr Tensor
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+std_tb = cast2 Unmanaged.std_tb
+
+std_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+std_t = cast1 Unmanaged.std_t
+
+std_tlbb
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> CBool
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+std_tlbb = cast4 Unmanaged.std_tlbb
+
+std_tlb
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+std_tlb = cast3 Unmanaged.std_tlb
+
+std_tl
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+std_tl = cast2 Unmanaged.std_tl
+
+std_tllb
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> Int64
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+std_tllb = cast4 Unmanaged.std_tllb
+
+std_tll
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+std_tll = cast3 Unmanaged.std_tll
+
+std_mean_tb
+  :: ForeignPtr Tensor
+  -> CBool
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+std_mean_tb = cast2 Unmanaged.std_mean_tb
+
+std_mean_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+std_mean_t = cast1 Unmanaged.std_mean_t
+
+std_mean_tlbb
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> CBool
+  -> CBool
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+std_mean_tlbb = cast4 Unmanaged.std_mean_tlbb
+
+std_mean_tlb
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> CBool
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+std_mean_tlb = cast3 Unmanaged.std_mean_tlb
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Native/Native7.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Native/Native7.hs
@@ -21,151 +21,26 @@ import Torch.Internal.Objects
 import qualified Torch.Internal.Unmanaged.Native.Native7 as Unmanaged
 
 
-nansum_ts
-  :: ForeignPtr Tensor
-  -> ScalarType
-  -> IO (ForeignPtr Tensor)
-nansum_ts = cast2 Unmanaged.nansum_ts
-
-nansum_t
-  :: ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-nansum_t = cast1 Unmanaged.nansum_t
-
-nansum_tlbs
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> CBool
-  -> ScalarType
-  -> IO (ForeignPtr Tensor)
-nansum_tlbs = cast4 Unmanaged.nansum_tlbs
-
-nansum_tlb
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> CBool
-  -> IO (ForeignPtr Tensor)
-nansum_tlb = cast3 Unmanaged.nansum_tlb
-
-nansum_tl
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-nansum_tl = cast2 Unmanaged.nansum_tl
-
-nansum_out_ttlbs
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> CBool
-  -> ScalarType
-  -> IO (ForeignPtr Tensor)
-nansum_out_ttlbs = cast5 Unmanaged.nansum_out_ttlbs
-
-nansum_out_ttlb
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> CBool
-  -> IO (ForeignPtr Tensor)
-nansum_out_ttlb = cast4 Unmanaged.nansum_out_ttlb
-
-nansum_out_ttl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-nansum_out_ttl = cast3 Unmanaged.nansum_out_ttl
-
-sqrt_t
-  :: ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-sqrt_t = cast1 Unmanaged.sqrt_t
-
-sqrt__t
-  :: ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-sqrt__t = cast1 Unmanaged.sqrt__t
-
-sqrt_out_tt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-sqrt_out_tt = cast2 Unmanaged.sqrt_out_tt
-
-square_t
-  :: ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-square_t = cast1 Unmanaged.square_t
-
-square__t
-  :: ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-square__t = cast1 Unmanaged.square__t
-
-std_tb
-  :: ForeignPtr Tensor
-  -> CBool
-  -> IO (ForeignPtr Tensor)
-std_tb = cast2 Unmanaged.std_tb
-
-std_t
-  :: ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-std_t = cast1 Unmanaged.std_t
-
-std_tlbb
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> CBool
-  -> CBool
-  -> IO (ForeignPtr Tensor)
-std_tlbb = cast4 Unmanaged.std_tlbb
-
-std_tlb
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> CBool
-  -> IO (ForeignPtr Tensor)
-std_tlb = cast3 Unmanaged.std_tlb
-
-std_tl
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-std_tl = cast2 Unmanaged.std_tl
-
-std_mean_tb
-  :: ForeignPtr Tensor
-  -> CBool
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-std_mean_tb = cast2 Unmanaged.std_mean_tb
-
-std_mean_t
-  :: ForeignPtr Tensor
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-std_mean_t = cast1 Unmanaged.std_mean_t
-
-std_mean_tlbb
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> CBool
-  -> CBool
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-std_mean_tlbb = cast4 Unmanaged.std_mean_tlbb
-
-std_mean_tlb
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> CBool
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-std_mean_tlb = cast3 Unmanaged.std_mean_tlb
-
 std_mean_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
 std_mean_tl = cast2 Unmanaged.std_mean_tl
+
+std_mean_tllb
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> Int64
+  -> CBool
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+std_mean_tllb = cast4 Unmanaged.std_mean_tllb
+
+std_mean_tll
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> Int64
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+std_mean_tll = cast3 Unmanaged.std_mean_tll
 
 std_mean_tNbb
   :: ForeignPtr Tensor
@@ -187,6 +62,21 @@ std_mean_tN
   -> ForeignPtr DimnameList
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
 std_mean_tN = cast2 Unmanaged.std_mean_tN
+
+std_mean_tNlb
+  :: ForeignPtr Tensor
+  -> ForeignPtr DimnameList
+  -> Int64
+  -> CBool
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+std_mean_tNlb = cast4 Unmanaged.std_mean_tNlb
+
+std_mean_tNl
+  :: ForeignPtr Tensor
+  -> ForeignPtr DimnameList
+  -> Int64
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+std_mean_tNl = cast3 Unmanaged.std_mean_tNl
 
 std_out_ttlbb
   :: ForeignPtr Tensor
@@ -211,6 +101,23 @@ std_out_ttl
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
 std_out_ttl = cast3 Unmanaged.std_out_ttl
+
+std_out_ttllb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> Int64
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+std_out_ttllb = cast5 Unmanaged.std_out_ttllb
+
+std_out_ttll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+std_out_ttll = cast4 Unmanaged.std_out_ttll
 
 std_tNbb
   :: ForeignPtr Tensor
@@ -256,6 +163,38 @@ std_out_ttN
   -> ForeignPtr DimnameList
   -> IO (ForeignPtr Tensor)
 std_out_ttN = cast3 Unmanaged.std_out_ttN
+
+std_tNlb
+  :: ForeignPtr Tensor
+  -> ForeignPtr DimnameList
+  -> Int64
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+std_tNlb = cast4 Unmanaged.std_tNlb
+
+std_tNl
+  :: ForeignPtr Tensor
+  -> ForeignPtr DimnameList
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+std_tNl = cast3 Unmanaged.std_tNl
+
+std_out_ttNlb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr DimnameList
+  -> Int64
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+std_out_ttNlb = cast5 Unmanaged.std_out_ttNlb
+
+std_out_ttNl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr DimnameList
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+std_out_ttNl = cast4 Unmanaged.std_out_ttNl
 
 prod_ts
   :: ForeignPtr Tensor
@@ -433,6 +372,14 @@ threshold_out_ttss
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
 threshold_out_ttss = cast4 Unmanaged.threshold_out_ttss
+
+threshold_backward_out_ttts
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+threshold_backward_out_ttts = cast4 Unmanaged.threshold_backward_out_ttts
 
 threshold_backward_tts
   :: ForeignPtr Tensor
@@ -865,6 +812,21 @@ var_tl
   -> IO (ForeignPtr Tensor)
 var_tl = cast2 Unmanaged.var_tl
 
+var_tllb
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> Int64
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+var_tllb = cast4 Unmanaged.var_tllb
+
+var_tll
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+var_tll = cast3 Unmanaged.var_tll
+
 var_out_ttlbb
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
@@ -888,6 +850,23 @@ var_out_ttl
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
 var_out_ttl = cast3 Unmanaged.var_out_ttl
+
+var_out_ttllb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> Int64
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+var_out_ttllb = cast5 Unmanaged.var_out_ttllb
+
+var_out_ttll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+var_out_ttll = cast4 Unmanaged.var_out_ttll
 
 var_tNbb
   :: ForeignPtr Tensor
@@ -934,6 +913,38 @@ var_out_ttN
   -> IO (ForeignPtr Tensor)
 var_out_ttN = cast3 Unmanaged.var_out_ttN
 
+var_tNlb
+  :: ForeignPtr Tensor
+  -> ForeignPtr DimnameList
+  -> Int64
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+var_tNlb = cast4 Unmanaged.var_tNlb
+
+var_tNl
+  :: ForeignPtr Tensor
+  -> ForeignPtr DimnameList
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+var_tNl = cast3 Unmanaged.var_tNl
+
+var_out_ttNlb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr DimnameList
+  -> Int64
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+var_out_ttNlb = cast5 Unmanaged.var_out_ttNlb
+
+var_out_ttNl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr DimnameList
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+var_out_ttNl = cast4 Unmanaged.var_out_ttNl
+
 var_mean_tb
   :: ForeignPtr Tensor
   -> CBool
@@ -966,6 +977,21 @@ var_mean_tl
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
 var_mean_tl = cast2 Unmanaged.var_mean_tl
 
+var_mean_tllb
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> Int64
+  -> CBool
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+var_mean_tllb = cast4 Unmanaged.var_mean_tllb
+
+var_mean_tll
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> Int64
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+var_mean_tll = cast3 Unmanaged.var_mean_tll
+
 var_mean_tNbb
   :: ForeignPtr Tensor
   -> ForeignPtr DimnameList
@@ -986,6 +1012,21 @@ var_mean_tN
   -> ForeignPtr DimnameList
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
 var_mean_tN = cast2 Unmanaged.var_mean_tN
+
+var_mean_tNlb
+  :: ForeignPtr Tensor
+  -> ForeignPtr DimnameList
+  -> Int64
+  -> CBool
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+var_mean_tNlb = cast4 Unmanaged.var_mean_tNlb
+
+var_mean_tNl
+  :: ForeignPtr Tensor
+  -> ForeignPtr DimnameList
+  -> Int64
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+var_mean_tNl = cast3 Unmanaged.var_mean_tNl
 
 where_ttt
   :: ForeignPtr Tensor
@@ -1182,4 +1223,109 @@ poisson_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
 poisson_t = cast1 Unmanaged.poisson_t
+
+binomial_ttG
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Generator
+  -> IO (ForeignPtr Tensor)
+binomial_ttG = cast3 Unmanaged.binomial_ttG
+
+binomial_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+binomial_tt = cast2 Unmanaged.binomial_tt
+
+native_norm_ts
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+native_norm_ts = cast2 Unmanaged.native_norm_ts
+
+native_norm_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+native_norm_t = cast1 Unmanaged.native_norm_t
+
+native_norm_tslbs
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr IntArray
+  -> CBool
+  -> ScalarType
+  -> IO (ForeignPtr Tensor)
+native_norm_tslbs = cast5 Unmanaged.native_norm_tslbs
+
+_sparse_sum_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+_sparse_sum_t = cast1 Unmanaged._sparse_sum_t
+
+_sparse_sum_ts
+  :: ForeignPtr Tensor
+  -> ScalarType
+  -> IO (ForeignPtr Tensor)
+_sparse_sum_ts = cast2 Unmanaged._sparse_sum_ts
+
+_sparse_sum_tl
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+_sparse_sum_tl = cast2 Unmanaged._sparse_sum_tl
+
+_sparse_sum_tls
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ScalarType
+  -> IO (ForeignPtr Tensor)
+_sparse_sum_tls = cast3 Unmanaged._sparse_sum_tls
+
+_sparse_sum_backward_ttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+_sparse_sum_backward_ttl = cast3 Unmanaged._sparse_sum_backward_ttl
+
+_sparse_softmax_tls
+  :: ForeignPtr Tensor
+  -> Int64
+  -> ScalarType
+  -> IO (ForeignPtr Tensor)
+_sparse_softmax_tls = cast3 Unmanaged._sparse_softmax_tls
+
+_sparse_softmax_tl
+  :: ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+_sparse_softmax_tl = cast2 Unmanaged._sparse_softmax_tl
+
+_sparse_softmax_tns
+  :: ForeignPtr Tensor
+  -> ForeignPtr Dimname
+  -> ScalarType
+  -> IO (ForeignPtr Tensor)
+_sparse_softmax_tns = cast3 Unmanaged._sparse_softmax_tns
+
+_sparse_softmax_tn
+  :: ForeignPtr Tensor
+  -> ForeignPtr Dimname
+  -> IO (ForeignPtr Tensor)
+_sparse_softmax_tn = cast2 Unmanaged._sparse_softmax_tn
+
+_sparse_softmax_tlb
+  :: ForeignPtr Tensor
+  -> Int64
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+_sparse_softmax_tlb = cast3 Unmanaged._sparse_softmax_tlb
+
+_sparse_softmax_backward_data_ttlt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+_sparse_softmax_backward_data_ttlt = cast4 Unmanaged._sparse_softmax_backward_data_ttlt
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Native/Native8.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Native/Native8.hs
@@ -21,111 +21,6 @@ import Torch.Internal.Objects
 import qualified Torch.Internal.Unmanaged.Native.Native8 as Unmanaged
 
 
-binomial_ttG
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Generator
-  -> IO (ForeignPtr Tensor)
-binomial_ttG = cast3 Unmanaged.binomial_ttG
-
-binomial_tt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-binomial_tt = cast2 Unmanaged.binomial_tt
-
-native_norm_ts
-  :: ForeignPtr Tensor
-  -> ForeignPtr Scalar
-  -> IO (ForeignPtr Tensor)
-native_norm_ts = cast2 Unmanaged.native_norm_ts
-
-native_norm_t
-  :: ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-native_norm_t = cast1 Unmanaged.native_norm_t
-
-native_norm_tslbs
-  :: ForeignPtr Tensor
-  -> ForeignPtr Scalar
-  -> ForeignPtr IntArray
-  -> CBool
-  -> ScalarType
-  -> IO (ForeignPtr Tensor)
-native_norm_tslbs = cast5 Unmanaged.native_norm_tslbs
-
-_sparse_sum_t
-  :: ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-_sparse_sum_t = cast1 Unmanaged._sparse_sum_t
-
-_sparse_sum_ts
-  :: ForeignPtr Tensor
-  -> ScalarType
-  -> IO (ForeignPtr Tensor)
-_sparse_sum_ts = cast2 Unmanaged._sparse_sum_ts
-
-_sparse_sum_tl
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-_sparse_sum_tl = cast2 Unmanaged._sparse_sum_tl
-
-_sparse_sum_tls
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ScalarType
-  -> IO (ForeignPtr Tensor)
-_sparse_sum_tls = cast3 Unmanaged._sparse_sum_tls
-
-_sparse_sum_backward_ttl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-_sparse_sum_backward_ttl = cast3 Unmanaged._sparse_sum_backward_ttl
-
-_sparse_softmax_tls
-  :: ForeignPtr Tensor
-  -> Int64
-  -> ScalarType
-  -> IO (ForeignPtr Tensor)
-_sparse_softmax_tls = cast3 Unmanaged._sparse_softmax_tls
-
-_sparse_softmax_tl
-  :: ForeignPtr Tensor
-  -> Int64
-  -> IO (ForeignPtr Tensor)
-_sparse_softmax_tl = cast2 Unmanaged._sparse_softmax_tl
-
-_sparse_softmax_tns
-  :: ForeignPtr Tensor
-  -> ForeignPtr Dimname
-  -> ScalarType
-  -> IO (ForeignPtr Tensor)
-_sparse_softmax_tns = cast3 Unmanaged._sparse_softmax_tns
-
-_sparse_softmax_tn
-  :: ForeignPtr Tensor
-  -> ForeignPtr Dimname
-  -> IO (ForeignPtr Tensor)
-_sparse_softmax_tn = cast2 Unmanaged._sparse_softmax_tn
-
-_sparse_softmax_tlb
-  :: ForeignPtr Tensor
-  -> Int64
-  -> CBool
-  -> IO (ForeignPtr Tensor)
-_sparse_softmax_tlb = cast3 Unmanaged._sparse_softmax_tlb
-
-_sparse_softmax_backward_data_ttlt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> Int64
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-_sparse_softmax_backward_data_ttlt = cast4 Unmanaged._sparse_softmax_backward_data_ttlt
-
 _sparse_log_softmax_tls
   :: ForeignPtr Tensor
   -> Int64
@@ -287,6 +182,18 @@ norm_out_ttsN
   -> IO (ForeignPtr Tensor)
 norm_out_ttsN = cast4 Unmanaged.norm_out_ttsN
 
+frexp_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+frexp_t = cast1 Unmanaged.frexp_t
+
+frexp_out_ttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+frexp_out_ttt = cast3 Unmanaged.frexp_out_ttt
+
 frobenius_norm_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
@@ -383,6 +290,11 @@ clone_t
   -> IO (ForeignPtr Tensor)
 clone_t = cast1 Unmanaged.clone_t
 
+positive_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+positive_t = cast1 Unmanaged.positive_t
+
 resize_as__ttM
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
@@ -395,6 +307,12 @@ resize_as__tt
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
 resize_as__tt = cast2 Unmanaged.resize_as__tt
+
+resize_as_sparse__tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+resize_as_sparse__tt = cast2 Unmanaged.resize_as_sparse__tt
 
 zero__t
   :: ForeignPtr Tensor
@@ -597,6 +515,23 @@ addmm_ttt
   -> IO (ForeignPtr Tensor)
 addmm_ttt = cast3 Unmanaged.addmm_ttt
 
+_sparse_csr_tensor_tttlo
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr TensorOptions
+  -> IO (ForeignPtr Tensor)
+_sparse_csr_tensor_tttlo = cast5 Unmanaged._sparse_csr_tensor_tttlo
+
+_sparse_csr_tensor_ttto
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr TensorOptions
+  -> IO (ForeignPtr Tensor)
+_sparse_csr_tensor_ttto = cast4 Unmanaged._sparse_csr_tensor_ttto
+
 sparse_coo_tensor_lo
   :: ForeignPtr IntArray
   -> ForeignPtr TensorOptions
@@ -676,6 +611,11 @@ to_dense_backward_tt
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
 to_dense_backward_tt = cast2 Unmanaged.to_dense_backward_tt
+
+_coalesce_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+_coalesce_t = cast1 Unmanaged._coalesce_t
 
 hspmm_out_ttt
   :: ForeignPtr Tensor
@@ -1304,4 +1244,260 @@ lstm_cell_tltttt
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
 lstm_cell_tltttt = cast6 Unmanaged.lstm_cell_tltttt
+
+lstm_cell_tlttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr TensorList
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+lstm_cell_tlttt = cast5 Unmanaged.lstm_cell_tlttt
+
+lstm_cell_tltt
+  :: ForeignPtr Tensor
+  -> ForeignPtr TensorList
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+lstm_cell_tltt = cast4 Unmanaged.lstm_cell_tltt
+
+gru_cell_tttttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+gru_cell_tttttt = cast6 Unmanaged.gru_cell_tttttt
+
+gru_cell_ttttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+gru_cell_ttttt = cast5 Unmanaged.gru_cell_ttttt
+
+gru_cell_tttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+gru_cell_tttt = cast4 Unmanaged.gru_cell_tttt
+
+rnn_tanh_cell_tttttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+rnn_tanh_cell_tttttt = cast6 Unmanaged.rnn_tanh_cell_tttttt
+
+rnn_tanh_cell_ttttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+rnn_tanh_cell_ttttt = cast5 Unmanaged.rnn_tanh_cell_ttttt
+
+rnn_tanh_cell_tttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+rnn_tanh_cell_tttt = cast4 Unmanaged.rnn_tanh_cell_tttt
+
+rnn_relu_cell_tttttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+rnn_relu_cell_tttttt = cast6 Unmanaged.rnn_relu_cell_tttttt
+
+rnn_relu_cell_ttttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+rnn_relu_cell_ttttt = cast5 Unmanaged.rnn_relu_cell_ttttt
+
+rnn_relu_cell_tttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+rnn_relu_cell_tttt = cast4 Unmanaged.rnn_relu_cell_tttt
+
+quantized_lstm_cell_tlttttttttssss
+  :: ForeignPtr Tensor
+  -> ForeignPtr TensorList
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr Scalar
+  -> ForeignPtr Scalar
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+quantized_lstm_cell_tlttttttttssss = cast14 Unmanaged.quantized_lstm_cell_tlttttttttssss
+
+quantized_gru_cell_ttttttttttssss
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr Scalar
+  -> ForeignPtr Scalar
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+quantized_gru_cell_ttttttttttssss = cast14 Unmanaged.quantized_gru_cell_ttttttttttssss
+
+quantized_rnn_relu_cell_ttttttttttssss
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr Scalar
+  -> ForeignPtr Scalar
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+quantized_rnn_relu_cell_ttttttttttssss = cast14 Unmanaged.quantized_rnn_relu_cell_ttttttttttssss
+
+quantized_rnn_tanh_cell_ttttttttttssss
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr Scalar
+  -> ForeignPtr Scalar
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+quantized_rnn_tanh_cell_ttttttttttssss = cast14 Unmanaged.quantized_rnn_tanh_cell_ttttttttttssss
+
+_pack_padded_sequence_ttb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> CBool
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+_pack_padded_sequence_ttb = cast3 Unmanaged._pack_padded_sequence_ttb
+
+_pack_padded_sequence_backward_tltb
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr Tensor
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+_pack_padded_sequence_backward_tltb = cast4 Unmanaged._pack_padded_sequence_backward_tltb
+
+_pad_packed_sequence_ttbsl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> CBool
+  -> ForeignPtr Scalar
+  -> Int64
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+_pad_packed_sequence_ttbsl = cast5 Unmanaged._pad_packed_sequence_ttbsl
+
+masked_fill_tts
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+masked_fill_tts = cast3 Unmanaged.masked_fill_tts
+
+masked_fill_ttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+masked_fill_ttt = cast3 Unmanaged.masked_fill_ttt
+
+masked_scatter_ttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+masked_scatter_ttt = cast3 Unmanaged.masked_scatter_ttt
+
+put_tttb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+put_tttb = cast4 Unmanaged.put_tttb
+
+put_ttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+put_ttt = cast3 Unmanaged.put_ttt
+
+index_add_tltt
+  :: ForeignPtr Tensor
+  -> Int64
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+index_add_tltt = cast4 Unmanaged.index_add_tltt
+
+index_add_tltts
+  :: ForeignPtr Tensor
+  -> Int64
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+index_add_tltts = cast5 Unmanaged.index_add_tltts
+
+index_add_tntts
+  :: ForeignPtr Tensor
+  -> ForeignPtr Dimname
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+index_add_tntts = cast5 Unmanaged.index_add_tntts
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Native/Native9.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Native/Native9.hs
@@ -21,229 +21,6 @@ import Torch.Internal.Objects
 import qualified Torch.Internal.Unmanaged.Native.Native9 as Unmanaged
 
 
-lstm_cell_tlttt
-  :: ForeignPtr Tensor
-  -> ForeignPtr TensorList
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-lstm_cell_tlttt = cast5 Unmanaged.lstm_cell_tlttt
-
-lstm_cell_tltt
-  :: ForeignPtr Tensor
-  -> ForeignPtr TensorList
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-lstm_cell_tltt = cast4 Unmanaged.lstm_cell_tltt
-
-gru_cell_tttttt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-gru_cell_tttttt = cast6 Unmanaged.gru_cell_tttttt
-
-gru_cell_ttttt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-gru_cell_ttttt = cast5 Unmanaged.gru_cell_ttttt
-
-gru_cell_tttt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-gru_cell_tttt = cast4 Unmanaged.gru_cell_tttt
-
-rnn_tanh_cell_tttttt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-rnn_tanh_cell_tttttt = cast6 Unmanaged.rnn_tanh_cell_tttttt
-
-rnn_tanh_cell_ttttt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-rnn_tanh_cell_ttttt = cast5 Unmanaged.rnn_tanh_cell_ttttt
-
-rnn_tanh_cell_tttt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-rnn_tanh_cell_tttt = cast4 Unmanaged.rnn_tanh_cell_tttt
-
-rnn_relu_cell_tttttt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-rnn_relu_cell_tttttt = cast6 Unmanaged.rnn_relu_cell_tttttt
-
-rnn_relu_cell_ttttt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-rnn_relu_cell_ttttt = cast5 Unmanaged.rnn_relu_cell_ttttt
-
-rnn_relu_cell_tttt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-rnn_relu_cell_tttt = cast4 Unmanaged.rnn_relu_cell_tttt
-
-quantized_lstm_cell_tlttttttttssss
-  :: ForeignPtr Tensor
-  -> ForeignPtr TensorList
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Scalar
-  -> ForeignPtr Scalar
-  -> ForeignPtr Scalar
-  -> ForeignPtr Scalar
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-quantized_lstm_cell_tlttttttttssss = cast14 Unmanaged.quantized_lstm_cell_tlttttttttssss
-
-quantized_gru_cell_ttttttttttssss
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Scalar
-  -> ForeignPtr Scalar
-  -> ForeignPtr Scalar
-  -> ForeignPtr Scalar
-  -> IO (ForeignPtr Tensor)
-quantized_gru_cell_ttttttttttssss = cast14 Unmanaged.quantized_gru_cell_ttttttttttssss
-
-quantized_rnn_relu_cell_ttttttttttssss
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Scalar
-  -> ForeignPtr Scalar
-  -> ForeignPtr Scalar
-  -> ForeignPtr Scalar
-  -> IO (ForeignPtr Tensor)
-quantized_rnn_relu_cell_ttttttttttssss = cast14 Unmanaged.quantized_rnn_relu_cell_ttttttttttssss
-
-quantized_rnn_tanh_cell_ttttttttttssss
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Scalar
-  -> ForeignPtr Scalar
-  -> ForeignPtr Scalar
-  -> ForeignPtr Scalar
-  -> IO (ForeignPtr Tensor)
-quantized_rnn_tanh_cell_ttttttttttssss = cast14 Unmanaged.quantized_rnn_tanh_cell_ttttttttttssss
-
-_pack_padded_sequence_ttb
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> CBool
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-_pack_padded_sequence_ttb = cast3 Unmanaged._pack_padded_sequence_ttb
-
-_pack_padded_sequence_backward_tltb
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr Tensor
-  -> CBool
-  -> IO (ForeignPtr Tensor)
-_pack_padded_sequence_backward_tltb = cast4 Unmanaged._pack_padded_sequence_backward_tltb
-
-_pad_packed_sequence_ttbsl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> CBool
-  -> ForeignPtr Scalar
-  -> Int64
-  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-_pad_packed_sequence_ttbsl = cast5 Unmanaged._pad_packed_sequence_ttbsl
-
-masked_fill_tts
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Scalar
-  -> IO (ForeignPtr Tensor)
-masked_fill_tts = cast3 Unmanaged.masked_fill_tts
-
-masked_fill_ttt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-masked_fill_ttt = cast3 Unmanaged.masked_fill_ttt
-
-masked_scatter_ttt
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-masked_scatter_ttt = cast3 Unmanaged.masked_scatter_ttt
-
-index_add_tltt
-  :: ForeignPtr Tensor
-  -> Int64
-  -> ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-index_add_tltt = cast4 Unmanaged.index_add_tltt
-
 index_add_tntt
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
@@ -980,12 +757,33 @@ take_tt
   -> IO (ForeignPtr Tensor)
 take_tt = cast2 Unmanaged.take_tt
 
-take_backward_ttt
+take_along_dim_out_tttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+take_along_dim_out_tttl = cast4 Unmanaged.take_along_dim_out_tttl
+
+take_along_dim_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-take_backward_ttt = cast3 Unmanaged.take_backward_ttt
+take_along_dim_out_ttt = cast3 Unmanaged.take_along_dim_out_ttt
+
+take_along_dim_ttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+take_along_dim_ttl = cast3 Unmanaged.take_along_dim_ttl
+
+take_along_dim_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+take_along_dim_tt = cast2 Unmanaged.take_along_dim_tt
 
 index_select_out_ttlt
   :: ForeignPtr Tensor
@@ -1206,6 +1004,36 @@ addcdiv_ttt
   -> IO (ForeignPtr Tensor)
 addcdiv_ttt = cast3 Unmanaged.addcdiv_ttt
 
+cross_entropy_loss_tttll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+cross_entropy_loss_tttll = cast5 Unmanaged.cross_entropy_loss_tttll
+
+cross_entropy_loss_tttl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+cross_entropy_loss_tttl = cast4 Unmanaged.cross_entropy_loss_tttl
+
+cross_entropy_loss_ttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+cross_entropy_loss_ttt = cast3 Unmanaged.cross_entropy_loss_ttt
+
+cross_entropy_loss_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+cross_entropy_loss_tt = cast2 Unmanaged.cross_entropy_loss_tt
+
 lstsq_out_tttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
@@ -1288,12 +1116,229 @@ triangular_solve_tt
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
 triangular_solve_tt = cast2 Unmanaged.triangular_solve_tt
 
-_triangular_solve_helper_ttbbb
+symeig_out_tttbb
   :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> CBool
   -> CBool
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+symeig_out_tttbb = cast5 Unmanaged.symeig_out_tttbb
+
+symeig_out_tttb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-_triangular_solve_helper_ttbbb = cast5 Unmanaged._triangular_solve_helper_ttbbb
+symeig_out_tttb = cast4 Unmanaged.symeig_out_tttb
+
+symeig_out_ttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+symeig_out_ttt = cast3 Unmanaged.symeig_out_ttt
+
+symeig_tbb
+  :: ForeignPtr Tensor
+  -> CBool
+  -> CBool
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+symeig_tbb = cast3 Unmanaged.symeig_tbb
+
+symeig_tb
+  :: ForeignPtr Tensor
+  -> CBool
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+symeig_tb = cast2 Unmanaged.symeig_tb
+
+symeig_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+symeig_t = cast1 Unmanaged.symeig_t
+
+_symeig_helper_tbb
+  :: ForeignPtr Tensor
+  -> CBool
+  -> CBool
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+_symeig_helper_tbb = cast3 Unmanaged._symeig_helper_tbb
+
+eig_out_tttb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> CBool
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+eig_out_tttb = cast4 Unmanaged.eig_out_tttb
+
+eig_out_ttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+eig_out_ttt = cast3 Unmanaged.eig_out_ttt
+
+eig_tb
+  :: ForeignPtr Tensor
+  -> CBool
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+eig_tb = cast2 Unmanaged.eig_tb
+
+eig_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+eig_t = cast1 Unmanaged.eig_t
+
+svd_out_ttttbb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> CBool
+  -> CBool
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
+svd_out_ttttbb = cast6 Unmanaged.svd_out_ttttbb
+
+svd_out_ttttb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> CBool
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
+svd_out_ttttb = cast5 Unmanaged.svd_out_ttttb
+
+svd_out_tttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
+svd_out_tttt = cast4 Unmanaged.svd_out_tttt
+
+svd_tbb
+  :: ForeignPtr Tensor
+  -> CBool
+  -> CBool
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
+svd_tbb = cast3 Unmanaged.svd_tbb
+
+svd_tb
+  :: ForeignPtr Tensor
+  -> CBool
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
+svd_tb = cast2 Unmanaged.svd_tb
+
+svd_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
+svd_t = cast1 Unmanaged.svd_t
+
+_svd_helper_tbb
+  :: ForeignPtr Tensor
+  -> CBool
+  -> CBool
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
+_svd_helper_tbb = cast3 Unmanaged._svd_helper_tbb
+
+swapaxes_tll
+  :: ForeignPtr Tensor
+  -> Int64
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+swapaxes_tll = cast3 Unmanaged.swapaxes_tll
+
+swapdims_tll
+  :: ForeignPtr Tensor
+  -> Int64
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+swapdims_tll = cast3 Unmanaged.swapdims_tll
+
+cholesky_out_ttb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+cholesky_out_ttb = cast3 Unmanaged.cholesky_out_ttb
+
+cholesky_out_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+cholesky_out_tt = cast2 Unmanaged.cholesky_out_tt
+
+cholesky_tb
+  :: ForeignPtr Tensor
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+cholesky_tb = cast2 Unmanaged.cholesky_tb
+
+cholesky_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+cholesky_t = cast1 Unmanaged.cholesky_t
+
+cholesky_solve_out_tttb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+cholesky_solve_out_tttb = cast4 Unmanaged.cholesky_solve_out_tttb
+
+cholesky_solve_out_ttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+cholesky_solve_out_ttt = cast3 Unmanaged.cholesky_solve_out_ttt
+
+cholesky_solve_ttb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+cholesky_solve_ttb = cast3 Unmanaged.cholesky_solve_ttb
+
+cholesky_solve_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+cholesky_solve_tt = cast2 Unmanaged.cholesky_solve_tt
+
+_cholesky_solve_helper_ttb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+_cholesky_solve_helper_ttb = cast3 Unmanaged._cholesky_solve_helper_ttb
+
+solve_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+solve_tt = cast2 Unmanaged.solve_tt
+
+solve_out_tttt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+solve_out_tttt = cast4 Unmanaged.solve_out_tttt
+
+_solve_helper_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+_solve_helper_tt = cast2 Unmanaged._solve_helper_tt
+
+cholesky_inverse_tb
+  :: ForeignPtr Tensor
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+cholesky_inverse_tb = cast2 Unmanaged.cholesky_inverse_tb
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/TensorFactories.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/TensorFactories.hs
@@ -116,24 +116,6 @@ blackman_window_lb
   -> IO (ForeignPtr Tensor)
 blackman_window_lb = cast2 Unmanaged.blackman_window_lb
 
-empty_meta_loM
-  :: ForeignPtr IntArray
-  -> ForeignPtr TensorOptions
-  -> MemoryFormat
-  -> IO (ForeignPtr Tensor)
-empty_meta_loM = cast3 Unmanaged.empty_meta_loM
-
-empty_meta_lo
-  :: ForeignPtr IntArray
-  -> ForeignPtr TensorOptions
-  -> IO (ForeignPtr Tensor)
-empty_meta_lo = cast2 Unmanaged.empty_meta_lo
-
-empty_meta_l
-  :: ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-empty_meta_l = cast1 Unmanaged.empty_meta_l
-
 empty_lNoM
   :: ForeignPtr IntArray
   -> ForeignPtr DimnameList
@@ -913,6 +895,23 @@ zeros_like_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
 zeros_like_t = cast1 Unmanaged.zeros_like_t
+
+_sparse_csr_tensor_tttlo
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr TensorOptions
+  -> IO (ForeignPtr Tensor)
+_sparse_csr_tensor_tttlo = cast5 Unmanaged._sparse_csr_tensor_tttlo
+
+_sparse_csr_tensor_ttto
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr TensorOptions
+  -> IO (ForeignPtr Tensor)
+_sparse_csr_tensor_ttto = cast4 Unmanaged._sparse_csr_tensor_ttto
 
 sparse_coo_tensor_lo
   :: ForeignPtr IntArray

--- a/libtorch-ffi/src/Torch/Internal/Managed/Type/Module.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Type/Module.hs
@@ -140,6 +140,5 @@ dumpToStr
   -> CBool
   -> CBool
   -> CBool
-  -> CInt
   -> IO (ForeignPtr StdString)
-dumpToStr = cast5 Unmanaged.dumpToStr
+dumpToStr = cast4 Unmanaged.dumpToStr

--- a/libtorch-ffi/src/Torch/Internal/Managed/Type/Tensor/Tensor0.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Type/Tensor/Tensor0.hs
@@ -81,12 +81,6 @@ tensor_element_size
   -> IO (Int64)
 tensor_element_size = cast1 Unmanaged.tensor_element_size
 
-tensor_fw_grad_L
-  :: ForeignPtr Tensor
-  -> Word64
-  -> IO (ForeignPtr Tensor)
-tensor_fw_grad_L = cast2 Unmanaged.tensor_fw_grad_L
-
 tensor_get_device
   :: ForeignPtr Tensor
   -> IO (Int64)
@@ -326,14 +320,6 @@ tensor_scalar_type
   :: ForeignPtr Tensor
   -> IO (ScalarType)
 tensor_scalar_type = cast1 Unmanaged.tensor_scalar_type
-
-tensor_set_fw_grad_tLb
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> Word64
-  -> CBool
-  -> IO (())
-tensor_set_fw_grad_tLb = cast4 Unmanaged.tensor_set_fw_grad_tLb
 
 tensor_set_requires_grad_b
   :: ForeignPtr Tensor
@@ -996,20 +982,6 @@ tensor_chunk_ll
   -> IO (ForeignPtr TensorList)
 tensor_chunk_ll = cast3 Unmanaged.tensor_chunk_ll
 
--- tensor_tensor_split_ll
---   :: ForeignPtr Tensor
---   -> Int64
---   -> Int64
---   -> IO (ForeignPtr TensorList)
--- tensor_tensor_split_ll = cast3 Unmanaged.tensor_tensor_split_ll
-
-tensor_tensor_split_ll
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> Int64
-  -> IO (ForeignPtr TensorList)
-tensor_tensor_split_ll = cast3 Unmanaged.tensor_tensor_split_ll
-
 tensor_tensor_split_tl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
@@ -1024,6 +996,13 @@ tensor_clamp_ss
   -> IO (ForeignPtr Tensor)
 tensor_clamp_ss = cast3 Unmanaged.tensor_clamp_ss
 
+tensor_clamp_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_clamp_tt = cast3 Unmanaged.tensor_clamp_tt
+
 tensor_clamp__ss
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
@@ -1031,11 +1010,24 @@ tensor_clamp__ss
   -> IO (ForeignPtr Tensor)
 tensor_clamp__ss = cast3 Unmanaged.tensor_clamp__ss
 
+tensor_clamp__tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_clamp__tt = cast3 Unmanaged.tensor_clamp__tt
+
 tensor_clamp_max_s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
 tensor_clamp_max_s = cast2 Unmanaged.tensor_clamp_max_s
+
+tensor_clamp_max_t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_clamp_max_t = cast2 Unmanaged.tensor_clamp_max_t
 
 tensor_clamp_max__s
   :: ForeignPtr Tensor
@@ -1043,17 +1035,35 @@ tensor_clamp_max__s
   -> IO (ForeignPtr Tensor)
 tensor_clamp_max__s = cast2 Unmanaged.tensor_clamp_max__s
 
+tensor_clamp_max__t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_clamp_max__t = cast2 Unmanaged.tensor_clamp_max__t
+
 tensor_clamp_min_s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
 tensor_clamp_min_s = cast2 Unmanaged.tensor_clamp_min_s
 
+tensor_clamp_min_t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_clamp_min_t = cast2 Unmanaged.tensor_clamp_min_t
+
 tensor_clamp_min__s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
 tensor_clamp_min__s = cast2 Unmanaged.tensor_clamp_min__s
+
+tensor_clamp_min__t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_clamp_min__t = cast2 Unmanaged.tensor_clamp_min__t
 
 tensor_clip_ss
   :: ForeignPtr Tensor
@@ -1062,12 +1072,26 @@ tensor_clip_ss
   -> IO (ForeignPtr Tensor)
 tensor_clip_ss = cast3 Unmanaged.tensor_clip_ss
 
+tensor_clip_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_clip_tt = cast3 Unmanaged.tensor_clip_tt
+
 tensor_clip__ss
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
 tensor_clip__ss = cast3 Unmanaged.tensor_clip__ss
+
+tensor_clip__tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_clip__tt = cast3 Unmanaged.tensor_clip__tt
 
 tensor_contiguous_M
   :: ForeignPtr Tensor
@@ -1101,18 +1125,6 @@ tensor_cosh_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
 tensor_cosh_ = cast1 Unmanaged.tensor_cosh_
-
-tensor_count_nonzero_l
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-tensor_count_nonzero_l = cast2 Unmanaged.tensor_count_nonzero_l
-
--- tensor_count_nonzero_l
---   :: ForeignPtr Tensor
---   -> Int64
---   -> IO (ForeignPtr Tensor)
--- tensor_count_nonzero_l = cast2 Unmanaged.tensor_count_nonzero_l
 
 tensor_cummax_l
   :: ForeignPtr Tensor

--- a/libtorch-ffi/src/Torch/Internal/Managed/Type/Tensor/Tensor1.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Type/Tensor/Tensor1.hs
@@ -1026,34 +1026,6 @@ tensor_permute_l
   -> IO (ForeignPtr Tensor)
 tensor_permute_l = cast2 Unmanaged.tensor_permute_l
 
-tensor_movedim_ll
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-tensor_movedim_ll = cast3 Unmanaged.tensor_movedim_ll
-
--- tensor_movedim_ll
---   :: ForeignPtr Tensor
---   -> Int64
---   -> Int64
---   -> IO (ForeignPtr Tensor)
--- tensor_movedim_ll = cast3 Unmanaged.tensor_movedim_ll
-
-tensor_moveaxis_ll
-  :: ForeignPtr Tensor
-  -> ForeignPtr IntArray
-  -> ForeignPtr IntArray
-  -> IO (ForeignPtr Tensor)
-tensor_moveaxis_ll = cast3 Unmanaged.tensor_moveaxis_ll
-
--- tensor_moveaxis_ll
---   :: ForeignPtr Tensor
---   -> Int64
---   -> Int64
---   -> IO (ForeignPtr Tensor)
--- tensor_moveaxis_ll = cast3 Unmanaged.tensor_moveaxis_ll
-
 tensor_numpy_T
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
@@ -1200,4 +1172,51 @@ tensor_hardshrink_s
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
 tensor_hardshrink_s = cast2 Unmanaged.tensor_hardshrink_s
+
+tensor_hardshrink_backward_ts
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_hardshrink_backward_ts = cast3 Unmanaged.tensor_hardshrink_backward_ts
+
+tensor_rsqrt
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_rsqrt = cast1 Unmanaged.tensor_rsqrt
+
+tensor_rsqrt_
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_rsqrt_ = cast1 Unmanaged.tensor_rsqrt_
+
+tensor_select_nl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Dimname
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+tensor_select_nl = cast3 Unmanaged.tensor_select_nl
+
+tensor_select_ll
+  :: ForeignPtr Tensor
+  -> Int64
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+tensor_select_ll = cast3 Unmanaged.tensor_select_ll
+
+tensor_sigmoid
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_sigmoid = cast1 Unmanaged.tensor_sigmoid
+
+tensor_sigmoid_
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_sigmoid_ = cast1 Unmanaged.tensor_sigmoid_
+
+tensor_logit_d
+  :: ForeignPtr Tensor
+  -> CDouble
+  -> IO (ForeignPtr Tensor)
+tensor_logit_d = cast2 Unmanaged.tensor_logit_d
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Type/Tensor/Tensor2.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Type/Tensor/Tensor2.hs
@@ -24,53 +24,6 @@ import qualified Torch.Internal.Unmanaged.Type.Tensor.Tensor2 as Unmanaged
 
 
 
-tensor_hardshrink_backward_ts
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> ForeignPtr Scalar
-  -> IO (ForeignPtr Tensor)
-tensor_hardshrink_backward_ts = cast3 Unmanaged.tensor_hardshrink_backward_ts
-
-tensor_rsqrt
-  :: ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-tensor_rsqrt = cast1 Unmanaged.tensor_rsqrt
-
-tensor_rsqrt_
-  :: ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-tensor_rsqrt_ = cast1 Unmanaged.tensor_rsqrt_
-
-tensor_select_nl
-  :: ForeignPtr Tensor
-  -> ForeignPtr Dimname
-  -> Int64
-  -> IO (ForeignPtr Tensor)
-tensor_select_nl = cast3 Unmanaged.tensor_select_nl
-
-tensor_select_ll
-  :: ForeignPtr Tensor
-  -> Int64
-  -> Int64
-  -> IO (ForeignPtr Tensor)
-tensor_select_ll = cast3 Unmanaged.tensor_select_ll
-
-tensor_sigmoid
-  :: ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-tensor_sigmoid = cast1 Unmanaged.tensor_sigmoid
-
-tensor_sigmoid_
-  :: ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-tensor_sigmoid_ = cast1 Unmanaged.tensor_sigmoid_
-
-tensor_logit_d
-  :: ForeignPtr Tensor
-  -> CDouble
-  -> IO (ForeignPtr Tensor)
-tensor_logit_d = cast2 Unmanaged.tensor_logit_d
-
 tensor_logit__d
   :: ForeignPtr Tensor
   -> CDouble
@@ -336,6 +289,14 @@ tensor_std_lbb
   -> IO (ForeignPtr Tensor)
 tensor_std_lbb = cast4 Unmanaged.tensor_std_lbb
 
+tensor_std_llb
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> Int64
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+tensor_std_llb = cast4 Unmanaged.tensor_std_llb
+
 tensor_std_Nbb
   :: ForeignPtr Tensor
   -> ForeignPtr DimnameList
@@ -343,6 +304,14 @@ tensor_std_Nbb
   -> CBool
   -> IO (ForeignPtr Tensor)
 tensor_std_Nbb = cast4 Unmanaged.tensor_std_Nbb
+
+tensor_std_Nlb
+  :: ForeignPtr Tensor
+  -> ForeignPtr DimnameList
+  -> Int64
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+tensor_std_Nlb = cast4 Unmanaged.tensor_std_Nlb
 
 tensor_prod_s
   :: ForeignPtr Tensor
@@ -505,6 +474,14 @@ tensor_var_lbb
   -> IO (ForeignPtr Tensor)
 tensor_var_lbb = cast4 Unmanaged.tensor_var_lbb
 
+tensor_var_llb
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> Int64
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+tensor_var_llb = cast4 Unmanaged.tensor_var_llb
+
 tensor_var_Nbb
   :: ForeignPtr Tensor
   -> ForeignPtr DimnameList
@@ -512,6 +489,14 @@ tensor_var_Nbb
   -> CBool
   -> IO (ForeignPtr Tensor)
 tensor_var_Nbb = cast4 Unmanaged.tensor_var_Nbb
+
+tensor_var_Nlb
+  :: ForeignPtr Tensor
+  -> ForeignPtr DimnameList
+  -> Int64
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+tensor_var_Nlb = cast4 Unmanaged.tensor_var_Nlb
 
 tensor_view_as_t
   :: ForeignPtr Tensor
@@ -573,11 +558,21 @@ tensor_norm_sNb
   -> IO (ForeignPtr Tensor)
 tensor_norm_sNb = cast4 Unmanaged.tensor_norm_sNb
 
+tensor_frexp
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+tensor_frexp = cast1 Unmanaged.tensor_frexp
+
 tensor_clone_M
   :: ForeignPtr Tensor
   -> MemoryFormat
   -> IO (ForeignPtr Tensor)
 tensor_clone_M = cast2 Unmanaged.tensor_clone_M
+
+tensor_positive
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_positive = cast1 Unmanaged.tensor_positive
 
 tensor_resize_as__tM
   :: ForeignPtr Tensor
@@ -765,6 +760,16 @@ tensor_values
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
 tensor_values = cast1 Unmanaged.tensor_values
+
+tensor_crow_indices
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_crow_indices = cast1 Unmanaged.tensor_crow_indices
+
+tensor_col_indices
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_col_indices = cast1 Unmanaged.tensor_col_indices
 
 tensor_unbind_l
   :: ForeignPtr Tensor
@@ -971,6 +976,14 @@ tensor_put__ttb
   -> IO (ForeignPtr Tensor)
 tensor_put__ttb = cast4 Unmanaged.tensor_put__ttb
 
+tensor_put_ttb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+tensor_put_ttb = cast4 Unmanaged.tensor_put_ttb
+
 tensor_index_add__ltt
   :: ForeignPtr Tensor
   -> Int64
@@ -978,6 +991,15 @@ tensor_index_add__ltt
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
 tensor_index_add__ltt = cast4 Unmanaged.tensor_index_add__ltt
+
+tensor_index_add__ltts
+  :: ForeignPtr Tensor
+  -> Int64
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_index_add__ltts = cast5 Unmanaged.tensor_index_add__ltts
 
 tensor_index_add_ltt
   :: ForeignPtr Tensor
@@ -987,13 +1009,23 @@ tensor_index_add_ltt
   -> IO (ForeignPtr Tensor)
 tensor_index_add_ltt = cast4 Unmanaged.tensor_index_add_ltt
 
-tensor_index_add_ntt
+tensor_index_add_ltts
+  :: ForeignPtr Tensor
+  -> Int64
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_index_add_ltts = cast5 Unmanaged.tensor_index_add_ltts
+
+tensor_index_add_ntts
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_index_add_ntt = cast4 Unmanaged.tensor_index_add_ntt
+tensor_index_add_ntts = cast5 Unmanaged.tensor_index_add_ntts
 
 tensor_index_fill__lts
   :: ForeignPtr Tensor
@@ -1244,10 +1276,4 @@ tensor___or___t
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
 tensor___or___t = cast2 Unmanaged.tensor___or___t
-
-tensor___ior___s
-  :: ForeignPtr Tensor
-  -> ForeignPtr Scalar
-  -> IO (ForeignPtr Tensor)
-tensor___ior___s = cast2 Unmanaged.tensor___ior___s
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Type/Tensor/Tensor3.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Type/Tensor/Tensor3.hs
@@ -24,6 +24,12 @@ import qualified Torch.Internal.Unmanaged.Type.Tensor.Tensor3 as Unmanaged
 
 
 
+tensor___ior___s
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor___ior___s = cast2 Unmanaged.tensor___ior___s
+
 tensor___ior___t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
@@ -126,12 +132,6 @@ tensor___irshift___t
   -> IO (ForeignPtr Tensor)
 tensor___irshift___t = cast2 Unmanaged.tensor___irshift___t
 
-tensor_atan2__t
-  :: ForeignPtr Tensor
-  -> ForeignPtr Tensor
-  -> IO (ForeignPtr Tensor)
-tensor_atan2__t = cast2 Unmanaged.tensor_atan2__t
-
 tensor_tril__l
   :: ForeignPtr Tensor
   -> Int64
@@ -148,12 +148,6 @@ tensor_digamma_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
 tensor_digamma_ = cast1 Unmanaged.tensor_digamma_
-
-tensor_polygamma__l
-  :: ForeignPtr Tensor
-  -> Int64
-  -> IO (ForeignPtr Tensor)
-tensor_polygamma__l = cast2 Unmanaged.tensor_polygamma__l
 
 tensor_renorm__sls
   :: ForeignPtr Tensor
@@ -574,6 +568,13 @@ tensor_take_t
   -> IO (ForeignPtr Tensor)
 tensor_take_t = cast2 Unmanaged.tensor_take_t
 
+tensor_take_along_dim_tl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+tensor_take_along_dim_tl = cast3 Unmanaged.tensor_take_along_dim_tl
+
 tensor_index_select_lt
   :: ForeignPtr Tensor
   -> Int64
@@ -788,11 +789,11 @@ tensor_digamma
   -> IO (ForeignPtr Tensor)
 tensor_digamma = cast1 Unmanaged.tensor_digamma
 
--- tensor_polygamma_t
---   :: ForeignPtr Tensor
---   -> ForeignPtr Tensor
---   -> IO (ForeignPtr Tensor)
--- tensor_polygamma_t = cast2 Unmanaged.tensor_polygamma_t
+tensor_polygamma__l
+  :: ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+tensor_polygamma__l = cast2 Unmanaged.tensor_polygamma__l
 
 tensor_erfinv
   :: ForeignPtr Tensor
@@ -835,6 +836,12 @@ tensor_dist_ts
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
 tensor_dist_ts = cast3 Unmanaged.tensor_dist_ts
+
+tensor_atan2__t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_atan2__t = cast2 Unmanaged.tensor_atan2__t
 
 tensor_atan2_t
   :: ForeignPtr Tensor
@@ -1014,6 +1021,42 @@ tensor_nanquantile_tlb
   -> IO (ForeignPtr Tensor)
 tensor_nanquantile_tlb = cast4 Unmanaged.tensor_nanquantile_tlb
 
+tensor_quantile_dlbs
+  :: ForeignPtr Tensor
+  -> CDouble
+  -> Int64
+  -> CBool
+  -> ForeignPtr StdString
+  -> IO (ForeignPtr Tensor)
+tensor_quantile_dlbs = cast5 Unmanaged.tensor_quantile_dlbs
+
+tensor_quantile_tlbs
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> CBool
+  -> ForeignPtr StdString
+  -> IO (ForeignPtr Tensor)
+tensor_quantile_tlbs = cast5 Unmanaged.tensor_quantile_tlbs
+
+tensor_nanquantile_dlbs
+  :: ForeignPtr Tensor
+  -> CDouble
+  -> Int64
+  -> CBool
+  -> ForeignPtr StdString
+  -> IO (ForeignPtr Tensor)
+tensor_nanquantile_dlbs = cast5 Unmanaged.tensor_nanquantile_dlbs
+
+tensor_nanquantile_tlbs
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> CBool
+  -> ForeignPtr StdString
+  -> IO (ForeignPtr Tensor)
+tensor_nanquantile_tlbs = cast5 Unmanaged.tensor_nanquantile_tlbs
+
 tensor_sort_lb
   :: ForeignPtr Tensor
   -> Int64
@@ -1021,12 +1064,28 @@ tensor_sort_lb
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
 tensor_sort_lb = cast3 Unmanaged.tensor_sort_lb
 
+tensor_sort_blb
+  :: ForeignPtr Tensor
+  -> CBool
+  -> Int64
+  -> CBool
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+tensor_sort_blb = cast4 Unmanaged.tensor_sort_blb
+
 tensor_sort_nb
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
 tensor_sort_nb = cast3 Unmanaged.tensor_sort_nb
+
+tensor_sort_bnb
+  :: ForeignPtr Tensor
+  -> CBool
+  -> ForeignPtr Dimname
+  -> CBool
+  -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
+tensor_sort_bnb = cast4 Unmanaged.tensor_sort_bnb
 
 tensor_msort
   :: ForeignPtr Tensor

--- a/libtorch-ffi/src/Torch/Internal/Objects.hs
+++ b/libtorch-ffi/src/Torch/Internal/Objects.hs
@@ -290,3 +290,15 @@ foreign import ccall unsafe "hasktorch_finalizer.h &delete_stream"
 
 instance CppObject Stream where
   fromPtr ptr = newForeignPtr c_delete_stream ptr
+
+foreign import ccall unsafe "hasktorch_finalizer.h &delete_arrayrefscalar"
+  c_delete_arrayrefscalar :: FunPtr ( Ptr (ArrayRef Scalar) -> IO ())
+
+instance CppObject (ArrayRef Scalar) where
+  fromPtr ptr = newForeignPtr c_delete_arrayrefscalar ptr
+
+foreign import ccall unsafe "hasktorch_finalizer.h &delete_vectorscalar"
+  c_delete_vectorscalar :: FunPtr ( Ptr (StdVector Scalar) -> IO ())
+
+instance CppObject (StdVector Scalar) where
+  fromPtr ptr = newForeignPtr c_delete_vectorscalar ptr

--- a/libtorch-ffi/src/Torch/Internal/Type.hs
+++ b/libtorch-ffi/src/Torch/Internal/Type.hs
@@ -132,5 +132,6 @@ typeTable = Map.fromList [
       , (C.TypeName "at::indexing::TensorIndex", [t|TensorIndex|])
       , (C.TypeName "torch::optim::Optimizer", [t|Optimizer|])
       , (C.TypeName "ArrayRef", [t|ArrayRef|])
+      , (C.TypeName "at::ArrayRef", [t|ArrayRef|])
     ]
 

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native0.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native0.hs
@@ -202,6 +202,14 @@ align_tensors_l _tensors =
     *$(std::vector<at::Tensor>* _tensors)));
   }|]
 
+_assert_async_t
+  :: Ptr Tensor
+  -> IO (())
+_assert_async_t _self =
+  [C.throwBlock| void {  (at::_assert_async(
+    *$(at::Tensor* _self)));
+  }|]
+
 _use_cudnn_ctc_loss_ttlll
   :: Ptr Tensor
   -> Ptr Tensor
@@ -236,6 +244,13 @@ _cudnn_ctc_loss_ttlllbb _log_probs _targets _input_lengths _target_lengths _blan
   , $(int64_t _blank)
   , $(bool _deterministic)
   , $(bool _zero_infinity)));
+  }|]
+
+_use_cudnn_rnn_flatten_weight
+  :: IO (CBool)
+_use_cudnn_rnn_flatten_weight  =
+  [C.throwBlock| bool { return (at::_use_cudnn_rnn_flatten_weight(
+    ));
   }|]
 
 _cudnn_rnn_flatten_weight_lllllllbb
@@ -1128,54 +1143,6 @@ addmv_out_tttt _out _self _mat _vec =
   , *$(at::Tensor* _vec)));
   }|]
 
-_addmv_impl__ttttss
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Scalar
-  -> Ptr Scalar
-  -> IO (Ptr Tensor)
-_addmv_impl__ttttss _self _self2 _mat _vec _beta _alpha =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_addmv_impl_(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _self2)
-  , *$(at::Tensor* _mat)
-  , *$(at::Tensor* _vec)
-  , *$(at::Scalar* _beta)
-  , *$(at::Scalar* _alpha)));
-  }|]
-
-_addmv_impl__tttts
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Scalar
-  -> IO (Ptr Tensor)
-_addmv_impl__tttts _self _self2 _mat _vec _beta =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_addmv_impl_(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _self2)
-  , *$(at::Tensor* _mat)
-  , *$(at::Tensor* _vec)
-  , *$(at::Scalar* _beta)));
-  }|]
-
-_addmv_impl__tttt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-_addmv_impl__tttt _self _self2 _mat _vec =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_addmv_impl_(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _self2)
-  , *$(at::Tensor* _mat)
-  , *$(at::Tensor* _vec)));
-  }|]
-
 addr_tttss
   :: Ptr Tensor
   -> Ptr Tensor
@@ -2026,5 +1993,187 @@ arcsin__t
 arcsin__t _self =
   [C.throwBlock| at::Tensor* { return new at::Tensor(at::arcsin_(
     *$(at::Tensor* _self)));
+  }|]
+
+arcsin_out_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+arcsin_out_tt _out _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::arcsin_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)));
+  }|]
+
+atan_t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+atan_t _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::atan(
+    *$(at::Tensor* _self)));
+  }|]
+
+atan__t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+atan__t _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::atan_(
+    *$(at::Tensor* _self)));
+  }|]
+
+atan_out_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+atan_out_tt _out _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::atan_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)));
+  }|]
+
+arctan_t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+arctan_t _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::arctan(
+    *$(at::Tensor* _self)));
+  }|]
+
+arctan__t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+arctan__t _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::arctan_(
+    *$(at::Tensor* _self)));
+  }|]
+
+arctan_out_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+arctan_out_tt _out _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::arctan_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)));
+  }|]
+
+atleast_1d_t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+atleast_1d_t _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::atleast_1d(
+    *$(at::Tensor* _self)));
+  }|]
+
+atleast_1d_l
+  :: Ptr TensorList
+  -> IO (Ptr TensorList)
+atleast_1d_l _tensors =
+  [C.throwBlock| std::vector<at::Tensor>* { return new std::vector<at::Tensor>(at::atleast_1d(
+    *$(std::vector<at::Tensor>* _tensors)));
+  }|]
+
+atleast_2d_t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+atleast_2d_t _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::atleast_2d(
+    *$(at::Tensor* _self)));
+  }|]
+
+atleast_2d_l
+  :: Ptr TensorList
+  -> IO (Ptr TensorList)
+atleast_2d_l _tensors =
+  [C.throwBlock| std::vector<at::Tensor>* { return new std::vector<at::Tensor>(at::atleast_2d(
+    *$(std::vector<at::Tensor>* _tensors)));
+  }|]
+
+atleast_3d_t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+atleast_3d_t _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::atleast_3d(
+    *$(at::Tensor* _self)));
+  }|]
+
+atleast_3d_l
+  :: Ptr TensorList
+  -> IO (Ptr TensorList)
+atleast_3d_l _tensors =
+  [C.throwBlock| std::vector<at::Tensor>* { return new std::vector<at::Tensor>(at::atleast_3d(
+    *$(std::vector<at::Tensor>* _tensors)));
+  }|]
+
+baddbmm_tttss
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+baddbmm_tttss _self _batch1 _batch2 _beta _alpha =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::baddbmm(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _batch1)
+  , *$(at::Tensor* _batch2)
+  , *$(at::Scalar* _beta)
+  , *$(at::Scalar* _alpha)));
+  }|]
+
+baddbmm_ttts
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+baddbmm_ttts _self _batch1 _batch2 _beta =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::baddbmm(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _batch1)
+  , *$(at::Tensor* _batch2)
+  , *$(at::Scalar* _beta)));
+  }|]
+
+baddbmm_ttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+baddbmm_ttt _self _batch1 _batch2 =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::baddbmm(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _batch1)
+  , *$(at::Tensor* _batch2)));
+  }|]
+
+_baddbmm_mkl__tttss
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+_baddbmm_mkl__tttss _self _batch1 _batch2 _beta _alpha =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_baddbmm_mkl_(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _batch1)
+  , *$(at::Tensor* _batch2)
+  , *$(at::Scalar* _beta)
+  , *$(at::Scalar* _alpha)));
+  }|]
+
+_baddbmm_mkl__ttts
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+_baddbmm_mkl__ttts _self _batch1 _batch2 _beta =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_baddbmm_mkl_(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _batch1)
+  , *$(at::Tensor* _batch2)
+  , *$(at::Scalar* _beta)));
   }|]
 

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native1.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native1.hs
@@ -28,188 +28,6 @@ C.include "<ATen/Tensor.h>"
 C.include "<ATen/Functions.h>"
 
 
-arcsin_out_tt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-arcsin_out_tt _out _self =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::arcsin_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)));
-  }|]
-
-atan_t
-  :: Ptr Tensor
-  -> IO (Ptr Tensor)
-atan_t _self =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::atan(
-    *$(at::Tensor* _self)));
-  }|]
-
-atan__t
-  :: Ptr Tensor
-  -> IO (Ptr Tensor)
-atan__t _self =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::atan_(
-    *$(at::Tensor* _self)));
-  }|]
-
-atan_out_tt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-atan_out_tt _out _self =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::atan_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)));
-  }|]
-
-arctan_t
-  :: Ptr Tensor
-  -> IO (Ptr Tensor)
-arctan_t _self =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::arctan(
-    *$(at::Tensor* _self)));
-  }|]
-
-arctan__t
-  :: Ptr Tensor
-  -> IO (Ptr Tensor)
-arctan__t _self =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::arctan_(
-    *$(at::Tensor* _self)));
-  }|]
-
-arctan_out_tt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-arctan_out_tt _out _self =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::arctan_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)));
-  }|]
-
-atleast_1d_t
-  :: Ptr Tensor
-  -> IO (Ptr Tensor)
-atleast_1d_t _self =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::atleast_1d(
-    *$(at::Tensor* _self)));
-  }|]
-
-atleast_1d_l
-  :: Ptr TensorList
-  -> IO (Ptr TensorList)
-atleast_1d_l _tensors =
-  [C.throwBlock| std::vector<at::Tensor>* { return new std::vector<at::Tensor>(at::atleast_1d(
-    *$(std::vector<at::Tensor>* _tensors)));
-  }|]
-
-atleast_2d_t
-  :: Ptr Tensor
-  -> IO (Ptr Tensor)
-atleast_2d_t _self =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::atleast_2d(
-    *$(at::Tensor* _self)));
-  }|]
-
-atleast_2d_l
-  :: Ptr TensorList
-  -> IO (Ptr TensorList)
-atleast_2d_l _tensors =
-  [C.throwBlock| std::vector<at::Tensor>* { return new std::vector<at::Tensor>(at::atleast_2d(
-    *$(std::vector<at::Tensor>* _tensors)));
-  }|]
-
-atleast_3d_t
-  :: Ptr Tensor
-  -> IO (Ptr Tensor)
-atleast_3d_t _self =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::atleast_3d(
-    *$(at::Tensor* _self)));
-  }|]
-
-atleast_3d_l
-  :: Ptr TensorList
-  -> IO (Ptr TensorList)
-atleast_3d_l _tensors =
-  [C.throwBlock| std::vector<at::Tensor>* { return new std::vector<at::Tensor>(at::atleast_3d(
-    *$(std::vector<at::Tensor>* _tensors)));
-  }|]
-
-baddbmm_tttss
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Scalar
-  -> Ptr Scalar
-  -> IO (Ptr Tensor)
-baddbmm_tttss _self _batch1 _batch2 _beta _alpha =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::baddbmm(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _batch1)
-  , *$(at::Tensor* _batch2)
-  , *$(at::Scalar* _beta)
-  , *$(at::Scalar* _alpha)));
-  }|]
-
-baddbmm_ttts
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Scalar
-  -> IO (Ptr Tensor)
-baddbmm_ttts _self _batch1 _batch2 _beta =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::baddbmm(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _batch1)
-  , *$(at::Tensor* _batch2)
-  , *$(at::Scalar* _beta)));
-  }|]
-
-baddbmm_ttt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-baddbmm_ttt _self _batch1 _batch2 =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::baddbmm(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _batch1)
-  , *$(at::Tensor* _batch2)));
-  }|]
-
-_baddbmm_mkl__tttss
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Scalar
-  -> Ptr Scalar
-  -> IO (Ptr Tensor)
-_baddbmm_mkl__tttss _self _batch1 _batch2 _beta _alpha =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_baddbmm_mkl_(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _batch1)
-  , *$(at::Tensor* _batch2)
-  , *$(at::Scalar* _beta)
-  , *$(at::Scalar* _alpha)));
-  }|]
-
-_baddbmm_mkl__ttts
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Scalar
-  -> IO (Ptr Tensor)
-_baddbmm_mkl__ttts _self _batch1 _batch2 _beta =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_baddbmm_mkl_(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _batch1)
-  , *$(at::Tensor* _batch2)
-  , *$(at::Scalar* _beta)));
-  }|]
-
 _baddbmm_mkl__ttt
   :: Ptr Tensor
   -> Ptr Tensor
@@ -814,16 +632,6 @@ bitwise_not_out_tt _out _self =
   , *$(at::Tensor* _self)));
   }|]
 
-copysign_tt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-copysign_tt _self _other =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::copysign(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _other)));
-  }|]
-
 copysign_out_ttt
   :: Ptr Tensor
   -> Ptr Tensor
@@ -836,6 +644,16 @@ copysign_out_ttt _out _self _other =
   , *$(at::Tensor* _other)));
   }|]
 
+copysign_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+copysign_tt _self _other =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::copysign(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _other)));
+  }|]
+
 copysign_ts
   :: Ptr Tensor
   -> Ptr Scalar
@@ -843,6 +661,18 @@ copysign_ts
 copysign_ts _self _other =
   [C.throwBlock| at::Tensor* { return new at::Tensor(at::copysign(
     *$(at::Tensor* _self)
+  , *$(at::Scalar* _other)));
+  }|]
+
+copysign_out_tts
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+copysign_out_tts _out _self _other =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::copysign_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
   , *$(at::Scalar* _other)));
   }|]
 
@@ -1162,6 +992,16 @@ chain_matmul_l _matrices =
     *$(std::vector<at::Tensor>* _matrices)));
   }|]
 
+chain_matmul_out_tl
+  :: Ptr Tensor
+  -> Ptr TensorList
+  -> IO (Ptr Tensor)
+chain_matmul_out_tl _out _matrices =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::chain_matmul_out(
+    *$(at::Tensor* _out)
+  , *$(std::vector<at::Tensor>* _matrices)));
+  }|]
+
 unsafe_chunk_tll
   :: Ptr Tensor
   -> Int64
@@ -1280,6 +1120,28 @@ clamp_t _self =
     *$(at::Tensor* _self)));
   }|]
 
+clamp_ttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+clamp_ttt _self _min _max =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::clamp(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _min)
+  , *$(at::Tensor* _max)));
+  }|]
+
+clamp_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+clamp_tt _self _min =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::clamp(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _min)));
+  }|]
+
 clamp__tss
   :: Ptr Tensor
   -> Ptr Scalar
@@ -1308,6 +1170,28 @@ clamp__t
 clamp__t _self =
   [C.throwBlock| at::Tensor* { return new at::Tensor(at::clamp_(
     *$(at::Tensor* _self)));
+  }|]
+
+clamp__ttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+clamp__ttt _self _min _max =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::clamp_(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _min)
+  , *$(at::Tensor* _max)));
+  }|]
+
+clamp__tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+clamp__tt _self _min =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::clamp_(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _min)));
   }|]
 
 clamp_out_ttss
@@ -1346,6 +1230,32 @@ clamp_out_tt _out _self =
   , *$(at::Tensor* _self)));
   }|]
 
+clamp_out_tttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+clamp_out_tttt _out _self _min _max =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::clamp_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _min)
+  , *$(at::Tensor* _max)));
+  }|]
+
+clamp_out_ttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+clamp_out_ttt _out _self _min =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::clamp_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _min)));
+  }|]
+
 clamp_max_ts
   :: Ptr Tensor
   -> Ptr Scalar
@@ -1356,6 +1266,16 @@ clamp_max_ts _self _max =
   , *$(at::Scalar* _max)));
   }|]
 
+clamp_max_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+clamp_max_tt _self _max =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::clamp_max(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _max)));
+  }|]
+
 clamp_max__ts
   :: Ptr Tensor
   -> Ptr Scalar
@@ -1364,6 +1284,16 @@ clamp_max__ts _self _max =
   [C.throwBlock| at::Tensor* { return new at::Tensor(at::clamp_max_(
     *$(at::Tensor* _self)
   , *$(at::Scalar* _max)));
+  }|]
+
+clamp_max__tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+clamp_max__tt _self _max =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::clamp_max_(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _max)));
   }|]
 
 clamp_max_out_tts
@@ -1378,6 +1308,18 @@ clamp_max_out_tts _out _self _max =
   , *$(at::Scalar* _max)));
   }|]
 
+clamp_max_out_ttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+clamp_max_out_ttt _out _self _max =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::clamp_max_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _max)));
+  }|]
+
 clamp_min_ts
   :: Ptr Tensor
   -> Ptr Scalar
@@ -1386,6 +1328,16 @@ clamp_min_ts _self _min =
   [C.throwBlock| at::Tensor* { return new at::Tensor(at::clamp_min(
     *$(at::Tensor* _self)
   , *$(at::Scalar* _min)));
+  }|]
+
+clamp_min_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+clamp_min_tt _self _min =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::clamp_min(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _min)));
   }|]
 
 clamp_min__ts
@@ -1398,6 +1350,16 @@ clamp_min__ts _self _min =
   , *$(at::Scalar* _min)));
   }|]
 
+clamp_min__tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+clamp_min__tt _self _min =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::clamp_min_(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _min)));
+  }|]
+
 clamp_min_out_tts
   :: Ptr Tensor
   -> Ptr Tensor
@@ -1408,6 +1370,18 @@ clamp_min_out_tts _out _self _min =
     *$(at::Tensor* _out)
   , *$(at::Tensor* _self)
   , *$(at::Scalar* _min)));
+  }|]
+
+clamp_min_out_ttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+clamp_min_out_ttt _out _self _min =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::clamp_min_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _min)));
   }|]
 
 clip_tss
@@ -1440,6 +1414,28 @@ clip_t _self =
     *$(at::Tensor* _self)));
   }|]
 
+clip_ttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+clip_ttt _self _min _max =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::clip(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _min)
+  , *$(at::Tensor* _max)));
+  }|]
+
+clip_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+clip_tt _self _min =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::clip(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _min)));
+  }|]
+
 clip__tss
   :: Ptr Tensor
   -> Ptr Scalar
@@ -1468,6 +1464,28 @@ clip__t
 clip__t _self =
   [C.throwBlock| at::Tensor* { return new at::Tensor(at::clip_(
     *$(at::Tensor* _self)));
+  }|]
+
+clip__ttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+clip__ttt _self _min _max =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::clip_(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _min)
+  , *$(at::Tensor* _max)));
+  }|]
+
+clip__tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+clip__tt _self _min =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::clip_(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _min)));
   }|]
 
 clip_out_ttss
@@ -1504,6 +1522,32 @@ clip_out_tt _out _self =
   [C.throwBlock| at::Tensor* { return new at::Tensor(at::clip_out(
     *$(at::Tensor* _out)
   , *$(at::Tensor* _self)));
+  }|]
+
+clip_out_tttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+clip_out_tttt _out _self _min _max =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::clip_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _min)
+  , *$(at::Tensor* _max)));
+  }|]
+
+clip_out_ttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+clip_out_ttt _out _self _min =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::clip_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _min)));
   }|]
 
 cudnn_is_acceptable_t
@@ -1714,6 +1758,26 @@ _convolution_tttlllbllbbb _input _weight _bias _stride _padding _dilation _trans
   , $(bool _benchmark)
   , $(bool _deterministic)
   , $(bool _cudnn_enabled)));
+  }|]
+
+_convolution_mode_tttlsll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr StdString
+  -> Ptr IntArray
+  -> Int64
+  -> IO (Ptr Tensor)
+_convolution_mode_tttlsll _input _weight _bias _stride _padding _dilation _groups =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_convolution_mode(
+    *$(at::Tensor* _input)
+  , *$(at::Tensor* _weight)
+  , *$(at::Tensor* _bias)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::string* _padding)
+  , *$(std::vector<int64_t>* _dilation)
+  , $(int64_t _groups)));
   }|]
 
 _convolution_nogroup_tttlllbl
@@ -2048,6 +2112,168 @@ conv3d_tt _input _weight =
   , *$(at::Tensor* _weight)));
   }|]
 
+conv1d_tttlsll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr StdString
+  -> Ptr IntArray
+  -> Int64
+  -> IO (Ptr Tensor)
+conv1d_tttlsll _input _weight _bias _stride _padding _dilation _groups =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::conv1d(
+    *$(at::Tensor* _input)
+  , *$(at::Tensor* _weight)
+  , *$(at::Tensor* _bias)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::string* _padding)
+  , *$(std::vector<int64_t>* _dilation)
+  , $(int64_t _groups)));
+  }|]
+
+conv1d_tttlsl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr StdString
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+conv1d_tttlsl _input _weight _bias _stride _padding _dilation =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::conv1d(
+    *$(at::Tensor* _input)
+  , *$(at::Tensor* _weight)
+  , *$(at::Tensor* _bias)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::string* _padding)
+  , *$(std::vector<int64_t>* _dilation)));
+  }|]
+
+conv1d_tttls
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr StdString
+  -> IO (Ptr Tensor)
+conv1d_tttls _input _weight _bias _stride _padding =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::conv1d(
+    *$(at::Tensor* _input)
+  , *$(at::Tensor* _weight)
+  , *$(at::Tensor* _bias)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::string* _padding)));
+  }|]
+
+conv2d_tttlsll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr StdString
+  -> Ptr IntArray
+  -> Int64
+  -> IO (Ptr Tensor)
+conv2d_tttlsll _input _weight _bias _stride _padding _dilation _groups =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::conv2d(
+    *$(at::Tensor* _input)
+  , *$(at::Tensor* _weight)
+  , *$(at::Tensor* _bias)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::string* _padding)
+  , *$(std::vector<int64_t>* _dilation)
+  , $(int64_t _groups)));
+  }|]
+
+conv2d_tttlsl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr StdString
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+conv2d_tttlsl _input _weight _bias _stride _padding _dilation =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::conv2d(
+    *$(at::Tensor* _input)
+  , *$(at::Tensor* _weight)
+  , *$(at::Tensor* _bias)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::string* _padding)
+  , *$(std::vector<int64_t>* _dilation)));
+  }|]
+
+conv2d_tttls
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr StdString
+  -> IO (Ptr Tensor)
+conv2d_tttls _input _weight _bias _stride _padding =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::conv2d(
+    *$(at::Tensor* _input)
+  , *$(at::Tensor* _weight)
+  , *$(at::Tensor* _bias)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::string* _padding)));
+  }|]
+
+conv3d_tttlsll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr StdString
+  -> Ptr IntArray
+  -> Int64
+  -> IO (Ptr Tensor)
+conv3d_tttlsll _input _weight _bias _stride _padding _dilation _groups =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::conv3d(
+    *$(at::Tensor* _input)
+  , *$(at::Tensor* _weight)
+  , *$(at::Tensor* _bias)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::string* _padding)
+  , *$(std::vector<int64_t>* _dilation)
+  , $(int64_t _groups)));
+  }|]
+
+conv3d_tttlsl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr StdString
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+conv3d_tttlsl _input _weight _bias _stride _padding _dilation =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::conv3d(
+    *$(at::Tensor* _input)
+  , *$(at::Tensor* _weight)
+  , *$(at::Tensor* _bias)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::string* _padding)
+  , *$(std::vector<int64_t>* _dilation)));
+  }|]
+
+conv3d_tttls
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr StdString
+  -> IO (Ptr Tensor)
+conv3d_tttls _input _weight _bias _stride _padding =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::conv3d(
+    *$(at::Tensor* _input)
+  , *$(at::Tensor* _weight)
+  , *$(at::Tensor* _bias)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::string* _padding)));
+  }|]
+
 conv_tbc_tttl
   :: Ptr Tensor
   -> Ptr Tensor
@@ -2060,167 +2286,5 @@ conv_tbc_tttl _self _weight _bias _pad =
   , *$(at::Tensor* _weight)
   , *$(at::Tensor* _bias)
   , $(int64_t _pad)));
-  }|]
-
-conv_tbc_ttt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-conv_tbc_ttt _self _weight _bias =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::conv_tbc(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(at::Tensor* _bias)));
-  }|]
-
-conv_tbc_backward_ttttl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Int64
-  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor)))
-conv_tbc_backward_ttttl _self _input _weight _bias _pad =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor>(at::conv_tbc_backward(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _input)
-  , *$(at::Tensor* _weight)
-  , *$(at::Tensor* _bias)
-  , $(int64_t _pad)));
-  }|]
-
-conv_transpose1d_tttlllll
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Int64
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-conv_transpose1d_tttlllll _input _weight _bias _stride _padding _output_padding _groups _dilation =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::conv_transpose1d(
-    *$(at::Tensor* _input)
-  , *$(at::Tensor* _weight)
-  , *$(at::Tensor* _bias)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)
-  , *$(std::vector<int64_t>* _output_padding)
-  , $(int64_t _groups)
-  , *$(std::vector<int64_t>* _dilation)));
-  }|]
-
-conv_transpose1d_tttllll
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Int64
-  -> IO (Ptr Tensor)
-conv_transpose1d_tttllll _input _weight _bias _stride _padding _output_padding _groups =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::conv_transpose1d(
-    *$(at::Tensor* _input)
-  , *$(at::Tensor* _weight)
-  , *$(at::Tensor* _bias)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)
-  , *$(std::vector<int64_t>* _output_padding)
-  , $(int64_t _groups)));
-  }|]
-
-conv_transpose1d_tttlll
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-conv_transpose1d_tttlll _input _weight _bias _stride _padding _output_padding =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::conv_transpose1d(
-    *$(at::Tensor* _input)
-  , *$(at::Tensor* _weight)
-  , *$(at::Tensor* _bias)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)
-  , *$(std::vector<int64_t>* _output_padding)));
-  }|]
-
-conv_transpose1d_tttll
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-conv_transpose1d_tttll _input _weight _bias _stride _padding =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::conv_transpose1d(
-    *$(at::Tensor* _input)
-  , *$(at::Tensor* _weight)
-  , *$(at::Tensor* _bias)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)));
-  }|]
-
-conv_transpose1d_tttl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-conv_transpose1d_tttl _input _weight _bias _stride =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::conv_transpose1d(
-    *$(at::Tensor* _input)
-  , *$(at::Tensor* _weight)
-  , *$(at::Tensor* _bias)
-  , *$(std::vector<int64_t>* _stride)));
-  }|]
-
-conv_transpose1d_ttt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-conv_transpose1d_ttt _input _weight _bias =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::conv_transpose1d(
-    *$(at::Tensor* _input)
-  , *$(at::Tensor* _weight)
-  , *$(at::Tensor* _bias)));
-  }|]
-
-conv_transpose1d_tt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-conv_transpose1d_tt _input _weight =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::conv_transpose1d(
-    *$(at::Tensor* _input)
-  , *$(at::Tensor* _weight)));
-  }|]
-
-conv_transpose2d_tttlllll
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Int64
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-conv_transpose2d_tttlllll _input _weight _bias _stride _padding _output_padding _groups _dilation =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::conv_transpose2d(
-    *$(at::Tensor* _input)
-  , *$(at::Tensor* _weight)
-  , *$(at::Tensor* _bias)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)
-  , *$(std::vector<int64_t>* _output_padding)
-  , $(int64_t _groups)
-  , *$(std::vector<int64_t>* _dilation)));
   }|]
 

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native10.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native10.hs
@@ -28,402 +28,6 @@ C.include "<ATen/Tensor.h>"
 C.include "<ATen/Functions.h>"
 
 
-symeig_out_tttbb
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> CBool
-  -> CBool
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-symeig_out_tttbb _e _V _self _eigenvectors _upper =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::symeig_out(
-    *$(at::Tensor* _e)
-  , *$(at::Tensor* _V)
-  , *$(at::Tensor* _self)
-  , $(bool _eigenvectors)
-  , $(bool _upper)));
-  }|]
-
-symeig_out_tttb
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> CBool
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-symeig_out_tttb _e _V _self _eigenvectors =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::symeig_out(
-    *$(at::Tensor* _e)
-  , *$(at::Tensor* _V)
-  , *$(at::Tensor* _self)
-  , $(bool _eigenvectors)));
-  }|]
-
-symeig_out_ttt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-symeig_out_ttt _e _V _self =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::symeig_out(
-    *$(at::Tensor* _e)
-  , *$(at::Tensor* _V)
-  , *$(at::Tensor* _self)));
-  }|]
-
-symeig_tbb
-  :: Ptr Tensor
-  -> CBool
-  -> CBool
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-symeig_tbb _self _eigenvectors _upper =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::symeig(
-    *$(at::Tensor* _self)
-  , $(bool _eigenvectors)
-  , $(bool _upper)));
-  }|]
-
-symeig_tb
-  :: Ptr Tensor
-  -> CBool
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-symeig_tb _self _eigenvectors =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::symeig(
-    *$(at::Tensor* _self)
-  , $(bool _eigenvectors)));
-  }|]
-
-symeig_t
-  :: Ptr Tensor
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-symeig_t _self =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::symeig(
-    *$(at::Tensor* _self)));
-  }|]
-
-_symeig_helper_tbb
-  :: Ptr Tensor
-  -> CBool
-  -> CBool
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-_symeig_helper_tbb _self _eigenvectors _upper =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::_symeig_helper(
-    *$(at::Tensor* _self)
-  , $(bool _eigenvectors)
-  , $(bool _upper)));
-  }|]
-
-eig_out_tttb
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> CBool
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-eig_out_tttb _e _v _self _eigenvectors =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::eig_out(
-    *$(at::Tensor* _e)
-  , *$(at::Tensor* _v)
-  , *$(at::Tensor* _self)
-  , $(bool _eigenvectors)));
-  }|]
-
-eig_out_ttt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-eig_out_ttt _e _v _self =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::eig_out(
-    *$(at::Tensor* _e)
-  , *$(at::Tensor* _v)
-  , *$(at::Tensor* _self)));
-  }|]
-
-eig_tb
-  :: Ptr Tensor
-  -> CBool
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-eig_tb _self _eigenvectors =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::eig(
-    *$(at::Tensor* _self)
-  , $(bool _eigenvectors)));
-  }|]
-
-eig_t
-  :: Ptr Tensor
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-eig_t _self =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::eig(
-    *$(at::Tensor* _self)));
-  }|]
-
-svd_out_ttttbb
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> CBool
-  -> CBool
-  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor)))
-svd_out_ttttbb _U _S _V _self _some _compute_uv =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor>(at::svd_out(
-    *$(at::Tensor* _U)
-  , *$(at::Tensor* _S)
-  , *$(at::Tensor* _V)
-  , *$(at::Tensor* _self)
-  , $(bool _some)
-  , $(bool _compute_uv)));
-  }|]
-
-svd_out_ttttb
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> CBool
-  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor)))
-svd_out_ttttb _U _S _V _self _some =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor>(at::svd_out(
-    *$(at::Tensor* _U)
-  , *$(at::Tensor* _S)
-  , *$(at::Tensor* _V)
-  , *$(at::Tensor* _self)
-  , $(bool _some)));
-  }|]
-
-svd_out_tttt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor)))
-svd_out_tttt _U _S _V _self =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor>(at::svd_out(
-    *$(at::Tensor* _U)
-  , *$(at::Tensor* _S)
-  , *$(at::Tensor* _V)
-  , *$(at::Tensor* _self)));
-  }|]
-
-svd_tbb
-  :: Ptr Tensor
-  -> CBool
-  -> CBool
-  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor)))
-svd_tbb _self _some _compute_uv =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor>(at::svd(
-    *$(at::Tensor* _self)
-  , $(bool _some)
-  , $(bool _compute_uv)));
-  }|]
-
-svd_tb
-  :: Ptr Tensor
-  -> CBool
-  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor)))
-svd_tb _self _some =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor>(at::svd(
-    *$(at::Tensor* _self)
-  , $(bool _some)));
-  }|]
-
-svd_t
-  :: Ptr Tensor
-  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor)))
-svd_t _self =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor>(at::svd(
-    *$(at::Tensor* _self)));
-  }|]
-
-_svd_helper_tbb
-  :: Ptr Tensor
-  -> CBool
-  -> CBool
-  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor)))
-_svd_helper_tbb _self _some _compute_uv =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor>(at::_svd_helper(
-    *$(at::Tensor* _self)
-  , $(bool _some)
-  , $(bool _compute_uv)));
-  }|]
-
-swapaxes_tll
-  :: Ptr Tensor
-  -> Int64
-  -> Int64
-  -> IO (Ptr Tensor)
-swapaxes_tll _self _axis0 _axis1 =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::swapaxes(
-    *$(at::Tensor* _self)
-  , $(int64_t _axis0)
-  , $(int64_t _axis1)));
-  }|]
-
-swapdims_tll
-  :: Ptr Tensor
-  -> Int64
-  -> Int64
-  -> IO (Ptr Tensor)
-swapdims_tll _self _dim0 _dim1 =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::swapdims(
-    *$(at::Tensor* _self)
-  , $(int64_t _dim0)
-  , $(int64_t _dim1)));
-  }|]
-
-cholesky_out_ttb
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> CBool
-  -> IO (Ptr Tensor)
-cholesky_out_ttb _out _self _upper =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::cholesky_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , $(bool _upper)));
-  }|]
-
-cholesky_out_tt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-cholesky_out_tt _out _self =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::cholesky_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)));
-  }|]
-
-cholesky_tb
-  :: Ptr Tensor
-  -> CBool
-  -> IO (Ptr Tensor)
-cholesky_tb _self _upper =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::cholesky(
-    *$(at::Tensor* _self)
-  , $(bool _upper)));
-  }|]
-
-cholesky_t
-  :: Ptr Tensor
-  -> IO (Ptr Tensor)
-cholesky_t _self =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::cholesky(
-    *$(at::Tensor* _self)));
-  }|]
-
-_cholesky_helper_tb
-  :: Ptr Tensor
-  -> CBool
-  -> IO (Ptr Tensor)
-_cholesky_helper_tb _self _upper =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_cholesky_helper(
-    *$(at::Tensor* _self)
-  , $(bool _upper)));
-  }|]
-
-cholesky_solve_out_tttb
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> CBool
-  -> IO (Ptr Tensor)
-cholesky_solve_out_tttb _out _self _input2 _upper =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::cholesky_solve_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _input2)
-  , $(bool _upper)));
-  }|]
-
-cholesky_solve_out_ttt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-cholesky_solve_out_ttt _out _self _input2 =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::cholesky_solve_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _input2)));
-  }|]
-
-cholesky_solve_ttb
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> CBool
-  -> IO (Ptr Tensor)
-cholesky_solve_ttb _self _input2 _upper =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::cholesky_solve(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _input2)
-  , $(bool _upper)));
-  }|]
-
-cholesky_solve_tt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-cholesky_solve_tt _self _input2 =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::cholesky_solve(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _input2)));
-  }|]
-
-_cholesky_solve_helper_ttb
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> CBool
-  -> IO (Ptr Tensor)
-_cholesky_solve_helper_ttb _self _A _upper =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_cholesky_solve_helper(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _A)
-  , $(bool _upper)));
-  }|]
-
-solve_tt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-solve_tt _self _A =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::solve(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _A)));
-  }|]
-
-solve_out_tttt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-solve_out_tttt _solution _lu _self _A =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::solve_out(
-    *$(at::Tensor* _solution)
-  , *$(at::Tensor* _lu)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _A)));
-  }|]
-
-_solve_helper_tt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-_solve_helper_tt _self _A =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::_solve_helper(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _A)));
-  }|]
-
-cholesky_inverse_tb
-  :: Ptr Tensor
-  -> CBool
-  -> IO (Ptr Tensor)
-cholesky_inverse_tb _self _upper =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::cholesky_inverse(
-    *$(at::Tensor* _self)
-  , $(bool _upper)));
-  }|]
-
 cholesky_inverse_t
   :: Ptr Tensor
   -> IO (Ptr Tensor)
@@ -518,6 +122,16 @@ geqrf_t _self =
     *$(at::Tensor* _self)));
   }|]
 
+orgqr_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+orgqr_tt _self _input2 =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::orgqr(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _input2)));
+  }|]
+
 orgqr_out_ttt
   :: Ptr Tensor
   -> Ptr Tensor
@@ -527,16 +141,6 @@ orgqr_out_ttt _out _self _input2 =
   [C.throwBlock| at::Tensor* { return new at::Tensor(at::orgqr_out(
     *$(at::Tensor* _out)
   , *$(at::Tensor* _self)
-  , *$(at::Tensor* _input2)));
-  }|]
-
-orgqr_tt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-orgqr_tt _self _input2 =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::orgqr(
-    *$(at::Tensor* _self)
   , *$(at::Tensor* _input2)));
   }|]
 
@@ -686,14 +290,92 @@ lu_solve_ttt _self _LU_data _LU_pivots =
   , *$(at::Tensor* _LU_pivots)));
   }|]
 
-_lu_solve_helper_ttt
+lu_unpack_ttbb
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> CBool
+  -> CBool
+  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor)))
+lu_unpack_ttbb _LU_data _LU_pivots _unpack_data _unpack_pivots =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor>(at::lu_unpack(
+    *$(at::Tensor* _LU_data)
+  , *$(at::Tensor* _LU_pivots)
+  , $(bool _unpack_data)
+  , $(bool _unpack_pivots)));
+  }|]
+
+lu_unpack_ttb
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> CBool
+  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor)))
+lu_unpack_ttb _LU_data _LU_pivots _unpack_data =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor>(at::lu_unpack(
+    *$(at::Tensor* _LU_data)
+  , *$(at::Tensor* _LU_pivots)
+  , $(bool _unpack_data)));
+  }|]
+
+lu_unpack_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor)))
+lu_unpack_tt _LU_data _LU_pivots =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor>(at::lu_unpack(
+    *$(at::Tensor* _LU_data)
+  , *$(at::Tensor* _LU_pivots)));
+  }|]
+
+lu_unpack_out_tttttbb
   :: Ptr Tensor
   -> Ptr Tensor
   -> Ptr Tensor
-  -> IO (Ptr Tensor)
-_lu_solve_helper_ttt _self _LU_data _LU_pivots =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_lu_solve_helper(
-    *$(at::Tensor* _self)
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> CBool
+  -> CBool
+  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor)))
+lu_unpack_out_tttttbb _P _L _U _LU_data _LU_pivots _unpack_data _unpack_pivots =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor>(at::lu_unpack_out(
+    *$(at::Tensor* _P)
+  , *$(at::Tensor* _L)
+  , *$(at::Tensor* _U)
+  , *$(at::Tensor* _LU_data)
+  , *$(at::Tensor* _LU_pivots)
+  , $(bool _unpack_data)
+  , $(bool _unpack_pivots)));
+  }|]
+
+lu_unpack_out_tttttb
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> CBool
+  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor)))
+lu_unpack_out_tttttb _P _L _U _LU_data _LU_pivots _unpack_data =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor>(at::lu_unpack_out(
+    *$(at::Tensor* _P)
+  , *$(at::Tensor* _L)
+  , *$(at::Tensor* _U)
+  , *$(at::Tensor* _LU_data)
+  , *$(at::Tensor* _LU_pivots)
+  , $(bool _unpack_data)));
+  }|]
+
+lu_unpack_out_ttttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor)))
+lu_unpack_out_ttttt _P _L _U _LU_data _LU_pivots =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor>(at::lu_unpack_out(
+    *$(at::Tensor* _P)
+  , *$(at::Tensor* _L)
+  , *$(at::Tensor* _U)
   , *$(at::Tensor* _LU_data)
   , *$(at::Tensor* _LU_pivots)));
   }|]
@@ -1742,6 +1424,142 @@ nanquantile_tt _self _q =
   , *$(at::Tensor* _q)));
   }|]
 
+quantile_out_ttdlbs
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> CDouble
+  -> Int64
+  -> CBool
+  -> Ptr StdString
+  -> IO (Ptr Tensor)
+quantile_out_ttdlbs _out _self _q _dim _keepdim _interpolation =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::quantile_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , $(double _q)
+  , $(int64_t _dim)
+  , $(bool _keepdim)
+  , *$(std::string* _interpolation)));
+  }|]
+
+quantile_tdlbs
+  :: Ptr Tensor
+  -> CDouble
+  -> Int64
+  -> CBool
+  -> Ptr StdString
+  -> IO (Ptr Tensor)
+quantile_tdlbs _self _q _dim _keepdim _interpolation =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::quantile(
+    *$(at::Tensor* _self)
+  , $(double _q)
+  , $(int64_t _dim)
+  , $(bool _keepdim)
+  , *$(std::string* _interpolation)));
+  }|]
+
+quantile_out_tttlbs
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> CBool
+  -> Ptr StdString
+  -> IO (Ptr Tensor)
+quantile_out_tttlbs _out _self _q _dim _keepdim _interpolation =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::quantile_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _q)
+  , $(int64_t _dim)
+  , $(bool _keepdim)
+  , *$(std::string* _interpolation)));
+  }|]
+
+quantile_ttlbs
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> CBool
+  -> Ptr StdString
+  -> IO (Ptr Tensor)
+quantile_ttlbs _self _q _dim _keepdim _interpolation =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::quantile(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _q)
+  , $(int64_t _dim)
+  , $(bool _keepdim)
+  , *$(std::string* _interpolation)));
+  }|]
+
+nanquantile_out_ttdlbs
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> CDouble
+  -> Int64
+  -> CBool
+  -> Ptr StdString
+  -> IO (Ptr Tensor)
+nanquantile_out_ttdlbs _out _self _q _dim _keepdim _interpolation =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::nanquantile_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , $(double _q)
+  , $(int64_t _dim)
+  , $(bool _keepdim)
+  , *$(std::string* _interpolation)));
+  }|]
+
+nanquantile_tdlbs
+  :: Ptr Tensor
+  -> CDouble
+  -> Int64
+  -> CBool
+  -> Ptr StdString
+  -> IO (Ptr Tensor)
+nanquantile_tdlbs _self _q _dim _keepdim _interpolation =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::nanquantile(
+    *$(at::Tensor* _self)
+  , $(double _q)
+  , $(int64_t _dim)
+  , $(bool _keepdim)
+  , *$(std::string* _interpolation)));
+  }|]
+
+nanquantile_out_tttlbs
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> CBool
+  -> Ptr StdString
+  -> IO (Ptr Tensor)
+nanquantile_out_tttlbs _out _self _q _dim _keepdim _interpolation =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::nanquantile_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _q)
+  , $(int64_t _dim)
+  , $(bool _keepdim)
+  , *$(std::string* _interpolation)));
+  }|]
+
+nanquantile_ttlbs
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> CBool
+  -> Ptr StdString
+  -> IO (Ptr Tensor)
+nanquantile_ttlbs _self _q _dim _keepdim _interpolation =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::nanquantile(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _q)
+  , $(int64_t _dim)
+  , $(bool _keepdim)
+  , *$(std::string* _interpolation)));
+  }|]
+
 sort_out_tttlb
   :: Ptr Tensor
   -> Ptr Tensor
@@ -1784,6 +1602,38 @@ sort_out_ttt _values _indices _self =
   , *$(at::Tensor* _self)));
   }|]
 
+sort_out_tttblb
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> CBool
+  -> Int64
+  -> CBool
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+sort_out_tttblb _values _indices _self _stable _dim _descending =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::sort_out(
+    *$(at::Tensor* _values)
+  , *$(at::Tensor* _indices)
+  , *$(at::Tensor* _self)
+  , $(bool _stable)
+  , $(int64_t _dim)
+  , $(bool _descending)));
+  }|]
+
+sort_out_tttb
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> CBool
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+sort_out_tttb _values _indices _self _stable =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::sort_out(
+    *$(at::Tensor* _values)
+  , *$(at::Tensor* _indices)
+  , *$(at::Tensor* _self)
+  , $(bool _stable)));
+  }|]
+
 sort_tlb
   :: Ptr Tensor
   -> Int64
@@ -1812,6 +1662,42 @@ sort_t
 sort_t _self =
   [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::sort(
     *$(at::Tensor* _self)));
+  }|]
+
+sort_tblb
+  :: Ptr Tensor
+  -> CBool
+  -> Int64
+  -> CBool
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+sort_tblb _self _stable _dim _descending =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::sort(
+    *$(at::Tensor* _self)
+  , $(bool _stable)
+  , $(int64_t _dim)
+  , $(bool _descending)));
+  }|]
+
+sort_tbl
+  :: Ptr Tensor
+  -> CBool
+  -> Int64
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+sort_tbl _self _stable _dim =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::sort(
+    *$(at::Tensor* _self)
+  , $(bool _stable)
+  , $(int64_t _dim)));
+  }|]
+
+sort_tb
+  :: Ptr Tensor
+  -> CBool
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+sort_tb _self _stable =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::sort(
+    *$(at::Tensor* _self)
+  , $(bool _stable)));
   }|]
 
 sort_out_tttnb
@@ -1844,6 +1730,40 @@ sort_out_tttn _values _indices _self _dim =
   , *$(at::Dimname* _dim)));
   }|]
 
+sort_out_tttbnb
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> CBool
+  -> Ptr Dimname
+  -> CBool
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+sort_out_tttbnb _values _indices _self _stable _dim _descending =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::sort_out(
+    *$(at::Tensor* _values)
+  , *$(at::Tensor* _indices)
+  , *$(at::Tensor* _self)
+  , $(bool _stable)
+  , *$(at::Dimname* _dim)
+  , $(bool _descending)));
+  }|]
+
+sort_out_tttbn
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> CBool
+  -> Ptr Dimname
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+sort_out_tttbn _values _indices _self _stable _dim =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::sort_out(
+    *$(at::Tensor* _values)
+  , *$(at::Tensor* _indices)
+  , *$(at::Tensor* _self)
+  , $(bool _stable)
+  , *$(at::Dimname* _dim)));
+  }|]
+
 sort_tnb
   :: Ptr Tensor
   -> Ptr Dimname
@@ -1863,6 +1783,32 @@ sort_tn
 sort_tn _self _dim =
   [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::sort(
     *$(at::Tensor* _self)
+  , *$(at::Dimname* _dim)));
+  }|]
+
+sort_tbnb
+  :: Ptr Tensor
+  -> CBool
+  -> Ptr Dimname
+  -> CBool
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+sort_tbnb _self _stable _dim _descending =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::sort(
+    *$(at::Tensor* _self)
+  , $(bool _stable)
+  , *$(at::Dimname* _dim)
+  , $(bool _descending)));
+  }|]
+
+sort_tbn
+  :: Ptr Tensor
+  -> CBool
+  -> Ptr Dimname
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+sort_tbn _self _stable _dim =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::sort(
+    *$(at::Tensor* _self)
+  , $(bool _stable)
   , *$(at::Dimname* _dim)));
   }|]
 
@@ -2054,5 +2000,323 @@ topk_tl _self _k =
   [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::topk(
     *$(at::Tensor* _self)
   , $(int64_t _k)));
+  }|]
+
+all_t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+all_t _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::all(
+    *$(at::Tensor* _self)));
+  }|]
+
+any_t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+any_t _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::any(
+    *$(at::Tensor* _self)));
+  }|]
+
+renorm_out_ttsls
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> Int64
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+renorm_out_ttsls _out _self _p _dim _maxnorm =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::renorm_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Scalar* _p)
+  , $(int64_t _dim)
+  , *$(at::Scalar* _maxnorm)));
+  }|]
+
+renorm_tsls
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> Int64
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+renorm_tsls _self _p _dim _maxnorm =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::renorm(
+    *$(at::Tensor* _self)
+  , *$(at::Scalar* _p)
+  , $(int64_t _dim)
+  , *$(at::Scalar* _maxnorm)));
+  }|]
+
+unfold_backward_tllll
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Int64
+  -> Int64
+  -> Int64
+  -> IO (Ptr Tensor)
+unfold_backward_tllll _grad_in _input_sizes _dim _size _step =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::unfold_backward(
+    *$(at::Tensor* _grad_in)
+  , *$(std::vector<int64_t>* _input_sizes)
+  , $(int64_t _dim)
+  , $(int64_t _size)
+  , $(int64_t _step)));
+  }|]
+
+equal_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (CBool)
+equal_tt _self _other =
+  [C.throwBlock| bool { return (at::equal(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _other)));
+  }|]
+
+pow_out_ttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+pow_out_ttt _out _self _exponent =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::pow_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _exponent)));
+  }|]
+
+pow_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+pow_tt _self _exponent =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::pow(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _exponent)));
+  }|]
+
+pow_out_tst
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+pow_out_tst _out _self _exponent =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::pow_out(
+    *$(at::Tensor* _out)
+  , *$(at::Scalar* _self)
+  , *$(at::Tensor* _exponent)));
+  }|]
+
+pow_st
+  :: Ptr Scalar
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+pow_st _self _exponent =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::pow(
+    *$(at::Scalar* _self)
+  , *$(at::Tensor* _exponent)));
+  }|]
+
+pow_out_tts
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+pow_out_tts _out _self _exponent =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::pow_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Scalar* _exponent)));
+  }|]
+
+pow_ts
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+pow_ts _self _exponent =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::pow(
+    *$(at::Tensor* _self)
+  , *$(at::Scalar* _exponent)));
+  }|]
+
+float_power_out_ttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+float_power_out_ttt _out _self _exponent =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::float_power_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _exponent)));
+  }|]
+
+float_power_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+float_power_tt _self _exponent =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::float_power(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _exponent)));
+  }|]
+
+float_power_out_tst
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+float_power_out_tst _out _self _exponent =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::float_power_out(
+    *$(at::Tensor* _out)
+  , *$(at::Scalar* _self)
+  , *$(at::Tensor* _exponent)));
+  }|]
+
+float_power_st
+  :: Ptr Scalar
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+float_power_st _self _exponent =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::float_power(
+    *$(at::Scalar* _self)
+  , *$(at::Tensor* _exponent)));
+  }|]
+
+float_power_out_tts
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+float_power_out_tts _out _self _exponent =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::float_power_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Scalar* _exponent)));
+  }|]
+
+float_power_ts
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+float_power_ts _self _exponent =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::float_power(
+    *$(at::Tensor* _self)
+  , *$(at::Scalar* _exponent)));
+  }|]
+
+normal_out_ttdG
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> CDouble
+  -> Ptr Generator
+  -> IO (Ptr Tensor)
+normal_out_ttdG _out _mean _std _generator =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::normal_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _mean)
+  , $(double _std)
+  , *$(at::Generator* _generator)));
+  }|]
+
+normal_out_ttd
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> CDouble
+  -> IO (Ptr Tensor)
+normal_out_ttd _out _mean _std =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::normal_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _mean)
+  , $(double _std)));
+  }|]
+
+normal_out_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+normal_out_tt _out _mean =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::normal_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _mean)));
+  }|]
+
+normal_tdG
+  :: Ptr Tensor
+  -> CDouble
+  -> Ptr Generator
+  -> IO (Ptr Tensor)
+normal_tdG _mean _std _generator =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::normal(
+    *$(at::Tensor* _mean)
+  , $(double _std)
+  , *$(at::Generator* _generator)));
+  }|]
+
+normal_td
+  :: Ptr Tensor
+  -> CDouble
+  -> IO (Ptr Tensor)
+normal_td _mean _std =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::normal(
+    *$(at::Tensor* _mean)
+  , $(double _std)));
+  }|]
+
+normal_t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+normal_t _mean =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::normal(
+    *$(at::Tensor* _mean)));
+  }|]
+
+normal_out_tdtG
+  :: Ptr Tensor
+  -> CDouble
+  -> Ptr Tensor
+  -> Ptr Generator
+  -> IO (Ptr Tensor)
+normal_out_tdtG _out _mean _std _generator =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::normal_out(
+    *$(at::Tensor* _out)
+  , $(double _mean)
+  , *$(at::Tensor* _std)
+  , *$(at::Generator* _generator)));
+  }|]
+
+normal_out_tdt
+  :: Ptr Tensor
+  -> CDouble
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+normal_out_tdt _out _mean _std =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::normal_out(
+    *$(at::Tensor* _out)
+  , $(double _mean)
+  , *$(at::Tensor* _std)));
+  }|]
+
+normal_dtG
+  :: CDouble
+  -> Ptr Tensor
+  -> Ptr Generator
+  -> IO (Ptr Tensor)
+normal_dtG _mean _std _generator =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::normal(
+    $(double _mean)
+  , *$(at::Tensor* _std)
+  , *$(at::Generator* _generator)));
+  }|]
+
+normal_dt
+  :: CDouble
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+normal_dt _mean _std =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::normal(
+    $(double _mean)
+  , *$(at::Tensor* _std)));
   }|]
 

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native10.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native10.hs
@@ -1678,17 +1678,17 @@ sort_tblb _self _stable _dim _descending =
   , $(bool _descending)));
   }|]
 
-sort_tbl
-  :: Ptr Tensor
-  -> CBool
-  -> Int64
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-sort_tbl _self _stable _dim =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::sort(
-    *$(at::Tensor* _self)
-  , $(bool _stable)
-  , $(int64_t _dim)));
-  }|]
+-- sort_tbl
+--   :: Ptr Tensor
+--   -> CBool
+--   -> Int64
+--   -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+-- sort_tbl _self _stable _dim =
+--   [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::sort(
+--     *$(at::Tensor* _self)
+--   , $(bool _stable)
+--   , $(int64_t _dim)));
+--   }|]
 
 sort_tb
   :: Ptr Tensor

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native11.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native11.hs
@@ -28,324 +28,6 @@ C.include "<ATen/Tensor.h>"
 C.include "<ATen/Functions.h>"
 
 
-all_t
-  :: Ptr Tensor
-  -> IO (Ptr Tensor)
-all_t _self =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::all(
-    *$(at::Tensor* _self)));
-  }|]
-
-any_t
-  :: Ptr Tensor
-  -> IO (Ptr Tensor)
-any_t _self =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::any(
-    *$(at::Tensor* _self)));
-  }|]
-
-renorm_out_ttsls
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Scalar
-  -> Int64
-  -> Ptr Scalar
-  -> IO (Ptr Tensor)
-renorm_out_ttsls _out _self _p _dim _maxnorm =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::renorm_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(at::Scalar* _p)
-  , $(int64_t _dim)
-  , *$(at::Scalar* _maxnorm)));
-  }|]
-
-renorm_tsls
-  :: Ptr Tensor
-  -> Ptr Scalar
-  -> Int64
-  -> Ptr Scalar
-  -> IO (Ptr Tensor)
-renorm_tsls _self _p _dim _maxnorm =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::renorm(
-    *$(at::Tensor* _self)
-  , *$(at::Scalar* _p)
-  , $(int64_t _dim)
-  , *$(at::Scalar* _maxnorm)));
-  }|]
-
-unfold_backward_tllll
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> Int64
-  -> Int64
-  -> Int64
-  -> IO (Ptr Tensor)
-unfold_backward_tllll _grad_in _input_sizes _dim _size _step =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::unfold_backward(
-    *$(at::Tensor* _grad_in)
-  , *$(std::vector<int64_t>* _input_sizes)
-  , $(int64_t _dim)
-  , $(int64_t _size)
-  , $(int64_t _step)));
-  }|]
-
-equal_tt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> IO (CBool)
-equal_tt _self _other =
-  [C.throwBlock| bool { return (at::equal(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _other)));
-  }|]
-
-pow_out_ttt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-pow_out_ttt _out _self _exponent =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::pow_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _exponent)));
-  }|]
-
-pow_tt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-pow_tt _self _exponent =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::pow(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _exponent)));
-  }|]
-
-pow_out_tst
-  :: Ptr Tensor
-  -> Ptr Scalar
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-pow_out_tst _out _self _exponent =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::pow_out(
-    *$(at::Tensor* _out)
-  , *$(at::Scalar* _self)
-  , *$(at::Tensor* _exponent)));
-  }|]
-
-pow_st
-  :: Ptr Scalar
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-pow_st _self _exponent =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::pow(
-    *$(at::Scalar* _self)
-  , *$(at::Tensor* _exponent)));
-  }|]
-
-pow_out_tts
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Scalar
-  -> IO (Ptr Tensor)
-pow_out_tts _out _self _exponent =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::pow_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(at::Scalar* _exponent)));
-  }|]
-
-pow_ts
-  :: Ptr Tensor
-  -> Ptr Scalar
-  -> IO (Ptr Tensor)
-pow_ts _self _exponent =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::pow(
-    *$(at::Tensor* _self)
-  , *$(at::Scalar* _exponent)));
-  }|]
-
-float_power_out_ttt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-float_power_out_ttt _out _self _exponent =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::float_power_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _exponent)));
-  }|]
-
-float_power_tt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-float_power_tt _self _exponent =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::float_power(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _exponent)));
-  }|]
-
-float_power_out_tst
-  :: Ptr Tensor
-  -> Ptr Scalar
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-float_power_out_tst _out _self _exponent =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::float_power_out(
-    *$(at::Tensor* _out)
-  , *$(at::Scalar* _self)
-  , *$(at::Tensor* _exponent)));
-  }|]
-
-float_power_st
-  :: Ptr Scalar
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-float_power_st _self _exponent =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::float_power(
-    *$(at::Scalar* _self)
-  , *$(at::Tensor* _exponent)));
-  }|]
-
-float_power_out_tts
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Scalar
-  -> IO (Ptr Tensor)
-float_power_out_tts _out _self _exponent =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::float_power_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(at::Scalar* _exponent)));
-  }|]
-
-float_power_ts
-  :: Ptr Tensor
-  -> Ptr Scalar
-  -> IO (Ptr Tensor)
-float_power_ts _self _exponent =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::float_power(
-    *$(at::Tensor* _self)
-  , *$(at::Scalar* _exponent)));
-  }|]
-
-normal_out_ttdG
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> CDouble
-  -> Ptr Generator
-  -> IO (Ptr Tensor)
-normal_out_ttdG _out _mean _std _generator =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::normal_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _mean)
-  , $(double _std)
-  , *$(at::Generator* _generator)));
-  }|]
-
-normal_out_ttd
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> CDouble
-  -> IO (Ptr Tensor)
-normal_out_ttd _out _mean _std =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::normal_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _mean)
-  , $(double _std)));
-  }|]
-
-normal_out_tt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-normal_out_tt _out _mean =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::normal_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _mean)));
-  }|]
-
-normal_tdG
-  :: Ptr Tensor
-  -> CDouble
-  -> Ptr Generator
-  -> IO (Ptr Tensor)
-normal_tdG _mean _std _generator =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::normal(
-    *$(at::Tensor* _mean)
-  , $(double _std)
-  , *$(at::Generator* _generator)));
-  }|]
-
-normal_td
-  :: Ptr Tensor
-  -> CDouble
-  -> IO (Ptr Tensor)
-normal_td _mean _std =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::normal(
-    *$(at::Tensor* _mean)
-  , $(double _std)));
-  }|]
-
-normal_t
-  :: Ptr Tensor
-  -> IO (Ptr Tensor)
-normal_t _mean =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::normal(
-    *$(at::Tensor* _mean)));
-  }|]
-
-normal_out_tdtG
-  :: Ptr Tensor
-  -> CDouble
-  -> Ptr Tensor
-  -> Ptr Generator
-  -> IO (Ptr Tensor)
-normal_out_tdtG _out _mean _std _generator =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::normal_out(
-    *$(at::Tensor* _out)
-  , $(double _mean)
-  , *$(at::Tensor* _std)
-  , *$(at::Generator* _generator)));
-  }|]
-
-normal_out_tdt
-  :: Ptr Tensor
-  -> CDouble
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-normal_out_tdt _out _mean _std =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::normal_out(
-    *$(at::Tensor* _out)
-  , $(double _mean)
-  , *$(at::Tensor* _std)));
-  }|]
-
-normal_dtG
-  :: CDouble
-  -> Ptr Tensor
-  -> Ptr Generator
-  -> IO (Ptr Tensor)
-normal_dtG _mean _std _generator =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::normal(
-    $(double _mean)
-  , *$(at::Tensor* _std)
-  , *$(at::Generator* _generator)));
-  }|]
-
-normal_dt
-  :: CDouble
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-normal_dt _mean _std =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::normal(
-    $(double _mean)
-  , *$(at::Tensor* _std)));
-  }|]
-
 normal_out_tttG
   :: Ptr Tensor
   -> Ptr Tensor
@@ -532,42 +214,6 @@ _cumprod_out_ttl _out _self _dim =
   , $(int64_t _dim)));
   }|]
 
-_var_tb
-  :: Ptr Tensor
-  -> CBool
-  -> IO (Ptr Tensor)
-_var_tb _self _unbiased =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_var(
-    *$(at::Tensor* _self)
-  , $(bool _unbiased)));
-  }|]
-
-_var_t
-  :: Ptr Tensor
-  -> IO (Ptr Tensor)
-_var_t _self =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_var(
-    *$(at::Tensor* _self)));
-  }|]
-
-_std_tb
-  :: Ptr Tensor
-  -> CBool
-  -> IO (Ptr Tensor)
-_std_tb _self _unbiased =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_std(
-    *$(at::Tensor* _self)
-  , $(bool _unbiased)));
-  }|]
-
-_std_t
-  :: Ptr Tensor
-  -> IO (Ptr Tensor)
-_std_t _self =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_std(
-    *$(at::Tensor* _self)));
-  }|]
-
 _amp_foreach_non_finite_check_and_unscale__ltt
   :: Ptr TensorList
   -> Ptr Tensor
@@ -580,7 +226,7 @@ _amp_foreach_non_finite_check_and_unscale__ltt _self _found_inf _inv_scale =
   , *$(at::Tensor* _inv_scale)));
   }|]
 
-_amp_update_scale_tttddl
+_amp_update_scale__tttddl
   :: Ptr Tensor
   -> Ptr Tensor
   -> Ptr Tensor
@@ -588,10 +234,10 @@ _amp_update_scale_tttddl
   -> CDouble
   -> Int64
   -> IO (Ptr Tensor)
-_amp_update_scale_tttddl _growth_tracker _current_scale _found_inf _scale_growth_factor _scale_backoff_factor _growth_interval =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_amp_update_scale(
-    *$(at::Tensor* _growth_tracker)
-  , *$(at::Tensor* _current_scale)
+_amp_update_scale__tttddl _self _growth_tracker _found_inf _scale_growth_factor _scale_backoff_factor _growth_interval =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_amp_update_scale_(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _growth_tracker)
   , *$(at::Tensor* _found_inf)
   , $(double _scale_growth_factor)
   , $(double _scale_backoff_factor)
@@ -846,84 +492,84 @@ _foreach_div__ll _self _other =
   , *$(std::vector<at::Tensor>* _other)));
   }|]
 
-_foreach_add_la
+_foreach_add_lA
   :: Ptr TensorList
-  -> Ptr (StdVector CDouble)
+  -> Ptr (StdVector Scalar)
   -> IO (Ptr TensorList)
-_foreach_add_la _tensors _scalars =
+_foreach_add_lA _tensors _scalars =
   [C.throwBlock| std::vector<at::Tensor>* { return new std::vector<at::Tensor>(at::_foreach_add(
     *$(std::vector<at::Tensor>* _tensors)
-  , *$(std::vector<double>* _scalars)));
+  , *$(std::vector<at::Scalar>* _scalars)));
   }|]
 
-_foreach_add__la
+_foreach_add__lA
   :: Ptr TensorList
-  -> Ptr (StdVector CDouble)
+  -> Ptr (StdVector Scalar)
   -> IO (())
-_foreach_add__la _self _scalars =
+_foreach_add__lA _self _scalars =
   [C.throwBlock| void {  (at::_foreach_add_(
     *$(std::vector<at::Tensor>* _self)
-  , *$(std::vector<double>* _scalars)));
+  , *$(std::vector<at::Scalar>* _scalars)));
   }|]
 
-_foreach_sub_la
+_foreach_sub_lA
   :: Ptr TensorList
-  -> Ptr (StdVector CDouble)
+  -> Ptr (StdVector Scalar)
   -> IO (Ptr TensorList)
-_foreach_sub_la _tensors _scalars =
+_foreach_sub_lA _tensors _scalars =
   [C.throwBlock| std::vector<at::Tensor>* { return new std::vector<at::Tensor>(at::_foreach_sub(
     *$(std::vector<at::Tensor>* _tensors)
-  , *$(std::vector<double>* _scalars)));
+  , *$(std::vector<at::Scalar>* _scalars)));
   }|]
 
-_foreach_sub__la
+_foreach_sub__lA
   :: Ptr TensorList
-  -> Ptr (StdVector CDouble)
+  -> Ptr (StdVector Scalar)
   -> IO (())
-_foreach_sub__la _self _scalars =
+_foreach_sub__lA _self _scalars =
   [C.throwBlock| void {  (at::_foreach_sub_(
     *$(std::vector<at::Tensor>* _self)
-  , *$(std::vector<double>* _scalars)));
+  , *$(std::vector<at::Scalar>* _scalars)));
   }|]
 
-_foreach_div_la
+_foreach_div_lA
   :: Ptr TensorList
-  -> Ptr (StdVector CDouble)
+  -> Ptr (StdVector Scalar)
   -> IO (Ptr TensorList)
-_foreach_div_la _tensors _scalars =
+_foreach_div_lA _tensors _scalars =
   [C.throwBlock| std::vector<at::Tensor>* { return new std::vector<at::Tensor>(at::_foreach_div(
     *$(std::vector<at::Tensor>* _tensors)
-  , *$(std::vector<double>* _scalars)));
+  , *$(std::vector<at::Scalar>* _scalars)));
   }|]
 
-_foreach_div__la
+_foreach_div__lA
   :: Ptr TensorList
-  -> Ptr (StdVector CDouble)
+  -> Ptr (StdVector Scalar)
   -> IO (())
-_foreach_div__la _self _scalars =
+_foreach_div__lA _self _scalars =
   [C.throwBlock| void {  (at::_foreach_div_(
     *$(std::vector<at::Tensor>* _self)
-  , *$(std::vector<double>* _scalars)));
+  , *$(std::vector<at::Scalar>* _scalars)));
   }|]
 
-_foreach_mul_la
+_foreach_mul_lA
   :: Ptr TensorList
-  -> Ptr (StdVector CDouble)
+  -> Ptr (StdVector Scalar)
   -> IO (Ptr TensorList)
-_foreach_mul_la _tensors _scalars =
+_foreach_mul_lA _tensors _scalars =
   [C.throwBlock| std::vector<at::Tensor>* { return new std::vector<at::Tensor>(at::_foreach_mul(
     *$(std::vector<at::Tensor>* _tensors)
-  , *$(std::vector<double>* _scalars)));
+  , *$(std::vector<at::Scalar>* _scalars)));
   }|]
 
-_foreach_mul__la
+_foreach_mul__lA
   :: Ptr TensorList
-  -> Ptr (StdVector CDouble)
+  -> Ptr (StdVector Scalar)
   -> IO (())
-_foreach_mul__la _self _scalars =
+_foreach_mul__lA _self _scalars =
   [C.throwBlock| void {  (at::_foreach_mul_(
     *$(std::vector<at::Tensor>* _self)
-  , *$(std::vector<double>* _scalars)));
+  , *$(std::vector<at::Scalar>* _scalars)));
   }|]
 
 _foreach_exp_l
@@ -1434,32 +1080,32 @@ _foreach_addcmul__lll _self _tensor1 _tensor2 =
   , *$(std::vector<at::Tensor>* _tensor2)));
   }|]
 
-_foreach_addcdiv__llla
+_foreach_addcdiv__lllA
   :: Ptr TensorList
   -> Ptr TensorList
   -> Ptr TensorList
-  -> Ptr (StdVector CDouble)
+  -> Ptr (StdVector Scalar)
   -> IO (())
-_foreach_addcdiv__llla _self _tensor1 _tensor2 _scalars =
+_foreach_addcdiv__lllA _self _tensor1 _tensor2 _scalars =
   [C.throwBlock| void {  (at::_foreach_addcdiv_(
     *$(std::vector<at::Tensor>* _self)
   , *$(std::vector<at::Tensor>* _tensor1)
   , *$(std::vector<at::Tensor>* _tensor2)
-  , *$(std::vector<double>* _scalars)));
+  , *$(std::vector<at::Scalar>* _scalars)));
   }|]
 
-_foreach_addcmul__llla
+_foreach_addcmul__lllA
   :: Ptr TensorList
   -> Ptr TensorList
   -> Ptr TensorList
-  -> Ptr (StdVector CDouble)
+  -> Ptr (StdVector Scalar)
   -> IO (())
-_foreach_addcmul__llla _self _tensor1 _tensor2 _scalars =
+_foreach_addcmul__lllA _self _tensor1 _tensor2 _scalars =
   [C.throwBlock| void {  (at::_foreach_addcmul_(
     *$(std::vector<at::Tensor>* _self)
   , *$(std::vector<at::Tensor>* _tensor1)
   , *$(std::vector<at::Tensor>* _tensor2)
-  , *$(std::vector<double>* _scalars)));
+  , *$(std::vector<at::Scalar>* _scalars)));
   }|]
 
 _foreach_addcdiv_llls
@@ -1514,32 +1160,32 @@ _foreach_addcmul_lll _input _tensor1 _tensor2 =
   , *$(std::vector<at::Tensor>* _tensor2)));
   }|]
 
-_foreach_addcdiv_llla
+_foreach_addcdiv_lllA
   :: Ptr TensorList
   -> Ptr TensorList
   -> Ptr TensorList
-  -> Ptr (StdVector CDouble)
+  -> Ptr (StdVector Scalar)
   -> IO (Ptr TensorList)
-_foreach_addcdiv_llla _input _tensor1 _tensor2 _scalars =
+_foreach_addcdiv_lllA _input _tensor1 _tensor2 _scalars =
   [C.throwBlock| std::vector<at::Tensor>* { return new std::vector<at::Tensor>(at::_foreach_addcdiv(
     *$(std::vector<at::Tensor>* _input)
   , *$(std::vector<at::Tensor>* _tensor1)
   , *$(std::vector<at::Tensor>* _tensor2)
-  , *$(std::vector<double>* _scalars)));
+  , *$(std::vector<at::Scalar>* _scalars)));
   }|]
 
-_foreach_addcmul_llla
+_foreach_addcmul_lllA
   :: Ptr TensorList
   -> Ptr TensorList
   -> Ptr TensorList
-  -> Ptr (StdVector CDouble)
+  -> Ptr (StdVector Scalar)
   -> IO (Ptr TensorList)
-_foreach_addcmul_llla _input _tensor1 _tensor2 _scalars =
+_foreach_addcmul_lllA _input _tensor1 _tensor2 _scalars =
   [C.throwBlock| std::vector<at::Tensor>* { return new std::vector<at::Tensor>(at::_foreach_addcmul(
     *$(std::vector<at::Tensor>* _input)
   , *$(std::vector<at::Tensor>* _tensor1)
   , *$(std::vector<at::Tensor>* _tensor2)
-  , *$(std::vector<double>* _scalars)));
+  , *$(std::vector<at::Scalar>* _scalars)));
   }|]
 
 _foreach_maximum_ll
@@ -1560,78 +1206,6 @@ _foreach_minimum_ll _tensors1 _tensors2 =
   [C.throwBlock| std::vector<at::Tensor>* { return new std::vector<at::Tensor>(at::_foreach_minimum(
     *$(std::vector<at::Tensor>* _tensors1)
   , *$(std::vector<at::Tensor>* _tensors2)));
-  }|]
-
-_mode_tlb
-  :: Ptr Tensor
-  -> Int64
-  -> CBool
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-_mode_tlb _self _dim _keepdim =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::_mode(
-    *$(at::Tensor* _self)
-  , $(int64_t _dim)
-  , $(bool _keepdim)));
-  }|]
-
-_mode_tl
-  :: Ptr Tensor
-  -> Int64
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-_mode_tl _self _dim =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::_mode(
-    *$(at::Tensor* _self)
-  , $(int64_t _dim)));
-  }|]
-
-_mode_t
-  :: Ptr Tensor
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-_mode_t _self =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::_mode(
-    *$(at::Tensor* _self)));
-  }|]
-
-_mode_out_tttlb
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Int64
-  -> CBool
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-_mode_out_tttlb _values _indices _self _dim _keepdim =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::_mode_out(
-    *$(at::Tensor* _values)
-  , *$(at::Tensor* _indices)
-  , *$(at::Tensor* _self)
-  , $(int64_t _dim)
-  , $(bool _keepdim)));
-  }|]
-
-_mode_out_tttl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Int64
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-_mode_out_tttl _values _indices _self _dim =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::_mode_out(
-    *$(at::Tensor* _values)
-  , *$(at::Tensor* _indices)
-  , *$(at::Tensor* _self)
-  , $(int64_t _dim)));
-  }|]
-
-_mode_out_ttt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-_mode_out_ttt _values _indices _self =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::_mode_out(
-    *$(at::Tensor* _values)
-  , *$(at::Tensor* _indices)
-  , *$(at::Tensor* _self)));
   }|]
 
 bucketize_ttbb
@@ -1824,5 +1398,813 @@ searchsorted_out_ttt _out _sorted_sequence _self =
     *$(at::Tensor* _out)
   , *$(at::Tensor* _sorted_sequence)
   , *$(at::Tensor* _self)));
+  }|]
+
+searchsorted_tsbb
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> CBool
+  -> CBool
+  -> IO (Ptr Tensor)
+searchsorted_tsbb _sorted_sequence _self _out_int32 _right =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::searchsorted(
+    *$(at::Tensor* _sorted_sequence)
+  , *$(at::Scalar* _self)
+  , $(bool _out_int32)
+  , $(bool _right)));
+  }|]
+
+searchsorted_tsb
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> CBool
+  -> IO (Ptr Tensor)
+searchsorted_tsb _sorted_sequence _self _out_int32 =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::searchsorted(
+    *$(at::Tensor* _sorted_sequence)
+  , *$(at::Scalar* _self)
+  , $(bool _out_int32)));
+  }|]
+
+searchsorted_ts
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+searchsorted_ts _sorted_sequence _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::searchsorted(
+    *$(at::Tensor* _sorted_sequence)
+  , *$(at::Scalar* _self)));
+  }|]
+
+mse_loss_out_tttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+mse_loss_out_tttl _out _self _target _reduction =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::mse_loss_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , $(int64_t _reduction)));
+  }|]
+
+mse_loss_out_ttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+mse_loss_out_ttt _out _self _target =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::mse_loss_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)));
+  }|]
+
+mse_loss_ttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+mse_loss_ttl _self _target _reduction =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::mse_loss(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , $(int64_t _reduction)));
+  }|]
+
+mse_loss_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+mse_loss_tt _self _target =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::mse_loss(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)));
+  }|]
+
+mse_loss_backward_out_ttttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+mse_loss_backward_out_ttttl _grad_input _grad_output _self _target _reduction =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::mse_loss_backward_out(
+    *$(at::Tensor* _grad_input)
+  , *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , $(int64_t _reduction)));
+  }|]
+
+mse_loss_backward_tttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+mse_loss_backward_tttl _grad_output _self _target _reduction =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::mse_loss_backward(
+    *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , $(int64_t _reduction)));
+  }|]
+
+l1_loss_out_tttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+l1_loss_out_tttl _out _self _target _reduction =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::l1_loss_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , $(int64_t _reduction)));
+  }|]
+
+l1_loss_out_ttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+l1_loss_out_ttt _out _self _target =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::l1_loss_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)));
+  }|]
+
+l1_loss_ttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+l1_loss_ttl _self _target _reduction =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::l1_loss(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , $(int64_t _reduction)));
+  }|]
+
+l1_loss_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+l1_loss_tt _self _target =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::l1_loss(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)));
+  }|]
+
+l1_loss_backward_out_ttttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+l1_loss_backward_out_ttttl _grad_input _grad_output _self _target _reduction =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::l1_loss_backward_out(
+    *$(at::Tensor* _grad_input)
+  , *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , $(int64_t _reduction)));
+  }|]
+
+l1_loss_backward_tttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+l1_loss_backward_tttl _grad_output _self _target _reduction =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::l1_loss_backward(
+    *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , $(int64_t _reduction)));
+  }|]
+
+multi_margin_loss_out_tttsstl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr Scalar
+  -> Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+multi_margin_loss_out_tttsstl _out _self _target _p _margin _weight _reduction =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::multi_margin_loss_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , *$(at::Scalar* _p)
+  , *$(at::Scalar* _margin)
+  , *$(at::Tensor* _weight)
+  , $(int64_t _reduction)));
+  }|]
+
+multi_margin_loss_out_tttsst
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr Scalar
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+multi_margin_loss_out_tttsst _out _self _target _p _margin _weight =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::multi_margin_loss_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , *$(at::Scalar* _p)
+  , *$(at::Scalar* _margin)
+  , *$(at::Tensor* _weight)));
+  }|]
+
+multi_margin_loss_out_tttss
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+multi_margin_loss_out_tttss _out _self _target _p _margin =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::multi_margin_loss_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , *$(at::Scalar* _p)
+  , *$(at::Scalar* _margin)));
+  }|]
+
+multi_margin_loss_out_ttts
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+multi_margin_loss_out_ttts _out _self _target _p =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::multi_margin_loss_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , *$(at::Scalar* _p)));
+  }|]
+
+multi_margin_loss_out_ttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+multi_margin_loss_out_ttt _out _self _target =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::multi_margin_loss_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)));
+  }|]
+
+multi_margin_loss_ttsstl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr Scalar
+  -> Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+multi_margin_loss_ttsstl _self _target _p _margin _weight _reduction =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::multi_margin_loss(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , *$(at::Scalar* _p)
+  , *$(at::Scalar* _margin)
+  , *$(at::Tensor* _weight)
+  , $(int64_t _reduction)));
+  }|]
+
+multi_margin_loss_ttsst
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr Scalar
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+multi_margin_loss_ttsst _self _target _p _margin _weight =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::multi_margin_loss(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , *$(at::Scalar* _p)
+  , *$(at::Scalar* _margin)
+  , *$(at::Tensor* _weight)));
+  }|]
+
+multi_margin_loss_ttss
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+multi_margin_loss_ttss _self _target _p _margin =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::multi_margin_loss(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , *$(at::Scalar* _p)
+  , *$(at::Scalar* _margin)));
+  }|]
+
+multi_margin_loss_tts
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+multi_margin_loss_tts _self _target _p =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::multi_margin_loss(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , *$(at::Scalar* _p)));
+  }|]
+
+multi_margin_loss_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+multi_margin_loss_tt _self _target =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::multi_margin_loss(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)));
+  }|]
+
+multi_margin_loss_backward_out_ttttsstl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr Scalar
+  -> Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+multi_margin_loss_backward_out_ttttsstl _grad_input _grad_output _self _target _p _margin _weight _reduction =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::multi_margin_loss_backward_out(
+    *$(at::Tensor* _grad_input)
+  , *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , *$(at::Scalar* _p)
+  , *$(at::Scalar* _margin)
+  , *$(at::Tensor* _weight)
+  , $(int64_t _reduction)));
+  }|]
+
+multi_margin_loss_backward_out_ttttsst
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr Scalar
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+multi_margin_loss_backward_out_ttttsst _grad_input _grad_output _self _target _p _margin _weight =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::multi_margin_loss_backward_out(
+    *$(at::Tensor* _grad_input)
+  , *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , *$(at::Scalar* _p)
+  , *$(at::Scalar* _margin)
+  , *$(at::Tensor* _weight)));
+  }|]
+
+multi_margin_loss_backward_out_ttttss
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+multi_margin_loss_backward_out_ttttss _grad_input _grad_output _self _target _p _margin =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::multi_margin_loss_backward_out(
+    *$(at::Tensor* _grad_input)
+  , *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , *$(at::Scalar* _p)
+  , *$(at::Scalar* _margin)));
+  }|]
+
+multi_margin_loss_backward_tttsstl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr Scalar
+  -> Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+multi_margin_loss_backward_tttsstl _grad_output _self _target _p _margin _weight _reduction =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::multi_margin_loss_backward(
+    *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , *$(at::Scalar* _p)
+  , *$(at::Scalar* _margin)
+  , *$(at::Tensor* _weight)
+  , $(int64_t _reduction)));
+  }|]
+
+multi_margin_loss_backward_tttsst
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr Scalar
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+multi_margin_loss_backward_tttsst _grad_output _self _target _p _margin _weight =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::multi_margin_loss_backward(
+    *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , *$(at::Scalar* _p)
+  , *$(at::Scalar* _margin)
+  , *$(at::Tensor* _weight)));
+  }|]
+
+multi_margin_loss_backward_tttss
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+multi_margin_loss_backward_tttss _grad_output _self _target _p _margin =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::multi_margin_loss_backward(
+    *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , *$(at::Scalar* _p)
+  , *$(at::Scalar* _margin)));
+  }|]
+
+multilabel_margin_loss_out_tttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+multilabel_margin_loss_out_tttl _out _self _target _reduction =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::multilabel_margin_loss_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , $(int64_t _reduction)));
+  }|]
+
+multilabel_margin_loss_out_ttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+multilabel_margin_loss_out_ttt _out _self _target =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::multilabel_margin_loss_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)));
+  }|]
+
+multilabel_margin_loss_ttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+multilabel_margin_loss_ttl _self _target _reduction =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::multilabel_margin_loss(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , $(int64_t _reduction)));
+  }|]
+
+multilabel_margin_loss_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+multilabel_margin_loss_tt _self _target =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::multilabel_margin_loss(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)));
+  }|]
+
+multilabel_margin_loss_forward_out_ttttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+multilabel_margin_loss_forward_out_ttttl _output _is_target _self _target _reduction =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::multilabel_margin_loss_forward_out(
+    *$(at::Tensor* _output)
+  , *$(at::Tensor* _is_target)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , $(int64_t _reduction)));
+  }|]
+
+multilabel_margin_loss_forward_ttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+multilabel_margin_loss_forward_ttl _self _target _reduction =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::multilabel_margin_loss_forward(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , $(int64_t _reduction)));
+  }|]
+
+multilabel_margin_loss_backward_out_ttttlt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+multilabel_margin_loss_backward_out_ttttlt _grad_input _grad_output _self _target _reduction _is_target =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::multilabel_margin_loss_backward_out(
+    *$(at::Tensor* _grad_input)
+  , *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , $(int64_t _reduction)
+  , *$(at::Tensor* _is_target)));
+  }|]
+
+multilabel_margin_loss_backward_tttlt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+multilabel_margin_loss_backward_tttlt _grad_output _self _target _reduction _is_target =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::multilabel_margin_loss_backward(
+    *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , $(int64_t _reduction)
+  , *$(at::Tensor* _is_target)));
+  }|]
+
+nll_loss_out_ttttll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> Int64
+  -> IO (Ptr Tensor)
+nll_loss_out_ttttll _out _self _target _weight _reduction _ignore_index =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::nll_loss_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , *$(at::Tensor* _weight)
+  , $(int64_t _reduction)
+  , $(int64_t _ignore_index)));
+  }|]
+
+nll_loss_out_ttttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+nll_loss_out_ttttl _out _self _target _weight _reduction =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::nll_loss_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , *$(at::Tensor* _weight)
+  , $(int64_t _reduction)));
+  }|]
+
+nll_loss_out_tttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+nll_loss_out_tttt _out _self _target _weight =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::nll_loss_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , *$(at::Tensor* _weight)));
+  }|]
+
+nll_loss_out_ttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+nll_loss_out_ttt _out _self _target =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::nll_loss_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)));
+  }|]
+
+nll_loss_nd_tttll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> Int64
+  -> IO (Ptr Tensor)
+nll_loss_nd_tttll _self _target _weight _reduction _ignore_index =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::nll_loss_nd(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , *$(at::Tensor* _weight)
+  , $(int64_t _reduction)
+  , $(int64_t _ignore_index)));
+  }|]
+
+nll_loss_nd_tttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+nll_loss_nd_tttl _self _target _weight _reduction =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::nll_loss_nd(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , *$(at::Tensor* _weight)
+  , $(int64_t _reduction)));
+  }|]
+
+nll_loss_nd_ttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+nll_loss_nd_ttt _self _target _weight =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::nll_loss_nd(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , *$(at::Tensor* _weight)));
+  }|]
+
+nll_loss_nd_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+nll_loss_nd_tt _self _target =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::nll_loss_nd(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)));
+  }|]
+
+nll_loss_tttll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> Int64
+  -> IO (Ptr Tensor)
+nll_loss_tttll _self _target _weight _reduction _ignore_index =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::nll_loss(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , *$(at::Tensor* _weight)
+  , $(int64_t _reduction)
+  , $(int64_t _ignore_index)));
+  }|]
+
+nll_loss_tttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+nll_loss_tttl _self _target _weight _reduction =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::nll_loss(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , *$(at::Tensor* _weight)
+  , $(int64_t _reduction)));
+  }|]
+
+nll_loss_ttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+nll_loss_ttt _self _target _weight =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::nll_loss(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , *$(at::Tensor* _weight)));
+  }|]
+
+nll_loss_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+nll_loss_tt _self _target =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::nll_loss(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)));
+  }|]
+
+nll_loss_forward_out_tttttll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> Int64
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+nll_loss_forward_out_tttttll _output _total_weight _self _target _weight _reduction _ignore_index =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::nll_loss_forward_out(
+    *$(at::Tensor* _output)
+  , *$(at::Tensor* _total_weight)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , *$(at::Tensor* _weight)
+  , $(int64_t _reduction)
+  , $(int64_t _ignore_index)));
+  }|]
+
+nll_loss_forward_tttll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> Int64
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+nll_loss_forward_tttll _self _target _weight _reduction _ignore_index =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::nll_loss_forward(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , *$(at::Tensor* _weight)
+  , $(int64_t _reduction)
+  , $(int64_t _ignore_index)));
+  }|]
+
+nll_loss_backward_out_tttttllt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> Int64
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+nll_loss_backward_out_tttttllt _grad_input _grad_output _self _target _weight _reduction _ignore_index _total_weight =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::nll_loss_backward_out(
+    *$(at::Tensor* _grad_input)
+  , *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , *$(at::Tensor* _weight)
+  , $(int64_t _reduction)
+  , $(int64_t _ignore_index)
+  , *$(at::Tensor* _total_weight)));
+  }|]
+
+nll_loss_backward_ttttllt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> Int64
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+nll_loss_backward_ttttllt _grad_output _self _target _weight _reduction _ignore_index _total_weight =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::nll_loss_backward(
+    *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , *$(at::Tensor* _weight)
+  , $(int64_t _reduction)
+  , $(int64_t _ignore_index)
+  , *$(at::Tensor* _total_weight)));
   }|]
 

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native12.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native12.hs
@@ -28,762 +28,6 @@ C.include "<ATen/Tensor.h>"
 C.include "<ATen/Functions.h>"
 
 
-searchsorted_tsbb
-  :: Ptr Tensor
-  -> Ptr Scalar
-  -> CBool
-  -> CBool
-  -> IO (Ptr Tensor)
-searchsorted_tsbb _sorted_sequence _self _out_int32 _right =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::searchsorted(
-    *$(at::Tensor* _sorted_sequence)
-  , *$(at::Scalar* _self)
-  , $(bool _out_int32)
-  , $(bool _right)));
-  }|]
-
-searchsorted_tsb
-  :: Ptr Tensor
-  -> Ptr Scalar
-  -> CBool
-  -> IO (Ptr Tensor)
-searchsorted_tsb _sorted_sequence _self _out_int32 =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::searchsorted(
-    *$(at::Tensor* _sorted_sequence)
-  , *$(at::Scalar* _self)
-  , $(bool _out_int32)));
-  }|]
-
-searchsorted_ts
-  :: Ptr Tensor
-  -> Ptr Scalar
-  -> IO (Ptr Tensor)
-searchsorted_ts _sorted_sequence _self =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::searchsorted(
-    *$(at::Tensor* _sorted_sequence)
-  , *$(at::Scalar* _self)));
-  }|]
-
-mse_loss_out_tttl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Int64
-  -> IO (Ptr Tensor)
-mse_loss_out_tttl _out _self _target _reduction =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::mse_loss_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _target)
-  , $(int64_t _reduction)));
-  }|]
-
-mse_loss_out_ttt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-mse_loss_out_ttt _out _self _target =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::mse_loss_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _target)));
-  }|]
-
-mse_loss_ttl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Int64
-  -> IO (Ptr Tensor)
-mse_loss_ttl _self _target _reduction =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::mse_loss(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _target)
-  , $(int64_t _reduction)));
-  }|]
-
-mse_loss_tt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-mse_loss_tt _self _target =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::mse_loss(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _target)));
-  }|]
-
-mse_loss_backward_out_ttttl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Int64
-  -> IO (Ptr Tensor)
-mse_loss_backward_out_ttttl _grad_input _grad_output _self _target _reduction =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::mse_loss_backward_out(
-    *$(at::Tensor* _grad_input)
-  , *$(at::Tensor* _grad_output)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _target)
-  , $(int64_t _reduction)));
-  }|]
-
-mse_loss_backward_tttl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Int64
-  -> IO (Ptr Tensor)
-mse_loss_backward_tttl _grad_output _self _target _reduction =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::mse_loss_backward(
-    *$(at::Tensor* _grad_output)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _target)
-  , $(int64_t _reduction)));
-  }|]
-
-l1_loss_out_tttl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Int64
-  -> IO (Ptr Tensor)
-l1_loss_out_tttl _out _self _target _reduction =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::l1_loss_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _target)
-  , $(int64_t _reduction)));
-  }|]
-
-l1_loss_out_ttt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-l1_loss_out_ttt _out _self _target =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::l1_loss_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _target)));
-  }|]
-
-l1_loss_ttl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Int64
-  -> IO (Ptr Tensor)
-l1_loss_ttl _self _target _reduction =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::l1_loss(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _target)
-  , $(int64_t _reduction)));
-  }|]
-
-l1_loss_tt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-l1_loss_tt _self _target =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::l1_loss(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _target)));
-  }|]
-
-l1_loss_backward_out_ttttl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Int64
-  -> IO (Ptr Tensor)
-l1_loss_backward_out_ttttl _grad_input _grad_output _self _target _reduction =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::l1_loss_backward_out(
-    *$(at::Tensor* _grad_input)
-  , *$(at::Tensor* _grad_output)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _target)
-  , $(int64_t _reduction)));
-  }|]
-
-l1_loss_backward_tttl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Int64
-  -> IO (Ptr Tensor)
-l1_loss_backward_tttl _grad_output _self _target _reduction =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::l1_loss_backward(
-    *$(at::Tensor* _grad_output)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _target)
-  , $(int64_t _reduction)));
-  }|]
-
-multi_margin_loss_out_tttsstl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Scalar
-  -> Ptr Scalar
-  -> Ptr Tensor
-  -> Int64
-  -> IO (Ptr Tensor)
-multi_margin_loss_out_tttsstl _out _self _target _p _margin _weight _reduction =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::multi_margin_loss_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _target)
-  , *$(at::Scalar* _p)
-  , *$(at::Scalar* _margin)
-  , *$(at::Tensor* _weight)
-  , $(int64_t _reduction)));
-  }|]
-
-multi_margin_loss_out_tttsst
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Scalar
-  -> Ptr Scalar
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-multi_margin_loss_out_tttsst _out _self _target _p _margin _weight =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::multi_margin_loss_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _target)
-  , *$(at::Scalar* _p)
-  , *$(at::Scalar* _margin)
-  , *$(at::Tensor* _weight)));
-  }|]
-
-multi_margin_loss_out_tttss
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Scalar
-  -> Ptr Scalar
-  -> IO (Ptr Tensor)
-multi_margin_loss_out_tttss _out _self _target _p _margin =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::multi_margin_loss_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _target)
-  , *$(at::Scalar* _p)
-  , *$(at::Scalar* _margin)));
-  }|]
-
-multi_margin_loss_out_ttts
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Scalar
-  -> IO (Ptr Tensor)
-multi_margin_loss_out_ttts _out _self _target _p =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::multi_margin_loss_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _target)
-  , *$(at::Scalar* _p)));
-  }|]
-
-multi_margin_loss_out_ttt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-multi_margin_loss_out_ttt _out _self _target =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::multi_margin_loss_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _target)));
-  }|]
-
-multi_margin_loss_ttsstl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Scalar
-  -> Ptr Scalar
-  -> Ptr Tensor
-  -> Int64
-  -> IO (Ptr Tensor)
-multi_margin_loss_ttsstl _self _target _p _margin _weight _reduction =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::multi_margin_loss(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _target)
-  , *$(at::Scalar* _p)
-  , *$(at::Scalar* _margin)
-  , *$(at::Tensor* _weight)
-  , $(int64_t _reduction)));
-  }|]
-
-multi_margin_loss_ttsst
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Scalar
-  -> Ptr Scalar
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-multi_margin_loss_ttsst _self _target _p _margin _weight =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::multi_margin_loss(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _target)
-  , *$(at::Scalar* _p)
-  , *$(at::Scalar* _margin)
-  , *$(at::Tensor* _weight)));
-  }|]
-
-multi_margin_loss_ttss
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Scalar
-  -> Ptr Scalar
-  -> IO (Ptr Tensor)
-multi_margin_loss_ttss _self _target _p _margin =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::multi_margin_loss(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _target)
-  , *$(at::Scalar* _p)
-  , *$(at::Scalar* _margin)));
-  }|]
-
-multi_margin_loss_tts
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Scalar
-  -> IO (Ptr Tensor)
-multi_margin_loss_tts _self _target _p =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::multi_margin_loss(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _target)
-  , *$(at::Scalar* _p)));
-  }|]
-
-multi_margin_loss_tt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-multi_margin_loss_tt _self _target =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::multi_margin_loss(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _target)));
-  }|]
-
-multi_margin_loss_backward_out_ttttsstl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Scalar
-  -> Ptr Scalar
-  -> Ptr Tensor
-  -> Int64
-  -> IO (Ptr Tensor)
-multi_margin_loss_backward_out_ttttsstl _grad_input _grad_output _self _target _p _margin _weight _reduction =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::multi_margin_loss_backward_out(
-    *$(at::Tensor* _grad_input)
-  , *$(at::Tensor* _grad_output)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _target)
-  , *$(at::Scalar* _p)
-  , *$(at::Scalar* _margin)
-  , *$(at::Tensor* _weight)
-  , $(int64_t _reduction)));
-  }|]
-
-multi_margin_loss_backward_out_ttttsst
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Scalar
-  -> Ptr Scalar
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-multi_margin_loss_backward_out_ttttsst _grad_input _grad_output _self _target _p _margin _weight =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::multi_margin_loss_backward_out(
-    *$(at::Tensor* _grad_input)
-  , *$(at::Tensor* _grad_output)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _target)
-  , *$(at::Scalar* _p)
-  , *$(at::Scalar* _margin)
-  , *$(at::Tensor* _weight)));
-  }|]
-
-multi_margin_loss_backward_out_ttttss
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Scalar
-  -> Ptr Scalar
-  -> IO (Ptr Tensor)
-multi_margin_loss_backward_out_ttttss _grad_input _grad_output _self _target _p _margin =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::multi_margin_loss_backward_out(
-    *$(at::Tensor* _grad_input)
-  , *$(at::Tensor* _grad_output)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _target)
-  , *$(at::Scalar* _p)
-  , *$(at::Scalar* _margin)));
-  }|]
-
-multi_margin_loss_backward_tttsstl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Scalar
-  -> Ptr Scalar
-  -> Ptr Tensor
-  -> Int64
-  -> IO (Ptr Tensor)
-multi_margin_loss_backward_tttsstl _grad_output _self _target _p _margin _weight _reduction =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::multi_margin_loss_backward(
-    *$(at::Tensor* _grad_output)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _target)
-  , *$(at::Scalar* _p)
-  , *$(at::Scalar* _margin)
-  , *$(at::Tensor* _weight)
-  , $(int64_t _reduction)));
-  }|]
-
-multi_margin_loss_backward_tttsst
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Scalar
-  -> Ptr Scalar
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-multi_margin_loss_backward_tttsst _grad_output _self _target _p _margin _weight =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::multi_margin_loss_backward(
-    *$(at::Tensor* _grad_output)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _target)
-  , *$(at::Scalar* _p)
-  , *$(at::Scalar* _margin)
-  , *$(at::Tensor* _weight)));
-  }|]
-
-multi_margin_loss_backward_tttss
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Scalar
-  -> Ptr Scalar
-  -> IO (Ptr Tensor)
-multi_margin_loss_backward_tttss _grad_output _self _target _p _margin =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::multi_margin_loss_backward(
-    *$(at::Tensor* _grad_output)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _target)
-  , *$(at::Scalar* _p)
-  , *$(at::Scalar* _margin)));
-  }|]
-
-multilabel_margin_loss_out_tttl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Int64
-  -> IO (Ptr Tensor)
-multilabel_margin_loss_out_tttl _out _self _target _reduction =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::multilabel_margin_loss_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _target)
-  , $(int64_t _reduction)));
-  }|]
-
-multilabel_margin_loss_out_ttt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-multilabel_margin_loss_out_ttt _out _self _target =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::multilabel_margin_loss_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _target)));
-  }|]
-
-multilabel_margin_loss_ttl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Int64
-  -> IO (Ptr Tensor)
-multilabel_margin_loss_ttl _self _target _reduction =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::multilabel_margin_loss(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _target)
-  , $(int64_t _reduction)));
-  }|]
-
-multilabel_margin_loss_tt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-multilabel_margin_loss_tt _self _target =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::multilabel_margin_loss(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _target)));
-  }|]
-
-multilabel_margin_loss_forward_out_ttttl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Int64
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-multilabel_margin_loss_forward_out_ttttl _output _is_target _self _target _reduction =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::multilabel_margin_loss_forward_out(
-    *$(at::Tensor* _output)
-  , *$(at::Tensor* _is_target)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _target)
-  , $(int64_t _reduction)));
-  }|]
-
-multilabel_margin_loss_forward_ttl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Int64
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-multilabel_margin_loss_forward_ttl _self _target _reduction =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::multilabel_margin_loss_forward(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _target)
-  , $(int64_t _reduction)));
-  }|]
-
-multilabel_margin_loss_backward_out_ttttlt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Int64
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-multilabel_margin_loss_backward_out_ttttlt _grad_input _grad_output _self _target _reduction _is_target =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::multilabel_margin_loss_backward_out(
-    *$(at::Tensor* _grad_input)
-  , *$(at::Tensor* _grad_output)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _target)
-  , $(int64_t _reduction)
-  , *$(at::Tensor* _is_target)));
-  }|]
-
-multilabel_margin_loss_backward_tttlt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Int64
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-multilabel_margin_loss_backward_tttlt _grad_output _self _target _reduction _is_target =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::multilabel_margin_loss_backward(
-    *$(at::Tensor* _grad_output)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _target)
-  , $(int64_t _reduction)
-  , *$(at::Tensor* _is_target)));
-  }|]
-
-nll_loss_out_ttttll
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Int64
-  -> Int64
-  -> IO (Ptr Tensor)
-nll_loss_out_ttttll _out _self _target _weight _reduction _ignore_index =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::nll_loss_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _target)
-  , *$(at::Tensor* _weight)
-  , $(int64_t _reduction)
-  , $(int64_t _ignore_index)));
-  }|]
-
-nll_loss_out_ttttl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Int64
-  -> IO (Ptr Tensor)
-nll_loss_out_ttttl _out _self _target _weight _reduction =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::nll_loss_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _target)
-  , *$(at::Tensor* _weight)
-  , $(int64_t _reduction)));
-  }|]
-
-nll_loss_out_tttt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-nll_loss_out_tttt _out _self _target _weight =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::nll_loss_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _target)
-  , *$(at::Tensor* _weight)));
-  }|]
-
-nll_loss_out_ttt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-nll_loss_out_ttt _out _self _target =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::nll_loss_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _target)));
-  }|]
-
-nll_loss_tttll
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Int64
-  -> Int64
-  -> IO (Ptr Tensor)
-nll_loss_tttll _self _target _weight _reduction _ignore_index =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::nll_loss(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _target)
-  , *$(at::Tensor* _weight)
-  , $(int64_t _reduction)
-  , $(int64_t _ignore_index)));
-  }|]
-
-nll_loss_tttl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Int64
-  -> IO (Ptr Tensor)
-nll_loss_tttl _self _target _weight _reduction =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::nll_loss(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _target)
-  , *$(at::Tensor* _weight)
-  , $(int64_t _reduction)));
-  }|]
-
-nll_loss_ttt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-nll_loss_ttt _self _target _weight =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::nll_loss(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _target)
-  , *$(at::Tensor* _weight)));
-  }|]
-
-nll_loss_tt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-nll_loss_tt _self _target =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::nll_loss(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _target)));
-  }|]
-
-nll_loss_forward_out_tttttll
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Int64
-  -> Int64
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-nll_loss_forward_out_tttttll _output _total_weight _self _target _weight _reduction _ignore_index =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::nll_loss_forward_out(
-    *$(at::Tensor* _output)
-  , *$(at::Tensor* _total_weight)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _target)
-  , *$(at::Tensor* _weight)
-  , $(int64_t _reduction)
-  , $(int64_t _ignore_index)));
-  }|]
-
-nll_loss_forward_tttll
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Int64
-  -> Int64
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-nll_loss_forward_tttll _self _target _weight _reduction _ignore_index =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::nll_loss_forward(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _target)
-  , *$(at::Tensor* _weight)
-  , $(int64_t _reduction)
-  , $(int64_t _ignore_index)));
-  }|]
-
-nll_loss_backward_out_tttttllt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Int64
-  -> Int64
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-nll_loss_backward_out_tttttllt _grad_input _grad_output _self _target _weight _reduction _ignore_index _total_weight =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::nll_loss_backward_out(
-    *$(at::Tensor* _grad_input)
-  , *$(at::Tensor* _grad_output)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _target)
-  , *$(at::Tensor* _weight)
-  , $(int64_t _reduction)
-  , $(int64_t _ignore_index)
-  , *$(at::Tensor* _total_weight)));
-  }|]
-
-nll_loss_backward_ttttllt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Int64
-  -> Int64
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-nll_loss_backward_ttttllt _grad_output _self _target _weight _reduction _ignore_index _total_weight =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::nll_loss_backward(
-    *$(at::Tensor* _grad_output)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _target)
-  , *$(at::Tensor* _weight)
-  , $(int64_t _reduction)
-  , $(int64_t _ignore_index)
-  , *$(at::Tensor* _total_weight)));
-  }|]
-
 nll_loss2d_out_ttttll
   :: Ptr Tensor
   -> Ptr Tensor
@@ -1084,6 +328,118 @@ smooth_l1_loss_backward_tttld _grad_output _self _target _reduction _beta =
   , *$(at::Tensor* _target)
   , $(int64_t _reduction)
   , $(double _beta)));
+  }|]
+
+huber_loss_out_tttld
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> CDouble
+  -> IO (Ptr Tensor)
+huber_loss_out_tttld _out _self _target _reduction _delta =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::huber_loss_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , $(int64_t _reduction)
+  , $(double _delta)));
+  }|]
+
+huber_loss_out_tttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+huber_loss_out_tttl _out _self _target _reduction =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::huber_loss_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , $(int64_t _reduction)));
+  }|]
+
+huber_loss_out_ttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+huber_loss_out_ttt _out _self _target =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::huber_loss_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)));
+  }|]
+
+huber_loss_ttld
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> CDouble
+  -> IO (Ptr Tensor)
+huber_loss_ttld _self _target _reduction _delta =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::huber_loss(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , $(int64_t _reduction)
+  , $(double _delta)));
+  }|]
+
+huber_loss_ttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+huber_loss_ttl _self _target _reduction =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::huber_loss(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , $(int64_t _reduction)));
+  }|]
+
+huber_loss_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+huber_loss_tt _self _target =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::huber_loss(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)));
+  }|]
+
+huber_loss_backward_out_ttttld
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> CDouble
+  -> IO (Ptr Tensor)
+huber_loss_backward_out_ttttld _grad_input _grad_output _self _target _reduction _delta =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::huber_loss_backward_out(
+    *$(at::Tensor* _grad_input)
+  , *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , $(int64_t _reduction)
+  , $(double _delta)));
+  }|]
+
+huber_loss_backward_tttld
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> CDouble
+  -> IO (Ptr Tensor)
+huber_loss_backward_tttld _grad_output _self _target _reduction _delta =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::huber_loss_backward(
+    *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , $(int64_t _reduction)
+  , $(double _delta)));
   }|]
 
 soft_margin_loss_out_tttl
@@ -2160,6 +1516,16 @@ mkldnn_adaptive_avg_pool2d_tl _self _output_size =
   , *$(std::vector<int64_t>* _output_size)));
   }|]
 
+mkldnn_adaptive_avg_pool2d_backward_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+mkldnn_adaptive_avg_pool2d_backward_tt _grad_output _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::mkldnn_adaptive_avg_pool2d_backward(
+    *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _self)));
+  }|]
+
 _adaptive_avg_pool2d_tl
   :: Ptr Tensor
   -> Ptr IntArray
@@ -2202,6 +1568,16 @@ adaptive_avg_pool3d_tl _self _output_size =
   , *$(std::vector<int64_t>* _output_size)));
   }|]
 
+_adaptive_avg_pool3d_tl
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+_adaptive_avg_pool3d_tl _self _output_size =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_adaptive_avg_pool3d(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _output_size)));
+  }|]
+
 adaptive_avg_pool3d_backward_out_ttt
   :: Ptr Tensor
   -> Ptr Tensor
@@ -2214,12 +1590,12 @@ adaptive_avg_pool3d_backward_out_ttt _grad_input _grad_output _self =
   , *$(at::Tensor* _self)));
   }|]
 
-adaptive_avg_pool3d_backward_tt
+_adaptive_avg_pool3d_backward_tt
   :: Ptr Tensor
   -> Ptr Tensor
   -> IO (Ptr Tensor)
-adaptive_avg_pool3d_backward_tt _grad_output _self =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::adaptive_avg_pool3d_backward(
+_adaptive_avg_pool3d_backward_tt _grad_output _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_adaptive_avg_pool3d_backward(
     *$(at::Tensor* _grad_output)
   , *$(at::Tensor* _self)));
   }|]
@@ -2296,5 +1672,983 @@ adaptive_max_pool3d_tl _self _output_size =
   [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::adaptive_max_pool3d(
     *$(at::Tensor* _self)
   , *$(std::vector<int64_t>* _output_size)));
+  }|]
+
+adaptive_max_pool3d_backward_out_tttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+adaptive_max_pool3d_backward_out_tttt _grad_input _grad_output _self _indices =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::adaptive_max_pool3d_backward_out(
+    *$(at::Tensor* _grad_input)
+  , *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _indices)));
+  }|]
+
+adaptive_max_pool3d_backward_ttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+adaptive_max_pool3d_backward_ttt _grad_output _self _indices =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::adaptive_max_pool3d_backward(
+    *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _indices)));
+  }|]
+
+avg_pool2d_out_ttlllbbl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> CBool
+  -> CBool
+  -> Int64
+  -> IO (Ptr Tensor)
+avg_pool2d_out_ttlllbbl _out _self _kernel_size _stride _padding _ceil_mode _count_include_pad _divisor_override =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool2d_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , $(bool _ceil_mode)
+  , $(bool _count_include_pad)
+  , $(int64_t _divisor_override)));
+  }|]
+
+avg_pool2d_out_ttlllbb
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> CBool
+  -> CBool
+  -> IO (Ptr Tensor)
+avg_pool2d_out_ttlllbb _out _self _kernel_size _stride _padding _ceil_mode _count_include_pad =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool2d_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , $(bool _ceil_mode)
+  , $(bool _count_include_pad)));
+  }|]
+
+avg_pool2d_out_ttlllb
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> CBool
+  -> IO (Ptr Tensor)
+avg_pool2d_out_ttlllb _out _self _kernel_size _stride _padding _ceil_mode =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool2d_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , $(bool _ceil_mode)));
+  }|]
+
+avg_pool2d_out_ttlll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+avg_pool2d_out_ttlll _out _self _kernel_size _stride _padding =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool2d_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)));
+  }|]
+
+avg_pool2d_out_ttll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+avg_pool2d_out_ttll _out _self _kernel_size _stride =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool2d_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)));
+  }|]
+
+avg_pool2d_out_ttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+avg_pool2d_out_ttl _out _self _kernel_size =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool2d_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)));
+  }|]
+
+avg_pool2d_tlllbbl
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> CBool
+  -> CBool
+  -> Int64
+  -> IO (Ptr Tensor)
+avg_pool2d_tlllbbl _self _kernel_size _stride _padding _ceil_mode _count_include_pad _divisor_override =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool2d(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , $(bool _ceil_mode)
+  , $(bool _count_include_pad)
+  , $(int64_t _divisor_override)));
+  }|]
+
+avg_pool2d_tlllbb
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> CBool
+  -> CBool
+  -> IO (Ptr Tensor)
+avg_pool2d_tlllbb _self _kernel_size _stride _padding _ceil_mode _count_include_pad =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool2d(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , $(bool _ceil_mode)
+  , $(bool _count_include_pad)));
+  }|]
+
+avg_pool2d_tlllb
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> CBool
+  -> IO (Ptr Tensor)
+avg_pool2d_tlllb _self _kernel_size _stride _padding _ceil_mode =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool2d(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , $(bool _ceil_mode)));
+  }|]
+
+avg_pool2d_tlll
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+avg_pool2d_tlll _self _kernel_size _stride _padding =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool2d(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)));
+  }|]
+
+avg_pool2d_tll
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+avg_pool2d_tll _self _kernel_size _stride =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool2d(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)));
+  }|]
+
+avg_pool2d_tl
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+avg_pool2d_tl _self _kernel_size =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool2d(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)));
+  }|]
+
+avg_pool2d_backward_out_tttlllbbl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> CBool
+  -> CBool
+  -> Int64
+  -> IO (Ptr Tensor)
+avg_pool2d_backward_out_tttlllbbl _grad_input _grad_output _self _kernel_size _stride _padding _ceil_mode _count_include_pad _divisor_override =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool2d_backward_out(
+    *$(at::Tensor* _grad_input)
+  , *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , $(bool _ceil_mode)
+  , $(bool _count_include_pad)
+  , $(int64_t _divisor_override)));
+  }|]
+
+avg_pool2d_backward_ttlllbbl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> CBool
+  -> CBool
+  -> Int64
+  -> IO (Ptr Tensor)
+avg_pool2d_backward_ttlllbbl _grad_output _self _kernel_size _stride _padding _ceil_mode _count_include_pad _divisor_override =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool2d_backward(
+    *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , $(bool _ceil_mode)
+  , $(bool _count_include_pad)
+  , $(int64_t _divisor_override)));
+  }|]
+
+avg_pool3d_out_ttlllbbl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> CBool
+  -> CBool
+  -> Int64
+  -> IO (Ptr Tensor)
+avg_pool3d_out_ttlllbbl _out _self _kernel_size _stride _padding _ceil_mode _count_include_pad _divisor_override =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool3d_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , $(bool _ceil_mode)
+  , $(bool _count_include_pad)
+  , $(int64_t _divisor_override)));
+  }|]
+
+avg_pool3d_out_ttlllbb
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> CBool
+  -> CBool
+  -> IO (Ptr Tensor)
+avg_pool3d_out_ttlllbb _out _self _kernel_size _stride _padding _ceil_mode _count_include_pad =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool3d_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , $(bool _ceil_mode)
+  , $(bool _count_include_pad)));
+  }|]
+
+avg_pool3d_out_ttlllb
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> CBool
+  -> IO (Ptr Tensor)
+avg_pool3d_out_ttlllb _out _self _kernel_size _stride _padding _ceil_mode =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool3d_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , $(bool _ceil_mode)));
+  }|]
+
+avg_pool3d_out_ttlll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+avg_pool3d_out_ttlll _out _self _kernel_size _stride _padding =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool3d_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)));
+  }|]
+
+avg_pool3d_out_ttll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+avg_pool3d_out_ttll _out _self _kernel_size _stride =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool3d_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)));
+  }|]
+
+avg_pool3d_out_ttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+avg_pool3d_out_ttl _out _self _kernel_size =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool3d_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)));
+  }|]
+
+avg_pool3d_tlllbbl
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> CBool
+  -> CBool
+  -> Int64
+  -> IO (Ptr Tensor)
+avg_pool3d_tlllbbl _self _kernel_size _stride _padding _ceil_mode _count_include_pad _divisor_override =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool3d(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , $(bool _ceil_mode)
+  , $(bool _count_include_pad)
+  , $(int64_t _divisor_override)));
+  }|]
+
+avg_pool3d_tlllbb
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> CBool
+  -> CBool
+  -> IO (Ptr Tensor)
+avg_pool3d_tlllbb _self _kernel_size _stride _padding _ceil_mode _count_include_pad =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool3d(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , $(bool _ceil_mode)
+  , $(bool _count_include_pad)));
+  }|]
+
+avg_pool3d_tlllb
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> CBool
+  -> IO (Ptr Tensor)
+avg_pool3d_tlllb _self _kernel_size _stride _padding _ceil_mode =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool3d(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , $(bool _ceil_mode)));
+  }|]
+
+avg_pool3d_tlll
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+avg_pool3d_tlll _self _kernel_size _stride _padding =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool3d(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)));
+  }|]
+
+avg_pool3d_tll
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+avg_pool3d_tll _self _kernel_size _stride =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool3d(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)));
+  }|]
+
+avg_pool3d_tl
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+avg_pool3d_tl _self _kernel_size =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool3d(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)));
+  }|]
+
+avg_pool3d_backward_out_tttlllbbl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> CBool
+  -> CBool
+  -> Int64
+  -> IO (Ptr Tensor)
+avg_pool3d_backward_out_tttlllbbl _grad_input _grad_output _self _kernel_size _stride _padding _ceil_mode _count_include_pad _divisor_override =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool3d_backward_out(
+    *$(at::Tensor* _grad_input)
+  , *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , $(bool _ceil_mode)
+  , $(bool _count_include_pad)
+  , $(int64_t _divisor_override)));
+  }|]
+
+avg_pool3d_backward_ttlllbbl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> CBool
+  -> CBool
+  -> Int64
+  -> IO (Ptr Tensor)
+avg_pool3d_backward_ttlllbbl _grad_output _self _kernel_size _stride _padding _ceil_mode _count_include_pad _divisor_override =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool3d_backward(
+    *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , $(bool _ceil_mode)
+  , $(bool _count_include_pad)
+  , $(int64_t _divisor_override)));
+  }|]
+
+fractional_max_pool2d_out_tttllt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+fractional_max_pool2d_out_tttllt _output _indices _self _kernel_size _output_size _random_samples =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::fractional_max_pool2d_out(
+    *$(at::Tensor* _output)
+  , *$(at::Tensor* _indices)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _output_size)
+  , *$(at::Tensor* _random_samples)));
+  }|]
+
+fractional_max_pool2d_tllt
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+fractional_max_pool2d_tllt _self _kernel_size _output_size _random_samples =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::fractional_max_pool2d(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _output_size)
+  , *$(at::Tensor* _random_samples)));
+  }|]
+
+fractional_max_pool2d_backward_out_tttllt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+fractional_max_pool2d_backward_out_tttllt _grad_input _grad_output _self _kernel_size _output_size _indices =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fractional_max_pool2d_backward_out(
+    *$(at::Tensor* _grad_input)
+  , *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _output_size)
+  , *$(at::Tensor* _indices)));
+  }|]
+
+fractional_max_pool2d_backward_ttllt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+fractional_max_pool2d_backward_ttllt _grad_output _self _kernel_size _output_size _indices =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fractional_max_pool2d_backward(
+    *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _output_size)
+  , *$(at::Tensor* _indices)));
+  }|]
+
+fractional_max_pool3d_out_tttllt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+fractional_max_pool3d_out_tttllt _output _indices _self _kernel_size _output_size _random_samples =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::fractional_max_pool3d_out(
+    *$(at::Tensor* _output)
+  , *$(at::Tensor* _indices)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _output_size)
+  , *$(at::Tensor* _random_samples)));
+  }|]
+
+fractional_max_pool3d_tllt
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+fractional_max_pool3d_tllt _self _kernel_size _output_size _random_samples =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::fractional_max_pool3d(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _output_size)
+  , *$(at::Tensor* _random_samples)));
+  }|]
+
+fractional_max_pool3d_backward_out_tttllt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+fractional_max_pool3d_backward_out_tttllt _grad_input _grad_output _self _kernel_size _output_size _indices =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fractional_max_pool3d_backward_out(
+    *$(at::Tensor* _grad_input)
+  , *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _output_size)
+  , *$(at::Tensor* _indices)));
+  }|]
+
+fractional_max_pool3d_backward_ttllt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+fractional_max_pool3d_backward_ttllt _grad_output _self _kernel_size _output_size _indices =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fractional_max_pool3d_backward(
+    *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _output_size)
+  , *$(at::Tensor* _indices)));
+  }|]
+
+max_pool2d_with_indices_out_tttllllb
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> CBool
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+max_pool2d_with_indices_out_tttllllb _out _indices _self _kernel_size _stride _padding _dilation _ceil_mode =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::max_pool2d_with_indices_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _indices)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , *$(std::vector<int64_t>* _dilation)
+  , $(bool _ceil_mode)));
+  }|]
+
+max_pool2d_with_indices_out_tttllll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+max_pool2d_with_indices_out_tttllll _out _indices _self _kernel_size _stride _padding _dilation =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::max_pool2d_with_indices_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _indices)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , *$(std::vector<int64_t>* _dilation)));
+  }|]
+
+max_pool2d_with_indices_out_tttlll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+max_pool2d_with_indices_out_tttlll _out _indices _self _kernel_size _stride _padding =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::max_pool2d_with_indices_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _indices)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)));
+  }|]
+
+max_pool2d_with_indices_out_tttll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+max_pool2d_with_indices_out_tttll _out _indices _self _kernel_size _stride =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::max_pool2d_with_indices_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _indices)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)));
+  }|]
+
+max_pool2d_with_indices_out_tttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+max_pool2d_with_indices_out_tttl _out _indices _self _kernel_size =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::max_pool2d_with_indices_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _indices)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)));
+  }|]
+
+max_pool2d_with_indices_tllllb
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> CBool
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+max_pool2d_with_indices_tllllb _self _kernel_size _stride _padding _dilation _ceil_mode =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::max_pool2d_with_indices(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , *$(std::vector<int64_t>* _dilation)
+  , $(bool _ceil_mode)));
+  }|]
+
+max_pool2d_with_indices_tllll
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+max_pool2d_with_indices_tllll _self _kernel_size _stride _padding _dilation =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::max_pool2d_with_indices(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , *$(std::vector<int64_t>* _dilation)));
+  }|]
+
+max_pool2d_with_indices_tlll
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+max_pool2d_with_indices_tlll _self _kernel_size _stride _padding =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::max_pool2d_with_indices(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)));
+  }|]
+
+max_pool2d_with_indices_tll
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+max_pool2d_with_indices_tll _self _kernel_size _stride =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::max_pool2d_with_indices(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)));
+  }|]
+
+max_pool2d_with_indices_tl
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+max_pool2d_with_indices_tl _self _kernel_size =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::max_pool2d_with_indices(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)));
+  }|]
+
+max_pool2d_with_indices_backward_out_tttllllbt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> CBool
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+max_pool2d_with_indices_backward_out_tttllllbt _grad_input _grad_output _self _kernel_size _stride _padding _dilation _ceil_mode _indices =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::max_pool2d_with_indices_backward_out(
+    *$(at::Tensor* _grad_input)
+  , *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , *$(std::vector<int64_t>* _dilation)
+  , $(bool _ceil_mode)
+  , *$(at::Tensor* _indices)));
+  }|]
+
+max_pool2d_with_indices_backward_ttllllbt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> CBool
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+max_pool2d_with_indices_backward_ttllllbt _grad_output _self _kernel_size _stride _padding _dilation _ceil_mode _indices =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::max_pool2d_with_indices_backward(
+    *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , *$(std::vector<int64_t>* _dilation)
+  , $(bool _ceil_mode)
+  , *$(at::Tensor* _indices)));
+  }|]
+
+max_pool3d_with_indices_out_tttllllb
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> CBool
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+max_pool3d_with_indices_out_tttllllb _out _indices _self _kernel_size _stride _padding _dilation _ceil_mode =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::max_pool3d_with_indices_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _indices)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , *$(std::vector<int64_t>* _dilation)
+  , $(bool _ceil_mode)));
+  }|]
+
+max_pool3d_with_indices_out_tttllll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+max_pool3d_with_indices_out_tttllll _out _indices _self _kernel_size _stride _padding _dilation =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::max_pool3d_with_indices_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _indices)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , *$(std::vector<int64_t>* _dilation)));
+  }|]
+
+max_pool3d_with_indices_out_tttlll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+max_pool3d_with_indices_out_tttlll _out _indices _self _kernel_size _stride _padding =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::max_pool3d_with_indices_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _indices)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)));
+  }|]
+
+max_pool3d_with_indices_out_tttll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+max_pool3d_with_indices_out_tttll _out _indices _self _kernel_size _stride =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::max_pool3d_with_indices_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _indices)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)));
+  }|]
+
+max_pool3d_with_indices_out_tttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+max_pool3d_with_indices_out_tttl _out _indices _self _kernel_size =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::max_pool3d_with_indices_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _indices)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)));
+  }|]
+
+max_pool3d_with_indices_tllllb
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> CBool
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+max_pool3d_with_indices_tllllb _self _kernel_size _stride _padding _dilation _ceil_mode =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::max_pool3d_with_indices(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , *$(std::vector<int64_t>* _dilation)
+  , $(bool _ceil_mode)));
+  }|]
+
+max_pool3d_with_indices_tllll
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+max_pool3d_with_indices_tllll _self _kernel_size _stride _padding _dilation =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::max_pool3d_with_indices(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , *$(std::vector<int64_t>* _dilation)));
+  }|]
+
+max_pool3d_with_indices_tlll
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+max_pool3d_with_indices_tlll _self _kernel_size _stride _padding =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::max_pool3d_with_indices(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)));
   }|]
 

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native13.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native13.hs
@@ -28,984 +28,6 @@ C.include "<ATen/Tensor.h>"
 C.include "<ATen/Functions.h>"
 
 
-adaptive_max_pool3d_backward_out_tttt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-adaptive_max_pool3d_backward_out_tttt _grad_input _grad_output _self _indices =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::adaptive_max_pool3d_backward_out(
-    *$(at::Tensor* _grad_input)
-  , *$(at::Tensor* _grad_output)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _indices)));
-  }|]
-
-adaptive_max_pool3d_backward_ttt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-adaptive_max_pool3d_backward_ttt _grad_output _self _indices =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::adaptive_max_pool3d_backward(
-    *$(at::Tensor* _grad_output)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _indices)));
-  }|]
-
-avg_pool2d_out_ttlllbbl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> CBool
-  -> CBool
-  -> Int64
-  -> IO (Ptr Tensor)
-avg_pool2d_out_ttlllbbl _out _self _kernel_size _stride _padding _ceil_mode _count_include_pad _divisor_override =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool2d_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)
-  , $(bool _ceil_mode)
-  , $(bool _count_include_pad)
-  , $(int64_t _divisor_override)));
-  }|]
-
-avg_pool2d_out_ttlllbb
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> CBool
-  -> CBool
-  -> IO (Ptr Tensor)
-avg_pool2d_out_ttlllbb _out _self _kernel_size _stride _padding _ceil_mode _count_include_pad =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool2d_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)
-  , $(bool _ceil_mode)
-  , $(bool _count_include_pad)));
-  }|]
-
-avg_pool2d_out_ttlllb
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> CBool
-  -> IO (Ptr Tensor)
-avg_pool2d_out_ttlllb _out _self _kernel_size _stride _padding _ceil_mode =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool2d_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)
-  , $(bool _ceil_mode)));
-  }|]
-
-avg_pool2d_out_ttlll
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-avg_pool2d_out_ttlll _out _self _kernel_size _stride _padding =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool2d_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)));
-  }|]
-
-avg_pool2d_out_ttll
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-avg_pool2d_out_ttll _out _self _kernel_size _stride =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool2d_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _stride)));
-  }|]
-
-avg_pool2d_out_ttl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-avg_pool2d_out_ttl _out _self _kernel_size =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool2d_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)));
-  }|]
-
-avg_pool2d_tlllbbl
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> CBool
-  -> CBool
-  -> Int64
-  -> IO (Ptr Tensor)
-avg_pool2d_tlllbbl _self _kernel_size _stride _padding _ceil_mode _count_include_pad _divisor_override =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool2d(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)
-  , $(bool _ceil_mode)
-  , $(bool _count_include_pad)
-  , $(int64_t _divisor_override)));
-  }|]
-
-avg_pool2d_tlllbb
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> CBool
-  -> CBool
-  -> IO (Ptr Tensor)
-avg_pool2d_tlllbb _self _kernel_size _stride _padding _ceil_mode _count_include_pad =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool2d(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)
-  , $(bool _ceil_mode)
-  , $(bool _count_include_pad)));
-  }|]
-
-avg_pool2d_tlllb
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> CBool
-  -> IO (Ptr Tensor)
-avg_pool2d_tlllb _self _kernel_size _stride _padding _ceil_mode =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool2d(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)
-  , $(bool _ceil_mode)));
-  }|]
-
-avg_pool2d_tlll
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-avg_pool2d_tlll _self _kernel_size _stride _padding =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool2d(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)));
-  }|]
-
-avg_pool2d_tll
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-avg_pool2d_tll _self _kernel_size _stride =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool2d(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _stride)));
-  }|]
-
-avg_pool2d_tl
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-avg_pool2d_tl _self _kernel_size =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool2d(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)));
-  }|]
-
-avg_pool2d_backward_out_tttlllbbl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> CBool
-  -> CBool
-  -> Int64
-  -> IO (Ptr Tensor)
-avg_pool2d_backward_out_tttlllbbl _grad_input _grad_output _self _kernel_size _stride _padding _ceil_mode _count_include_pad _divisor_override =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool2d_backward_out(
-    *$(at::Tensor* _grad_input)
-  , *$(at::Tensor* _grad_output)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)
-  , $(bool _ceil_mode)
-  , $(bool _count_include_pad)
-  , $(int64_t _divisor_override)));
-  }|]
-
-avg_pool2d_backward_ttlllbbl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> CBool
-  -> CBool
-  -> Int64
-  -> IO (Ptr Tensor)
-avg_pool2d_backward_ttlllbbl _grad_output _self _kernel_size _stride _padding _ceil_mode _count_include_pad _divisor_override =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool2d_backward(
-    *$(at::Tensor* _grad_output)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)
-  , $(bool _ceil_mode)
-  , $(bool _count_include_pad)
-  , $(int64_t _divisor_override)));
-  }|]
-
-avg_pool3d_out_ttlllbbl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> CBool
-  -> CBool
-  -> Int64
-  -> IO (Ptr Tensor)
-avg_pool3d_out_ttlllbbl _out _self _kernel_size _stride _padding _ceil_mode _count_include_pad _divisor_override =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool3d_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)
-  , $(bool _ceil_mode)
-  , $(bool _count_include_pad)
-  , $(int64_t _divisor_override)));
-  }|]
-
-avg_pool3d_out_ttlllbb
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> CBool
-  -> CBool
-  -> IO (Ptr Tensor)
-avg_pool3d_out_ttlllbb _out _self _kernel_size _stride _padding _ceil_mode _count_include_pad =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool3d_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)
-  , $(bool _ceil_mode)
-  , $(bool _count_include_pad)));
-  }|]
-
-avg_pool3d_out_ttlllb
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> CBool
-  -> IO (Ptr Tensor)
-avg_pool3d_out_ttlllb _out _self _kernel_size _stride _padding _ceil_mode =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool3d_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)
-  , $(bool _ceil_mode)));
-  }|]
-
-avg_pool3d_out_ttlll
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-avg_pool3d_out_ttlll _out _self _kernel_size _stride _padding =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool3d_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)));
-  }|]
-
-avg_pool3d_out_ttll
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-avg_pool3d_out_ttll _out _self _kernel_size _stride =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool3d_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _stride)));
-  }|]
-
-avg_pool3d_out_ttl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-avg_pool3d_out_ttl _out _self _kernel_size =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool3d_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)));
-  }|]
-
-avg_pool3d_tlllbbl
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> CBool
-  -> CBool
-  -> Int64
-  -> IO (Ptr Tensor)
-avg_pool3d_tlllbbl _self _kernel_size _stride _padding _ceil_mode _count_include_pad _divisor_override =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool3d(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)
-  , $(bool _ceil_mode)
-  , $(bool _count_include_pad)
-  , $(int64_t _divisor_override)));
-  }|]
-
-avg_pool3d_tlllbb
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> CBool
-  -> CBool
-  -> IO (Ptr Tensor)
-avg_pool3d_tlllbb _self _kernel_size _stride _padding _ceil_mode _count_include_pad =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool3d(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)
-  , $(bool _ceil_mode)
-  , $(bool _count_include_pad)));
-  }|]
-
-avg_pool3d_tlllb
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> CBool
-  -> IO (Ptr Tensor)
-avg_pool3d_tlllb _self _kernel_size _stride _padding _ceil_mode =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool3d(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)
-  , $(bool _ceil_mode)));
-  }|]
-
-avg_pool3d_tlll
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-avg_pool3d_tlll _self _kernel_size _stride _padding =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool3d(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)));
-  }|]
-
-avg_pool3d_tll
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-avg_pool3d_tll _self _kernel_size _stride =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool3d(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _stride)));
-  }|]
-
-avg_pool3d_tl
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-avg_pool3d_tl _self _kernel_size =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool3d(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)));
-  }|]
-
-avg_pool3d_backward_out_tttlllbbl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> CBool
-  -> CBool
-  -> Int64
-  -> IO (Ptr Tensor)
-avg_pool3d_backward_out_tttlllbbl _grad_input _grad_output _self _kernel_size _stride _padding _ceil_mode _count_include_pad _divisor_override =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool3d_backward_out(
-    *$(at::Tensor* _grad_input)
-  , *$(at::Tensor* _grad_output)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)
-  , $(bool _ceil_mode)
-  , $(bool _count_include_pad)
-  , $(int64_t _divisor_override)));
-  }|]
-
-avg_pool3d_backward_ttlllbbl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> CBool
-  -> CBool
-  -> Int64
-  -> IO (Ptr Tensor)
-avg_pool3d_backward_ttlllbbl _grad_output _self _kernel_size _stride _padding _ceil_mode _count_include_pad _divisor_override =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::avg_pool3d_backward(
-    *$(at::Tensor* _grad_output)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)
-  , $(bool _ceil_mode)
-  , $(bool _count_include_pad)
-  , $(int64_t _divisor_override)));
-  }|]
-
-fractional_max_pool2d_out_tttllt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-fractional_max_pool2d_out_tttllt _output _indices _self _kernel_size _output_size _random_samples =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::fractional_max_pool2d_out(
-    *$(at::Tensor* _output)
-  , *$(at::Tensor* _indices)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _output_size)
-  , *$(at::Tensor* _random_samples)));
-  }|]
-
-fractional_max_pool2d_tllt
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-fractional_max_pool2d_tllt _self _kernel_size _output_size _random_samples =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::fractional_max_pool2d(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _output_size)
-  , *$(at::Tensor* _random_samples)));
-  }|]
-
-fractional_max_pool2d_backward_out_tttllt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-fractional_max_pool2d_backward_out_tttllt _grad_input _grad_output _self _kernel_size _output_size _indices =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fractional_max_pool2d_backward_out(
-    *$(at::Tensor* _grad_input)
-  , *$(at::Tensor* _grad_output)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _output_size)
-  , *$(at::Tensor* _indices)));
-  }|]
-
-fractional_max_pool2d_backward_ttllt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-fractional_max_pool2d_backward_ttllt _grad_output _self _kernel_size _output_size _indices =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fractional_max_pool2d_backward(
-    *$(at::Tensor* _grad_output)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _output_size)
-  , *$(at::Tensor* _indices)));
-  }|]
-
-fractional_max_pool3d_out_tttllt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-fractional_max_pool3d_out_tttllt _output _indices _self _kernel_size _output_size _random_samples =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::fractional_max_pool3d_out(
-    *$(at::Tensor* _output)
-  , *$(at::Tensor* _indices)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _output_size)
-  , *$(at::Tensor* _random_samples)));
-  }|]
-
-fractional_max_pool3d_tllt
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-fractional_max_pool3d_tllt _self _kernel_size _output_size _random_samples =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::fractional_max_pool3d(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _output_size)
-  , *$(at::Tensor* _random_samples)));
-  }|]
-
-fractional_max_pool3d_backward_out_tttllt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-fractional_max_pool3d_backward_out_tttllt _grad_input _grad_output _self _kernel_size _output_size _indices =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fractional_max_pool3d_backward_out(
-    *$(at::Tensor* _grad_input)
-  , *$(at::Tensor* _grad_output)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _output_size)
-  , *$(at::Tensor* _indices)));
-  }|]
-
-fractional_max_pool3d_backward_ttllt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-fractional_max_pool3d_backward_ttllt _grad_output _self _kernel_size _output_size _indices =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fractional_max_pool3d_backward(
-    *$(at::Tensor* _grad_output)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _output_size)
-  , *$(at::Tensor* _indices)));
-  }|]
-
-max_pool2d_with_indices_out_tttllllb
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> CBool
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-max_pool2d_with_indices_out_tttllllb _out _indices _self _kernel_size _stride _padding _dilation _ceil_mode =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::max_pool2d_with_indices_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _indices)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)
-  , *$(std::vector<int64_t>* _dilation)
-  , $(bool _ceil_mode)));
-  }|]
-
-max_pool2d_with_indices_out_tttllll
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-max_pool2d_with_indices_out_tttllll _out _indices _self _kernel_size _stride _padding _dilation =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::max_pool2d_with_indices_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _indices)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)
-  , *$(std::vector<int64_t>* _dilation)));
-  }|]
-
-max_pool2d_with_indices_out_tttlll
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-max_pool2d_with_indices_out_tttlll _out _indices _self _kernel_size _stride _padding =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::max_pool2d_with_indices_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _indices)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)));
-  }|]
-
-max_pool2d_with_indices_out_tttll
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-max_pool2d_with_indices_out_tttll _out _indices _self _kernel_size _stride =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::max_pool2d_with_indices_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _indices)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _stride)));
-  }|]
-
-max_pool2d_with_indices_out_tttl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-max_pool2d_with_indices_out_tttl _out _indices _self _kernel_size =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::max_pool2d_with_indices_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _indices)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)));
-  }|]
-
-max_pool2d_with_indices_tllllb
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> CBool
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-max_pool2d_with_indices_tllllb _self _kernel_size _stride _padding _dilation _ceil_mode =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::max_pool2d_with_indices(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)
-  , *$(std::vector<int64_t>* _dilation)
-  , $(bool _ceil_mode)));
-  }|]
-
-max_pool2d_with_indices_tllll
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-max_pool2d_with_indices_tllll _self _kernel_size _stride _padding _dilation =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::max_pool2d_with_indices(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)
-  , *$(std::vector<int64_t>* _dilation)));
-  }|]
-
-max_pool2d_with_indices_tlll
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-max_pool2d_with_indices_tlll _self _kernel_size _stride _padding =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::max_pool2d_with_indices(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)));
-  }|]
-
-max_pool2d_with_indices_tll
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-max_pool2d_with_indices_tll _self _kernel_size _stride =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::max_pool2d_with_indices(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _stride)));
-  }|]
-
-max_pool2d_with_indices_tl
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-max_pool2d_with_indices_tl _self _kernel_size =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::max_pool2d_with_indices(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)));
-  }|]
-
-max_pool2d_with_indices_backward_out_tttllllbt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> CBool
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-max_pool2d_with_indices_backward_out_tttllllbt _grad_input _grad_output _self _kernel_size _stride _padding _dilation _ceil_mode _indices =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::max_pool2d_with_indices_backward_out(
-    *$(at::Tensor* _grad_input)
-  , *$(at::Tensor* _grad_output)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)
-  , *$(std::vector<int64_t>* _dilation)
-  , $(bool _ceil_mode)
-  , *$(at::Tensor* _indices)));
-  }|]
-
-max_pool2d_with_indices_backward_ttllllbt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> CBool
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-max_pool2d_with_indices_backward_ttllllbt _grad_output _self _kernel_size _stride _padding _dilation _ceil_mode _indices =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::max_pool2d_with_indices_backward(
-    *$(at::Tensor* _grad_output)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)
-  , *$(std::vector<int64_t>* _dilation)
-  , $(bool _ceil_mode)
-  , *$(at::Tensor* _indices)));
-  }|]
-
-max_pool3d_with_indices_out_tttllllb
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> CBool
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-max_pool3d_with_indices_out_tttllllb _out _indices _self _kernel_size _stride _padding _dilation _ceil_mode =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::max_pool3d_with_indices_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _indices)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)
-  , *$(std::vector<int64_t>* _dilation)
-  , $(bool _ceil_mode)));
-  }|]
-
-max_pool3d_with_indices_out_tttllll
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-max_pool3d_with_indices_out_tttllll _out _indices _self _kernel_size _stride _padding _dilation =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::max_pool3d_with_indices_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _indices)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)
-  , *$(std::vector<int64_t>* _dilation)));
-  }|]
-
-max_pool3d_with_indices_out_tttlll
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-max_pool3d_with_indices_out_tttlll _out _indices _self _kernel_size _stride _padding =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::max_pool3d_with_indices_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _indices)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)));
-  }|]
-
-max_pool3d_with_indices_out_tttll
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-max_pool3d_with_indices_out_tttll _out _indices _self _kernel_size _stride =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::max_pool3d_with_indices_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _indices)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _stride)));
-  }|]
-
-max_pool3d_with_indices_out_tttl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-max_pool3d_with_indices_out_tttl _out _indices _self _kernel_size =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::max_pool3d_with_indices_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _indices)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)));
-  }|]
-
-max_pool3d_with_indices_tllllb
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> CBool
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-max_pool3d_with_indices_tllllb _self _kernel_size _stride _padding _dilation _ceil_mode =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::max_pool3d_with_indices(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)
-  , *$(std::vector<int64_t>* _dilation)
-  , $(bool _ceil_mode)));
-  }|]
-
-max_pool3d_with_indices_tllll
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-max_pool3d_with_indices_tllll _self _kernel_size _stride _padding _dilation =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::max_pool3d_with_indices(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)
-  , *$(std::vector<int64_t>* _dilation)));
-  }|]
-
-max_pool3d_with_indices_tlll
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-max_pool3d_with_indices_tlll _self _kernel_size _stride _padding =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::max_pool3d_with_indices(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)));
-  }|]
-
 max_pool3d_with_indices_tll
   :: Ptr Tensor
   -> Ptr IntArray
@@ -1670,20 +692,6 @@ upsample_linear1d_out_ttlb _out _self _output_size _align_corners =
   , $(bool _align_corners)));
   }|]
 
--- upsample_linear1d_tlbd
---   :: Ptr Tensor
---   -> Ptr IntArray
---   -> CBool
---   -> CDouble
---   -> IO (Ptr Tensor)
--- upsample_linear1d_tlbd _self _output_size _align_corners _scales =
---   [C.throwBlock| at::Tensor* { return new at::Tensor(at::upsample_linear1d(
---     *$(at::Tensor* _self)
---   , *$(std::vector<int64_t>* _output_size)
---   , $(bool _align_corners)
---   , $(double _scales)));
---   }|]
-
 upsample_linear1d_tlb
   :: Ptr Tensor
   -> Ptr IntArray
@@ -1729,22 +737,6 @@ upsample_linear1d_backward_out_ttllb _grad_input _grad_output _output_size _inpu
   , *$(std::vector<int64_t>* _input_size)
   , $(bool _align_corners)));
   }|]
-
--- upsample_linear1d_backward_tllbd
---   :: Ptr Tensor
---   -> Ptr IntArray
---   -> Ptr IntArray
---   -> CBool
---   -> CDouble
---   -> IO (Ptr Tensor)
--- upsample_linear1d_backward_tllbd _grad_output _output_size _input_size _align_corners _scales =
---   [C.throwBlock| at::Tensor* { return new at::Tensor(at::upsample_linear1d_backward(
---     *$(at::Tensor* _grad_output)
---   , *$(std::vector<int64_t>* _output_size)
---   , *$(std::vector<int64_t>* _input_size)
---   , $(bool _align_corners)
---   , $(double _scales)));
---   }|]
 
 upsample_linear1d_backward_tllb
   :: Ptr Tensor
@@ -1823,20 +815,6 @@ upsample_bilinear2d_tlbdd _self _output_size _align_corners _scales_h _scales_w 
   , $(double _scales_h)
   , $(double _scales_w)));
   }|]
-
--- upsample_bilinear2d_tlbd
---   :: Ptr Tensor
---   -> Ptr IntArray
---   -> CBool
---   -> CDouble
---   -> IO (Ptr Tensor)
--- upsample_bilinear2d_tlbd _self _output_size _align_corners _scales_h =
---   [C.throwBlock| at::Tensor* { return new at::Tensor(at::upsample_bilinear2d(
---     *$(at::Tensor* _self)
---   , *$(std::vector<int64_t>* _output_size)
---   , $(bool _align_corners)
---   , $(double _scales_h)));
---   }|]
 
 upsample_bilinear2d_tlb
   :: Ptr Tensor
@@ -1922,22 +900,6 @@ upsample_bilinear2d_backward_tllbdd _grad_output _output_size _input_size _align
   , $(double _scales_w)));
   }|]
 
--- upsample_bilinear2d_backward_tllbd
---   :: Ptr Tensor
---   -> Ptr IntArray
---   -> Ptr IntArray
---   -> CBool
---   -> CDouble
---   -> IO (Ptr Tensor)
--- upsample_bilinear2d_backward_tllbd _grad_output _output_size _input_size _align_corners _scales_h =
---   [C.throwBlock| at::Tensor* { return new at::Tensor(at::upsample_bilinear2d_backward(
---     *$(at::Tensor* _grad_output)
---   , *$(std::vector<int64_t>* _output_size)
---   , *$(std::vector<int64_t>* _input_size)
---   , $(bool _align_corners)
---   , $(double _scales_h)));
---   }|]
-
 upsample_bilinear2d_backward_tllb
   :: Ptr Tensor
   -> Ptr IntArray
@@ -2015,20 +977,6 @@ upsample_bicubic2d_tlbdd _self _output_size _align_corners _scales_h _scales_w =
   , $(double _scales_h)
   , $(double _scales_w)));
   }|]
-
--- upsample_bicubic2d_tlbd
---   :: Ptr Tensor
---   -> Ptr IntArray
---   -> CBool
---   -> CDouble
---   -> IO (Ptr Tensor)
--- upsample_bicubic2d_tlbd _self _output_size _align_corners _scales_h =
---   [C.throwBlock| at::Tensor* { return new at::Tensor(at::upsample_bicubic2d(
---     *$(at::Tensor* _self)
---   , *$(std::vector<int64_t>* _output_size)
---   , $(bool _align_corners)
---   , $(double _scales_h)));
---   }|]
 
 upsample_bicubic2d_tlb
   :: Ptr Tensor
@@ -2113,22 +1061,6 @@ upsample_bicubic2d_backward_tllbdd _grad_output _output_size _input_size _align_
   , $(double _scales_h)
   , $(double _scales_w)));
   }|]
-
--- upsample_bicubic2d_backward_tllbd
---   :: Ptr Tensor
---   -> Ptr IntArray
---   -> Ptr IntArray
---   -> CBool
---   -> CDouble
---   -> IO (Ptr Tensor)
--- upsample_bicubic2d_backward_tllbd _grad_output _output_size _input_size _align_corners _scales_h =
---   [C.throwBlock| at::Tensor* { return new at::Tensor(at::upsample_bicubic2d_backward(
---     *$(at::Tensor* _grad_output)
---   , *$(std::vector<int64_t>* _output_size)
---   , *$(std::vector<int64_t>* _input_size)
---   , $(bool _align_corners)
---   , $(double _scales_h)));
---   }|]
 
 upsample_bicubic2d_backward_tllb
   :: Ptr Tensor
@@ -2245,20 +1177,6 @@ upsample_trilinear3d_tlbdd _self _output_size _align_corners _scales_d _scales_h
   , $(double _scales_d)
   , $(double _scales_h)));
   }|]
-
--- upsample_trilinear3d_tlbd
---   :: Ptr Tensor
---   -> Ptr IntArray
---   -> CBool
---   -> CDouble
---   -> IO (Ptr Tensor)
--- upsample_trilinear3d_tlbd _self _output_size _align_corners _scales_d =
---   [C.throwBlock| at::Tensor* { return new at::Tensor(at::upsample_trilinear3d(
---     *$(at::Tensor* _self)
---   , *$(std::vector<int64_t>* _output_size)
---   , $(bool _align_corners)
---   , $(double _scales_d)));
---   }|]
 
 upsample_trilinear3d_tlb
   :: Ptr Tensor
@@ -2386,22 +1304,6 @@ upsample_trilinear3d_backward_tllbdd _grad_output _output_size _input_size _alig
   , $(double _scales_h)));
   }|]
 
--- upsample_trilinear3d_backward_tllbd
---   :: Ptr Tensor
---   -> Ptr IntArray
---   -> Ptr IntArray
---   -> CBool
---   -> CDouble
---   -> IO (Ptr Tensor)
--- upsample_trilinear3d_backward_tllbd _grad_output _output_size _input_size _align_corners _scales_d =
---   [C.throwBlock| at::Tensor* { return new at::Tensor(at::upsample_trilinear3d_backward(
---     *$(at::Tensor* _grad_output)
---   , *$(std::vector<int64_t>* _output_size)
---   , *$(std::vector<int64_t>* _input_size)
---   , $(bool _align_corners)
---   , $(double _scales_d)));
---   }|]
-
 upsample_trilinear3d_backward_tllb
   :: Ptr Tensor
   -> Ptr IntArray
@@ -2442,18 +1344,6 @@ upsample_nearest1d_out_ttl _out _self _output_size =
   , *$(std::vector<int64_t>* _output_size)));
   }|]
 
--- upsample_nearest1d_tld
---   :: Ptr Tensor
---   -> Ptr IntArray
---   -> CDouble
---   -> IO (Ptr Tensor)
--- upsample_nearest1d_tld _self _output_size _scales =
---   [C.throwBlock| at::Tensor* { return new at::Tensor(at::upsample_nearest1d(
---     *$(at::Tensor* _self)
---   , *$(std::vector<int64_t>* _output_size)
---   , $(double _scales)));
---   }|]
-
 upsample_nearest1d_tl
   :: Ptr Tensor
   -> Ptr IntArray
@@ -2493,20 +1383,6 @@ upsample_nearest1d_backward_out_ttll _grad_input _grad_output _output_size _inpu
   , *$(std::vector<int64_t>* _output_size)
   , *$(std::vector<int64_t>* _input_size)));
   }|]
-
--- upsample_nearest1d_backward_tlld
---   :: Ptr Tensor
---   -> Ptr IntArray
---   -> Ptr IntArray
---   -> CDouble
---   -> IO (Ptr Tensor)
--- upsample_nearest1d_backward_tlld _grad_output _output_size _input_size _scales =
---   [C.throwBlock| at::Tensor* { return new at::Tensor(at::upsample_nearest1d_backward(
---     *$(at::Tensor* _grad_output)
---   , *$(std::vector<int64_t>* _output_size)
---   , *$(std::vector<int64_t>* _input_size)
---   , $(double _scales)));
---   }|]
 
 upsample_nearest1d_backward_tll
   :: Ptr Tensor
@@ -2575,18 +1451,6 @@ upsample_nearest2d_tldd _self _output_size _scales_h _scales_w =
   , $(double _scales_h)
   , $(double _scales_w)));
   }|]
-
--- upsample_nearest2d_tld
---   :: Ptr Tensor
---   -> Ptr IntArray
---   -> CDouble
---   -> IO (Ptr Tensor)
--- upsample_nearest2d_tld _self _output_size _scales_h =
---   [C.throwBlock| at::Tensor* { return new at::Tensor(at::upsample_nearest2d(
---     *$(at::Tensor* _self)
---   , *$(std::vector<int64_t>* _output_size)
---   , $(double _scales_h)));
---   }|]
 
 upsample_nearest2d_tl
   :: Ptr Tensor
@@ -2662,20 +1526,6 @@ upsample_nearest2d_backward_tlldd _grad_output _output_size _input_size _scales_
   , $(double _scales_w)));
   }|]
 
--- upsample_nearest2d_backward_tlld
---   :: Ptr Tensor
---   -> Ptr IntArray
---   -> Ptr IntArray
---   -> CDouble
---   -> IO (Ptr Tensor)
--- upsample_nearest2d_backward_tlld _grad_output _output_size _input_size _scales_h =
---   [C.throwBlock| at::Tensor* { return new at::Tensor(at::upsample_nearest2d_backward(
---     *$(at::Tensor* _grad_output)
---   , *$(std::vector<int64_t>* _output_size)
---   , *$(std::vector<int64_t>* _input_size)
---   , $(double _scales_h)));
---   }|]
-
 upsample_nearest2d_backward_tll
   :: Ptr Tensor
   -> Ptr IntArray
@@ -2704,5 +1554,1279 @@ upsample_nearest3d_out_ttlddd _out _self _output_size _scales_d _scales_h _scale
   , $(double _scales_d)
   , $(double _scales_h)
   , $(double _scales_w)));
+  }|]
+
+upsample_nearest3d_out_ttldd
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> CDouble
+  -> CDouble
+  -> IO (Ptr Tensor)
+upsample_nearest3d_out_ttldd _out _self _output_size _scales_d _scales_h =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::upsample_nearest3d_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _output_size)
+  , $(double _scales_d)
+  , $(double _scales_h)));
+  }|]
+
+upsample_nearest3d_out_ttld
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> CDouble
+  -> IO (Ptr Tensor)
+upsample_nearest3d_out_ttld _out _self _output_size _scales_d =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::upsample_nearest3d_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _output_size)
+  , $(double _scales_d)));
+  }|]
+
+upsample_nearest3d_out_ttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+upsample_nearest3d_out_ttl _out _self _output_size =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::upsample_nearest3d_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _output_size)));
+  }|]
+
+upsample_nearest3d_tlddd
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> CDouble
+  -> CDouble
+  -> CDouble
+  -> IO (Ptr Tensor)
+upsample_nearest3d_tlddd _self _output_size _scales_d _scales_h _scales_w =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::upsample_nearest3d(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _output_size)
+  , $(double _scales_d)
+  , $(double _scales_h)
+  , $(double _scales_w)));
+  }|]
+
+upsample_nearest3d_tldd
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> CDouble
+  -> CDouble
+  -> IO (Ptr Tensor)
+upsample_nearest3d_tldd _self _output_size _scales_d _scales_h =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::upsample_nearest3d(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _output_size)
+  , $(double _scales_d)
+  , $(double _scales_h)));
+  }|]
+
+upsample_nearest3d_tl
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+upsample_nearest3d_tl _self _output_size =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::upsample_nearest3d(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _output_size)));
+  }|]
+
+upsample_nearest3d_backward_out_ttllddd
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> CDouble
+  -> CDouble
+  -> CDouble
+  -> IO (Ptr Tensor)
+upsample_nearest3d_backward_out_ttllddd _grad_input _grad_output _output_size _input_size _scales_d _scales_h _scales_w =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::upsample_nearest3d_backward_out(
+    *$(at::Tensor* _grad_input)
+  , *$(at::Tensor* _grad_output)
+  , *$(std::vector<int64_t>* _output_size)
+  , *$(std::vector<int64_t>* _input_size)
+  , $(double _scales_d)
+  , $(double _scales_h)
+  , $(double _scales_w)));
+  }|]
+
+upsample_nearest3d_backward_out_ttlldd
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> CDouble
+  -> CDouble
+  -> IO (Ptr Tensor)
+upsample_nearest3d_backward_out_ttlldd _grad_input _grad_output _output_size _input_size _scales_d _scales_h =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::upsample_nearest3d_backward_out(
+    *$(at::Tensor* _grad_input)
+  , *$(at::Tensor* _grad_output)
+  , *$(std::vector<int64_t>* _output_size)
+  , *$(std::vector<int64_t>* _input_size)
+  , $(double _scales_d)
+  , $(double _scales_h)));
+  }|]
+
+upsample_nearest3d_backward_out_ttlld
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> CDouble
+  -> IO (Ptr Tensor)
+upsample_nearest3d_backward_out_ttlld _grad_input _grad_output _output_size _input_size _scales_d =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::upsample_nearest3d_backward_out(
+    *$(at::Tensor* _grad_input)
+  , *$(at::Tensor* _grad_output)
+  , *$(std::vector<int64_t>* _output_size)
+  , *$(std::vector<int64_t>* _input_size)
+  , $(double _scales_d)));
+  }|]
+
+upsample_nearest3d_backward_out_ttll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+upsample_nearest3d_backward_out_ttll _grad_input _grad_output _output_size _input_size =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::upsample_nearest3d_backward_out(
+    *$(at::Tensor* _grad_input)
+  , *$(at::Tensor* _grad_output)
+  , *$(std::vector<int64_t>* _output_size)
+  , *$(std::vector<int64_t>* _input_size)));
+  }|]
+
+upsample_nearest3d_backward_tllddd
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> CDouble
+  -> CDouble
+  -> CDouble
+  -> IO (Ptr Tensor)
+upsample_nearest3d_backward_tllddd _grad_output _output_size _input_size _scales_d _scales_h _scales_w =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::upsample_nearest3d_backward(
+    *$(at::Tensor* _grad_output)
+  , *$(std::vector<int64_t>* _output_size)
+  , *$(std::vector<int64_t>* _input_size)
+  , $(double _scales_d)
+  , $(double _scales_h)
+  , $(double _scales_w)));
+  }|]
+
+upsample_nearest3d_backward_tlldd
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> CDouble
+  -> CDouble
+  -> IO (Ptr Tensor)
+upsample_nearest3d_backward_tlldd _grad_output _output_size _input_size _scales_d _scales_h =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::upsample_nearest3d_backward(
+    *$(at::Tensor* _grad_output)
+  , *$(std::vector<int64_t>* _output_size)
+  , *$(std::vector<int64_t>* _input_size)
+  , $(double _scales_d)
+  , $(double _scales_h)));
+  }|]
+
+upsample_nearest3d_backward_tll
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+upsample_nearest3d_backward_tll _grad_output _output_size _input_size =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::upsample_nearest3d_backward(
+    *$(at::Tensor* _grad_output)
+  , *$(std::vector<int64_t>* _output_size)
+  , *$(std::vector<int64_t>* _input_size)));
+  }|]
+
+sigmoid_backward_out_ttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+sigmoid_backward_out_ttt _grad_input _grad_output _output =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::sigmoid_backward_out(
+    *$(at::Tensor* _grad_input)
+  , *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _output)));
+  }|]
+
+sigmoid_backward_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+sigmoid_backward_tt _grad_output _output =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::sigmoid_backward(
+    *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _output)));
+  }|]
+
+logit_backward_out_tttd
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> CDouble
+  -> IO (Ptr Tensor)
+logit_backward_out_tttd _grad_input _grad_output _self _eps =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::logit_backward_out(
+    *$(at::Tensor* _grad_input)
+  , *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _self)
+  , $(double _eps)));
+  }|]
+
+logit_backward_out_ttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+logit_backward_out_ttt _grad_input _grad_output _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::logit_backward_out(
+    *$(at::Tensor* _grad_input)
+  , *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _self)));
+  }|]
+
+logit_backward_ttd
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> CDouble
+  -> IO (Ptr Tensor)
+logit_backward_ttd _grad_output _self _eps =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::logit_backward(
+    *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _self)
+  , $(double _eps)));
+  }|]
+
+logit_backward_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+logit_backward_tt _grad_output _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::logit_backward(
+    *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _self)));
+  }|]
+
+tanh_backward_out_ttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tanh_backward_out_ttt _grad_input _grad_output _output =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::tanh_backward_out(
+    *$(at::Tensor* _grad_input)
+  , *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _output)));
+  }|]
+
+tanh_backward_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tanh_backward_tt _grad_output _output =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::tanh_backward(
+    *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _output)));
+  }|]
+
+slow_conv_transpose2d_out_tttltllll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+slow_conv_transpose2d_out_tttltllll _out _self _weight _kernel_size _bias _stride _padding _output_padding _dilation =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::slow_conv_transpose2d_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(at::Tensor* _bias)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , *$(std::vector<int64_t>* _output_padding)
+  , *$(std::vector<int64_t>* _dilation)));
+  }|]
+
+slow_conv_transpose2d_out_tttltlll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+slow_conv_transpose2d_out_tttltlll _out _self _weight _kernel_size _bias _stride _padding _output_padding =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::slow_conv_transpose2d_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(at::Tensor* _bias)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , *$(std::vector<int64_t>* _output_padding)));
+  }|]
+
+slow_conv_transpose2d_out_tttltll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+slow_conv_transpose2d_out_tttltll _out _self _weight _kernel_size _bias _stride _padding =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::slow_conv_transpose2d_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(at::Tensor* _bias)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)));
+  }|]
+
+slow_conv_transpose2d_out_tttltl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+slow_conv_transpose2d_out_tttltl _out _self _weight _kernel_size _bias _stride =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::slow_conv_transpose2d_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(at::Tensor* _bias)
+  , *$(std::vector<int64_t>* _stride)));
+  }|]
+
+slow_conv_transpose2d_out_tttlt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+slow_conv_transpose2d_out_tttlt _out _self _weight _kernel_size _bias =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::slow_conv_transpose2d_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(at::Tensor* _bias)));
+  }|]
+
+slow_conv_transpose2d_out_tttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+slow_conv_transpose2d_out_tttl _out _self _weight _kernel_size =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::slow_conv_transpose2d_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)));
+  }|]
+
+slow_conv_transpose2d_ttltllll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+slow_conv_transpose2d_ttltllll _self _weight _kernel_size _bias _stride _padding _output_padding _dilation =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::slow_conv_transpose2d(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(at::Tensor* _bias)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , *$(std::vector<int64_t>* _output_padding)
+  , *$(std::vector<int64_t>* _dilation)));
+  }|]
+
+slow_conv_transpose2d_ttltlll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+slow_conv_transpose2d_ttltlll _self _weight _kernel_size _bias _stride _padding _output_padding =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::slow_conv_transpose2d(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(at::Tensor* _bias)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , *$(std::vector<int64_t>* _output_padding)));
+  }|]
+
+slow_conv_transpose2d_ttltll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+slow_conv_transpose2d_ttltll _self _weight _kernel_size _bias _stride _padding =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::slow_conv_transpose2d(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(at::Tensor* _bias)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)));
+  }|]
+
+slow_conv_transpose2d_ttltl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+slow_conv_transpose2d_ttltl _self _weight _kernel_size _bias _stride =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::slow_conv_transpose2d(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(at::Tensor* _bias)
+  , *$(std::vector<int64_t>* _stride)));
+  }|]
+
+slow_conv_transpose2d_ttlt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+slow_conv_transpose2d_ttlt _self _weight _kernel_size _bias =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::slow_conv_transpose2d(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(at::Tensor* _bias)));
+  }|]
+
+slow_conv_transpose2d_ttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+slow_conv_transpose2d_ttl _self _weight _kernel_size =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::slow_conv_transpose2d(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)));
+  }|]
+
+slow_conv_transpose2d_backward_out_ttttttllllltt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor)))
+slow_conv_transpose2d_backward_out_ttttttllllltt _grad_input _grad_weight _grad_bias _grad_output _self _weight _kernel_size _stride _padding _output_padding _dilation _columns _ones =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor>(at::slow_conv_transpose2d_backward_out(
+    *$(at::Tensor* _grad_input)
+  , *$(at::Tensor* _grad_weight)
+  , *$(at::Tensor* _grad_bias)
+  , *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , *$(std::vector<int64_t>* _output_padding)
+  , *$(std::vector<int64_t>* _dilation)
+  , *$(at::Tensor* _columns)
+  , *$(at::Tensor* _ones)));
+  }|]
+
+slow_conv_transpose2d_backward_tttllllltta
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr (StdArray '(CBool,3))
+  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor)))
+slow_conv_transpose2d_backward_tttllllltta _grad_output _self _weight _kernel_size _stride _padding _output_padding _dilation _columns _ones _output_mask =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor>(at::slow_conv_transpose2d_backward(
+    *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , *$(std::vector<int64_t>* _output_padding)
+  , *$(std::vector<int64_t>* _dilation)
+  , *$(at::Tensor* _columns)
+  , *$(at::Tensor* _ones)
+  , *$(std::array<bool,3>* _output_mask)));
+  }|]
+
+slow_conv_transpose3d_out_tttltllll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+slow_conv_transpose3d_out_tttltllll _out _self _weight _kernel_size _bias _stride _padding _output_padding _dilation =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::slow_conv_transpose3d_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(at::Tensor* _bias)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , *$(std::vector<int64_t>* _output_padding)
+  , *$(std::vector<int64_t>* _dilation)));
+  }|]
+
+slow_conv_transpose3d_out_tttltlll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+slow_conv_transpose3d_out_tttltlll _out _self _weight _kernel_size _bias _stride _padding _output_padding =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::slow_conv_transpose3d_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(at::Tensor* _bias)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , *$(std::vector<int64_t>* _output_padding)));
+  }|]
+
+slow_conv_transpose3d_out_tttltll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+slow_conv_transpose3d_out_tttltll _out _self _weight _kernel_size _bias _stride _padding =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::slow_conv_transpose3d_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(at::Tensor* _bias)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)));
+  }|]
+
+slow_conv_transpose3d_out_tttltl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+slow_conv_transpose3d_out_tttltl _out _self _weight _kernel_size _bias _stride =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::slow_conv_transpose3d_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(at::Tensor* _bias)
+  , *$(std::vector<int64_t>* _stride)));
+  }|]
+
+slow_conv_transpose3d_out_tttlt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+slow_conv_transpose3d_out_tttlt _out _self _weight _kernel_size _bias =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::slow_conv_transpose3d_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(at::Tensor* _bias)));
+  }|]
+
+slow_conv_transpose3d_out_tttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+slow_conv_transpose3d_out_tttl _out _self _weight _kernel_size =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::slow_conv_transpose3d_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)));
+  }|]
+
+slow_conv_transpose3d_ttltllll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+slow_conv_transpose3d_ttltllll _self _weight _kernel_size _bias _stride _padding _output_padding _dilation =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::slow_conv_transpose3d(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(at::Tensor* _bias)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , *$(std::vector<int64_t>* _output_padding)
+  , *$(std::vector<int64_t>* _dilation)));
+  }|]
+
+slow_conv_transpose3d_ttltlll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+slow_conv_transpose3d_ttltlll _self _weight _kernel_size _bias _stride _padding _output_padding =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::slow_conv_transpose3d(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(at::Tensor* _bias)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , *$(std::vector<int64_t>* _output_padding)));
+  }|]
+
+slow_conv_transpose3d_ttltll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+slow_conv_transpose3d_ttltll _self _weight _kernel_size _bias _stride _padding =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::slow_conv_transpose3d(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(at::Tensor* _bias)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)));
+  }|]
+
+slow_conv_transpose3d_ttltl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+slow_conv_transpose3d_ttltl _self _weight _kernel_size _bias _stride =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::slow_conv_transpose3d(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(at::Tensor* _bias)
+  , *$(std::vector<int64_t>* _stride)));
+  }|]
+
+slow_conv_transpose3d_ttlt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+slow_conv_transpose3d_ttlt _self _weight _kernel_size _bias =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::slow_conv_transpose3d(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(at::Tensor* _bias)));
+  }|]
+
+slow_conv_transpose3d_ttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+slow_conv_transpose3d_ttl _self _weight _kernel_size =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::slow_conv_transpose3d(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)));
+  }|]
+
+slow_conv_transpose3d_backward_out_ttttttllllltt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor)))
+slow_conv_transpose3d_backward_out_ttttttllllltt _grad_input _grad_weight _grad_bias _grad_output _self _weight _kernel_size _stride _padding _output_padding _dilation _finput _fgrad_input =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor>(at::slow_conv_transpose3d_backward_out(
+    *$(at::Tensor* _grad_input)
+  , *$(at::Tensor* _grad_weight)
+  , *$(at::Tensor* _grad_bias)
+  , *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , *$(std::vector<int64_t>* _output_padding)
+  , *$(std::vector<int64_t>* _dilation)
+  , *$(at::Tensor* _finput)
+  , *$(at::Tensor* _fgrad_input)));
+  }|]
+
+slow_conv_transpose3d_backward_tttllllltta
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr (StdArray '(CBool,3))
+  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor)))
+slow_conv_transpose3d_backward_tttllllltta _grad_output _self _weight _kernel_size _stride _padding _output_padding _dilation _finput _fgrad_input _output_mask =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor>(at::slow_conv_transpose3d_backward(
+    *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , *$(std::vector<int64_t>* _output_padding)
+  , *$(std::vector<int64_t>* _dilation)
+  , *$(at::Tensor* _finput)
+  , *$(at::Tensor* _fgrad_input)
+  , *$(std::array<bool,3>* _output_mask)));
+  }|]
+
+thnn_conv2d_out_tttltll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+thnn_conv2d_out_tttltll _out _self _weight _kernel_size _bias _stride _padding =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::thnn_conv2d_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(at::Tensor* _bias)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)));
+  }|]
+
+thnn_conv2d_out_tttltl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+thnn_conv2d_out_tttltl _out _self _weight _kernel_size _bias _stride =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::thnn_conv2d_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(at::Tensor* _bias)
+  , *$(std::vector<int64_t>* _stride)));
+  }|]
+
+thnn_conv2d_out_tttlt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+thnn_conv2d_out_tttlt _out _self _weight _kernel_size _bias =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::thnn_conv2d_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(at::Tensor* _bias)));
+  }|]
+
+thnn_conv2d_out_tttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+thnn_conv2d_out_tttl _out _self _weight _kernel_size =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::thnn_conv2d_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)));
+  }|]
+
+thnn_conv2d_ttltll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+thnn_conv2d_ttltll _self _weight _kernel_size _bias _stride _padding =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::thnn_conv2d(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(at::Tensor* _bias)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)));
+  }|]
+
+thnn_conv2d_ttltl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+thnn_conv2d_ttltl _self _weight _kernel_size _bias _stride =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::thnn_conv2d(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(at::Tensor* _bias)
+  , *$(std::vector<int64_t>* _stride)));
+  }|]
+
+thnn_conv2d_ttlt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+thnn_conv2d_ttlt _self _weight _kernel_size _bias =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::thnn_conv2d(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(at::Tensor* _bias)));
+  }|]
+
+thnn_conv2d_ttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+thnn_conv2d_ttl _self _weight _kernel_size =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::thnn_conv2d(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)));
+  }|]
+
+thnn_conv2d_forward_out_tttttltll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor)))
+thnn_conv2d_forward_out_tttttltll _output _finput _fgrad_input _self _weight _kernel_size _bias _stride _padding =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor>(at::thnn_conv2d_forward_out(
+    *$(at::Tensor* _output)
+  , *$(at::Tensor* _finput)
+  , *$(at::Tensor* _fgrad_input)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(at::Tensor* _bias)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)));
+  }|]
+
+thnn_conv2d_forward_ttltll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor)))
+thnn_conv2d_forward_ttltll _self _weight _kernel_size _bias _stride _padding =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor>(at::thnn_conv2d_forward(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(at::Tensor* _bias)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)));
+  }|]
+
+thnn_conv2d_backward_out_ttttttllltt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor)))
+thnn_conv2d_backward_out_ttttttllltt _grad_input _grad_weight _grad_bias _grad_output _self _weight _kernel_size _stride _padding _finput _fgrad_input =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor>(at::thnn_conv2d_backward_out(
+    *$(at::Tensor* _grad_input)
+  , *$(at::Tensor* _grad_weight)
+  , *$(at::Tensor* _grad_bias)
+  , *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , *$(at::Tensor* _finput)
+  , *$(at::Tensor* _fgrad_input)));
+  }|]
+
+thnn_conv2d_backward_tttllltta
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr (StdArray '(CBool,3))
+  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor)))
+thnn_conv2d_backward_tttllltta _grad_output _self _weight _kernel_size _stride _padding _finput _fgrad_input _output_mask =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor>(at::thnn_conv2d_backward(
+    *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , *$(at::Tensor* _finput)
+  , *$(at::Tensor* _fgrad_input)
+  , *$(std::array<bool,3>* _output_mask)));
+  }|]
+
+thnn_conv_depthwise2d_out_tttltlll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+thnn_conv_depthwise2d_out_tttltlll _out _self _weight _kernel_size _bias _stride _padding _dilation =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::thnn_conv_depthwise2d_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(at::Tensor* _bias)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , *$(std::vector<int64_t>* _dilation)));
+  }|]
+
+thnn_conv_depthwise2d_out_tttltll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+thnn_conv_depthwise2d_out_tttltll _out _self _weight _kernel_size _bias _stride _padding =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::thnn_conv_depthwise2d_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(at::Tensor* _bias)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)));
+  }|]
+
+thnn_conv_depthwise2d_out_tttltl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+thnn_conv_depthwise2d_out_tttltl _out _self _weight _kernel_size _bias _stride =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::thnn_conv_depthwise2d_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(at::Tensor* _bias)
+  , *$(std::vector<int64_t>* _stride)));
+  }|]
+
+thnn_conv_depthwise2d_out_tttlt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+thnn_conv_depthwise2d_out_tttlt _out _self _weight _kernel_size _bias =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::thnn_conv_depthwise2d_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(at::Tensor* _bias)));
+  }|]
+
+thnn_conv_depthwise2d_out_tttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+thnn_conv_depthwise2d_out_tttl _out _self _weight _kernel_size =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::thnn_conv_depthwise2d_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)));
+  }|]
+
+thnn_conv_depthwise2d_ttltlll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+thnn_conv_depthwise2d_ttltlll _self _weight _kernel_size _bias _stride _padding _dilation =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::thnn_conv_depthwise2d(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(at::Tensor* _bias)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , *$(std::vector<int64_t>* _dilation)));
+  }|]
+
+thnn_conv_depthwise2d_ttltll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+thnn_conv_depthwise2d_ttltll _self _weight _kernel_size _bias _stride _padding =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::thnn_conv_depthwise2d(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(at::Tensor* _bias)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)));
+  }|]
+
+thnn_conv_depthwise2d_ttltl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+thnn_conv_depthwise2d_ttltl _self _weight _kernel_size _bias _stride =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::thnn_conv_depthwise2d(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(at::Tensor* _bias)
+  , *$(std::vector<int64_t>* _stride)));
+  }|]
+
+thnn_conv_depthwise2d_ttlt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+thnn_conv_depthwise2d_ttlt _self _weight _kernel_size _bias =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::thnn_conv_depthwise2d(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(at::Tensor* _bias)));
+  }|]
+
+thnn_conv_depthwise2d_ttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+thnn_conv_depthwise2d_ttl _self _weight _kernel_size =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::thnn_conv_depthwise2d(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)));
+  }|]
+
+thnn_conv_depthwise2d_forward_out_tttltlll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+thnn_conv_depthwise2d_forward_out_tttltlll _out _self _weight _kernel_size _bias _stride _padding _dilation =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::thnn_conv_depthwise2d_forward_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(at::Tensor* _bias)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , *$(std::vector<int64_t>* _dilation)));
+  }|]
+
+thnn_conv_depthwise2d_forward_ttltlll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+thnn_conv_depthwise2d_forward_ttltlll _self _weight _kernel_size _bias _stride _padding _dilation =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::thnn_conv_depthwise2d_forward(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(at::Tensor* _bias)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , *$(std::vector<int64_t>* _dilation)));
   }|]
 

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native14.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native14.hs
@@ -28,1306 +28,6 @@ C.include "<ATen/Tensor.h>"
 C.include "<ATen/Functions.h>"
 
 
-upsample_nearest3d_out_ttldd
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> CDouble
-  -> CDouble
-  -> IO (Ptr Tensor)
-upsample_nearest3d_out_ttldd _out _self _output_size _scales_d _scales_h =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::upsample_nearest3d_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _output_size)
-  , $(double _scales_d)
-  , $(double _scales_h)));
-  }|]
-
-upsample_nearest3d_out_ttld
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> CDouble
-  -> IO (Ptr Tensor)
-upsample_nearest3d_out_ttld _out _self _output_size _scales_d =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::upsample_nearest3d_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _output_size)
-  , $(double _scales_d)));
-  }|]
-
-upsample_nearest3d_out_ttl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-upsample_nearest3d_out_ttl _out _self _output_size =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::upsample_nearest3d_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _output_size)));
-  }|]
-
-upsample_nearest3d_tlddd
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> CDouble
-  -> CDouble
-  -> CDouble
-  -> IO (Ptr Tensor)
-upsample_nearest3d_tlddd _self _output_size _scales_d _scales_h _scales_w =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::upsample_nearest3d(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _output_size)
-  , $(double _scales_d)
-  , $(double _scales_h)
-  , $(double _scales_w)));
-  }|]
-
-upsample_nearest3d_tldd
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> CDouble
-  -> CDouble
-  -> IO (Ptr Tensor)
-upsample_nearest3d_tldd _self _output_size _scales_d _scales_h =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::upsample_nearest3d(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _output_size)
-  , $(double _scales_d)
-  , $(double _scales_h)));
-  }|]
-
--- upsample_nearest3d_tld
---   :: Ptr Tensor
---   -> Ptr IntArray
---   -> CDouble
---   -> IO (Ptr Tensor)
--- upsample_nearest3d_tld _self _output_size _scales_d =
---   [C.throwBlock| at::Tensor* { return new at::Tensor(at::upsample_nearest3d(
---     *$(at::Tensor* _self)
---   , *$(std::vector<int64_t>* _output_size)
---   , $(double _scales_d)));
---   }|]
-
-upsample_nearest3d_tl
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-upsample_nearest3d_tl _self _output_size =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::upsample_nearest3d(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _output_size)));
-  }|]
-
-upsample_nearest3d_backward_out_ttllddd
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> CDouble
-  -> CDouble
-  -> CDouble
-  -> IO (Ptr Tensor)
-upsample_nearest3d_backward_out_ttllddd _grad_input _grad_output _output_size _input_size _scales_d _scales_h _scales_w =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::upsample_nearest3d_backward_out(
-    *$(at::Tensor* _grad_input)
-  , *$(at::Tensor* _grad_output)
-  , *$(std::vector<int64_t>* _output_size)
-  , *$(std::vector<int64_t>* _input_size)
-  , $(double _scales_d)
-  , $(double _scales_h)
-  , $(double _scales_w)));
-  }|]
-
-upsample_nearest3d_backward_out_ttlldd
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> CDouble
-  -> CDouble
-  -> IO (Ptr Tensor)
-upsample_nearest3d_backward_out_ttlldd _grad_input _grad_output _output_size _input_size _scales_d _scales_h =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::upsample_nearest3d_backward_out(
-    *$(at::Tensor* _grad_input)
-  , *$(at::Tensor* _grad_output)
-  , *$(std::vector<int64_t>* _output_size)
-  , *$(std::vector<int64_t>* _input_size)
-  , $(double _scales_d)
-  , $(double _scales_h)));
-  }|]
-
-upsample_nearest3d_backward_out_ttlld
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> CDouble
-  -> IO (Ptr Tensor)
-upsample_nearest3d_backward_out_ttlld _grad_input _grad_output _output_size _input_size _scales_d =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::upsample_nearest3d_backward_out(
-    *$(at::Tensor* _grad_input)
-  , *$(at::Tensor* _grad_output)
-  , *$(std::vector<int64_t>* _output_size)
-  , *$(std::vector<int64_t>* _input_size)
-  , $(double _scales_d)));
-  }|]
-
-upsample_nearest3d_backward_out_ttll
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-upsample_nearest3d_backward_out_ttll _grad_input _grad_output _output_size _input_size =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::upsample_nearest3d_backward_out(
-    *$(at::Tensor* _grad_input)
-  , *$(at::Tensor* _grad_output)
-  , *$(std::vector<int64_t>* _output_size)
-  , *$(std::vector<int64_t>* _input_size)));
-  }|]
-
-upsample_nearest3d_backward_tllddd
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> CDouble
-  -> CDouble
-  -> CDouble
-  -> IO (Ptr Tensor)
-upsample_nearest3d_backward_tllddd _grad_output _output_size _input_size _scales_d _scales_h _scales_w =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::upsample_nearest3d_backward(
-    *$(at::Tensor* _grad_output)
-  , *$(std::vector<int64_t>* _output_size)
-  , *$(std::vector<int64_t>* _input_size)
-  , $(double _scales_d)
-  , $(double _scales_h)
-  , $(double _scales_w)));
-  }|]
-
-upsample_nearest3d_backward_tlldd
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> CDouble
-  -> CDouble
-  -> IO (Ptr Tensor)
-upsample_nearest3d_backward_tlldd _grad_output _output_size _input_size _scales_d _scales_h =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::upsample_nearest3d_backward(
-    *$(at::Tensor* _grad_output)
-  , *$(std::vector<int64_t>* _output_size)
-  , *$(std::vector<int64_t>* _input_size)
-  , $(double _scales_d)
-  , $(double _scales_h)));
-  }|]
-
--- upsample_nearest3d_backward_tlld
---   :: Ptr Tensor
---   -> Ptr IntArray
---   -> Ptr IntArray
---   -> CDouble
---   -> IO (Ptr Tensor)
--- upsample_nearest3d_backward_tlld _grad_output _output_size _input_size _scales_d =
---   [C.throwBlock| at::Tensor* { return new at::Tensor(at::upsample_nearest3d_backward(
---     *$(at::Tensor* _grad_output)
---   , *$(std::vector<int64_t>* _output_size)
---   , *$(std::vector<int64_t>* _input_size)
---   , $(double _scales_d)));
---   }|]
-
-upsample_nearest3d_backward_tll
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-upsample_nearest3d_backward_tll _grad_output _output_size _input_size =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::upsample_nearest3d_backward(
-    *$(at::Tensor* _grad_output)
-  , *$(std::vector<int64_t>* _output_size)
-  , *$(std::vector<int64_t>* _input_size)));
-  }|]
-
-sigmoid_backward_out_ttt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-sigmoid_backward_out_ttt _grad_input _grad_output _output =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::sigmoid_backward_out(
-    *$(at::Tensor* _grad_input)
-  , *$(at::Tensor* _grad_output)
-  , *$(at::Tensor* _output)));
-  }|]
-
-sigmoid_backward_tt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-sigmoid_backward_tt _grad_output _output =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::sigmoid_backward(
-    *$(at::Tensor* _grad_output)
-  , *$(at::Tensor* _output)));
-  }|]
-
-logit_backward_out_tttd
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> CDouble
-  -> IO (Ptr Tensor)
-logit_backward_out_tttd _grad_input _grad_output _self _eps =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::logit_backward_out(
-    *$(at::Tensor* _grad_input)
-  , *$(at::Tensor* _grad_output)
-  , *$(at::Tensor* _self)
-  , $(double _eps)));
-  }|]
-
-logit_backward_out_ttt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-logit_backward_out_ttt _grad_input _grad_output _self =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::logit_backward_out(
-    *$(at::Tensor* _grad_input)
-  , *$(at::Tensor* _grad_output)
-  , *$(at::Tensor* _self)));
-  }|]
-
-logit_backward_ttd
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> CDouble
-  -> IO (Ptr Tensor)
-logit_backward_ttd _grad_output _self _eps =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::logit_backward(
-    *$(at::Tensor* _grad_output)
-  , *$(at::Tensor* _self)
-  , $(double _eps)));
-  }|]
-
-logit_backward_tt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-logit_backward_tt _grad_output _self =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::logit_backward(
-    *$(at::Tensor* _grad_output)
-  , *$(at::Tensor* _self)));
-  }|]
-
-tanh_backward_out_ttt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-tanh_backward_out_ttt _grad_input _grad_output _output =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::tanh_backward_out(
-    *$(at::Tensor* _grad_input)
-  , *$(at::Tensor* _grad_output)
-  , *$(at::Tensor* _output)));
-  }|]
-
-tanh_backward_tt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-tanh_backward_tt _grad_output _output =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::tanh_backward(
-    *$(at::Tensor* _grad_output)
-  , *$(at::Tensor* _output)));
-  }|]
-
-slow_conv_transpose2d_out_tttltllll
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-slow_conv_transpose2d_out_tttltllll _out _self _weight _kernel_size _bias _stride _padding _output_padding _dilation =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::slow_conv_transpose2d_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(at::Tensor* _bias)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)
-  , *$(std::vector<int64_t>* _output_padding)
-  , *$(std::vector<int64_t>* _dilation)));
-  }|]
-
-slow_conv_transpose2d_out_tttltlll
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-slow_conv_transpose2d_out_tttltlll _out _self _weight _kernel_size _bias _stride _padding _output_padding =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::slow_conv_transpose2d_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(at::Tensor* _bias)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)
-  , *$(std::vector<int64_t>* _output_padding)));
-  }|]
-
-slow_conv_transpose2d_out_tttltll
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-slow_conv_transpose2d_out_tttltll _out _self _weight _kernel_size _bias _stride _padding =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::slow_conv_transpose2d_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(at::Tensor* _bias)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)));
-  }|]
-
-slow_conv_transpose2d_out_tttltl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-slow_conv_transpose2d_out_tttltl _out _self _weight _kernel_size _bias _stride =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::slow_conv_transpose2d_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(at::Tensor* _bias)
-  , *$(std::vector<int64_t>* _stride)));
-  }|]
-
-slow_conv_transpose2d_out_tttlt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-slow_conv_transpose2d_out_tttlt _out _self _weight _kernel_size _bias =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::slow_conv_transpose2d_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(at::Tensor* _bias)));
-  }|]
-
-slow_conv_transpose2d_out_tttl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-slow_conv_transpose2d_out_tttl _out _self _weight _kernel_size =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::slow_conv_transpose2d_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)));
-  }|]
-
-slow_conv_transpose2d_ttltllll
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-slow_conv_transpose2d_ttltllll _self _weight _kernel_size _bias _stride _padding _output_padding _dilation =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::slow_conv_transpose2d(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(at::Tensor* _bias)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)
-  , *$(std::vector<int64_t>* _output_padding)
-  , *$(std::vector<int64_t>* _dilation)));
-  }|]
-
-slow_conv_transpose2d_ttltlll
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-slow_conv_transpose2d_ttltlll _self _weight _kernel_size _bias _stride _padding _output_padding =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::slow_conv_transpose2d(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(at::Tensor* _bias)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)
-  , *$(std::vector<int64_t>* _output_padding)));
-  }|]
-
-slow_conv_transpose2d_ttltll
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-slow_conv_transpose2d_ttltll _self _weight _kernel_size _bias _stride _padding =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::slow_conv_transpose2d(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(at::Tensor* _bias)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)));
-  }|]
-
-slow_conv_transpose2d_ttltl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-slow_conv_transpose2d_ttltl _self _weight _kernel_size _bias _stride =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::slow_conv_transpose2d(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(at::Tensor* _bias)
-  , *$(std::vector<int64_t>* _stride)));
-  }|]
-
-slow_conv_transpose2d_ttlt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-slow_conv_transpose2d_ttlt _self _weight _kernel_size _bias =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::slow_conv_transpose2d(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(at::Tensor* _bias)));
-  }|]
-
-slow_conv_transpose2d_ttl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-slow_conv_transpose2d_ttl _self _weight _kernel_size =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::slow_conv_transpose2d(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)));
-  }|]
-
-slow_conv_transpose2d_backward_out_ttttttllllltt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor)))
-slow_conv_transpose2d_backward_out_ttttttllllltt _grad_input _grad_weight _grad_bias _grad_output _self _weight _kernel_size _stride _padding _output_padding _dilation _columns _ones =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor>(at::slow_conv_transpose2d_backward_out(
-    *$(at::Tensor* _grad_input)
-  , *$(at::Tensor* _grad_weight)
-  , *$(at::Tensor* _grad_bias)
-  , *$(at::Tensor* _grad_output)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)
-  , *$(std::vector<int64_t>* _output_padding)
-  , *$(std::vector<int64_t>* _dilation)
-  , *$(at::Tensor* _columns)
-  , *$(at::Tensor* _ones)));
-  }|]
-
-slow_conv_transpose2d_backward_tttllllltta
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr (StdArray '(CBool,3))
-  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor)))
-slow_conv_transpose2d_backward_tttllllltta _grad_output _self _weight _kernel_size _stride _padding _output_padding _dilation _columns _ones _output_mask =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor>(at::slow_conv_transpose2d_backward(
-    *$(at::Tensor* _grad_output)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)
-  , *$(std::vector<int64_t>* _output_padding)
-  , *$(std::vector<int64_t>* _dilation)
-  , *$(at::Tensor* _columns)
-  , *$(at::Tensor* _ones)
-  , *$(std::array<bool,3>* _output_mask)));
-  }|]
-
-slow_conv_transpose3d_out_tttltllll
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-slow_conv_transpose3d_out_tttltllll _out _self _weight _kernel_size _bias _stride _padding _output_padding _dilation =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::slow_conv_transpose3d_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(at::Tensor* _bias)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)
-  , *$(std::vector<int64_t>* _output_padding)
-  , *$(std::vector<int64_t>* _dilation)));
-  }|]
-
-slow_conv_transpose3d_out_tttltlll
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-slow_conv_transpose3d_out_tttltlll _out _self _weight _kernel_size _bias _stride _padding _output_padding =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::slow_conv_transpose3d_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(at::Tensor* _bias)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)
-  , *$(std::vector<int64_t>* _output_padding)));
-  }|]
-
-slow_conv_transpose3d_out_tttltll
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-slow_conv_transpose3d_out_tttltll _out _self _weight _kernel_size _bias _stride _padding =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::slow_conv_transpose3d_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(at::Tensor* _bias)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)));
-  }|]
-
-slow_conv_transpose3d_out_tttltl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-slow_conv_transpose3d_out_tttltl _out _self _weight _kernel_size _bias _stride =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::slow_conv_transpose3d_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(at::Tensor* _bias)
-  , *$(std::vector<int64_t>* _stride)));
-  }|]
-
-slow_conv_transpose3d_out_tttlt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-slow_conv_transpose3d_out_tttlt _out _self _weight _kernel_size _bias =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::slow_conv_transpose3d_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(at::Tensor* _bias)));
-  }|]
-
-slow_conv_transpose3d_out_tttl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-slow_conv_transpose3d_out_tttl _out _self _weight _kernel_size =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::slow_conv_transpose3d_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)));
-  }|]
-
-slow_conv_transpose3d_ttltllll
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-slow_conv_transpose3d_ttltllll _self _weight _kernel_size _bias _stride _padding _output_padding _dilation =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::slow_conv_transpose3d(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(at::Tensor* _bias)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)
-  , *$(std::vector<int64_t>* _output_padding)
-  , *$(std::vector<int64_t>* _dilation)));
-  }|]
-
-slow_conv_transpose3d_ttltlll
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-slow_conv_transpose3d_ttltlll _self _weight _kernel_size _bias _stride _padding _output_padding =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::slow_conv_transpose3d(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(at::Tensor* _bias)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)
-  , *$(std::vector<int64_t>* _output_padding)));
-  }|]
-
-slow_conv_transpose3d_ttltll
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-slow_conv_transpose3d_ttltll _self _weight _kernel_size _bias _stride _padding =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::slow_conv_transpose3d(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(at::Tensor* _bias)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)));
-  }|]
-
-slow_conv_transpose3d_ttltl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-slow_conv_transpose3d_ttltl _self _weight _kernel_size _bias _stride =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::slow_conv_transpose3d(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(at::Tensor* _bias)
-  , *$(std::vector<int64_t>* _stride)));
-  }|]
-
-slow_conv_transpose3d_ttlt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-slow_conv_transpose3d_ttlt _self _weight _kernel_size _bias =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::slow_conv_transpose3d(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(at::Tensor* _bias)));
-  }|]
-
-slow_conv_transpose3d_ttl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-slow_conv_transpose3d_ttl _self _weight _kernel_size =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::slow_conv_transpose3d(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)));
-  }|]
-
-slow_conv_transpose3d_backward_out_ttttttllllltt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor)))
-slow_conv_transpose3d_backward_out_ttttttllllltt _grad_input _grad_weight _grad_bias _grad_output _self _weight _kernel_size _stride _padding _output_padding _dilation _finput _fgrad_input =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor>(at::slow_conv_transpose3d_backward_out(
-    *$(at::Tensor* _grad_input)
-  , *$(at::Tensor* _grad_weight)
-  , *$(at::Tensor* _grad_bias)
-  , *$(at::Tensor* _grad_output)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)
-  , *$(std::vector<int64_t>* _output_padding)
-  , *$(std::vector<int64_t>* _dilation)
-  , *$(at::Tensor* _finput)
-  , *$(at::Tensor* _fgrad_input)));
-  }|]
-
-slow_conv_transpose3d_backward_tttllllltta
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr (StdArray '(CBool,3))
-  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor)))
-slow_conv_transpose3d_backward_tttllllltta _grad_output _self _weight _kernel_size _stride _padding _output_padding _dilation _finput _fgrad_input _output_mask =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor>(at::slow_conv_transpose3d_backward(
-    *$(at::Tensor* _grad_output)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)
-  , *$(std::vector<int64_t>* _output_padding)
-  , *$(std::vector<int64_t>* _dilation)
-  , *$(at::Tensor* _finput)
-  , *$(at::Tensor* _fgrad_input)
-  , *$(std::array<bool,3>* _output_mask)));
-  }|]
-
-thnn_conv2d_out_tttltll
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-thnn_conv2d_out_tttltll _out _self _weight _kernel_size _bias _stride _padding =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::thnn_conv2d_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(at::Tensor* _bias)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)));
-  }|]
-
-thnn_conv2d_out_tttltl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-thnn_conv2d_out_tttltl _out _self _weight _kernel_size _bias _stride =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::thnn_conv2d_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(at::Tensor* _bias)
-  , *$(std::vector<int64_t>* _stride)));
-  }|]
-
-thnn_conv2d_out_tttlt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-thnn_conv2d_out_tttlt _out _self _weight _kernel_size _bias =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::thnn_conv2d_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(at::Tensor* _bias)));
-  }|]
-
-thnn_conv2d_out_tttl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-thnn_conv2d_out_tttl _out _self _weight _kernel_size =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::thnn_conv2d_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)));
-  }|]
-
-thnn_conv2d_ttltll
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-thnn_conv2d_ttltll _self _weight _kernel_size _bias _stride _padding =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::thnn_conv2d(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(at::Tensor* _bias)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)));
-  }|]
-
-thnn_conv2d_ttltl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-thnn_conv2d_ttltl _self _weight _kernel_size _bias _stride =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::thnn_conv2d(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(at::Tensor* _bias)
-  , *$(std::vector<int64_t>* _stride)));
-  }|]
-
-thnn_conv2d_ttlt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-thnn_conv2d_ttlt _self _weight _kernel_size _bias =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::thnn_conv2d(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(at::Tensor* _bias)));
-  }|]
-
-thnn_conv2d_ttl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-thnn_conv2d_ttl _self _weight _kernel_size =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::thnn_conv2d(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)));
-  }|]
-
-thnn_conv2d_forward_out_tttttltll
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor)))
-thnn_conv2d_forward_out_tttttltll _output _finput _fgrad_input _self _weight _kernel_size _bias _stride _padding =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor>(at::thnn_conv2d_forward_out(
-    *$(at::Tensor* _output)
-  , *$(at::Tensor* _finput)
-  , *$(at::Tensor* _fgrad_input)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(at::Tensor* _bias)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)));
-  }|]
-
-thnn_conv2d_forward_ttltll
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor)))
-thnn_conv2d_forward_ttltll _self _weight _kernel_size _bias _stride _padding =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor>(at::thnn_conv2d_forward(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(at::Tensor* _bias)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)));
-  }|]
-
-thnn_conv2d_backward_out_ttttttllltt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor)))
-thnn_conv2d_backward_out_ttttttllltt _grad_input _grad_weight _grad_bias _grad_output _self _weight _kernel_size _stride _padding _finput _fgrad_input =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor>(at::thnn_conv2d_backward_out(
-    *$(at::Tensor* _grad_input)
-  , *$(at::Tensor* _grad_weight)
-  , *$(at::Tensor* _grad_bias)
-  , *$(at::Tensor* _grad_output)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)
-  , *$(at::Tensor* _finput)
-  , *$(at::Tensor* _fgrad_input)));
-  }|]
-
-thnn_conv2d_backward_tttllltta
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr (StdArray '(CBool,3))
-  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor)))
-thnn_conv2d_backward_tttllltta _grad_output _self _weight _kernel_size _stride _padding _finput _fgrad_input _output_mask =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor>(at::thnn_conv2d_backward(
-    *$(at::Tensor* _grad_output)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)
-  , *$(at::Tensor* _finput)
-  , *$(at::Tensor* _fgrad_input)
-  , *$(std::array<bool,3>* _output_mask)));
-  }|]
-
-thnn_conv_depthwise2d_out_tttltlll
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-thnn_conv_depthwise2d_out_tttltlll _out _self _weight _kernel_size _bias _stride _padding _dilation =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::thnn_conv_depthwise2d_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(at::Tensor* _bias)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)
-  , *$(std::vector<int64_t>* _dilation)));
-  }|]
-
-thnn_conv_depthwise2d_out_tttltll
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-thnn_conv_depthwise2d_out_tttltll _out _self _weight _kernel_size _bias _stride _padding =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::thnn_conv_depthwise2d_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(at::Tensor* _bias)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)));
-  }|]
-
-thnn_conv_depthwise2d_out_tttltl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-thnn_conv_depthwise2d_out_tttltl _out _self _weight _kernel_size _bias _stride =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::thnn_conv_depthwise2d_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(at::Tensor* _bias)
-  , *$(std::vector<int64_t>* _stride)));
-  }|]
-
-thnn_conv_depthwise2d_out_tttlt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-thnn_conv_depthwise2d_out_tttlt _out _self _weight _kernel_size _bias =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::thnn_conv_depthwise2d_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(at::Tensor* _bias)));
-  }|]
-
-thnn_conv_depthwise2d_out_tttl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-thnn_conv_depthwise2d_out_tttl _out _self _weight _kernel_size =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::thnn_conv_depthwise2d_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)));
-  }|]
-
-thnn_conv_depthwise2d_ttltlll
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-thnn_conv_depthwise2d_ttltlll _self _weight _kernel_size _bias _stride _padding _dilation =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::thnn_conv_depthwise2d(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(at::Tensor* _bias)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)
-  , *$(std::vector<int64_t>* _dilation)));
-  }|]
-
-thnn_conv_depthwise2d_ttltll
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-thnn_conv_depthwise2d_ttltll _self _weight _kernel_size _bias _stride _padding =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::thnn_conv_depthwise2d(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(at::Tensor* _bias)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)));
-  }|]
-
-thnn_conv_depthwise2d_ttltl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-thnn_conv_depthwise2d_ttltl _self _weight _kernel_size _bias _stride =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::thnn_conv_depthwise2d(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(at::Tensor* _bias)
-  , *$(std::vector<int64_t>* _stride)));
-  }|]
-
-thnn_conv_depthwise2d_ttlt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-thnn_conv_depthwise2d_ttlt _self _weight _kernel_size _bias =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::thnn_conv_depthwise2d(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(at::Tensor* _bias)));
-  }|]
-
-thnn_conv_depthwise2d_ttl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-thnn_conv_depthwise2d_ttl _self _weight _kernel_size =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::thnn_conv_depthwise2d(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)));
-  }|]
-
-thnn_conv_depthwise2d_forward_out_tttltlll
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-thnn_conv_depthwise2d_forward_out_tttltlll _out _self _weight _kernel_size _bias _stride _padding _dilation =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::thnn_conv_depthwise2d_forward_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(at::Tensor* _bias)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)
-  , *$(std::vector<int64_t>* _dilation)));
-  }|]
-
-thnn_conv_depthwise2d_forward_ttltlll
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-thnn_conv_depthwise2d_forward_ttltlll _self _weight _kernel_size _bias _stride _padding _dilation =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::thnn_conv_depthwise2d_forward(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _weight)
-  , *$(std::vector<int64_t>* _kernel_size)
-  , *$(at::Tensor* _bias)
-  , *$(std::vector<int64_t>* _stride)
-  , *$(std::vector<int64_t>* _padding)
-  , *$(std::vector<int64_t>* _dilation)));
-  }|]
-
 thnn_conv_depthwise2d_backward_out_tttttllll
   :: Ptr Tensor
   -> Ptr Tensor
@@ -1372,6 +72,74 @@ thnn_conv_depthwise2d_backward_tttlllla _grad_output _self _weight _kernel_size 
   , *$(std::vector<int64_t>* _padding)
   , *$(std::vector<int64_t>* _dilation)
   , *$(std::array<bool,2>* _output_mask)));
+  }|]
+
+conv_depthwise3d_ttltlll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+conv_depthwise3d_ttltlll _self _weight _kernel_size _bias _stride _padding _dilation =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::conv_depthwise3d(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(at::Tensor* _bias)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , *$(std::vector<int64_t>* _dilation)));
+  }|]
+
+conv_depthwise3d_backward_out_ttttttllll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor)))
+conv_depthwise3d_backward_out_ttttttllll _grad_input _grad_weight _grad_bias _grad_output _self _weight _kernel_size _stride _padding _dilation =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor>(at::conv_depthwise3d_backward_out(
+    *$(at::Tensor* _grad_input)
+  , *$(at::Tensor* _grad_weight)
+  , *$(at::Tensor* _grad_bias)
+  , *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , *$(std::vector<int64_t>* _dilation)));
+  }|]
+
+conv_depthwise3d_backward_tttlllla
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr (StdArray '(CBool,3))
+  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor)))
+conv_depthwise3d_backward_tttlllla _grad_output _self _weight _kernel_size _stride _padding _dilation _output_mask =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor>(at::conv_depthwise3d_backward(
+    *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , *$(std::vector<int64_t>* _dilation)
+  , *$(std::array<bool,3>* _output_mask)));
   }|]
 
 slow_conv3d_out_tttltll
@@ -2040,6 +808,274 @@ _remove_batch_dim_tlll _self _level _batch_size _out_dim =
   , $(int64_t _out_dim)));
   }|]
 
+special_entr_t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+special_entr_t _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::special_entr(
+    *$(at::Tensor* _self)));
+  }|]
+
+special_entr_out_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+special_entr_out_tt _out _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::special_entr_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)));
+  }|]
+
+special_expm1_t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+special_expm1_t _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::special_expm1(
+    *$(at::Tensor* _self)));
+  }|]
+
+special_expm1_out_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+special_expm1_out_tt _out _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::special_expm1_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)));
+  }|]
+
+special_exp2_t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+special_exp2_t _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::special_exp2(
+    *$(at::Tensor* _self)));
+  }|]
+
+special_exp2_out_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+special_exp2_out_tt _out _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::special_exp2_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)));
+  }|]
+
+special_gammaln_t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+special_gammaln_t _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::special_gammaln(
+    *$(at::Tensor* _self)));
+  }|]
+
+special_gammaln_out_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+special_gammaln_out_tt _out _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::special_gammaln_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)));
+  }|]
+
+special_erf_t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+special_erf_t _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::special_erf(
+    *$(at::Tensor* _self)));
+  }|]
+
+special_erf_out_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+special_erf_out_tt _out _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::special_erf_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)));
+  }|]
+
+special_erfc_t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+special_erfc_t _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::special_erfc(
+    *$(at::Tensor* _self)));
+  }|]
+
+special_erfc_out_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+special_erfc_out_tt _out _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::special_erfc_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)));
+  }|]
+
+special_erfinv_t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+special_erfinv_t _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::special_erfinv(
+    *$(at::Tensor* _self)));
+  }|]
+
+special_erfinv_out_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+special_erfinv_out_tt _out _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::special_erfinv_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)));
+  }|]
+
+special_xlog1py_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+special_xlog1py_tt _self _other =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::special_xlog1py(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _other)));
+  }|]
+
+special_xlog1py_st
+  :: Ptr Scalar
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+special_xlog1py_st _self _other =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::special_xlog1py(
+    *$(at::Scalar* _self)
+  , *$(at::Tensor* _other)));
+  }|]
+
+special_xlog1py_ts
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+special_xlog1py_ts _self _other =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::special_xlog1py(
+    *$(at::Tensor* _self)
+  , *$(at::Scalar* _other)));
+  }|]
+
+special_xlog1py_out_ttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+special_xlog1py_out_ttt _out _self _other =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::special_xlog1py_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _other)));
+  }|]
+
+special_xlog1py_out_tst
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+special_xlog1py_out_tst _out _self _other =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::special_xlog1py_out(
+    *$(at::Tensor* _out)
+  , *$(at::Scalar* _self)
+  , *$(at::Tensor* _other)));
+  }|]
+
+special_xlog1py_out_tts
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+special_xlog1py_out_tts _out _self _other =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::special_xlog1py_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Scalar* _other)));
+  }|]
+
+special_i0e_t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+special_i0e_t _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::special_i0e(
+    *$(at::Tensor* _self)));
+  }|]
+
+special_i0e_out_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+special_i0e_out_tt _out _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::special_i0e_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)));
+  }|]
+
+special_logit_td
+  :: Ptr Tensor
+  -> CDouble
+  -> IO (Ptr Tensor)
+special_logit_td _self _eps =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::special_logit(
+    *$(at::Tensor* _self)
+  , $(double _eps)));
+  }|]
+
+special_logit_t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+special_logit_t _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::special_logit(
+    *$(at::Tensor* _self)));
+  }|]
+
+special_logit_out_ttd
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> CDouble
+  -> IO (Ptr Tensor)
+special_logit_out_ttd _out _self _eps =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::special_logit_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , $(double _eps)));
+  }|]
+
+special_logit_out_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+special_logit_out_tt _out _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::special_logit_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)));
+  }|]
+
+special_expit_t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+special_expit_t _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::special_expit(
+    *$(at::Tensor* _self)));
+  }|]
+
+special_expit_out_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+special_expit_out_tt _out _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::special_expit_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)));
+  }|]
+
 fft_fft_tlls
   :: Ptr Tensor
   -> Int64
@@ -2688,5 +1724,729 @@ fft_fft2_out_ttll _out _self _s _dim =
   , *$(at::Tensor* _self)
   , *$(std::vector<int64_t>* _s)
   , *$(std::vector<int64_t>* _dim)));
+  }|]
+
+fft_fft2_out_ttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+fft_fft2_out_ttl _out _self _s =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_fft2_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _s)));
+  }|]
+
+fft_fft2_out_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+fft_fft2_out_tt _out _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_fft2_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)));
+  }|]
+
+fft_ifft2_tlls
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr StdString
+  -> IO (Ptr Tensor)
+fft_ifft2_tlls _self _s _dim _norm =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_ifft2(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _s)
+  , *$(std::vector<int64_t>* _dim)
+  , *$(std::string* _norm)));
+  }|]
+
+fft_ifft2_tll
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+fft_ifft2_tll _self _s _dim =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_ifft2(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _s)
+  , *$(std::vector<int64_t>* _dim)));
+  }|]
+
+fft_ifft2_tl
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+fft_ifft2_tl _self _s =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_ifft2(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _s)));
+  }|]
+
+fft_ifft2_t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+fft_ifft2_t _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_ifft2(
+    *$(at::Tensor* _self)));
+  }|]
+
+fft_ifft2_out_ttlls
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr StdString
+  -> IO (Ptr Tensor)
+fft_ifft2_out_ttlls _out _self _s _dim _norm =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_ifft2_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _s)
+  , *$(std::vector<int64_t>* _dim)
+  , *$(std::string* _norm)));
+  }|]
+
+fft_ifft2_out_ttll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+fft_ifft2_out_ttll _out _self _s _dim =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_ifft2_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _s)
+  , *$(std::vector<int64_t>* _dim)));
+  }|]
+
+fft_ifft2_out_ttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+fft_ifft2_out_ttl _out _self _s =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_ifft2_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _s)));
+  }|]
+
+fft_ifft2_out_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+fft_ifft2_out_tt _out _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_ifft2_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)));
+  }|]
+
+fft_rfft2_tlls
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr StdString
+  -> IO (Ptr Tensor)
+fft_rfft2_tlls _self _s _dim _norm =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_rfft2(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _s)
+  , *$(std::vector<int64_t>* _dim)
+  , *$(std::string* _norm)));
+  }|]
+
+fft_rfft2_tll
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+fft_rfft2_tll _self _s _dim =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_rfft2(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _s)
+  , *$(std::vector<int64_t>* _dim)));
+  }|]
+
+fft_rfft2_tl
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+fft_rfft2_tl _self _s =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_rfft2(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _s)));
+  }|]
+
+fft_rfft2_t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+fft_rfft2_t _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_rfft2(
+    *$(at::Tensor* _self)));
+  }|]
+
+fft_rfft2_out_ttlls
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr StdString
+  -> IO (Ptr Tensor)
+fft_rfft2_out_ttlls _out _self _s _dim _norm =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_rfft2_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _s)
+  , *$(std::vector<int64_t>* _dim)
+  , *$(std::string* _norm)));
+  }|]
+
+fft_rfft2_out_ttll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+fft_rfft2_out_ttll _out _self _s _dim =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_rfft2_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _s)
+  , *$(std::vector<int64_t>* _dim)));
+  }|]
+
+fft_rfft2_out_ttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+fft_rfft2_out_ttl _out _self _s =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_rfft2_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _s)));
+  }|]
+
+fft_rfft2_out_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+fft_rfft2_out_tt _out _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_rfft2_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)));
+  }|]
+
+fft_irfft2_tlls
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr StdString
+  -> IO (Ptr Tensor)
+fft_irfft2_tlls _self _s _dim _norm =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_irfft2(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _s)
+  , *$(std::vector<int64_t>* _dim)
+  , *$(std::string* _norm)));
+  }|]
+
+fft_irfft2_tll
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+fft_irfft2_tll _self _s _dim =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_irfft2(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _s)
+  , *$(std::vector<int64_t>* _dim)));
+  }|]
+
+fft_irfft2_tl
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+fft_irfft2_tl _self _s =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_irfft2(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _s)));
+  }|]
+
+fft_irfft2_t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+fft_irfft2_t _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_irfft2(
+    *$(at::Tensor* _self)));
+  }|]
+
+fft_irfft2_out_ttlls
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr StdString
+  -> IO (Ptr Tensor)
+fft_irfft2_out_ttlls _out _self _s _dim _norm =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_irfft2_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _s)
+  , *$(std::vector<int64_t>* _dim)
+  , *$(std::string* _norm)));
+  }|]
+
+fft_irfft2_out_ttll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+fft_irfft2_out_ttll _out _self _s _dim =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_irfft2_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _s)
+  , *$(std::vector<int64_t>* _dim)));
+  }|]
+
+fft_irfft2_out_ttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+fft_irfft2_out_ttl _out _self _s =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_irfft2_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _s)));
+  }|]
+
+fft_irfft2_out_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+fft_irfft2_out_tt _out _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_irfft2_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)));
+  }|]
+
+fft_fftn_tlls
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr StdString
+  -> IO (Ptr Tensor)
+fft_fftn_tlls _self _s _dim _norm =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_fftn(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _s)
+  , *$(std::vector<int64_t>* _dim)
+  , *$(std::string* _norm)));
+  }|]
+
+fft_fftn_tll
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+fft_fftn_tll _self _s _dim =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_fftn(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _s)
+  , *$(std::vector<int64_t>* _dim)));
+  }|]
+
+fft_fftn_tl
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+fft_fftn_tl _self _s =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_fftn(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _s)));
+  }|]
+
+fft_fftn_t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+fft_fftn_t _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_fftn(
+    *$(at::Tensor* _self)));
+  }|]
+
+fft_fftn_out_ttlls
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr StdString
+  -> IO (Ptr Tensor)
+fft_fftn_out_ttlls _out _self _s _dim _norm =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_fftn_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _s)
+  , *$(std::vector<int64_t>* _dim)
+  , *$(std::string* _norm)));
+  }|]
+
+fft_fftn_out_ttll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+fft_fftn_out_ttll _out _self _s _dim =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_fftn_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _s)
+  , *$(std::vector<int64_t>* _dim)));
+  }|]
+
+fft_fftn_out_ttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+fft_fftn_out_ttl _out _self _s =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_fftn_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _s)));
+  }|]
+
+fft_fftn_out_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+fft_fftn_out_tt _out _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_fftn_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)));
+  }|]
+
+fft_ifftn_tlls
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr StdString
+  -> IO (Ptr Tensor)
+fft_ifftn_tlls _self _s _dim _norm =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_ifftn(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _s)
+  , *$(std::vector<int64_t>* _dim)
+  , *$(std::string* _norm)));
+  }|]
+
+fft_ifftn_tll
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+fft_ifftn_tll _self _s _dim =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_ifftn(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _s)
+  , *$(std::vector<int64_t>* _dim)));
+  }|]
+
+fft_ifftn_tl
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+fft_ifftn_tl _self _s =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_ifftn(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _s)));
+  }|]
+
+fft_ifftn_t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+fft_ifftn_t _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_ifftn(
+    *$(at::Tensor* _self)));
+  }|]
+
+fft_ifftn_out_ttlls
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr StdString
+  -> IO (Ptr Tensor)
+fft_ifftn_out_ttlls _out _self _s _dim _norm =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_ifftn_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _s)
+  , *$(std::vector<int64_t>* _dim)
+  , *$(std::string* _norm)));
+  }|]
+
+fft_ifftn_out_ttll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+fft_ifftn_out_ttll _out _self _s _dim =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_ifftn_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _s)
+  , *$(std::vector<int64_t>* _dim)));
+  }|]
+
+fft_ifftn_out_ttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+fft_ifftn_out_ttl _out _self _s =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_ifftn_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _s)));
+  }|]
+
+fft_ifftn_out_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+fft_ifftn_out_tt _out _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_ifftn_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)));
+  }|]
+
+fft_rfftn_tlls
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr StdString
+  -> IO (Ptr Tensor)
+fft_rfftn_tlls _self _s _dim _norm =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_rfftn(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _s)
+  , *$(std::vector<int64_t>* _dim)
+  , *$(std::string* _norm)));
+  }|]
+
+fft_rfftn_tll
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+fft_rfftn_tll _self _s _dim =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_rfftn(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _s)
+  , *$(std::vector<int64_t>* _dim)));
+  }|]
+
+fft_rfftn_tl
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+fft_rfftn_tl _self _s =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_rfftn(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _s)));
+  }|]
+
+fft_rfftn_t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+fft_rfftn_t _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_rfftn(
+    *$(at::Tensor* _self)));
+  }|]
+
+fft_rfftn_out_ttlls
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr StdString
+  -> IO (Ptr Tensor)
+fft_rfftn_out_ttlls _out _self _s _dim _norm =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_rfftn_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _s)
+  , *$(std::vector<int64_t>* _dim)
+  , *$(std::string* _norm)));
+  }|]
+
+fft_rfftn_out_ttll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+fft_rfftn_out_ttll _out _self _s _dim =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_rfftn_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _s)
+  , *$(std::vector<int64_t>* _dim)));
+  }|]
+
+fft_rfftn_out_ttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+fft_rfftn_out_ttl _out _self _s =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_rfftn_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _s)));
+  }|]
+
+fft_rfftn_out_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+fft_rfftn_out_tt _out _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_rfftn_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)));
+  }|]
+
+fft_irfftn_tlls
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr StdString
+  -> IO (Ptr Tensor)
+fft_irfftn_tlls _self _s _dim _norm =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_irfftn(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _s)
+  , *$(std::vector<int64_t>* _dim)
+  , *$(std::string* _norm)));
+  }|]
+
+fft_irfftn_tll
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+fft_irfftn_tll _self _s _dim =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_irfftn(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _s)
+  , *$(std::vector<int64_t>* _dim)));
+  }|]
+
+fft_irfftn_tl
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+fft_irfftn_tl _self _s =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_irfftn(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _s)));
+  }|]
+
+fft_irfftn_t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+fft_irfftn_t _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_irfftn(
+    *$(at::Tensor* _self)));
+  }|]
+
+fft_irfftn_out_ttlls
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr StdString
+  -> IO (Ptr Tensor)
+fft_irfftn_out_ttlls _out _self _s _dim _norm =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_irfftn_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _s)
+  , *$(std::vector<int64_t>* _dim)
+  , *$(std::string* _norm)));
+  }|]
+
+fft_irfftn_out_ttll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+fft_irfftn_out_ttll _out _self _s _dim =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_irfftn_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _s)
+  , *$(std::vector<int64_t>* _dim)));
+  }|]
+
+fft_irfftn_out_ttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+fft_irfftn_out_ttl _out _self _s =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_irfftn_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _s)));
+  }|]
+
+fft_irfftn_out_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+fft_irfftn_out_tt _out _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_irfftn_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)));
+  }|]
+
+fft_fftfreq_ldo
+  :: Int64
+  -> CDouble
+  -> Ptr TensorOptions
+  -> IO (Ptr Tensor)
+fft_fftfreq_ldo _n _d _options =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_fftfreq(
+    $(int64_t _n)
+  , $(double _d)
+  , *$(at::TensorOptions* _options)));
+  }|]
+
+fft_fftfreq_ld
+  :: Int64
+  -> CDouble
+  -> IO (Ptr Tensor)
+fft_fftfreq_ld _n _d =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_fftfreq(
+    $(int64_t _n)
+  , $(double _d)));
+  }|]
+
+fft_fftfreq_l
+  :: Int64
+  -> IO (Ptr Tensor)
+fft_fftfreq_l _n =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_fftfreq(
+    $(int64_t _n)));
   }|]
 

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native15.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native15.hs
@@ -28,730 +28,6 @@ C.include "<ATen/Tensor.h>"
 C.include "<ATen/Functions.h>"
 
 
-fft_fft2_out_ttl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-fft_fft2_out_ttl _out _self _s =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_fft2_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _s)));
-  }|]
-
-fft_fft2_out_tt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-fft_fft2_out_tt _out _self =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_fft2_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)));
-  }|]
-
-fft_ifft2_tlls
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr StdString
-  -> IO (Ptr Tensor)
-fft_ifft2_tlls _self _s _dim _norm =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_ifft2(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _s)
-  , *$(std::vector<int64_t>* _dim)
-  , *$(std::string* _norm)));
-  }|]
-
-fft_ifft2_tll
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-fft_ifft2_tll _self _s _dim =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_ifft2(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _s)
-  , *$(std::vector<int64_t>* _dim)));
-  }|]
-
-fft_ifft2_tl
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-fft_ifft2_tl _self _s =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_ifft2(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _s)));
-  }|]
-
-fft_ifft2_t
-  :: Ptr Tensor
-  -> IO (Ptr Tensor)
-fft_ifft2_t _self =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_ifft2(
-    *$(at::Tensor* _self)));
-  }|]
-
-fft_ifft2_out_ttlls
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr StdString
-  -> IO (Ptr Tensor)
-fft_ifft2_out_ttlls _out _self _s _dim _norm =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_ifft2_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _s)
-  , *$(std::vector<int64_t>* _dim)
-  , *$(std::string* _norm)));
-  }|]
-
-fft_ifft2_out_ttll
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-fft_ifft2_out_ttll _out _self _s _dim =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_ifft2_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _s)
-  , *$(std::vector<int64_t>* _dim)));
-  }|]
-
-fft_ifft2_out_ttl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-fft_ifft2_out_ttl _out _self _s =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_ifft2_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _s)));
-  }|]
-
-fft_ifft2_out_tt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-fft_ifft2_out_tt _out _self =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_ifft2_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)));
-  }|]
-
-fft_rfft2_tlls
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr StdString
-  -> IO (Ptr Tensor)
-fft_rfft2_tlls _self _s _dim _norm =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_rfft2(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _s)
-  , *$(std::vector<int64_t>* _dim)
-  , *$(std::string* _norm)));
-  }|]
-
-fft_rfft2_tll
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-fft_rfft2_tll _self _s _dim =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_rfft2(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _s)
-  , *$(std::vector<int64_t>* _dim)));
-  }|]
-
-fft_rfft2_tl
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-fft_rfft2_tl _self _s =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_rfft2(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _s)));
-  }|]
-
-fft_rfft2_t
-  :: Ptr Tensor
-  -> IO (Ptr Tensor)
-fft_rfft2_t _self =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_rfft2(
-    *$(at::Tensor* _self)));
-  }|]
-
-fft_rfft2_out_ttlls
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr StdString
-  -> IO (Ptr Tensor)
-fft_rfft2_out_ttlls _out _self _s _dim _norm =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_rfft2_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _s)
-  , *$(std::vector<int64_t>* _dim)
-  , *$(std::string* _norm)));
-  }|]
-
-fft_rfft2_out_ttll
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-fft_rfft2_out_ttll _out _self _s _dim =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_rfft2_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _s)
-  , *$(std::vector<int64_t>* _dim)));
-  }|]
-
-fft_rfft2_out_ttl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-fft_rfft2_out_ttl _out _self _s =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_rfft2_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _s)));
-  }|]
-
-fft_rfft2_out_tt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-fft_rfft2_out_tt _out _self =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_rfft2_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)));
-  }|]
-
-fft_irfft2_tlls
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr StdString
-  -> IO (Ptr Tensor)
-fft_irfft2_tlls _self _s _dim _norm =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_irfft2(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _s)
-  , *$(std::vector<int64_t>* _dim)
-  , *$(std::string* _norm)));
-  }|]
-
-fft_irfft2_tll
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-fft_irfft2_tll _self _s _dim =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_irfft2(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _s)
-  , *$(std::vector<int64_t>* _dim)));
-  }|]
-
-fft_irfft2_tl
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-fft_irfft2_tl _self _s =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_irfft2(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _s)));
-  }|]
-
-fft_irfft2_t
-  :: Ptr Tensor
-  -> IO (Ptr Tensor)
-fft_irfft2_t _self =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_irfft2(
-    *$(at::Tensor* _self)));
-  }|]
-
-fft_irfft2_out_ttlls
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr StdString
-  -> IO (Ptr Tensor)
-fft_irfft2_out_ttlls _out _self _s _dim _norm =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_irfft2_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _s)
-  , *$(std::vector<int64_t>* _dim)
-  , *$(std::string* _norm)));
-  }|]
-
-fft_irfft2_out_ttll
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-fft_irfft2_out_ttll _out _self _s _dim =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_irfft2_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _s)
-  , *$(std::vector<int64_t>* _dim)));
-  }|]
-
-fft_irfft2_out_ttl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-fft_irfft2_out_ttl _out _self _s =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_irfft2_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _s)));
-  }|]
-
-fft_irfft2_out_tt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-fft_irfft2_out_tt _out _self =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_irfft2_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)));
-  }|]
-
-fft_fftn_tlls
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr StdString
-  -> IO (Ptr Tensor)
-fft_fftn_tlls _self _s _dim _norm =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_fftn(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _s)
-  , *$(std::vector<int64_t>* _dim)
-  , *$(std::string* _norm)));
-  }|]
-
-fft_fftn_tll
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-fft_fftn_tll _self _s _dim =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_fftn(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _s)
-  , *$(std::vector<int64_t>* _dim)));
-  }|]
-
-fft_fftn_tl
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-fft_fftn_tl _self _s =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_fftn(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _s)));
-  }|]
-
-fft_fftn_t
-  :: Ptr Tensor
-  -> IO (Ptr Tensor)
-fft_fftn_t _self =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_fftn(
-    *$(at::Tensor* _self)));
-  }|]
-
-fft_fftn_out_ttlls
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr StdString
-  -> IO (Ptr Tensor)
-fft_fftn_out_ttlls _out _self _s _dim _norm =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_fftn_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _s)
-  , *$(std::vector<int64_t>* _dim)
-  , *$(std::string* _norm)));
-  }|]
-
-fft_fftn_out_ttll
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-fft_fftn_out_ttll _out _self _s _dim =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_fftn_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _s)
-  , *$(std::vector<int64_t>* _dim)));
-  }|]
-
-fft_fftn_out_ttl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-fft_fftn_out_ttl _out _self _s =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_fftn_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _s)));
-  }|]
-
-fft_fftn_out_tt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-fft_fftn_out_tt _out _self =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_fftn_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)));
-  }|]
-
-fft_ifftn_tlls
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr StdString
-  -> IO (Ptr Tensor)
-fft_ifftn_tlls _self _s _dim _norm =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_ifftn(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _s)
-  , *$(std::vector<int64_t>* _dim)
-  , *$(std::string* _norm)));
-  }|]
-
-fft_ifftn_tll
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-fft_ifftn_tll _self _s _dim =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_ifftn(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _s)
-  , *$(std::vector<int64_t>* _dim)));
-  }|]
-
-fft_ifftn_tl
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-fft_ifftn_tl _self _s =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_ifftn(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _s)));
-  }|]
-
-fft_ifftn_t
-  :: Ptr Tensor
-  -> IO (Ptr Tensor)
-fft_ifftn_t _self =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_ifftn(
-    *$(at::Tensor* _self)));
-  }|]
-
-fft_ifftn_out_ttlls
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr StdString
-  -> IO (Ptr Tensor)
-fft_ifftn_out_ttlls _out _self _s _dim _norm =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_ifftn_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _s)
-  , *$(std::vector<int64_t>* _dim)
-  , *$(std::string* _norm)));
-  }|]
-
-fft_ifftn_out_ttll
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-fft_ifftn_out_ttll _out _self _s _dim =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_ifftn_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _s)
-  , *$(std::vector<int64_t>* _dim)));
-  }|]
-
-fft_ifftn_out_ttl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-fft_ifftn_out_ttl _out _self _s =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_ifftn_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _s)));
-  }|]
-
-fft_ifftn_out_tt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-fft_ifftn_out_tt _out _self =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_ifftn_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)));
-  }|]
-
-fft_rfftn_tlls
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr StdString
-  -> IO (Ptr Tensor)
-fft_rfftn_tlls _self _s _dim _norm =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_rfftn(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _s)
-  , *$(std::vector<int64_t>* _dim)
-  , *$(std::string* _norm)));
-  }|]
-
-fft_rfftn_tll
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-fft_rfftn_tll _self _s _dim =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_rfftn(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _s)
-  , *$(std::vector<int64_t>* _dim)));
-  }|]
-
-fft_rfftn_tl
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-fft_rfftn_tl _self _s =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_rfftn(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _s)));
-  }|]
-
-fft_rfftn_t
-  :: Ptr Tensor
-  -> IO (Ptr Tensor)
-fft_rfftn_t _self =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_rfftn(
-    *$(at::Tensor* _self)));
-  }|]
-
-fft_rfftn_out_ttlls
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr StdString
-  -> IO (Ptr Tensor)
-fft_rfftn_out_ttlls _out _self _s _dim _norm =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_rfftn_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _s)
-  , *$(std::vector<int64_t>* _dim)
-  , *$(std::string* _norm)));
-  }|]
-
-fft_rfftn_out_ttll
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-fft_rfftn_out_ttll _out _self _s _dim =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_rfftn_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _s)
-  , *$(std::vector<int64_t>* _dim)));
-  }|]
-
-fft_rfftn_out_ttl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-fft_rfftn_out_ttl _out _self _s =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_rfftn_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _s)));
-  }|]
-
-fft_rfftn_out_tt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-fft_rfftn_out_tt _out _self =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_rfftn_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)));
-  }|]
-
-fft_irfftn_tlls
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr StdString
-  -> IO (Ptr Tensor)
-fft_irfftn_tlls _self _s _dim _norm =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_irfftn(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _s)
-  , *$(std::vector<int64_t>* _dim)
-  , *$(std::string* _norm)));
-  }|]
-
-fft_irfftn_tll
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-fft_irfftn_tll _self _s _dim =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_irfftn(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _s)
-  , *$(std::vector<int64_t>* _dim)));
-  }|]
-
-fft_irfftn_tl
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-fft_irfftn_tl _self _s =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_irfftn(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _s)));
-  }|]
-
-fft_irfftn_t
-  :: Ptr Tensor
-  -> IO (Ptr Tensor)
-fft_irfftn_t _self =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_irfftn(
-    *$(at::Tensor* _self)));
-  }|]
-
-fft_irfftn_out_ttlls
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> Ptr StdString
-  -> IO (Ptr Tensor)
-fft_irfftn_out_ttlls _out _self _s _dim _norm =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_irfftn_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _s)
-  , *$(std::vector<int64_t>* _dim)
-  , *$(std::string* _norm)));
-  }|]
-
-fft_irfftn_out_ttll
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-fft_irfftn_out_ttll _out _self _s _dim =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_irfftn_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _s)
-  , *$(std::vector<int64_t>* _dim)));
-  }|]
-
-fft_irfftn_out_ttl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-fft_irfftn_out_ttl _out _self _s =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_irfftn_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _s)));
-  }|]
-
-fft_irfftn_out_tt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-fft_irfftn_out_tt _out _self =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_irfftn_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)));
-  }|]
-
-fft_fftfreq_ldo
-  :: Int64
-  -> CDouble
-  -> Ptr TensorOptions
-  -> IO (Ptr Tensor)
-fft_fftfreq_ldo _n _d _options =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_fftfreq(
-    $(int64_t _n)
-  , $(double _d)
-  , *$(at::TensorOptions* _options)));
-  }|]
-
-fft_fftfreq_ld
-  :: Int64
-  -> CDouble
-  -> IO (Ptr Tensor)
-fft_fftfreq_ld _n _d =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_fftfreq(
-    $(int64_t _n)
-  , $(double _d)));
-  }|]
-
-fft_fftfreq_l
-  :: Int64
-  -> IO (Ptr Tensor)
-fft_fftfreq_l _n =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::fft_fftfreq(
-    $(int64_t _n)));
-  }|]
-
 fft_fftfreq_out_tld
   :: Ptr Tensor
   -> Int64
@@ -862,6 +138,50 @@ fft_ifftshift_t _self =
     *$(at::Tensor* _self)));
   }|]
 
+linalg_cholesky_ex_tb
+  :: Ptr Tensor
+  -> CBool
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+linalg_cholesky_ex_tb _self _check_errors =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::linalg_cholesky_ex(
+    *$(at::Tensor* _self)
+  , $(bool _check_errors)));
+  }|]
+
+linalg_cholesky_ex_t
+  :: Ptr Tensor
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+linalg_cholesky_ex_t _self =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::linalg_cholesky_ex(
+    *$(at::Tensor* _self)));
+  }|]
+
+linalg_cholesky_ex_out_tttb
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> CBool
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+linalg_cholesky_ex_out_tttb _L _info _self _check_errors =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::linalg_cholesky_ex_out(
+    *$(at::Tensor* _L)
+  , *$(at::Tensor* _info)
+  , *$(at::Tensor* _self)
+  , $(bool _check_errors)));
+  }|]
+
+linalg_cholesky_ex_out_ttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+linalg_cholesky_ex_out_ttt _L _info _self =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::linalg_cholesky_ex_out(
+    *$(at::Tensor* _L)
+  , *$(at::Tensor* _info)
+  , *$(at::Tensor* _self)));
+  }|]
+
 linalg_cholesky_t
   :: Ptr Tensor
   -> IO (Ptr Tensor)
@@ -888,12 +208,118 @@ linalg_det_t _self =
     *$(at::Tensor* _self)));
   }|]
 
+linalg_det_out_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+linalg_det_out_tt _out _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::linalg_det_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)));
+  }|]
+
 det_t
   :: Ptr Tensor
   -> IO (Ptr Tensor)
 det_t _self =
   [C.throwBlock| at::Tensor* { return new at::Tensor(at::det(
     *$(at::Tensor* _self)));
+  }|]
+
+linalg_lstsq_ttds
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> CDouble
+  -> Ptr StdString
+  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
+linalg_lstsq_ttds _self _b _rcond _driver =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor,at::Tensor>(at::linalg_lstsq(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _b)
+  , $(double _rcond)
+  , *$(std::string* _driver)));
+  }|]
+
+linalg_lstsq_ttd
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> CDouble
+  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
+linalg_lstsq_ttd _self _b _rcond =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor,at::Tensor>(at::linalg_lstsq(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _b)
+  , $(double _rcond)));
+  }|]
+
+linalg_lstsq_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
+linalg_lstsq_tt _self _b =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor,at::Tensor>(at::linalg_lstsq(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _b)));
+  }|]
+
+linalg_lstsq_out_ttttttds
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> CDouble
+  -> Ptr StdString
+  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
+linalg_lstsq_out_ttttttds _solution _residuals _rank _singular_values _self _b _rcond _driver =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor,at::Tensor>(at::linalg_lstsq_out(
+    *$(at::Tensor* _solution)
+  , *$(at::Tensor* _residuals)
+  , *$(at::Tensor* _rank)
+  , *$(at::Tensor* _singular_values)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _b)
+  , $(double _rcond)
+  , *$(std::string* _driver)));
+  }|]
+
+linalg_lstsq_out_ttttttd
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> CDouble
+  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
+linalg_lstsq_out_ttttttd _solution _residuals _rank _singular_values _self _b _rcond =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor,at::Tensor>(at::linalg_lstsq_out(
+    *$(at::Tensor* _solution)
+  , *$(at::Tensor* _residuals)
+  , *$(at::Tensor* _rank)
+  , *$(at::Tensor* _singular_values)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _b)
+  , $(double _rcond)));
+  }|]
+
+linalg_lstsq_out_tttttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
+linalg_lstsq_out_tttttt _solution _residuals _rank _singular_values _self _b =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor,at::Tensor>(at::linalg_lstsq_out(
+    *$(at::Tensor* _solution)
+  , *$(at::Tensor* _residuals)
+  , *$(at::Tensor* _rank)
+  , *$(at::Tensor* _singular_values)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _b)));
   }|]
 
 linalg_slogdet_t
@@ -916,16 +342,42 @@ linalg_slogdet_out_ttt _sign _logabsdet _self =
   , *$(at::Tensor* _self)));
   }|]
 
-_syevd_helper_tbs
+linalg_eig_t
   :: Ptr Tensor
-  -> CBool
-  -> Ptr StdString
   -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-_syevd_helper_tbs _self _compute_eigenvectors _uplo =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::_syevd_helper(
-    *$(at::Tensor* _self)
-  , $(bool _compute_eigenvectors)
-  , *$(std::string* _uplo)));
+linalg_eig_t _self =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::linalg_eig(
+    *$(at::Tensor* _self)));
+  }|]
+
+linalg_eig_out_ttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+linalg_eig_out_ttt _eigenvalues _eigenvectors _self =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::linalg_eig_out(
+    *$(at::Tensor* _eigenvalues)
+  , *$(at::Tensor* _eigenvectors)
+  , *$(at::Tensor* _self)));
+  }|]
+
+linalg_eigvals_t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+linalg_eigvals_t _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::linalg_eigvals(
+    *$(at::Tensor* _self)));
+  }|]
+
+linalg_eigvals_out_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+linalg_eigvals_out_tt _out _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::linalg_eigvals_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)));
   }|]
 
 linalg_eigh_ts
@@ -1012,6 +464,28 @@ linalg_eigvalsh_out_tt _out _self =
   , *$(at::Tensor* _self)));
   }|]
 
+linalg_householder_product_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+linalg_householder_product_tt _input _tau =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::linalg_householder_product(
+    *$(at::Tensor* _input)
+  , *$(at::Tensor* _tau)));
+  }|]
+
+linalg_householder_product_out_ttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+linalg_householder_product_out_ttt _out _input _tau =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::linalg_householder_product_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _input)
+  , *$(at::Tensor* _tau)));
+  }|]
+
 _linalg_inv_out_helper__ttt
   :: Ptr Tensor
   -> Ptr Tensor
@@ -1022,6 +496,50 @@ _linalg_inv_out_helper__ttt _self _infos_lu _infos_getri =
     *$(at::Tensor* _self)
   , *$(at::Tensor* _infos_lu)
   , *$(at::Tensor* _infos_getri)));
+  }|]
+
+linalg_inv_ex_tb
+  :: Ptr Tensor
+  -> CBool
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+linalg_inv_ex_tb _self _check_errors =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::linalg_inv_ex(
+    *$(at::Tensor* _self)
+  , $(bool _check_errors)));
+  }|]
+
+linalg_inv_ex_t
+  :: Ptr Tensor
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+linalg_inv_ex_t _self =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::linalg_inv_ex(
+    *$(at::Tensor* _self)));
+  }|]
+
+linalg_inv_ex_out_tttb
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> CBool
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+linalg_inv_ex_out_tttb _inverse _info _self _check_errors =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::linalg_inv_ex_out(
+    *$(at::Tensor* _inverse)
+  , *$(at::Tensor* _info)
+  , *$(at::Tensor* _self)
+  , $(bool _check_errors)));
+  }|]
+
+linalg_inv_ex_out_ttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+linalg_inv_ex_out_ttt _inverse _info _self =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::linalg_inv_ex_out(
+    *$(at::Tensor* _inverse)
+  , *$(at::Tensor* _info)
+  , *$(at::Tensor* _self)));
   }|]
 
 linalg_inv_t
@@ -1238,22 +756,264 @@ linalg_norm_out_tt _out _self =
   , *$(at::Tensor* _self)));
   }|]
 
-linalg_svd_out_ttttbb
+linalg_vector_norm_tslbs
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr IntArray
+  -> CBool
+  -> ScalarType
+  -> IO (Ptr Tensor)
+linalg_vector_norm_tslbs _self _ord _dim _keepdim _dtype =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::linalg_vector_norm(
+    *$(at::Tensor* _self)
+  , *$(at::Scalar* _ord)
+  , *$(std::vector<int64_t>* _dim)
+  , $(bool _keepdim)
+  , $(at::ScalarType _dtype)));
+  }|]
+
+linalg_vector_norm_tslb
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr IntArray
+  -> CBool
+  -> IO (Ptr Tensor)
+linalg_vector_norm_tslb _self _ord _dim _keepdim =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::linalg_vector_norm(
+    *$(at::Tensor* _self)
+  , *$(at::Scalar* _ord)
+  , *$(std::vector<int64_t>* _dim)
+  , $(bool _keepdim)));
+  }|]
+
+linalg_vector_norm_tsl
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+linalg_vector_norm_tsl _self _ord _dim =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::linalg_vector_norm(
+    *$(at::Tensor* _self)
+  , *$(at::Scalar* _ord)
+  , *$(std::vector<int64_t>* _dim)));
+  }|]
+
+linalg_vector_norm_ts
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+linalg_vector_norm_ts _self _ord =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::linalg_vector_norm(
+    *$(at::Tensor* _self)
+  , *$(at::Scalar* _ord)));
+  }|]
+
+linalg_vector_norm_t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+linalg_vector_norm_t _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::linalg_vector_norm(
+    *$(at::Tensor* _self)));
+  }|]
+
+linalg_vector_norm_out_ttslbs
   :: Ptr Tensor
   -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr IntArray
   -> CBool
-  -> CBool
-  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor)))
-linalg_svd_out_ttttbb _U _S _V _self _full_matrices _compute_uv =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor>(at::linalg_svd_out(
-    *$(at::Tensor* _U)
-  , *$(at::Tensor* _S)
-  , *$(at::Tensor* _V)
+  -> ScalarType
+  -> IO (Ptr Tensor)
+linalg_vector_norm_out_ttslbs _out _self _ord _dim _keepdim _dtype =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::linalg_vector_norm_out(
+    *$(at::Tensor* _out)
   , *$(at::Tensor* _self)
-  , $(bool _full_matrices)
-  , $(bool _compute_uv)));
+  , *$(at::Scalar* _ord)
+  , *$(std::vector<int64_t>* _dim)
+  , $(bool _keepdim)
+  , $(at::ScalarType _dtype)));
+  }|]
+
+linalg_vector_norm_out_ttslb
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr IntArray
+  -> CBool
+  -> IO (Ptr Tensor)
+linalg_vector_norm_out_ttslb _out _self _ord _dim _keepdim =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::linalg_vector_norm_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Scalar* _ord)
+  , *$(std::vector<int64_t>* _dim)
+  , $(bool _keepdim)));
+  }|]
+
+linalg_vector_norm_out_ttsl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+linalg_vector_norm_out_ttsl _out _self _ord _dim =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::linalg_vector_norm_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Scalar* _ord)
+  , *$(std::vector<int64_t>* _dim)));
+  }|]
+
+linalg_vector_norm_out_tts
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+linalg_vector_norm_out_tts _out _self _ord =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::linalg_vector_norm_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Scalar* _ord)));
+  }|]
+
+linalg_vector_norm_out_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+linalg_vector_norm_out_tt _out _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::linalg_vector_norm_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)));
+  }|]
+
+linalg_matrix_norm_tslbs
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr IntArray
+  -> CBool
+  -> ScalarType
+  -> IO (Ptr Tensor)
+linalg_matrix_norm_tslbs _self _ord _dim _keepdim _dtype =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::linalg_matrix_norm(
+    *$(at::Tensor* _self)
+  , *$(at::Scalar* _ord)
+  , *$(std::vector<int64_t>* _dim)
+  , $(bool _keepdim)
+  , $(at::ScalarType _dtype)));
+  }|]
+
+linalg_matrix_norm_tslb
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr IntArray
+  -> CBool
+  -> IO (Ptr Tensor)
+linalg_matrix_norm_tslb _self _ord _dim _keepdim =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::linalg_matrix_norm(
+    *$(at::Tensor* _self)
+  , *$(at::Scalar* _ord)
+  , *$(std::vector<int64_t>* _dim)
+  , $(bool _keepdim)));
+  }|]
+
+linalg_matrix_norm_tsl
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+linalg_matrix_norm_tsl _self _ord _dim =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::linalg_matrix_norm(
+    *$(at::Tensor* _self)
+  , *$(at::Scalar* _ord)
+  , *$(std::vector<int64_t>* _dim)));
+  }|]
+
+linalg_matrix_norm_ts
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+linalg_matrix_norm_ts _self _ord =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::linalg_matrix_norm(
+    *$(at::Tensor* _self)
+  , *$(at::Scalar* _ord)));
+  }|]
+
+linalg_matrix_norm_out_ttslbs
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr IntArray
+  -> CBool
+  -> ScalarType
+  -> IO (Ptr Tensor)
+linalg_matrix_norm_out_ttslbs _out _self _ord _dim _keepdim _dtype =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::linalg_matrix_norm_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Scalar* _ord)
+  , *$(std::vector<int64_t>* _dim)
+  , $(bool _keepdim)
+  , $(at::ScalarType _dtype)));
+  }|]
+
+linalg_matrix_norm_out_ttslb
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr IntArray
+  -> CBool
+  -> IO (Ptr Tensor)
+linalg_matrix_norm_out_ttslb _out _self _ord _dim _keepdim =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::linalg_matrix_norm_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Scalar* _ord)
+  , *$(std::vector<int64_t>* _dim)
+  , $(bool _keepdim)));
+  }|]
+
+linalg_matrix_norm_out_ttsl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+linalg_matrix_norm_out_ttsl _out _self _ord _dim =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::linalg_matrix_norm_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Scalar* _ord)
+  , *$(std::vector<int64_t>* _dim)));
+  }|]
+
+linalg_matrix_norm_out_tts
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+linalg_matrix_norm_out_tts _out _self _ord =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::linalg_matrix_norm_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Scalar* _ord)));
+  }|]
+
+linalg_matrix_norm_t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+linalg_matrix_norm_t _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::linalg_matrix_norm(
+    *$(at::Tensor* _self)));
+  }|]
+
+linalg_matrix_norm_out_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+linalg_matrix_norm_out_tt _out _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::linalg_matrix_norm_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)));
   }|]
 
 linalg_svd_out_ttttb
@@ -1263,11 +1023,11 @@ linalg_svd_out_ttttb
   -> Ptr Tensor
   -> CBool
   -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor)))
-linalg_svd_out_ttttb _U _S _V _self _full_matrices =
+linalg_svd_out_ttttb _U _S _Vh _self _full_matrices =
   [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor>(at::linalg_svd_out(
     *$(at::Tensor* _U)
   , *$(at::Tensor* _S)
-  , *$(at::Tensor* _V)
+  , *$(at::Tensor* _Vh)
   , *$(at::Tensor* _self)
   , $(bool _full_matrices)));
   }|]
@@ -1278,24 +1038,12 @@ linalg_svd_out_tttt
   -> Ptr Tensor
   -> Ptr Tensor
   -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor)))
-linalg_svd_out_tttt _U _S _V _self =
+linalg_svd_out_tttt _U _S _Vh _self =
   [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor>(at::linalg_svd_out(
     *$(at::Tensor* _U)
   , *$(at::Tensor* _S)
-  , *$(at::Tensor* _V)
+  , *$(at::Tensor* _Vh)
   , *$(at::Tensor* _self)));
-  }|]
-
-linalg_svd_tbb
-  :: Ptr Tensor
-  -> CBool
-  -> CBool
-  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor)))
-linalg_svd_tbb _self _full_matrices _compute_uv =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor>(at::linalg_svd(
-    *$(at::Tensor* _self)
-  , $(bool _full_matrices)
-  , $(bool _compute_uv)));
   }|]
 
 linalg_svd_tb
@@ -1314,6 +1062,24 @@ linalg_svd_t
 linalg_svd_t _self =
   [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor>(at::linalg_svd(
     *$(at::Tensor* _self)));
+  }|]
+
+linalg_svdvals_t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+linalg_svdvals_t _input =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::linalg_svdvals(
+    *$(at::Tensor* _input)));
+  }|]
+
+linalg_svdvals_out_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+linalg_svdvals_out_tt _out _input =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::linalg_svdvals_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _input)));
   }|]
 
 linalg_cond_ts
@@ -1646,6 +1412,28 @@ _linalg_qr_helper_ts _self _mode =
   , *$(std::string* _mode)));
   }|]
 
+linalg_matrix_power_tl
+  :: Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+linalg_matrix_power_tl _self _n =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::linalg_matrix_power(
+    *$(at::Tensor* _self)
+  , $(int64_t _n)));
+  }|]
+
+linalg_matrix_power_out_ttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+linalg_matrix_power_out_ttl _out _self _n =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::linalg_matrix_power_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , $(int64_t _n)));
+  }|]
+
 linalg_matrix_rank_tdb
   :: Ptr Tensor
   -> CDouble
@@ -1710,6 +1498,72 @@ linalg_matrix_rank_out_tt _out _self =
   [C.throwBlock| at::Tensor* { return new at::Tensor(at::linalg_matrix_rank_out(
     *$(at::Tensor* _out)
   , *$(at::Tensor* _self)));
+  }|]
+
+linalg_matrix_rank_ttb
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> CBool
+  -> IO (Ptr Tensor)
+linalg_matrix_rank_ttb _input _tol _hermitian =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::linalg_matrix_rank(
+    *$(at::Tensor* _input)
+  , *$(at::Tensor* _tol)
+  , $(bool _hermitian)));
+  }|]
+
+linalg_matrix_rank_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+linalg_matrix_rank_tt _input _tol =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::linalg_matrix_rank(
+    *$(at::Tensor* _input)
+  , *$(at::Tensor* _tol)));
+  }|]
+
+linalg_matrix_rank_out_tttb
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> CBool
+  -> IO (Ptr Tensor)
+linalg_matrix_rank_out_tttb _out _input _tol _hermitian =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::linalg_matrix_rank_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _input)
+  , *$(at::Tensor* _tol)
+  , $(bool _hermitian)));
+  }|]
+
+linalg_matrix_rank_out_ttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+linalg_matrix_rank_out_ttt _out _input _tol =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::linalg_matrix_rank_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _input)
+  , *$(at::Tensor* _tol)));
+  }|]
+
+linalg_multi_dot_l
+  :: Ptr TensorList
+  -> IO (Ptr Tensor)
+linalg_multi_dot_l _tensors =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::linalg_multi_dot(
+    *$(std::vector<at::Tensor>* _tensors)));
+  }|]
+
+linalg_multi_dot_out_tl
+  :: Ptr Tensor
+  -> Ptr TensorList
+  -> IO (Ptr Tensor)
+linalg_multi_dot_out_tl _out _tensors =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::linalg_multi_dot_out(
+    *$(at::Tensor* _out)
+  , *$(std::vector<at::Tensor>* _tensors)));
   }|]
 
 _test_serialization_subcmul_tts
@@ -1834,5 +1688,169 @@ _test_ambiguous_defaults_tls _dummy _a _b =
     *$(at::Tensor* _dummy)
   , $(int64_t _a)
   , *$(std::string* _b)));
+  }|]
+
+segment_reduce_tsttlbs
+  :: Ptr Tensor
+  -> Ptr StdString
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> CBool
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+segment_reduce_tsttlbs _data _reduce _lengths _indices _axis _unsafe _initial =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::segment_reduce(
+    *$(at::Tensor* _data)
+  , *$(std::string* _reduce)
+  , *$(at::Tensor* _lengths)
+  , *$(at::Tensor* _indices)
+  , $(int64_t _axis)
+  , $(bool _unsafe)
+  , *$(at::Scalar* _initial)));
+  }|]
+
+segment_reduce_tsttlb
+  :: Ptr Tensor
+  -> Ptr StdString
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> CBool
+  -> IO (Ptr Tensor)
+segment_reduce_tsttlb _data _reduce _lengths _indices _axis _unsafe =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::segment_reduce(
+    *$(at::Tensor* _data)
+  , *$(std::string* _reduce)
+  , *$(at::Tensor* _lengths)
+  , *$(at::Tensor* _indices)
+  , $(int64_t _axis)
+  , $(bool _unsafe)));
+  }|]
+
+segment_reduce_tsttl
+  :: Ptr Tensor
+  -> Ptr StdString
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+segment_reduce_tsttl _data _reduce _lengths _indices _axis =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::segment_reduce(
+    *$(at::Tensor* _data)
+  , *$(std::string* _reduce)
+  , *$(at::Tensor* _lengths)
+  , *$(at::Tensor* _indices)
+  , $(int64_t _axis)));
+  }|]
+
+segment_reduce_tstt
+  :: Ptr Tensor
+  -> Ptr StdString
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+segment_reduce_tstt _data _reduce _lengths _indices =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::segment_reduce(
+    *$(at::Tensor* _data)
+  , *$(std::string* _reduce)
+  , *$(at::Tensor* _lengths)
+  , *$(at::Tensor* _indices)));
+  }|]
+
+segment_reduce_tst
+  :: Ptr Tensor
+  -> Ptr StdString
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+segment_reduce_tst _data _reduce _lengths =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::segment_reduce(
+    *$(at::Tensor* _data)
+  , *$(std::string* _reduce)
+  , *$(at::Tensor* _lengths)));
+  }|]
+
+segment_reduce_ts
+  :: Ptr Tensor
+  -> Ptr StdString
+  -> IO (Ptr Tensor)
+segment_reduce_ts _data _reduce =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::segment_reduce(
+    *$(at::Tensor* _data)
+  , *$(std::string* _reduce)));
+  }|]
+
+segment_reduce_backward_tttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+segment_reduce_backward_tttt _grad _output _data _lengths =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::segment_reduce_backward(
+    *$(at::Tensor* _grad)
+  , *$(at::Tensor* _output)
+  , *$(at::Tensor* _data)
+  , *$(at::Tensor* _lengths)));
+  }|]
+
+segment_reduce_backward_ttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+segment_reduce_backward_ttt _grad _output _data =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::segment_reduce_backward(
+    *$(at::Tensor* _grad)
+  , *$(at::Tensor* _output)
+  , *$(at::Tensor* _data)));
+  }|]
+
+pad_sequence_lbd
+  :: Ptr TensorList
+  -> CBool
+  -> CDouble
+  -> IO (Ptr Tensor)
+pad_sequence_lbd _sequences _batch_first _padding_value =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::pad_sequence(
+    *$(std::vector<at::Tensor>* _sequences)
+  , $(bool _batch_first)
+  , $(double _padding_value)));
+  }|]
+
+pad_sequence_lb
+  :: Ptr TensorList
+  -> CBool
+  -> IO (Ptr Tensor)
+pad_sequence_lb _sequences _batch_first =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::pad_sequence(
+    *$(std::vector<at::Tensor>* _sequences)
+  , $(bool _batch_first)));
+  }|]
+
+pad_sequence_l
+  :: Ptr TensorList
+  -> IO (Ptr Tensor)
+pad_sequence_l _sequences =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::pad_sequence(
+    *$(std::vector<at::Tensor>* _sequences)));
+  }|]
+
+flatten_dense_tensors_l
+  :: Ptr TensorList
+  -> IO (Ptr Tensor)
+flatten_dense_tensors_l _tensors =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::flatten_dense_tensors(
+    *$(std::vector<at::Tensor>* _tensors)));
+  }|]
+
+unflatten_dense_tensors_tl
+  :: Ptr Tensor
+  -> Ptr TensorList
+  -> IO (Ptr TensorList)
+unflatten_dense_tensors_tl _flat _tensors =
+  [C.throwBlock| std::vector<at::Tensor>* { return new std::vector<at::Tensor>(at::unflatten_dense_tensors(
+    *$(at::Tensor* _flat)
+  , *$(std::vector<at::Tensor>* _tensors)));
   }|]
 

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native2.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native2.hs
@@ -28,6 +28,168 @@ C.include "<ATen/Tensor.h>"
 C.include "<ATen/Functions.h>"
 
 
+conv_tbc_ttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+conv_tbc_ttt _self _weight _bias =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::conv_tbc(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(at::Tensor* _bias)));
+  }|]
+
+conv_tbc_backward_ttttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor)))
+conv_tbc_backward_ttttl _self _input _weight _bias _pad =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor>(at::conv_tbc_backward(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _input)
+  , *$(at::Tensor* _weight)
+  , *$(at::Tensor* _bias)
+  , $(int64_t _pad)));
+  }|]
+
+conv_transpose1d_tttlllll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Int64
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+conv_transpose1d_tttlllll _input _weight _bias _stride _padding _output_padding _groups _dilation =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::conv_transpose1d(
+    *$(at::Tensor* _input)
+  , *$(at::Tensor* _weight)
+  , *$(at::Tensor* _bias)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , *$(std::vector<int64_t>* _output_padding)
+  , $(int64_t _groups)
+  , *$(std::vector<int64_t>* _dilation)));
+  }|]
+
+conv_transpose1d_tttllll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Int64
+  -> IO (Ptr Tensor)
+conv_transpose1d_tttllll _input _weight _bias _stride _padding _output_padding _groups =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::conv_transpose1d(
+    *$(at::Tensor* _input)
+  , *$(at::Tensor* _weight)
+  , *$(at::Tensor* _bias)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , *$(std::vector<int64_t>* _output_padding)
+  , $(int64_t _groups)));
+  }|]
+
+conv_transpose1d_tttlll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+conv_transpose1d_tttlll _input _weight _bias _stride _padding _output_padding =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::conv_transpose1d(
+    *$(at::Tensor* _input)
+  , *$(at::Tensor* _weight)
+  , *$(at::Tensor* _bias)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , *$(std::vector<int64_t>* _output_padding)));
+  }|]
+
+conv_transpose1d_tttll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+conv_transpose1d_tttll _input _weight _bias _stride _padding =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::conv_transpose1d(
+    *$(at::Tensor* _input)
+  , *$(at::Tensor* _weight)
+  , *$(at::Tensor* _bias)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)));
+  }|]
+
+conv_transpose1d_tttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+conv_transpose1d_tttl _input _weight _bias _stride =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::conv_transpose1d(
+    *$(at::Tensor* _input)
+  , *$(at::Tensor* _weight)
+  , *$(at::Tensor* _bias)
+  , *$(std::vector<int64_t>* _stride)));
+  }|]
+
+conv_transpose1d_ttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+conv_transpose1d_ttt _input _weight _bias =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::conv_transpose1d(
+    *$(at::Tensor* _input)
+  , *$(at::Tensor* _weight)
+  , *$(at::Tensor* _bias)));
+  }|]
+
+conv_transpose1d_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+conv_transpose1d_tt _input _weight =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::conv_transpose1d(
+    *$(at::Tensor* _input)
+  , *$(at::Tensor* _weight)));
+  }|]
+
+conv_transpose2d_tttlllll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Int64
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+conv_transpose2d_tttlllll _input _weight _bias _stride _padding _output_padding _groups _dilation =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::conv_transpose2d(
+    *$(at::Tensor* _input)
+  , *$(at::Tensor* _weight)
+  , *$(at::Tensor* _bias)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , *$(std::vector<int64_t>* _output_padding)
+  , $(int64_t _groups)
+  , *$(std::vector<int64_t>* _dilation)));
+  }|]
+
 conv_transpose2d_tttllll
   :: Ptr Tensor
   -> Ptr Tensor
@@ -748,6 +910,50 @@ cudnn_convolution_transpose_backward_weight_lttllllbbb _weight_size _grad_output
   , $(bool _allow_tf32)));
   }|]
 
+cudnn_convolution_relu_tttllll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Int64
+  -> IO (Ptr Tensor)
+cudnn_convolution_relu_tttllll _self _weight _bias _stride _padding _dilation _groups =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::cudnn_convolution_relu(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(at::Tensor* _bias)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , *$(std::vector<int64_t>* _dilation)
+  , $(int64_t _groups)));
+  }|]
+
+cudnn_convolution_add_relu_tttstllll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Int64
+  -> IO (Ptr Tensor)
+cudnn_convolution_add_relu_tttstllll _self _weight _z _alpha _bias _stride _padding _dilation _groups =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::cudnn_convolution_add_relu(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _weight)
+  , *$(at::Tensor* _z)
+  , *$(at::Scalar* _alpha)
+  , *$(at::Tensor* _bias)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , *$(std::vector<int64_t>* _dilation)
+  , $(int64_t _groups)));
+  }|]
+
 cudnn_grid_sampler_tt
   :: Ptr Tensor
   -> Ptr Tensor
@@ -1004,16 +1210,18 @@ cumprod_out_ttn _out _self _dim =
   , *$(at::Dimname* _dim)));
   }|]
 
-cumprod_backward_ttl
+cumprod_backward_ttlt
   :: Ptr Tensor
   -> Ptr Tensor
   -> Int64
+  -> Ptr Tensor
   -> IO (Ptr Tensor)
-cumprod_backward_ttl _grad _input _dim =
+cumprod_backward_ttlt _grad _input _dim _output =
   [C.throwBlock| at::Tensor* { return new at::Tensor(at::cumprod_backward(
     *$(at::Tensor* _grad)
   , *$(at::Tensor* _input)
-  , $(int64_t _dim)));
+  , $(int64_t _dim)
+  , *$(at::Tensor* _output)));
   }|]
 
 cumsum_tls
@@ -1624,6 +1832,72 @@ diff_out_tt _out _self =
   , *$(at::Tensor* _self)));
   }|]
 
+gradient_tsll
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> Int64
+  -> Int64
+  -> IO (Ptr TensorList)
+gradient_tsll _self _spacing _dim _edge_order =
+  [C.throwBlock| std::vector<at::Tensor>* { return new std::vector<at::Tensor>(at::gradient(
+    *$(at::Tensor* _self)
+  , *$(at::Scalar* _spacing)
+  , $(int64_t _dim)
+  , $(int64_t _edge_order)));
+  }|]
+
+gradient_tsl
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> Int64
+  -> IO (Ptr TensorList)
+gradient_tsl _self _spacing _dim =
+  [C.throwBlock| std::vector<at::Tensor>* { return new std::vector<at::Tensor>(at::gradient(
+    *$(at::Tensor* _self)
+  , *$(at::Scalar* _spacing)
+  , $(int64_t _dim)));
+  }|]
+
+gradient_t
+  :: Ptr Tensor
+  -> IO (Ptr TensorList)
+gradient_t _self =
+  [C.throwBlock| std::vector<at::Tensor>* { return new std::vector<at::Tensor>(at::gradient(
+    *$(at::Tensor* _self)));
+  }|]
+
+gradient_tll
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Int64
+  -> IO (Ptr TensorList)
+gradient_tll _self _dim _edge_order =
+  [C.throwBlock| std::vector<at::Tensor>* { return new std::vector<at::Tensor>(at::gradient(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _dim)
+  , $(int64_t _edge_order)));
+  }|]
+
+gradient_tl
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr TensorList)
+gradient_tl _self _dim =
+  [C.throwBlock| std::vector<at::Tensor>* { return new std::vector<at::Tensor>(at::gradient(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _dim)));
+  }|]
+
+gradient_tA
+  :: Ptr Tensor
+  -> Ptr (StdVector Scalar)
+  -> IO (Ptr TensorList)
+gradient_tA _self _spacing =
+  [C.throwBlock| std::vector<at::Tensor>* { return new std::vector<at::Tensor>(at::gradient(
+    *$(at::Tensor* _self)
+  , *$(std::vector<at::Scalar>* _spacing)));
+  }|]
+
 div_tt
   :: Ptr Tensor
   -> Ptr Tensor
@@ -1966,6 +2240,30 @@ embedding_sparse_backward_ttllb _grad _indices _num_weights _padding_idx _scale_
   , $(bool _scale_grad_by_freq)));
   }|]
 
+_embedding_bag_forward_only_tttblbtbl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> CBool
+  -> Int64
+  -> CBool
+  -> Ptr Tensor
+  -> CBool
+  -> Int64
+  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
+_embedding_bag_forward_only_tttblbtbl _weight _indices _offsets _scale_grad_by_freq _mode _sparse _per_sample_weights _include_last_offset _padding_idx =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor,at::Tensor>(at::_embedding_bag_forward_only(
+    *$(at::Tensor* _weight)
+  , *$(at::Tensor* _indices)
+  , *$(at::Tensor* _offsets)
+  , $(bool _scale_grad_by_freq)
+  , $(int64_t _mode)
+  , $(bool _sparse)
+  , *$(at::Tensor* _per_sample_weights)
+  , $(bool _include_last_offset)
+  , $(int64_t _padding_idx)));
+  }|]
+
 _embedding_bag_forward_only_tttblbtb
   :: Ptr Tensor
   -> Ptr Tensor
@@ -2200,6 +2498,54 @@ embedding_bag_ttt _weight _indices _offsets =
   , *$(at::Tensor* _offsets)));
   }|]
 
+embedding_bag_tttblbtbl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> CBool
+  -> Int64
+  -> CBool
+  -> Ptr Tensor
+  -> CBool
+  -> Int64
+  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
+embedding_bag_tttblbtbl _weight _indices _offsets _scale_grad_by_freq _mode _sparse _per_sample_weights _include_last_offset _padding_idx =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor,at::Tensor>(at::embedding_bag(
+    *$(at::Tensor* _weight)
+  , *$(at::Tensor* _indices)
+  , *$(at::Tensor* _offsets)
+  , $(bool _scale_grad_by_freq)
+  , $(int64_t _mode)
+  , $(bool _sparse)
+  , *$(at::Tensor* _per_sample_weights)
+  , $(bool _include_last_offset)
+  , $(int64_t _padding_idx)));
+  }|]
+
+_embedding_bag_tttblbtbl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> CBool
+  -> Int64
+  -> CBool
+  -> Ptr Tensor
+  -> CBool
+  -> Int64
+  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
+_embedding_bag_tttblbtbl _weight _indices _offsets _scale_grad_by_freq _mode _sparse _per_sample_weights _include_last_offset _padding_idx =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor,at::Tensor>(at::_embedding_bag(
+    *$(at::Tensor* _weight)
+  , *$(at::Tensor* _indices)
+  , *$(at::Tensor* _offsets)
+  , $(bool _scale_grad_by_freq)
+  , $(int64_t _mode)
+  , $(bool _sparse)
+  , *$(at::Tensor* _per_sample_weights)
+  , $(bool _include_last_offset)
+  , $(int64_t _padding_idx)));
+  }|]
+
 _embedding_bag_tttblbtb
   :: Ptr Tensor
   -> Ptr Tensor
@@ -2288,239 +2634,5 @@ _embedding_bag_tttb _weight _indices _offsets _scale_grad_by_freq =
   , *$(at::Tensor* _indices)
   , *$(at::Tensor* _offsets)
   , $(bool _scale_grad_by_freq)));
-  }|]
-
-_embedding_bag_ttt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
-_embedding_bag_ttt _weight _indices _offsets =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor,at::Tensor>(at::_embedding_bag(
-    *$(at::Tensor* _weight)
-  , *$(at::Tensor* _indices)
-  , *$(at::Tensor* _offsets)));
-  }|]
-
-_embedding_bag_backward_ttttttlblbt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Int64
-  -> CBool
-  -> Int64
-  -> CBool
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-_embedding_bag_backward_ttttttlblbt _grad _indices _offsets _offset2bag _bag_size _maximum_indices _num_weights _scale_grad_by_freq _mode _sparse _per_sample_weights =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_embedding_bag_backward(
-    *$(at::Tensor* _grad)
-  , *$(at::Tensor* _indices)
-  , *$(at::Tensor* _offsets)
-  , *$(at::Tensor* _offset2bag)
-  , *$(at::Tensor* _bag_size)
-  , *$(at::Tensor* _maximum_indices)
-  , $(int64_t _num_weights)
-  , $(bool _scale_grad_by_freq)
-  , $(int64_t _mode)
-  , $(bool _sparse)
-  , *$(at::Tensor* _per_sample_weights)));
-  }|]
-
-_embedding_bag_sparse_backward_tttttlblt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Int64
-  -> CBool
-  -> Int64
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-_embedding_bag_sparse_backward_tttttlblt _grad _indices _offsets _offset2bag _bag_size _num_weights _scale_grad_by_freq _mode _per_sample_weights =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_embedding_bag_sparse_backward(
-    *$(at::Tensor* _grad)
-  , *$(at::Tensor* _indices)
-  , *$(at::Tensor* _offsets)
-  , *$(at::Tensor* _offset2bag)
-  , *$(at::Tensor* _bag_size)
-  , $(int64_t _num_weights)
-  , $(bool _scale_grad_by_freq)
-  , $(int64_t _mode)
-  , *$(at::Tensor* _per_sample_weights)));
-  }|]
-
-_embedding_bag_dense_backward_ttttttlblt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Int64
-  -> CBool
-  -> Int64
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-_embedding_bag_dense_backward_ttttttlblt _grad _indices _offsets _offset2bag _bag_size _maximum_indices _num_weights _scale_grad_by_freq _mode _per_sample_weights =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_embedding_bag_dense_backward(
-    *$(at::Tensor* _grad)
-  , *$(at::Tensor* _indices)
-  , *$(at::Tensor* _offsets)
-  , *$(at::Tensor* _offset2bag)
-  , *$(at::Tensor* _bag_size)
-  , *$(at::Tensor* _maximum_indices)
-  , $(int64_t _num_weights)
-  , $(bool _scale_grad_by_freq)
-  , $(int64_t _mode)
-  , *$(at::Tensor* _per_sample_weights)));
-  }|]
-
-_embedding_bag_per_sample_weights_backward_tttttl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Int64
-  -> IO (Ptr Tensor)
-_embedding_bag_per_sample_weights_backward_tttttl _grad _weight _indices _offsets _offset2bag _mode =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_embedding_bag_per_sample_weights_backward(
-    *$(at::Tensor* _grad)
-  , *$(at::Tensor* _weight)
-  , *$(at::Tensor* _indices)
-  , *$(at::Tensor* _offsets)
-  , *$(at::Tensor* _offset2bag)
-  , $(int64_t _mode)));
-  }|]
-
-empty_meta_loM
-  :: Ptr IntArray
-  -> Ptr TensorOptions
-  -> MemoryFormat
-  -> IO (Ptr Tensor)
-empty_meta_loM _size _options _memory_format =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::empty_meta(
-    *$(std::vector<int64_t>* _size)
-  , *$(at::TensorOptions* _options)
-  , $(at::MemoryFormat _memory_format)));
-  }|]
-
-empty_meta_lo
-  :: Ptr IntArray
-  -> Ptr TensorOptions
-  -> IO (Ptr Tensor)
-empty_meta_lo _size _options =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::empty_meta(
-    *$(std::vector<int64_t>* _size)
-  , *$(at::TensorOptions* _options)));
-  }|]
-
-empty_meta_l
-  :: Ptr IntArray
-  -> IO (Ptr Tensor)
-empty_meta_l _size =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::empty_meta(
-    *$(std::vector<int64_t>* _size)));
-  }|]
-
-empty_lNoM
-  :: Ptr IntArray
-  -> Ptr DimnameList
-  -> Ptr TensorOptions
-  -> MemoryFormat
-  -> IO (Ptr Tensor)
-empty_lNoM _size _names _options _memory_format =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::empty(
-    *$(std::vector<int64_t>* _size)
-  , *$(std::vector<at::Dimname>* _names)
-  , *$(at::TensorOptions* _options)
-  , $(at::MemoryFormat _memory_format)));
-  }|]
-
-empty_lNo
-  :: Ptr IntArray
-  -> Ptr DimnameList
-  -> Ptr TensorOptions
-  -> IO (Ptr Tensor)
-empty_lNo _size _names _options =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::empty(
-    *$(std::vector<int64_t>* _size)
-  , *$(std::vector<at::Dimname>* _names)
-  , *$(at::TensorOptions* _options)));
-  }|]
-
-empty_lN
-  :: Ptr IntArray
-  -> Ptr DimnameList
-  -> IO (Ptr Tensor)
-empty_lN _size _names =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::empty(
-    *$(std::vector<int64_t>* _size)
-  , *$(std::vector<at::Dimname>* _names)));
-  }|]
-
-empty_loM
-  :: Ptr IntArray
-  -> Ptr TensorOptions
-  -> MemoryFormat
-  -> IO (Ptr Tensor)
-empty_loM _size _options _memory_format =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::empty(
-    *$(std::vector<int64_t>* _size)
-  , *$(at::TensorOptions* _options)
-  , $(at::MemoryFormat _memory_format)));
-  }|]
-
-empty_lo
-  :: Ptr IntArray
-  -> Ptr TensorOptions
-  -> IO (Ptr Tensor)
-empty_lo _size _options =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::empty(
-    *$(std::vector<int64_t>* _size)
-  , *$(at::TensorOptions* _options)));
-  }|]
-
-empty_l
-  :: Ptr IntArray
-  -> IO (Ptr Tensor)
-empty_l _size =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::empty(
-    *$(std::vector<int64_t>* _size)));
-  }|]
-
-_empty_affine_quantized_lodlM
-  :: Ptr IntArray
-  -> Ptr TensorOptions
-  -> CDouble
-  -> Int64
-  -> MemoryFormat
-  -> IO (Ptr Tensor)
-_empty_affine_quantized_lodlM _size _options _scale _zero_point _memory_format =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_empty_affine_quantized(
-    *$(std::vector<int64_t>* _size)
-  , *$(at::TensorOptions* _options)
-  , $(double _scale)
-  , $(int64_t _zero_point)
-  , $(at::MemoryFormat _memory_format)));
-  }|]
-
-_empty_affine_quantized_lodl
-  :: Ptr IntArray
-  -> Ptr TensorOptions
-  -> CDouble
-  -> Int64
-  -> IO (Ptr Tensor)
-_empty_affine_quantized_lodl _size _options _scale _zero_point =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_empty_affine_quantized(
-    *$(std::vector<int64_t>* _size)
-  , *$(at::TensorOptions* _options)
-  , $(double _scale)
-  , $(int64_t _zero_point)));
   }|]
 

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native3.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native3.hs
@@ -28,6 +28,310 @@ C.include "<ATen/Tensor.h>"
 C.include "<ATen/Functions.h>"
 
 
+_embedding_bag_ttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
+_embedding_bag_ttt _weight _indices _offsets =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor,at::Tensor>(at::_embedding_bag(
+    *$(at::Tensor* _weight)
+  , *$(at::Tensor* _indices)
+  , *$(at::Tensor* _offsets)));
+  }|]
+
+_embedding_bag_backward_ttttttlblbtl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> CBool
+  -> Int64
+  -> CBool
+  -> Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+_embedding_bag_backward_ttttttlblbtl _grad _indices _offsets _offset2bag _bag_size _maximum_indices _num_weights _scale_grad_by_freq _mode _sparse _per_sample_weights _padding_idx =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_embedding_bag_backward(
+    *$(at::Tensor* _grad)
+  , *$(at::Tensor* _indices)
+  , *$(at::Tensor* _offsets)
+  , *$(at::Tensor* _offset2bag)
+  , *$(at::Tensor* _bag_size)
+  , *$(at::Tensor* _maximum_indices)
+  , $(int64_t _num_weights)
+  , $(bool _scale_grad_by_freq)
+  , $(int64_t _mode)
+  , $(bool _sparse)
+  , *$(at::Tensor* _per_sample_weights)
+  , $(int64_t _padding_idx)));
+  }|]
+
+_embedding_bag_backward_ttttttlblbt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> CBool
+  -> Int64
+  -> CBool
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+_embedding_bag_backward_ttttttlblbt _grad _indices _offsets _offset2bag _bag_size _maximum_indices _num_weights _scale_grad_by_freq _mode _sparse _per_sample_weights =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_embedding_bag_backward(
+    *$(at::Tensor* _grad)
+  , *$(at::Tensor* _indices)
+  , *$(at::Tensor* _offsets)
+  , *$(at::Tensor* _offset2bag)
+  , *$(at::Tensor* _bag_size)
+  , *$(at::Tensor* _maximum_indices)
+  , $(int64_t _num_weights)
+  , $(bool _scale_grad_by_freq)
+  , $(int64_t _mode)
+  , $(bool _sparse)
+  , *$(at::Tensor* _per_sample_weights)));
+  }|]
+
+_embedding_bag_sparse_backward_tttttlbltl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> CBool
+  -> Int64
+  -> Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+_embedding_bag_sparse_backward_tttttlbltl _grad _indices _offsets _offset2bag _bag_size _num_weights _scale_grad_by_freq _mode _per_sample_weights _padding_idx =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_embedding_bag_sparse_backward(
+    *$(at::Tensor* _grad)
+  , *$(at::Tensor* _indices)
+  , *$(at::Tensor* _offsets)
+  , *$(at::Tensor* _offset2bag)
+  , *$(at::Tensor* _bag_size)
+  , $(int64_t _num_weights)
+  , $(bool _scale_grad_by_freq)
+  , $(int64_t _mode)
+  , *$(at::Tensor* _per_sample_weights)
+  , $(int64_t _padding_idx)));
+  }|]
+
+_embedding_bag_sparse_backward_tttttlblt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> CBool
+  -> Int64
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+_embedding_bag_sparse_backward_tttttlblt _grad _indices _offsets _offset2bag _bag_size _num_weights _scale_grad_by_freq _mode _per_sample_weights =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_embedding_bag_sparse_backward(
+    *$(at::Tensor* _grad)
+  , *$(at::Tensor* _indices)
+  , *$(at::Tensor* _offsets)
+  , *$(at::Tensor* _offset2bag)
+  , *$(at::Tensor* _bag_size)
+  , $(int64_t _num_weights)
+  , $(bool _scale_grad_by_freq)
+  , $(int64_t _mode)
+  , *$(at::Tensor* _per_sample_weights)));
+  }|]
+
+_embedding_bag_dense_backward_tttttlbltl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> CBool
+  -> Int64
+  -> Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+_embedding_bag_dense_backward_tttttlbltl _grad _indices _offset2bag _bag_size _maximum_indices _num_weights _scale_grad_by_freq _mode _per_sample_weights _padding_idx =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_embedding_bag_dense_backward(
+    *$(at::Tensor* _grad)
+  , *$(at::Tensor* _indices)
+  , *$(at::Tensor* _offset2bag)
+  , *$(at::Tensor* _bag_size)
+  , *$(at::Tensor* _maximum_indices)
+  , $(int64_t _num_weights)
+  , $(bool _scale_grad_by_freq)
+  , $(int64_t _mode)
+  , *$(at::Tensor* _per_sample_weights)
+  , $(int64_t _padding_idx)));
+  }|]
+
+_embedding_bag_dense_backward_tttttlblt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> CBool
+  -> Int64
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+_embedding_bag_dense_backward_tttttlblt _grad _indices _offset2bag _bag_size _maximum_indices _num_weights _scale_grad_by_freq _mode _per_sample_weights =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_embedding_bag_dense_backward(
+    *$(at::Tensor* _grad)
+  , *$(at::Tensor* _indices)
+  , *$(at::Tensor* _offset2bag)
+  , *$(at::Tensor* _bag_size)
+  , *$(at::Tensor* _maximum_indices)
+  , $(int64_t _num_weights)
+  , $(bool _scale_grad_by_freq)
+  , $(int64_t _mode)
+  , *$(at::Tensor* _per_sample_weights)));
+  }|]
+
+_embedding_bag_per_sample_weights_backward_tttttll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> Int64
+  -> IO (Ptr Tensor)
+_embedding_bag_per_sample_weights_backward_tttttll _grad _weight _indices _offsets _offset2bag _mode _padding_idx =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_embedding_bag_per_sample_weights_backward(
+    *$(at::Tensor* _grad)
+  , *$(at::Tensor* _weight)
+  , *$(at::Tensor* _indices)
+  , *$(at::Tensor* _offsets)
+  , *$(at::Tensor* _offset2bag)
+  , $(int64_t _mode)
+  , $(int64_t _padding_idx)));
+  }|]
+
+_embedding_bag_per_sample_weights_backward_tttttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+_embedding_bag_per_sample_weights_backward_tttttl _grad _weight _indices _offsets _offset2bag _mode =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_embedding_bag_per_sample_weights_backward(
+    *$(at::Tensor* _grad)
+  , *$(at::Tensor* _weight)
+  , *$(at::Tensor* _indices)
+  , *$(at::Tensor* _offsets)
+  , *$(at::Tensor* _offset2bag)
+  , $(int64_t _mode)));
+  }|]
+
+empty_lNoM
+  :: Ptr IntArray
+  -> Ptr DimnameList
+  -> Ptr TensorOptions
+  -> MemoryFormat
+  -> IO (Ptr Tensor)
+empty_lNoM _size _names _options _memory_format =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::empty(
+    *$(std::vector<int64_t>* _size)
+  , *$(std::vector<at::Dimname>* _names)
+  , *$(at::TensorOptions* _options)
+  , $(at::MemoryFormat _memory_format)));
+  }|]
+
+empty_lNo
+  :: Ptr IntArray
+  -> Ptr DimnameList
+  -> Ptr TensorOptions
+  -> IO (Ptr Tensor)
+empty_lNo _size _names _options =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::empty(
+    *$(std::vector<int64_t>* _size)
+  , *$(std::vector<at::Dimname>* _names)
+  , *$(at::TensorOptions* _options)));
+  }|]
+
+empty_lN
+  :: Ptr IntArray
+  -> Ptr DimnameList
+  -> IO (Ptr Tensor)
+empty_lN _size _names =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::empty(
+    *$(std::vector<int64_t>* _size)
+  , *$(std::vector<at::Dimname>* _names)));
+  }|]
+
+empty_loM
+  :: Ptr IntArray
+  -> Ptr TensorOptions
+  -> MemoryFormat
+  -> IO (Ptr Tensor)
+empty_loM _size _options _memory_format =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::empty(
+    *$(std::vector<int64_t>* _size)
+  , *$(at::TensorOptions* _options)
+  , $(at::MemoryFormat _memory_format)));
+  }|]
+
+empty_lo
+  :: Ptr IntArray
+  -> Ptr TensorOptions
+  -> IO (Ptr Tensor)
+empty_lo _size _options =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::empty(
+    *$(std::vector<int64_t>* _size)
+  , *$(at::TensorOptions* _options)));
+  }|]
+
+empty_l
+  :: Ptr IntArray
+  -> IO (Ptr Tensor)
+empty_l _size =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::empty(
+    *$(std::vector<int64_t>* _size)));
+  }|]
+
+_empty_affine_quantized_lodlM
+  :: Ptr IntArray
+  -> Ptr TensorOptions
+  -> CDouble
+  -> Int64
+  -> MemoryFormat
+  -> IO (Ptr Tensor)
+_empty_affine_quantized_lodlM _size _options _scale _zero_point _memory_format =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_empty_affine_quantized(
+    *$(std::vector<int64_t>* _size)
+  , *$(at::TensorOptions* _options)
+  , $(double _scale)
+  , $(int64_t _zero_point)
+  , $(at::MemoryFormat _memory_format)));
+  }|]
+
+_empty_affine_quantized_lodl
+  :: Ptr IntArray
+  -> Ptr TensorOptions
+  -> CDouble
+  -> Int64
+  -> IO (Ptr Tensor)
+_empty_affine_quantized_lodl _size _options _scale _zero_point =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_empty_affine_quantized(
+    *$(std::vector<int64_t>* _size)
+  , *$(at::TensorOptions* _options)
+  , $(double _scale)
+  , $(int64_t _zero_point)));
+  }|]
+
 _empty_affine_quantized_lod
   :: Ptr IntArray
   -> Ptr TensorOptions

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native4.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native4.hs
@@ -1048,6 +1048,18 @@ matrix_power_tl _self _n =
   , $(int64_t _n)));
   }|]
 
+matrix_power_out_ttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+matrix_power_out_ttl _out _self _n =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::matrix_power_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , $(int64_t _n)));
+  }|]
+
 matrix_exp_t
   :: Ptr Tensor
   -> IO (Ptr Tensor)
@@ -1584,6 +1596,96 @@ mkldnn_max_pool2d_tl _self _kernel_size =
   , *$(std::vector<int64_t>* _kernel_size)));
   }|]
 
+mkldnn_max_pool2d_backward_tttllllb
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> CBool
+  -> IO (Ptr Tensor)
+mkldnn_max_pool2d_backward_tttllllb _grad_output _output _input _kernel_size _stride _padding _dilation _ceil_mode =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::mkldnn_max_pool2d_backward(
+    *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _output)
+  , *$(at::Tensor* _input)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , *$(std::vector<int64_t>* _dilation)
+  , $(bool _ceil_mode)));
+  }|]
+
+mkldnn_max_pool2d_backward_tttllll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+mkldnn_max_pool2d_backward_tttllll _grad_output _output _input _kernel_size _stride _padding _dilation =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::mkldnn_max_pool2d_backward(
+    *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _output)
+  , *$(at::Tensor* _input)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , *$(std::vector<int64_t>* _dilation)));
+  }|]
+
+mkldnn_max_pool2d_backward_tttlll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+mkldnn_max_pool2d_backward_tttlll _grad_output _output _input _kernel_size _stride _padding =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::mkldnn_max_pool2d_backward(
+    *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _output)
+  , *$(at::Tensor* _input)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)));
+  }|]
+
+mkldnn_max_pool2d_backward_tttll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+mkldnn_max_pool2d_backward_tttll _grad_output _output _input _kernel_size _stride =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::mkldnn_max_pool2d_backward(
+    *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _output)
+  , *$(at::Tensor* _input)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)));
+  }|]
+
+mkldnn_max_pool2d_backward_tttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+mkldnn_max_pool2d_backward_tttl _grad_output _output _input _kernel_size =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::mkldnn_max_pool2d_backward(
+    *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _output)
+  , *$(at::Tensor* _input)
+  , *$(std::vector<int64_t>* _kernel_size)));
+  }|]
+
 mkldnn_max_pool3d_tllllb
   :: Ptr Tensor
   -> Ptr IntArray
@@ -1651,6 +1753,96 @@ mkldnn_max_pool3d_tl
 mkldnn_max_pool3d_tl _self _kernel_size =
   [C.throwBlock| at::Tensor* { return new at::Tensor(at::mkldnn_max_pool3d(
     *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _kernel_size)));
+  }|]
+
+mkldnn_max_pool3d_backward_tttllllb
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> CBool
+  -> IO (Ptr Tensor)
+mkldnn_max_pool3d_backward_tttllllb _grad_output _output _input _kernel_size _stride _padding _dilation _ceil_mode =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::mkldnn_max_pool3d_backward(
+    *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _output)
+  , *$(at::Tensor* _input)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , *$(std::vector<int64_t>* _dilation)
+  , $(bool _ceil_mode)));
+  }|]
+
+mkldnn_max_pool3d_backward_tttllll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+mkldnn_max_pool3d_backward_tttllll _grad_output _output _input _kernel_size _stride _padding _dilation =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::mkldnn_max_pool3d_backward(
+    *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _output)
+  , *$(at::Tensor* _input)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)
+  , *$(std::vector<int64_t>* _dilation)));
+  }|]
+
+mkldnn_max_pool3d_backward_tttlll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+mkldnn_max_pool3d_backward_tttlll _grad_output _output _input _kernel_size _stride _padding =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::mkldnn_max_pool3d_backward(
+    *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _output)
+  , *$(at::Tensor* _input)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)
+  , *$(std::vector<int64_t>* _padding)));
+  }|]
+
+mkldnn_max_pool3d_backward_tttll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+mkldnn_max_pool3d_backward_tttll _grad_output _output _input _kernel_size _stride =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::mkldnn_max_pool3d_backward(
+    *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _output)
+  , *$(at::Tensor* _input)
+  , *$(std::vector<int64_t>* _kernel_size)
+  , *$(std::vector<int64_t>* _stride)));
+  }|]
+
+mkldnn_max_pool3d_backward_tttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+mkldnn_max_pool3d_backward_tttl _grad_output _output _input _kernel_size =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::mkldnn_max_pool3d_backward(
+    *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _output)
+  , *$(at::Tensor* _input)
   , *$(std::vector<int64_t>* _kernel_size)));
   }|]
 
@@ -2118,5 +2310,81 @@ median_tn _self _dim =
   [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::median(
     *$(at::Tensor* _self)
   , *$(at::Dimname* _dim)));
+  }|]
+
+median_out_tttnb
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Dimname
+  -> CBool
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+median_out_tttnb _values _indices _self _dim _keepdim =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::median_out(
+    *$(at::Tensor* _values)
+  , *$(at::Tensor* _indices)
+  , *$(at::Tensor* _self)
+  , *$(at::Dimname* _dim)
+  , $(bool _keepdim)));
+  }|]
+
+median_out_tttn
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Dimname
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+median_out_tttn _values _indices _self _dim =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::median_out(
+    *$(at::Tensor* _values)
+  , *$(at::Tensor* _indices)
+  , *$(at::Tensor* _self)
+  , *$(at::Dimname* _dim)));
+  }|]
+
+nanmedian_t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+nanmedian_t _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::nanmedian(
+    *$(at::Tensor* _self)));
+  }|]
+
+nanmedian_tlb
+  :: Ptr Tensor
+  -> Int64
+  -> CBool
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+nanmedian_tlb _self _dim _keepdim =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::nanmedian(
+    *$(at::Tensor* _self)
+  , $(int64_t _dim)
+  , $(bool _keepdim)));
+  }|]
+
+nanmedian_tl
+  :: Ptr Tensor
+  -> Int64
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+nanmedian_tl _self _dim =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::nanmedian(
+    *$(at::Tensor* _self)
+  , $(int64_t _dim)));
+  }|]
+
+nanmedian_out_tttlb
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> CBool
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+nanmedian_out_tttlb _values _indices _self _dim _keepdim =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::nanmedian_out(
+    *$(at::Tensor* _values)
+  , *$(at::Tensor* _indices)
+  , *$(at::Tensor* _self)
+  , $(int64_t _dim)
+  , $(bool _keepdim)));
   }|]
 

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native5.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native5.hs
@@ -28,82 +28,6 @@ C.include "<ATen/Tensor.h>"
 C.include "<ATen/Functions.h>"
 
 
-median_out_tttnb
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Dimname
-  -> CBool
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-median_out_tttnb _values _indices _self _dim _keepdim =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::median_out(
-    *$(at::Tensor* _values)
-  , *$(at::Tensor* _indices)
-  , *$(at::Tensor* _self)
-  , *$(at::Dimname* _dim)
-  , $(bool _keepdim)));
-  }|]
-
-median_out_tttn
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Dimname
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-median_out_tttn _values _indices _self _dim =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::median_out(
-    *$(at::Tensor* _values)
-  , *$(at::Tensor* _indices)
-  , *$(at::Tensor* _self)
-  , *$(at::Dimname* _dim)));
-  }|]
-
-nanmedian_t
-  :: Ptr Tensor
-  -> IO (Ptr Tensor)
-nanmedian_t _self =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::nanmedian(
-    *$(at::Tensor* _self)));
-  }|]
-
-nanmedian_tlb
-  :: Ptr Tensor
-  -> Int64
-  -> CBool
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-nanmedian_tlb _self _dim _keepdim =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::nanmedian(
-    *$(at::Tensor* _self)
-  , $(int64_t _dim)
-  , $(bool _keepdim)));
-  }|]
-
-nanmedian_tl
-  :: Ptr Tensor
-  -> Int64
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-nanmedian_tl _self _dim =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::nanmedian(
-    *$(at::Tensor* _self)
-  , $(int64_t _dim)));
-  }|]
-
-nanmedian_out_tttlb
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Int64
-  -> CBool
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-nanmedian_out_tttlb _values _indices _self _dim _keepdim =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::nanmedian_out(
-    *$(at::Tensor* _values)
-  , *$(at::Tensor* _indices)
-  , *$(at::Tensor* _self)
-  , $(int64_t _dim)
-  , $(bool _keepdim)));
-  }|]
-
 nanmedian_out_tttl
   :: Ptr Tensor
   -> Ptr Tensor
@@ -898,12 +822,12 @@ _sparse_sparse_matmul_tt _self _other =
   , *$(at::Tensor* _other)));
   }|]
 
-_sparse_matrix_mask_helper_tt
+_sparse_mask_helper_tt
   :: Ptr Tensor
   -> Ptr Tensor
   -> IO (Ptr Tensor)
-_sparse_matrix_mask_helper_tt _t _mask_indices =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_sparse_matrix_mask_helper(
+_sparse_mask_helper_tt _t _mask_indices =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_sparse_mask_helper(
     *$(at::Tensor* _t)
   , *$(at::Tensor* _mask_indices)));
   }|]
@@ -1376,7 +1300,7 @@ batch_norm_backward_reduce_tttttbbb _grad_out _input _mean _invstd _weight _inpu
   , $(bool _bias_g)));
   }|]
 
-batch_norm_backward_elemt_ttttttt
+batch_norm_backward_elemt_tttttttt
   :: Ptr Tensor
   -> Ptr Tensor
   -> Ptr Tensor
@@ -1384,8 +1308,9 @@ batch_norm_backward_elemt_ttttttt
   -> Ptr Tensor
   -> Ptr Tensor
   -> Ptr Tensor
+  -> Ptr Tensor
   -> IO (Ptr Tensor)
-batch_norm_backward_elemt_ttttttt _grad_out _input _mean _invstd _weight _mean_dy _mean_dy_xmu =
+batch_norm_backward_elemt_tttttttt _grad_out _input _mean _invstd _weight _mean_dy _mean_dy_xmu _count =
   [C.throwBlock| at::Tensor* { return new at::Tensor(at::batch_norm_backward_elemt(
     *$(at::Tensor* _grad_out)
   , *$(at::Tensor* _input)
@@ -1393,7 +1318,8 @@ batch_norm_backward_elemt_ttttttt _grad_out _input _mean _invstd _weight _mean_d
   , *$(at::Tensor* _invstd)
   , *$(at::Tensor* _weight)
   , *$(at::Tensor* _mean_dy)
-  , *$(at::Tensor* _mean_dy_xmu)));
+  , *$(at::Tensor* _mean_dy_xmu)
+  , *$(at::Tensor* _count)));
   }|]
 
 batch_norm_update_stats_tttd
@@ -1408,6 +1334,20 @@ batch_norm_update_stats_tttd _input _running_mean _running_var _momentum =
   , *$(at::Tensor* _running_mean)
   , *$(at::Tensor* _running_var)
   , $(double _momentum)));
+  }|]
+
+is_vulkan_available
+  :: IO (CBool)
+is_vulkan_available  =
+  [C.throwBlock| bool { return (at::is_vulkan_available(
+    ));
+  }|]
+
+_nnpack_available
+  :: IO (CBool)
+_nnpack_available  =
+  [C.throwBlock| bool { return (at::_nnpack_available(
+    ));
   }|]
 
 _nnpack_spatial_convolution_tttll
@@ -1776,6 +1716,16 @@ cosine_similarity_tt _x1 _x2 =
   [C.throwBlock| at::Tensor* { return new at::Tensor(at::cosine_similarity(
     *$(at::Tensor* _x1)
   , *$(at::Tensor* _x2)));
+  }|]
+
+permute_tl
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+permute_tl _self _dims =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::permute(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _dims)));
   }|]
 
 movedim_tll
@@ -2402,5 +2352,187 @@ randn_lGN _size _generator _names =
     *$(std::vector<int64_t>* _size)
   , *$(at::Generator* _generator)
   , *$(std::vector<at::Dimname>* _names)));
+  }|]
+
+randn_out_tl
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+randn_out_tl _out _size =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::randn_out(
+    *$(at::Tensor* _out)
+  , *$(std::vector<int64_t>* _size)));
+  }|]
+
+randn_out_tlG
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr Generator
+  -> IO (Ptr Tensor)
+randn_out_tlG _out _size _generator =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::randn_out(
+    *$(at::Tensor* _out)
+  , *$(std::vector<int64_t>* _size)
+  , *$(at::Generator* _generator)));
+  }|]
+
+randn_like_toM
+  :: Ptr Tensor
+  -> Ptr TensorOptions
+  -> MemoryFormat
+  -> IO (Ptr Tensor)
+randn_like_toM _self _options _memory_format =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::randn_like(
+    *$(at::Tensor* _self)
+  , *$(at::TensorOptions* _options)
+  , $(at::MemoryFormat _memory_format)));
+  }|]
+
+randn_like_to
+  :: Ptr Tensor
+  -> Ptr TensorOptions
+  -> IO (Ptr Tensor)
+randn_like_to _self _options =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::randn_like(
+    *$(at::Tensor* _self)
+  , *$(at::TensorOptions* _options)));
+  }|]
+
+randn_like_t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+randn_like_t _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::randn_like(
+    *$(at::Tensor* _self)));
+  }|]
+
+randperm_lo
+  :: Int64
+  -> Ptr TensorOptions
+  -> IO (Ptr Tensor)
+randperm_lo _n _options =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::randperm(
+    $(int64_t _n)
+  , *$(at::TensorOptions* _options)));
+  }|]
+
+randperm_l
+  :: Int64
+  -> IO (Ptr Tensor)
+randperm_l _n =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::randperm(
+    $(int64_t _n)));
+  }|]
+
+randperm_lGo
+  :: Int64
+  -> Ptr Generator
+  -> Ptr TensorOptions
+  -> IO (Ptr Tensor)
+randperm_lGo _n _generator _options =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::randperm(
+    $(int64_t _n)
+  , *$(at::Generator* _generator)
+  , *$(at::TensorOptions* _options)));
+  }|]
+
+randperm_lG
+  :: Int64
+  -> Ptr Generator
+  -> IO (Ptr Tensor)
+randperm_lG _n _generator =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::randperm(
+    $(int64_t _n)
+  , *$(at::Generator* _generator)));
+  }|]
+
+randperm_out_tl
+  :: Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+randperm_out_tl _out _n =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::randperm_out(
+    *$(at::Tensor* _out)
+  , $(int64_t _n)));
+  }|]
+
+randperm_out_tlG
+  :: Ptr Tensor
+  -> Int64
+  -> Ptr Generator
+  -> IO (Ptr Tensor)
+randperm_out_tlG _out _n _generator =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::randperm_out(
+    *$(at::Tensor* _out)
+  , $(int64_t _n)
+  , *$(at::Generator* _generator)));
+  }|]
+
+range_ssso
+  :: Ptr Scalar
+  -> Ptr Scalar
+  -> Ptr Scalar
+  -> Ptr TensorOptions
+  -> IO (Ptr Tensor)
+range_ssso _start _end _step _options =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::range(
+    *$(at::Scalar* _start)
+  , *$(at::Scalar* _end)
+  , *$(at::Scalar* _step)
+  , *$(at::TensorOptions* _options)));
+  }|]
+
+range_sss
+  :: Ptr Scalar
+  -> Ptr Scalar
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+range_sss _start _end _step =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::range(
+    *$(at::Scalar* _start)
+  , *$(at::Scalar* _end)
+  , *$(at::Scalar* _step)));
+  }|]
+
+range_out_tsss
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr Scalar
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+range_out_tsss _out _start _end _step =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::range_out(
+    *$(at::Tensor* _out)
+  , *$(at::Scalar* _start)
+  , *$(at::Scalar* _end)
+  , *$(at::Scalar* _step)));
+  }|]
+
+range_out_tss
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+range_out_tss _out _start _end =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::range_out(
+    *$(at::Tensor* _out)
+  , *$(at::Scalar* _start)
+  , *$(at::Scalar* _end)));
+  }|]
+
+ravel_t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+ravel_t _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::ravel(
+    *$(at::Tensor* _self)));
+  }|]
+
+reciprocal_t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+reciprocal_t _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::reciprocal(
+    *$(at::Tensor* _self)));
   }|]
 

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native6.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native6.hs
@@ -28,188 +28,6 @@ C.include "<ATen/Tensor.h>"
 C.include "<ATen/Functions.h>"
 
 
-randn_out_tl
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-randn_out_tl _out _size =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::randn_out(
-    *$(at::Tensor* _out)
-  , *$(std::vector<int64_t>* _size)));
-  }|]
-
-randn_out_tlG
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr Generator
-  -> IO (Ptr Tensor)
-randn_out_tlG _out _size _generator =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::randn_out(
-    *$(at::Tensor* _out)
-  , *$(std::vector<int64_t>* _size)
-  , *$(at::Generator* _generator)));
-  }|]
-
-randn_like_toM
-  :: Ptr Tensor
-  -> Ptr TensorOptions
-  -> MemoryFormat
-  -> IO (Ptr Tensor)
-randn_like_toM _self _options _memory_format =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::randn_like(
-    *$(at::Tensor* _self)
-  , *$(at::TensorOptions* _options)
-  , $(at::MemoryFormat _memory_format)));
-  }|]
-
-randn_like_to
-  :: Ptr Tensor
-  -> Ptr TensorOptions
-  -> IO (Ptr Tensor)
-randn_like_to _self _options =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::randn_like(
-    *$(at::Tensor* _self)
-  , *$(at::TensorOptions* _options)));
-  }|]
-
-randn_like_t
-  :: Ptr Tensor
-  -> IO (Ptr Tensor)
-randn_like_t _self =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::randn_like(
-    *$(at::Tensor* _self)));
-  }|]
-
-randperm_lo
-  :: Int64
-  -> Ptr TensorOptions
-  -> IO (Ptr Tensor)
-randperm_lo _n _options =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::randperm(
-    $(int64_t _n)
-  , *$(at::TensorOptions* _options)));
-  }|]
-
-randperm_l
-  :: Int64
-  -> IO (Ptr Tensor)
-randperm_l _n =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::randperm(
-    $(int64_t _n)));
-  }|]
-
-randperm_lGo
-  :: Int64
-  -> Ptr Generator
-  -> Ptr TensorOptions
-  -> IO (Ptr Tensor)
-randperm_lGo _n _generator _options =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::randperm(
-    $(int64_t _n)
-  , *$(at::Generator* _generator)
-  , *$(at::TensorOptions* _options)));
-  }|]
-
-randperm_lG
-  :: Int64
-  -> Ptr Generator
-  -> IO (Ptr Tensor)
-randperm_lG _n _generator =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::randperm(
-    $(int64_t _n)
-  , *$(at::Generator* _generator)));
-  }|]
-
-randperm_out_tl
-  :: Ptr Tensor
-  -> Int64
-  -> IO (Ptr Tensor)
-randperm_out_tl _out _n =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::randperm_out(
-    *$(at::Tensor* _out)
-  , $(int64_t _n)));
-  }|]
-
-randperm_out_tlG
-  :: Ptr Tensor
-  -> Int64
-  -> Ptr Generator
-  -> IO (Ptr Tensor)
-randperm_out_tlG _out _n _generator =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::randperm_out(
-    *$(at::Tensor* _out)
-  , $(int64_t _n)
-  , *$(at::Generator* _generator)));
-  }|]
-
-range_ssso
-  :: Ptr Scalar
-  -> Ptr Scalar
-  -> Ptr Scalar
-  -> Ptr TensorOptions
-  -> IO (Ptr Tensor)
-range_ssso _start _end _step _options =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::range(
-    *$(at::Scalar* _start)
-  , *$(at::Scalar* _end)
-  , *$(at::Scalar* _step)
-  , *$(at::TensorOptions* _options)));
-  }|]
-
-range_sss
-  :: Ptr Scalar
-  -> Ptr Scalar
-  -> Ptr Scalar
-  -> IO (Ptr Tensor)
-range_sss _start _end _step =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::range(
-    *$(at::Scalar* _start)
-  , *$(at::Scalar* _end)
-  , *$(at::Scalar* _step)));
-  }|]
-
-range_out_tsss
-  :: Ptr Tensor
-  -> Ptr Scalar
-  -> Ptr Scalar
-  -> Ptr Scalar
-  -> IO (Ptr Tensor)
-range_out_tsss _out _start _end _step =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::range_out(
-    *$(at::Tensor* _out)
-  , *$(at::Scalar* _start)
-  , *$(at::Scalar* _end)
-  , *$(at::Scalar* _step)));
-  }|]
-
-range_out_tss
-  :: Ptr Tensor
-  -> Ptr Scalar
-  -> Ptr Scalar
-  -> IO (Ptr Tensor)
-range_out_tss _out _start _end =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::range_out(
-    *$(at::Tensor* _out)
-  , *$(at::Scalar* _start)
-  , *$(at::Scalar* _end)));
-  }|]
-
-ravel_t
-  :: Ptr Tensor
-  -> IO (Ptr Tensor)
-ravel_t _self =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::ravel(
-    *$(at::Tensor* _self)));
-  }|]
-
-reciprocal_t
-  :: Ptr Tensor
-  -> IO (Ptr Tensor)
-reciprocal_t _self =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::reciprocal(
-    *$(at::Tensor* _self)));
-  }|]
-
 reciprocal__t
   :: Ptr Tensor
   -> IO (Ptr Tensor)
@@ -514,6 +332,22 @@ relu__t _self =
     *$(at::Tensor* _self)));
   }|]
 
+relu6_t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+relu6_t _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::relu6(
+    *$(at::Tensor* _self)));
+  }|]
+
+relu6__t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+relu6__t _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::relu6_(
+    *$(at::Tensor* _self)));
+  }|]
+
 prelu_tt
   :: Ptr Tensor
   -> Ptr Tensor
@@ -742,6 +576,42 @@ silu_backward_tt
   -> IO (Ptr Tensor)
 silu_backward_tt _grad_output _self =
   [C.throwBlock| at::Tensor* { return new at::Tensor(at::silu_backward(
+    *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _self)));
+  }|]
+
+mish_t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+mish_t _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::mish(
+    *$(at::Tensor* _self)));
+  }|]
+
+mish__t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+mish__t _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::mish_(
+    *$(at::Tensor* _self)));
+  }|]
+
+mish_out_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+mish_out_tt _out _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::mish_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)));
+  }|]
+
+mish_backward_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+mish_backward_tt _grad_output _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::mish_backward(
     *$(at::Tensor* _grad_output)
   , *$(at::Tensor* _self)));
   }|]
@@ -1196,6 +1066,36 @@ split_with_sizes_tl _self _split_sizes =
   [C.throwBlock| std::vector<at::Tensor>* { return new std::vector<at::Tensor>(at::split_with_sizes(
     *$(at::Tensor* _self)
   , *$(std::vector<int64_t>* _split_sizes)));
+  }|]
+
+hsplit_tl
+  :: Ptr Tensor
+  -> Int64
+  -> IO (Ptr TensorList)
+hsplit_tl _self _sections =
+  [C.throwBlock| std::vector<at::Tensor>* { return new std::vector<at::Tensor>(at::hsplit(
+    *$(at::Tensor* _self)
+  , $(int64_t _sections)));
+  }|]
+
+vsplit_tl
+  :: Ptr Tensor
+  -> Int64
+  -> IO (Ptr TensorList)
+vsplit_tl _self _sections =
+  [C.throwBlock| std::vector<at::Tensor>* { return new std::vector<at::Tensor>(at::vsplit(
+    *$(at::Tensor* _self)
+  , $(int64_t _sections)));
+  }|]
+
+dsplit_tl
+  :: Ptr Tensor
+  -> Int64
+  -> IO (Ptr TensorList)
+dsplit_tl _self _sections =
+  [C.throwBlock| std::vector<at::Tensor>* { return new std::vector<at::Tensor>(at::dsplit(
+    *$(at::Tensor* _self)
+  , $(int64_t _sections)));
   }|]
 
 squeeze_t
@@ -1916,5 +1816,277 @@ sum_out_ttN _out _self _dim =
     *$(at::Tensor* _out)
   , *$(at::Tensor* _self)
   , *$(std::vector<at::Dimname>* _dim)));
+  }|]
+
+nansum_ts
+  :: Ptr Tensor
+  -> ScalarType
+  -> IO (Ptr Tensor)
+nansum_ts _self _dtype =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::nansum(
+    *$(at::Tensor* _self)
+  , $(at::ScalarType _dtype)));
+  }|]
+
+nansum_t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+nansum_t _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::nansum(
+    *$(at::Tensor* _self)));
+  }|]
+
+nansum_tlbs
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> CBool
+  -> ScalarType
+  -> IO (Ptr Tensor)
+nansum_tlbs _self _dim _keepdim _dtype =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::nansum(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _dim)
+  , $(bool _keepdim)
+  , $(at::ScalarType _dtype)));
+  }|]
+
+nansum_tlb
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> CBool
+  -> IO (Ptr Tensor)
+nansum_tlb _self _dim _keepdim =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::nansum(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _dim)
+  , $(bool _keepdim)));
+  }|]
+
+nansum_tl
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+nansum_tl _self _dim =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::nansum(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _dim)));
+  }|]
+
+nansum_out_ttlbs
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> CBool
+  -> ScalarType
+  -> IO (Ptr Tensor)
+nansum_out_ttlbs _out _self _dim _keepdim _dtype =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::nansum_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _dim)
+  , $(bool _keepdim)
+  , $(at::ScalarType _dtype)));
+  }|]
+
+nansum_out_ttlb
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> CBool
+  -> IO (Ptr Tensor)
+nansum_out_ttlb _out _self _dim _keepdim =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::nansum_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _dim)
+  , $(bool _keepdim)));
+  }|]
+
+nansum_out_ttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+nansum_out_ttl _out _self _dim =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::nansum_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _dim)));
+  }|]
+
+sqrt_t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+sqrt_t _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::sqrt(
+    *$(at::Tensor* _self)));
+  }|]
+
+sqrt__t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+sqrt__t _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::sqrt_(
+    *$(at::Tensor* _self)));
+  }|]
+
+sqrt_out_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+sqrt_out_tt _out _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::sqrt_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)));
+  }|]
+
+square_t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+square_t _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::square(
+    *$(at::Tensor* _self)));
+  }|]
+
+square__t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+square__t _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::square_(
+    *$(at::Tensor* _self)));
+  }|]
+
+square_out_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+square_out_tt _out _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::square_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)));
+  }|]
+
+std_tb
+  :: Ptr Tensor
+  -> CBool
+  -> IO (Ptr Tensor)
+std_tb _self _unbiased =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::std(
+    *$(at::Tensor* _self)
+  , $(bool _unbiased)));
+  }|]
+
+std_t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+std_t _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::std(
+    *$(at::Tensor* _self)));
+  }|]
+
+std_tlbb
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> CBool
+  -> CBool
+  -> IO (Ptr Tensor)
+std_tlbb _self _dim _unbiased _keepdim =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::std(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _dim)
+  , $(bool _unbiased)
+  , $(bool _keepdim)));
+  }|]
+
+std_tlb
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> CBool
+  -> IO (Ptr Tensor)
+std_tlb _self _dim _unbiased =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::std(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _dim)
+  , $(bool _unbiased)));
+  }|]
+
+std_tl
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+std_tl _self _dim =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::std(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _dim)));
+  }|]
+
+std_tllb
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Int64
+  -> CBool
+  -> IO (Ptr Tensor)
+std_tllb _self _dim _correction _keepdim =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::std(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _dim)
+  , $(int64_t _correction)
+  , $(bool _keepdim)));
+  }|]
+
+std_tll
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Int64
+  -> IO (Ptr Tensor)
+std_tll _self _dim _correction =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::std(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _dim)
+  , $(int64_t _correction)));
+  }|]
+
+std_mean_tb
+  :: Ptr Tensor
+  -> CBool
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+std_mean_tb _self _unbiased =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::std_mean(
+    *$(at::Tensor* _self)
+  , $(bool _unbiased)));
+  }|]
+
+std_mean_t
+  :: Ptr Tensor
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+std_mean_t _self =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::std_mean(
+    *$(at::Tensor* _self)));
+  }|]
+
+std_mean_tlbb
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> CBool
+  -> CBool
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+std_mean_tlbb _self _dim _unbiased _keepdim =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::std_mean(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _dim)
+  , $(bool _unbiased)
+  , $(bool _keepdim)));
+  }|]
+
+std_mean_tlb
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> CBool
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+std_mean_tlb _self _dim _unbiased =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::std_mean(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _dim)
+  , $(bool _unbiased)));
   }|]
 

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native7.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native7.hs
@@ -28,242 +28,6 @@ C.include "<ATen/Tensor.h>"
 C.include "<ATen/Functions.h>"
 
 
-nansum_ts
-  :: Ptr Tensor
-  -> ScalarType
-  -> IO (Ptr Tensor)
-nansum_ts _self _dtype =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::nansum(
-    *$(at::Tensor* _self)
-  , $(at::ScalarType _dtype)));
-  }|]
-
-nansum_t
-  :: Ptr Tensor
-  -> IO (Ptr Tensor)
-nansum_t _self =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::nansum(
-    *$(at::Tensor* _self)));
-  }|]
-
-nansum_tlbs
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> CBool
-  -> ScalarType
-  -> IO (Ptr Tensor)
-nansum_tlbs _self _dim _keepdim _dtype =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::nansum(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _dim)
-  , $(bool _keepdim)
-  , $(at::ScalarType _dtype)));
-  }|]
-
-nansum_tlb
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> CBool
-  -> IO (Ptr Tensor)
-nansum_tlb _self _dim _keepdim =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::nansum(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _dim)
-  , $(bool _keepdim)));
-  }|]
-
-nansum_tl
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-nansum_tl _self _dim =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::nansum(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _dim)));
-  }|]
-
-nansum_out_ttlbs
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> CBool
-  -> ScalarType
-  -> IO (Ptr Tensor)
-nansum_out_ttlbs _out _self _dim _keepdim _dtype =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::nansum_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _dim)
-  , $(bool _keepdim)
-  , $(at::ScalarType _dtype)));
-  }|]
-
-nansum_out_ttlb
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> CBool
-  -> IO (Ptr Tensor)
-nansum_out_ttlb _out _self _dim _keepdim =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::nansum_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _dim)
-  , $(bool _keepdim)));
-  }|]
-
-nansum_out_ttl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-nansum_out_ttl _out _self _dim =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::nansum_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _dim)));
-  }|]
-
-sqrt_t
-  :: Ptr Tensor
-  -> IO (Ptr Tensor)
-sqrt_t _self =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::sqrt(
-    *$(at::Tensor* _self)));
-  }|]
-
-sqrt__t
-  :: Ptr Tensor
-  -> IO (Ptr Tensor)
-sqrt__t _self =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::sqrt_(
-    *$(at::Tensor* _self)));
-  }|]
-
-sqrt_out_tt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-sqrt_out_tt _out _self =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::sqrt_out(
-    *$(at::Tensor* _out)
-  , *$(at::Tensor* _self)));
-  }|]
-
-square_t
-  :: Ptr Tensor
-  -> IO (Ptr Tensor)
-square_t _self =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::square(
-    *$(at::Tensor* _self)));
-  }|]
-
-square__t
-  :: Ptr Tensor
-  -> IO (Ptr Tensor)
-square__t _self =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::square_(
-    *$(at::Tensor* _self)));
-  }|]
-
-std_tb
-  :: Ptr Tensor
-  -> CBool
-  -> IO (Ptr Tensor)
-std_tb _self _unbiased =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::std(
-    *$(at::Tensor* _self)
-  , $(bool _unbiased)));
-  }|]
-
-std_t
-  :: Ptr Tensor
-  -> IO (Ptr Tensor)
-std_t _self =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::std(
-    *$(at::Tensor* _self)));
-  }|]
-
-std_tlbb
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> CBool
-  -> CBool
-  -> IO (Ptr Tensor)
-std_tlbb _self _dim _unbiased _keepdim =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::std(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _dim)
-  , $(bool _unbiased)
-  , $(bool _keepdim)));
-  }|]
-
-std_tlb
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> CBool
-  -> IO (Ptr Tensor)
-std_tlb _self _dim _unbiased =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::std(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _dim)
-  , $(bool _unbiased)));
-  }|]
-
-std_tl
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-std_tl _self _dim =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::std(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _dim)));
-  }|]
-
-std_mean_tb
-  :: Ptr Tensor
-  -> CBool
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-std_mean_tb _self _unbiased =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::std_mean(
-    *$(at::Tensor* _self)
-  , $(bool _unbiased)));
-  }|]
-
-std_mean_t
-  :: Ptr Tensor
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-std_mean_t _self =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::std_mean(
-    *$(at::Tensor* _self)));
-  }|]
-
-std_mean_tlbb
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> CBool
-  -> CBool
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-std_mean_tlbb _self _dim _unbiased _keepdim =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::std_mean(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _dim)
-  , $(bool _unbiased)
-  , $(bool _keepdim)));
-  }|]
-
-std_mean_tlb
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> CBool
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-std_mean_tlb _self _dim _unbiased =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::std_mean(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _dim)
-  , $(bool _unbiased)));
-  }|]
-
 std_mean_tl
   :: Ptr Tensor
   -> Ptr IntArray
@@ -272,6 +36,32 @@ std_mean_tl _self _dim =
   [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::std_mean(
     *$(at::Tensor* _self)
   , *$(std::vector<int64_t>* _dim)));
+  }|]
+
+std_mean_tllb
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Int64
+  -> CBool
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+std_mean_tllb _self _dim _correction _keepdim =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::std_mean(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _dim)
+  , $(int64_t _correction)
+  , $(bool _keepdim)));
+  }|]
+
+std_mean_tll
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Int64
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+std_mean_tll _self _dim _correction =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::std_mean(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _dim)
+  , $(int64_t _correction)));
   }|]
 
 std_mean_tNbb
@@ -308,6 +98,32 @@ std_mean_tN _self _dim =
   [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::std_mean(
     *$(at::Tensor* _self)
   , *$(std::vector<at::Dimname>* _dim)));
+  }|]
+
+std_mean_tNlb
+  :: Ptr Tensor
+  -> Ptr DimnameList
+  -> Int64
+  -> CBool
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+std_mean_tNlb _self _dim _correction _keepdim =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::std_mean(
+    *$(at::Tensor* _self)
+  , *$(std::vector<at::Dimname>* _dim)
+  , $(int64_t _correction)
+  , $(bool _keepdim)));
+  }|]
+
+std_mean_tNl
+  :: Ptr Tensor
+  -> Ptr DimnameList
+  -> Int64
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+std_mean_tNl _self _dim _correction =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::std_mean(
+    *$(at::Tensor* _self)
+  , *$(std::vector<at::Dimname>* _dim)
+  , $(int64_t _correction)));
   }|]
 
 std_out_ttlbb
@@ -350,6 +166,36 @@ std_out_ttl _out _self _dim =
     *$(at::Tensor* _out)
   , *$(at::Tensor* _self)
   , *$(std::vector<int64_t>* _dim)));
+  }|]
+
+std_out_ttllb
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Int64
+  -> CBool
+  -> IO (Ptr Tensor)
+std_out_ttllb _out _self _dim _correction _keepdim =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::std_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _dim)
+  , $(int64_t _correction)
+  , $(bool _keepdim)));
+  }|]
+
+std_out_ttll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Int64
+  -> IO (Ptr Tensor)
+std_out_ttll _out _self _dim _correction =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::std_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _dim)
+  , $(int64_t _correction)));
   }|]
 
 std_tNbb
@@ -428,6 +274,62 @@ std_out_ttN _out _self _dim =
     *$(at::Tensor* _out)
   , *$(at::Tensor* _self)
   , *$(std::vector<at::Dimname>* _dim)));
+  }|]
+
+std_tNlb
+  :: Ptr Tensor
+  -> Ptr DimnameList
+  -> Int64
+  -> CBool
+  -> IO (Ptr Tensor)
+std_tNlb _self _dim _correction _keepdim =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::std(
+    *$(at::Tensor* _self)
+  , *$(std::vector<at::Dimname>* _dim)
+  , $(int64_t _correction)
+  , $(bool _keepdim)));
+  }|]
+
+std_tNl
+  :: Ptr Tensor
+  -> Ptr DimnameList
+  -> Int64
+  -> IO (Ptr Tensor)
+std_tNl _self _dim _correction =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::std(
+    *$(at::Tensor* _self)
+  , *$(std::vector<at::Dimname>* _dim)
+  , $(int64_t _correction)));
+  }|]
+
+std_out_ttNlb
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr DimnameList
+  -> Int64
+  -> CBool
+  -> IO (Ptr Tensor)
+std_out_ttNlb _out _self _dim _correction _keepdim =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::std_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<at::Dimname>* _dim)
+  , $(int64_t _correction)
+  , $(bool _keepdim)));
+  }|]
+
+std_out_ttNl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr DimnameList
+  -> Int64
+  -> IO (Ptr Tensor)
+std_out_ttNl _out _self _dim _correction =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::std_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<at::Dimname>* _dim)
+  , $(int64_t _correction)));
   }|]
 
 prod_ts
@@ -730,6 +632,20 @@ threshold_out_ttss _out _self _threshold _value =
   , *$(at::Tensor* _self)
   , *$(at::Scalar* _threshold)
   , *$(at::Scalar* _value)));
+  }|]
+
+threshold_backward_out_ttts
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+threshold_backward_out_ttts _grad_input _grad_output _self _threshold =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::threshold_backward_out(
+    *$(at::Tensor* _grad_input)
+  , *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _self)
+  , *$(at::Scalar* _threshold)));
   }|]
 
 threshold_backward_tts
@@ -1466,6 +1382,32 @@ var_tl _self _dim =
   , *$(std::vector<int64_t>* _dim)));
   }|]
 
+var_tllb
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Int64
+  -> CBool
+  -> IO (Ptr Tensor)
+var_tllb _self _dim _correction _keepdim =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::var(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _dim)
+  , $(int64_t _correction)
+  , $(bool _keepdim)));
+  }|]
+
+var_tll
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Int64
+  -> IO (Ptr Tensor)
+var_tll _self _dim _correction =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::var(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _dim)
+  , $(int64_t _correction)));
+  }|]
+
 var_out_ttlbb
   :: Ptr Tensor
   -> Ptr Tensor
@@ -1506,6 +1448,36 @@ var_out_ttl _out _self _dim =
     *$(at::Tensor* _out)
   , *$(at::Tensor* _self)
   , *$(std::vector<int64_t>* _dim)));
+  }|]
+
+var_out_ttllb
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Int64
+  -> CBool
+  -> IO (Ptr Tensor)
+var_out_ttllb _out _self _dim _correction _keepdim =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::var_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _dim)
+  , $(int64_t _correction)
+  , $(bool _keepdim)));
+  }|]
+
+var_out_ttll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Int64
+  -> IO (Ptr Tensor)
+var_out_ttll _out _self _dim _correction =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::var_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _dim)
+  , $(int64_t _correction)));
   }|]
 
 var_tNbb
@@ -1586,6 +1558,62 @@ var_out_ttN _out _self _dim =
   , *$(std::vector<at::Dimname>* _dim)));
   }|]
 
+var_tNlb
+  :: Ptr Tensor
+  -> Ptr DimnameList
+  -> Int64
+  -> CBool
+  -> IO (Ptr Tensor)
+var_tNlb _self _dim _correction _keepdim =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::var(
+    *$(at::Tensor* _self)
+  , *$(std::vector<at::Dimname>* _dim)
+  , $(int64_t _correction)
+  , $(bool _keepdim)));
+  }|]
+
+var_tNl
+  :: Ptr Tensor
+  -> Ptr DimnameList
+  -> Int64
+  -> IO (Ptr Tensor)
+var_tNl _self _dim _correction =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::var(
+    *$(at::Tensor* _self)
+  , *$(std::vector<at::Dimname>* _dim)
+  , $(int64_t _correction)));
+  }|]
+
+var_out_ttNlb
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr DimnameList
+  -> Int64
+  -> CBool
+  -> IO (Ptr Tensor)
+var_out_ttNlb _out _self _dim _correction _keepdim =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::var_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<at::Dimname>* _dim)
+  , $(int64_t _correction)
+  , $(bool _keepdim)));
+  }|]
+
+var_out_ttNl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr DimnameList
+  -> Int64
+  -> IO (Ptr Tensor)
+var_out_ttNl _out _self _dim _correction =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::var_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<at::Dimname>* _dim)
+  , $(int64_t _correction)));
+  }|]
+
 var_mean_tb
   :: Ptr Tensor
   -> CBool
@@ -1640,6 +1668,32 @@ var_mean_tl _self _dim =
   , *$(std::vector<int64_t>* _dim)));
   }|]
 
+var_mean_tllb
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Int64
+  -> CBool
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+var_mean_tllb _self _dim _correction _keepdim =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::var_mean(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _dim)
+  , $(int64_t _correction)
+  , $(bool _keepdim)));
+  }|]
+
+var_mean_tll
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Int64
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+var_mean_tll _self _dim _correction =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::var_mean(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _dim)
+  , $(int64_t _correction)));
+  }|]
+
 var_mean_tNbb
   :: Ptr Tensor
   -> Ptr DimnameList
@@ -1674,6 +1728,32 @@ var_mean_tN _self _dim =
   [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::var_mean(
     *$(at::Tensor* _self)
   , *$(std::vector<at::Dimname>* _dim)));
+  }|]
+
+var_mean_tNlb
+  :: Ptr Tensor
+  -> Ptr DimnameList
+  -> Int64
+  -> CBool
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+var_mean_tNlb _self _dim _correction _keepdim =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::var_mean(
+    *$(at::Tensor* _self)
+  , *$(std::vector<at::Dimname>* _dim)
+  , $(int64_t _correction)
+  , $(bool _keepdim)));
+  }|]
+
+var_mean_tNl
+  :: Ptr Tensor
+  -> Ptr DimnameList
+  -> Int64
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+var_mean_tNl _self _dim _correction =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::var_mean(
+    *$(at::Tensor* _self)
+  , *$(std::vector<at::Dimname>* _dim)
+  , $(int64_t _correction)));
   }|]
 
 where_ttt
@@ -2004,5 +2084,183 @@ poisson_t
 poisson_t _self =
   [C.throwBlock| at::Tensor* { return new at::Tensor(at::poisson(
     *$(at::Tensor* _self)));
+  }|]
+
+binomial_ttG
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Generator
+  -> IO (Ptr Tensor)
+binomial_ttG _count _prob _generator =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::binomial(
+    *$(at::Tensor* _count)
+  , *$(at::Tensor* _prob)
+  , *$(at::Generator* _generator)));
+  }|]
+
+binomial_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+binomial_tt _count _prob =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::binomial(
+    *$(at::Tensor* _count)
+  , *$(at::Tensor* _prob)));
+  }|]
+
+native_norm_ts
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+native_norm_ts _self _p =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::native_norm(
+    *$(at::Tensor* _self)
+  , *$(at::Scalar* _p)));
+  }|]
+
+native_norm_t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+native_norm_t _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::native_norm(
+    *$(at::Tensor* _self)));
+  }|]
+
+native_norm_tslbs
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr IntArray
+  -> CBool
+  -> ScalarType
+  -> IO (Ptr Tensor)
+native_norm_tslbs _self _p _dim _keepdim _dtype =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::native_norm(
+    *$(at::Tensor* _self)
+  , *$(at::Scalar* _p)
+  , *$(std::vector<int64_t>* _dim)
+  , $(bool _keepdim)
+  , $(at::ScalarType _dtype)));
+  }|]
+
+_sparse_sum_t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+_sparse_sum_t _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_sparse_sum(
+    *$(at::Tensor* _self)));
+  }|]
+
+_sparse_sum_ts
+  :: Ptr Tensor
+  -> ScalarType
+  -> IO (Ptr Tensor)
+_sparse_sum_ts _self _dtype =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_sparse_sum(
+    *$(at::Tensor* _self)
+  , $(at::ScalarType _dtype)));
+  }|]
+
+_sparse_sum_tl
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+_sparse_sum_tl _self _dim =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_sparse_sum(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _dim)));
+  }|]
+
+_sparse_sum_tls
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> ScalarType
+  -> IO (Ptr Tensor)
+_sparse_sum_tls _self _dim _dtype =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_sparse_sum(
+    *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _dim)
+  , $(at::ScalarType _dtype)));
+  }|]
+
+_sparse_sum_backward_ttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+_sparse_sum_backward_ttl _grad _self _dim =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_sparse_sum_backward(
+    *$(at::Tensor* _grad)
+  , *$(at::Tensor* _self)
+  , *$(std::vector<int64_t>* _dim)));
+  }|]
+
+_sparse_softmax_tls
+  :: Ptr Tensor
+  -> Int64
+  -> ScalarType
+  -> IO (Ptr Tensor)
+_sparse_softmax_tls _self _dim _dtype =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_sparse_softmax(
+    *$(at::Tensor* _self)
+  , $(int64_t _dim)
+  , $(at::ScalarType _dtype)));
+  }|]
+
+_sparse_softmax_tl
+  :: Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+_sparse_softmax_tl _self _dim =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_sparse_softmax(
+    *$(at::Tensor* _self)
+  , $(int64_t _dim)));
+  }|]
+
+_sparse_softmax_tns
+  :: Ptr Tensor
+  -> Ptr Dimname
+  -> ScalarType
+  -> IO (Ptr Tensor)
+_sparse_softmax_tns _self _dim _dtype =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_sparse_softmax(
+    *$(at::Tensor* _self)
+  , *$(at::Dimname* _dim)
+  , $(at::ScalarType _dtype)));
+  }|]
+
+_sparse_softmax_tn
+  :: Ptr Tensor
+  -> Ptr Dimname
+  -> IO (Ptr Tensor)
+_sparse_softmax_tn _self _dim =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_sparse_softmax(
+    *$(at::Tensor* _self)
+  , *$(at::Dimname* _dim)));
+  }|]
+
+_sparse_softmax_tlb
+  :: Ptr Tensor
+  -> Int64
+  -> CBool
+  -> IO (Ptr Tensor)
+_sparse_softmax_tlb _self _dim _half_to_float =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_sparse_softmax(
+    *$(at::Tensor* _self)
+  , $(int64_t _dim)
+  , $(bool _half_to_float)));
+  }|]
+
+_sparse_softmax_backward_data_ttlt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+_sparse_softmax_backward_data_ttlt _grad_output _output _dim _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_sparse_softmax_backward_data(
+    *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _output)
+  , $(int64_t _dim)
+  , *$(at::Tensor* _self)));
   }|]
 

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native8.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native8.hs
@@ -28,184 +28,6 @@ C.include "<ATen/Tensor.h>"
 C.include "<ATen/Functions.h>"
 
 
-binomial_ttG
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Generator
-  -> IO (Ptr Tensor)
-binomial_ttG _count _prob _generator =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::binomial(
-    *$(at::Tensor* _count)
-  , *$(at::Tensor* _prob)
-  , *$(at::Generator* _generator)));
-  }|]
-
-binomial_tt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-binomial_tt _count _prob =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::binomial(
-    *$(at::Tensor* _count)
-  , *$(at::Tensor* _prob)));
-  }|]
-
-native_norm_ts
-  :: Ptr Tensor
-  -> Ptr Scalar
-  -> IO (Ptr Tensor)
-native_norm_ts _self _p =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::native_norm(
-    *$(at::Tensor* _self)
-  , *$(at::Scalar* _p)));
-  }|]
-
-native_norm_t
-  :: Ptr Tensor
-  -> IO (Ptr Tensor)
-native_norm_t _self =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::native_norm(
-    *$(at::Tensor* _self)));
-  }|]
-
-native_norm_tslbs
-  :: Ptr Tensor
-  -> Ptr Scalar
-  -> Ptr IntArray
-  -> CBool
-  -> ScalarType
-  -> IO (Ptr Tensor)
-native_norm_tslbs _self _p _dim _keepdim _dtype =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::native_norm(
-    *$(at::Tensor* _self)
-  , *$(at::Scalar* _p)
-  , *$(std::vector<int64_t>* _dim)
-  , $(bool _keepdim)
-  , $(at::ScalarType _dtype)));
-  }|]
-
-_sparse_sum_t
-  :: Ptr Tensor
-  -> IO (Ptr Tensor)
-_sparse_sum_t _self =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_sparse_sum(
-    *$(at::Tensor* _self)));
-  }|]
-
-_sparse_sum_ts
-  :: Ptr Tensor
-  -> ScalarType
-  -> IO (Ptr Tensor)
-_sparse_sum_ts _self _dtype =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_sparse_sum(
-    *$(at::Tensor* _self)
-  , $(at::ScalarType _dtype)));
-  }|]
-
-_sparse_sum_tl
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-_sparse_sum_tl _self _dim =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_sparse_sum(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _dim)));
-  }|]
-
-_sparse_sum_tls
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> ScalarType
-  -> IO (Ptr Tensor)
-_sparse_sum_tls _self _dim _dtype =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_sparse_sum(
-    *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _dim)
-  , $(at::ScalarType _dtype)));
-  }|]
-
-_sparse_sum_backward_ttl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-_sparse_sum_backward_ttl _grad _self _dim =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_sparse_sum_backward(
-    *$(at::Tensor* _grad)
-  , *$(at::Tensor* _self)
-  , *$(std::vector<int64_t>* _dim)));
-  }|]
-
-_sparse_softmax_tls
-  :: Ptr Tensor
-  -> Int64
-  -> ScalarType
-  -> IO (Ptr Tensor)
-_sparse_softmax_tls _self _dim _dtype =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_sparse_softmax(
-    *$(at::Tensor* _self)
-  , $(int64_t _dim)
-  , $(at::ScalarType _dtype)));
-  }|]
-
-_sparse_softmax_tl
-  :: Ptr Tensor
-  -> Int64
-  -> IO (Ptr Tensor)
-_sparse_softmax_tl _self _dim =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_sparse_softmax(
-    *$(at::Tensor* _self)
-  , $(int64_t _dim)));
-  }|]
-
-_sparse_softmax_tns
-  :: Ptr Tensor
-  -> Ptr Dimname
-  -> ScalarType
-  -> IO (Ptr Tensor)
-_sparse_softmax_tns _self _dim _dtype =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_sparse_softmax(
-    *$(at::Tensor* _self)
-  , *$(at::Dimname* _dim)
-  , $(at::ScalarType _dtype)));
-  }|]
-
-_sparse_softmax_tn
-  :: Ptr Tensor
-  -> Ptr Dimname
-  -> IO (Ptr Tensor)
-_sparse_softmax_tn _self _dim =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_sparse_softmax(
-    *$(at::Tensor* _self)
-  , *$(at::Dimname* _dim)));
-  }|]
-
-_sparse_softmax_tlb
-  :: Ptr Tensor
-  -> Int64
-  -> CBool
-  -> IO (Ptr Tensor)
-_sparse_softmax_tlb _self _dim _half_to_float =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_sparse_softmax(
-    *$(at::Tensor* _self)
-  , $(int64_t _dim)
-  , $(bool _half_to_float)));
-  }|]
-
-_sparse_softmax_backward_data_ttlt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Int64
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-_sparse_softmax_backward_data_ttlt _grad_output _output _dim _self =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_sparse_softmax_backward_data(
-    *$(at::Tensor* _grad_output)
-  , *$(at::Tensor* _output)
-  , $(int64_t _dim)
-  , *$(at::Tensor* _self)));
-  }|]
-
 _sparse_log_softmax_tls
   :: Ptr Tensor
   -> Int64
@@ -486,6 +308,26 @@ norm_out_ttsN _out _self _p _dim =
   , *$(std::vector<at::Dimname>* _dim)));
   }|]
 
+frexp_t
+  :: Ptr Tensor
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+frexp_t _self =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::frexp(
+    *$(at::Tensor* _self)));
+  }|]
+
+frexp_out_ttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+frexp_out_ttt _mantissa _exponent _self =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::frexp_out(
+    *$(at::Tensor* _mantissa)
+  , *$(at::Tensor* _exponent)
+  , *$(at::Tensor* _self)));
+  }|]
+
 frobenius_norm_t
   :: Ptr Tensor
   -> IO (Ptr Tensor)
@@ -648,6 +490,14 @@ clone_t _self =
     *$(at::Tensor* _self)));
   }|]
 
+positive_t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+positive_t _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::positive(
+    *$(at::Tensor* _self)));
+  }|]
+
 resize_as__ttM
   :: Ptr Tensor
   -> Ptr Tensor
@@ -666,6 +516,16 @@ resize_as__tt
   -> IO (Ptr Tensor)
 resize_as__tt _self _the_template =
   [C.throwBlock| at::Tensor* { return new at::Tensor(at::resize_as_(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _the_template)));
+  }|]
+
+resize_as_sparse__tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+resize_as_sparse__tt _self _the_template =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::resize_as_sparse_(
     *$(at::Tensor* _self)
   , *$(at::Tensor* _the_template)));
   }|]
@@ -1016,6 +876,36 @@ addmm_ttt _self _mat1 _mat2 =
   , *$(at::Tensor* _mat2)));
   }|]
 
+_sparse_csr_tensor_tttlo
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr TensorOptions
+  -> IO (Ptr Tensor)
+_sparse_csr_tensor_tttlo _crow_indices _col_indices _values _size _options =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_sparse_csr_tensor(
+    *$(at::Tensor* _crow_indices)
+  , *$(at::Tensor* _col_indices)
+  , *$(at::Tensor* _values)
+  , *$(std::vector<int64_t>* _size)
+  , *$(at::TensorOptions* _options)));
+  }|]
+
+_sparse_csr_tensor_ttto
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr TensorOptions
+  -> IO (Ptr Tensor)
+_sparse_csr_tensor_ttto _crow_indices _col_indices _values _options =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_sparse_csr_tensor(
+    *$(at::Tensor* _crow_indices)
+  , *$(at::Tensor* _col_indices)
+  , *$(at::Tensor* _values)
+  , *$(at::TensorOptions* _options)));
+  }|]
+
 sparse_coo_tensor_lo
   :: Ptr IntArray
   -> Ptr TensorOptions
@@ -1152,6 +1042,14 @@ to_dense_backward_tt _grad _input =
   [C.throwBlock| at::Tensor* { return new at::Tensor(at::to_dense_backward(
     *$(at::Tensor* _grad)
   , *$(at::Tensor* _input)));
+  }|]
+
+_coalesce_t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+_coalesce_t _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_coalesce(
+    *$(at::Tensor* _self)));
   }|]
 
 hspmm_out_ttt
@@ -2248,5 +2146,465 @@ lstm_cell_tltttt _input _hx _w_ih _w_hh _b_ih _b_hh =
   , *$(at::Tensor* _w_hh)
   , *$(at::Tensor* _b_ih)
   , *$(at::Tensor* _b_hh)));
+  }|]
+
+lstm_cell_tlttt
+  :: Ptr Tensor
+  -> Ptr TensorList
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+lstm_cell_tlttt _input _hx _w_ih _w_hh _b_ih =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::lstm_cell(
+    *$(at::Tensor* _input)
+  , *$(std::vector<at::Tensor>* _hx)
+  , *$(at::Tensor* _w_ih)
+  , *$(at::Tensor* _w_hh)
+  , *$(at::Tensor* _b_ih)));
+  }|]
+
+lstm_cell_tltt
+  :: Ptr Tensor
+  -> Ptr TensorList
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+lstm_cell_tltt _input _hx _w_ih _w_hh =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::lstm_cell(
+    *$(at::Tensor* _input)
+  , *$(std::vector<at::Tensor>* _hx)
+  , *$(at::Tensor* _w_ih)
+  , *$(at::Tensor* _w_hh)));
+  }|]
+
+gru_cell_tttttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+gru_cell_tttttt _input _hx _w_ih _w_hh _b_ih _b_hh =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::gru_cell(
+    *$(at::Tensor* _input)
+  , *$(at::Tensor* _hx)
+  , *$(at::Tensor* _w_ih)
+  , *$(at::Tensor* _w_hh)
+  , *$(at::Tensor* _b_ih)
+  , *$(at::Tensor* _b_hh)));
+  }|]
+
+gru_cell_ttttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+gru_cell_ttttt _input _hx _w_ih _w_hh _b_ih =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::gru_cell(
+    *$(at::Tensor* _input)
+  , *$(at::Tensor* _hx)
+  , *$(at::Tensor* _w_ih)
+  , *$(at::Tensor* _w_hh)
+  , *$(at::Tensor* _b_ih)));
+  }|]
+
+gru_cell_tttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+gru_cell_tttt _input _hx _w_ih _w_hh =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::gru_cell(
+    *$(at::Tensor* _input)
+  , *$(at::Tensor* _hx)
+  , *$(at::Tensor* _w_ih)
+  , *$(at::Tensor* _w_hh)));
+  }|]
+
+rnn_tanh_cell_tttttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+rnn_tanh_cell_tttttt _input _hx _w_ih _w_hh _b_ih _b_hh =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::rnn_tanh_cell(
+    *$(at::Tensor* _input)
+  , *$(at::Tensor* _hx)
+  , *$(at::Tensor* _w_ih)
+  , *$(at::Tensor* _w_hh)
+  , *$(at::Tensor* _b_ih)
+  , *$(at::Tensor* _b_hh)));
+  }|]
+
+rnn_tanh_cell_ttttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+rnn_tanh_cell_ttttt _input _hx _w_ih _w_hh _b_ih =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::rnn_tanh_cell(
+    *$(at::Tensor* _input)
+  , *$(at::Tensor* _hx)
+  , *$(at::Tensor* _w_ih)
+  , *$(at::Tensor* _w_hh)
+  , *$(at::Tensor* _b_ih)));
+  }|]
+
+rnn_tanh_cell_tttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+rnn_tanh_cell_tttt _input _hx _w_ih _w_hh =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::rnn_tanh_cell(
+    *$(at::Tensor* _input)
+  , *$(at::Tensor* _hx)
+  , *$(at::Tensor* _w_ih)
+  , *$(at::Tensor* _w_hh)));
+  }|]
+
+rnn_relu_cell_tttttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+rnn_relu_cell_tttttt _input _hx _w_ih _w_hh _b_ih _b_hh =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::rnn_relu_cell(
+    *$(at::Tensor* _input)
+  , *$(at::Tensor* _hx)
+  , *$(at::Tensor* _w_ih)
+  , *$(at::Tensor* _w_hh)
+  , *$(at::Tensor* _b_ih)
+  , *$(at::Tensor* _b_hh)));
+  }|]
+
+rnn_relu_cell_ttttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+rnn_relu_cell_ttttt _input _hx _w_ih _w_hh _b_ih =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::rnn_relu_cell(
+    *$(at::Tensor* _input)
+  , *$(at::Tensor* _hx)
+  , *$(at::Tensor* _w_ih)
+  , *$(at::Tensor* _w_hh)
+  , *$(at::Tensor* _b_ih)));
+  }|]
+
+rnn_relu_cell_tttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+rnn_relu_cell_tttt _input _hx _w_ih _w_hh =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::rnn_relu_cell(
+    *$(at::Tensor* _input)
+  , *$(at::Tensor* _hx)
+  , *$(at::Tensor* _w_ih)
+  , *$(at::Tensor* _w_hh)));
+  }|]
+
+quantized_lstm_cell_tlttttttttssss
+  :: Ptr Tensor
+  -> Ptr TensorList
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr Scalar
+  -> Ptr Scalar
+  -> Ptr Scalar
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+quantized_lstm_cell_tlttttttttssss _input _hx _w_ih _w_hh _b_ih _b_hh _packed_ih _packed_hh _col_offsets_ih _col_offsets_hh _scale_ih _scale_hh _zero_point_ih _zero_point_hh =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::quantized_lstm_cell(
+    *$(at::Tensor* _input)
+  , *$(std::vector<at::Tensor>* _hx)
+  , *$(at::Tensor* _w_ih)
+  , *$(at::Tensor* _w_hh)
+  , *$(at::Tensor* _b_ih)
+  , *$(at::Tensor* _b_hh)
+  , *$(at::Tensor* _packed_ih)
+  , *$(at::Tensor* _packed_hh)
+  , *$(at::Tensor* _col_offsets_ih)
+  , *$(at::Tensor* _col_offsets_hh)
+  , *$(at::Scalar* _scale_ih)
+  , *$(at::Scalar* _scale_hh)
+  , *$(at::Scalar* _zero_point_ih)
+  , *$(at::Scalar* _zero_point_hh)));
+  }|]
+
+quantized_gru_cell_ttttttttttssss
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr Scalar
+  -> Ptr Scalar
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+quantized_gru_cell_ttttttttttssss _input _hx _w_ih _w_hh _b_ih _b_hh _packed_ih _packed_hh _col_offsets_ih _col_offsets_hh _scale_ih _scale_hh _zero_point_ih _zero_point_hh =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::quantized_gru_cell(
+    *$(at::Tensor* _input)
+  , *$(at::Tensor* _hx)
+  , *$(at::Tensor* _w_ih)
+  , *$(at::Tensor* _w_hh)
+  , *$(at::Tensor* _b_ih)
+  , *$(at::Tensor* _b_hh)
+  , *$(at::Tensor* _packed_ih)
+  , *$(at::Tensor* _packed_hh)
+  , *$(at::Tensor* _col_offsets_ih)
+  , *$(at::Tensor* _col_offsets_hh)
+  , *$(at::Scalar* _scale_ih)
+  , *$(at::Scalar* _scale_hh)
+  , *$(at::Scalar* _zero_point_ih)
+  , *$(at::Scalar* _zero_point_hh)));
+  }|]
+
+quantized_rnn_relu_cell_ttttttttttssss
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr Scalar
+  -> Ptr Scalar
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+quantized_rnn_relu_cell_ttttttttttssss _input _hx _w_ih _w_hh _b_ih _b_hh _packed_ih _packed_hh _col_offsets_ih _col_offsets_hh _scale_ih _scale_hh _zero_point_ih _zero_point_hh =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::quantized_rnn_relu_cell(
+    *$(at::Tensor* _input)
+  , *$(at::Tensor* _hx)
+  , *$(at::Tensor* _w_ih)
+  , *$(at::Tensor* _w_hh)
+  , *$(at::Tensor* _b_ih)
+  , *$(at::Tensor* _b_hh)
+  , *$(at::Tensor* _packed_ih)
+  , *$(at::Tensor* _packed_hh)
+  , *$(at::Tensor* _col_offsets_ih)
+  , *$(at::Tensor* _col_offsets_hh)
+  , *$(at::Scalar* _scale_ih)
+  , *$(at::Scalar* _scale_hh)
+  , *$(at::Scalar* _zero_point_ih)
+  , *$(at::Scalar* _zero_point_hh)));
+  }|]
+
+quantized_rnn_tanh_cell_ttttttttttssss
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr Scalar
+  -> Ptr Scalar
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+quantized_rnn_tanh_cell_ttttttttttssss _input _hx _w_ih _w_hh _b_ih _b_hh _packed_ih _packed_hh _col_offsets_ih _col_offsets_hh _scale_ih _scale_hh _zero_point_ih _zero_point_hh =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::quantized_rnn_tanh_cell(
+    *$(at::Tensor* _input)
+  , *$(at::Tensor* _hx)
+  , *$(at::Tensor* _w_ih)
+  , *$(at::Tensor* _w_hh)
+  , *$(at::Tensor* _b_ih)
+  , *$(at::Tensor* _b_hh)
+  , *$(at::Tensor* _packed_ih)
+  , *$(at::Tensor* _packed_hh)
+  , *$(at::Tensor* _col_offsets_ih)
+  , *$(at::Tensor* _col_offsets_hh)
+  , *$(at::Scalar* _scale_ih)
+  , *$(at::Scalar* _scale_hh)
+  , *$(at::Scalar* _zero_point_ih)
+  , *$(at::Scalar* _zero_point_hh)));
+  }|]
+
+_pack_padded_sequence_ttb
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> CBool
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+_pack_padded_sequence_ttb _input _lengths _batch_first =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::_pack_padded_sequence(
+    *$(at::Tensor* _input)
+  , *$(at::Tensor* _lengths)
+  , $(bool _batch_first)));
+  }|]
+
+_pack_padded_sequence_backward_tltb
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr Tensor
+  -> CBool
+  -> IO (Ptr Tensor)
+_pack_padded_sequence_backward_tltb _grad _input_size _batch_sizes _batch_first =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_pack_padded_sequence_backward(
+    *$(at::Tensor* _grad)
+  , *$(std::vector<int64_t>* _input_size)
+  , *$(at::Tensor* _batch_sizes)
+  , $(bool _batch_first)));
+  }|]
+
+_pad_packed_sequence_ttbsl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> CBool
+  -> Ptr Scalar
+  -> Int64
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+_pad_packed_sequence_ttbsl _data _batch_sizes _batch_first _padding_value _total_length =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::_pad_packed_sequence(
+    *$(at::Tensor* _data)
+  , *$(at::Tensor* _batch_sizes)
+  , $(bool _batch_first)
+  , *$(at::Scalar* _padding_value)
+  , $(int64_t _total_length)));
+  }|]
+
+masked_fill_tts
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+masked_fill_tts _self _mask _value =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::masked_fill(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _mask)
+  , *$(at::Scalar* _value)));
+  }|]
+
+masked_fill_ttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+masked_fill_ttt _self _mask _value =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::masked_fill(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _mask)
+  , *$(at::Tensor* _value)));
+  }|]
+
+masked_scatter_ttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+masked_scatter_ttt _self _mask _source =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::masked_scatter(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _mask)
+  , *$(at::Tensor* _source)));
+  }|]
+
+put_tttb
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> CBool
+  -> IO (Ptr Tensor)
+put_tttb _self _index _source _accumulate =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::put(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _index)
+  , *$(at::Tensor* _source)
+  , $(bool _accumulate)));
+  }|]
+
+put_ttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+put_ttt _self _index _source =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::put(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _index)
+  , *$(at::Tensor* _source)));
+  }|]
+
+index_add_tltt
+  :: Ptr Tensor
+  -> Int64
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+index_add_tltt _self _dim _index _source =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::index_add(
+    *$(at::Tensor* _self)
+  , $(int64_t _dim)
+  , *$(at::Tensor* _index)
+  , *$(at::Tensor* _source)));
+  }|]
+
+index_add_tltts
+  :: Ptr Tensor
+  -> Int64
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+index_add_tltts _self _dim _index _source _alpha =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::index_add(
+    *$(at::Tensor* _self)
+  , $(int64_t _dim)
+  , *$(at::Tensor* _index)
+  , *$(at::Tensor* _source)
+  , *$(at::Scalar* _alpha)));
+  }|]
+
+index_add_tntts
+  :: Ptr Tensor
+  -> Ptr Dimname
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+index_add_tntts _self _dim _index _source _alpha =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::index_add(
+    *$(at::Tensor* _self)
+  , *$(at::Dimname* _dim)
+  , *$(at::Tensor* _index)
+  , *$(at::Tensor* _source)
+  , *$(at::Scalar* _alpha)));
   }|]
 

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native9.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native9.hs
@@ -28,408 +28,6 @@ C.include "<ATen/Tensor.h>"
 C.include "<ATen/Functions.h>"
 
 
-lstm_cell_tlttt
-  :: Ptr Tensor
-  -> Ptr TensorList
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-lstm_cell_tlttt _input _hx _w_ih _w_hh _b_ih =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::lstm_cell(
-    *$(at::Tensor* _input)
-  , *$(std::vector<at::Tensor>* _hx)
-  , *$(at::Tensor* _w_ih)
-  , *$(at::Tensor* _w_hh)
-  , *$(at::Tensor* _b_ih)));
-  }|]
-
-lstm_cell_tltt
-  :: Ptr Tensor
-  -> Ptr TensorList
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-lstm_cell_tltt _input _hx _w_ih _w_hh =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::lstm_cell(
-    *$(at::Tensor* _input)
-  , *$(std::vector<at::Tensor>* _hx)
-  , *$(at::Tensor* _w_ih)
-  , *$(at::Tensor* _w_hh)));
-  }|]
-
-gru_cell_tttttt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-gru_cell_tttttt _input _hx _w_ih _w_hh _b_ih _b_hh =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::gru_cell(
-    *$(at::Tensor* _input)
-  , *$(at::Tensor* _hx)
-  , *$(at::Tensor* _w_ih)
-  , *$(at::Tensor* _w_hh)
-  , *$(at::Tensor* _b_ih)
-  , *$(at::Tensor* _b_hh)));
-  }|]
-
-gru_cell_ttttt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-gru_cell_ttttt _input _hx _w_ih _w_hh _b_ih =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::gru_cell(
-    *$(at::Tensor* _input)
-  , *$(at::Tensor* _hx)
-  , *$(at::Tensor* _w_ih)
-  , *$(at::Tensor* _w_hh)
-  , *$(at::Tensor* _b_ih)));
-  }|]
-
-gru_cell_tttt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-gru_cell_tttt _input _hx _w_ih _w_hh =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::gru_cell(
-    *$(at::Tensor* _input)
-  , *$(at::Tensor* _hx)
-  , *$(at::Tensor* _w_ih)
-  , *$(at::Tensor* _w_hh)));
-  }|]
-
-rnn_tanh_cell_tttttt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-rnn_tanh_cell_tttttt _input _hx _w_ih _w_hh _b_ih _b_hh =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::rnn_tanh_cell(
-    *$(at::Tensor* _input)
-  , *$(at::Tensor* _hx)
-  , *$(at::Tensor* _w_ih)
-  , *$(at::Tensor* _w_hh)
-  , *$(at::Tensor* _b_ih)
-  , *$(at::Tensor* _b_hh)));
-  }|]
-
-rnn_tanh_cell_ttttt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-rnn_tanh_cell_ttttt _input _hx _w_ih _w_hh _b_ih =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::rnn_tanh_cell(
-    *$(at::Tensor* _input)
-  , *$(at::Tensor* _hx)
-  , *$(at::Tensor* _w_ih)
-  , *$(at::Tensor* _w_hh)
-  , *$(at::Tensor* _b_ih)));
-  }|]
-
-rnn_tanh_cell_tttt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-rnn_tanh_cell_tttt _input _hx _w_ih _w_hh =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::rnn_tanh_cell(
-    *$(at::Tensor* _input)
-  , *$(at::Tensor* _hx)
-  , *$(at::Tensor* _w_ih)
-  , *$(at::Tensor* _w_hh)));
-  }|]
-
-rnn_relu_cell_tttttt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-rnn_relu_cell_tttttt _input _hx _w_ih _w_hh _b_ih _b_hh =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::rnn_relu_cell(
-    *$(at::Tensor* _input)
-  , *$(at::Tensor* _hx)
-  , *$(at::Tensor* _w_ih)
-  , *$(at::Tensor* _w_hh)
-  , *$(at::Tensor* _b_ih)
-  , *$(at::Tensor* _b_hh)));
-  }|]
-
-rnn_relu_cell_ttttt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-rnn_relu_cell_ttttt _input _hx _w_ih _w_hh _b_ih =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::rnn_relu_cell(
-    *$(at::Tensor* _input)
-  , *$(at::Tensor* _hx)
-  , *$(at::Tensor* _w_ih)
-  , *$(at::Tensor* _w_hh)
-  , *$(at::Tensor* _b_ih)));
-  }|]
-
-rnn_relu_cell_tttt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-rnn_relu_cell_tttt _input _hx _w_ih _w_hh =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::rnn_relu_cell(
-    *$(at::Tensor* _input)
-  , *$(at::Tensor* _hx)
-  , *$(at::Tensor* _w_ih)
-  , *$(at::Tensor* _w_hh)));
-  }|]
-
-quantized_lstm_cell_tlttttttttssss
-  :: Ptr Tensor
-  -> Ptr TensorList
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Scalar
-  -> Ptr Scalar
-  -> Ptr Scalar
-  -> Ptr Scalar
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-quantized_lstm_cell_tlttttttttssss _input _hx _w_ih _w_hh _b_ih _b_hh _packed_ih _packed_hh _col_offsets_ih _col_offsets_hh _scale_ih _scale_hh _zero_point_ih _zero_point_hh =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::quantized_lstm_cell(
-    *$(at::Tensor* _input)
-  , *$(std::vector<at::Tensor>* _hx)
-  , *$(at::Tensor* _w_ih)
-  , *$(at::Tensor* _w_hh)
-  , *$(at::Tensor* _b_ih)
-  , *$(at::Tensor* _b_hh)
-  , *$(at::Tensor* _packed_ih)
-  , *$(at::Tensor* _packed_hh)
-  , *$(at::Tensor* _col_offsets_ih)
-  , *$(at::Tensor* _col_offsets_hh)
-  , *$(at::Scalar* _scale_ih)
-  , *$(at::Scalar* _scale_hh)
-  , *$(at::Scalar* _zero_point_ih)
-  , *$(at::Scalar* _zero_point_hh)));
-  }|]
-
-quantized_gru_cell_ttttttttttssss
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Scalar
-  -> Ptr Scalar
-  -> Ptr Scalar
-  -> Ptr Scalar
-  -> IO (Ptr Tensor)
-quantized_gru_cell_ttttttttttssss _input _hx _w_ih _w_hh _b_ih _b_hh _packed_ih _packed_hh _col_offsets_ih _col_offsets_hh _scale_ih _scale_hh _zero_point_ih _zero_point_hh =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::quantized_gru_cell(
-    *$(at::Tensor* _input)
-  , *$(at::Tensor* _hx)
-  , *$(at::Tensor* _w_ih)
-  , *$(at::Tensor* _w_hh)
-  , *$(at::Tensor* _b_ih)
-  , *$(at::Tensor* _b_hh)
-  , *$(at::Tensor* _packed_ih)
-  , *$(at::Tensor* _packed_hh)
-  , *$(at::Tensor* _col_offsets_ih)
-  , *$(at::Tensor* _col_offsets_hh)
-  , *$(at::Scalar* _scale_ih)
-  , *$(at::Scalar* _scale_hh)
-  , *$(at::Scalar* _zero_point_ih)
-  , *$(at::Scalar* _zero_point_hh)));
-  }|]
-
-quantized_rnn_relu_cell_ttttttttttssss
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Scalar
-  -> Ptr Scalar
-  -> Ptr Scalar
-  -> Ptr Scalar
-  -> IO (Ptr Tensor)
-quantized_rnn_relu_cell_ttttttttttssss _input _hx _w_ih _w_hh _b_ih _b_hh _packed_ih _packed_hh _col_offsets_ih _col_offsets_hh _scale_ih _scale_hh _zero_point_ih _zero_point_hh =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::quantized_rnn_relu_cell(
-    *$(at::Tensor* _input)
-  , *$(at::Tensor* _hx)
-  , *$(at::Tensor* _w_ih)
-  , *$(at::Tensor* _w_hh)
-  , *$(at::Tensor* _b_ih)
-  , *$(at::Tensor* _b_hh)
-  , *$(at::Tensor* _packed_ih)
-  , *$(at::Tensor* _packed_hh)
-  , *$(at::Tensor* _col_offsets_ih)
-  , *$(at::Tensor* _col_offsets_hh)
-  , *$(at::Scalar* _scale_ih)
-  , *$(at::Scalar* _scale_hh)
-  , *$(at::Scalar* _zero_point_ih)
-  , *$(at::Scalar* _zero_point_hh)));
-  }|]
-
-quantized_rnn_tanh_cell_ttttttttttssss
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Scalar
-  -> Ptr Scalar
-  -> Ptr Scalar
-  -> Ptr Scalar
-  -> IO (Ptr Tensor)
-quantized_rnn_tanh_cell_ttttttttttssss _input _hx _w_ih _w_hh _b_ih _b_hh _packed_ih _packed_hh _col_offsets_ih _col_offsets_hh _scale_ih _scale_hh _zero_point_ih _zero_point_hh =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::quantized_rnn_tanh_cell(
-    *$(at::Tensor* _input)
-  , *$(at::Tensor* _hx)
-  , *$(at::Tensor* _w_ih)
-  , *$(at::Tensor* _w_hh)
-  , *$(at::Tensor* _b_ih)
-  , *$(at::Tensor* _b_hh)
-  , *$(at::Tensor* _packed_ih)
-  , *$(at::Tensor* _packed_hh)
-  , *$(at::Tensor* _col_offsets_ih)
-  , *$(at::Tensor* _col_offsets_hh)
-  , *$(at::Scalar* _scale_ih)
-  , *$(at::Scalar* _scale_hh)
-  , *$(at::Scalar* _zero_point_ih)
-  , *$(at::Scalar* _zero_point_hh)));
-  }|]
-
-_pack_padded_sequence_ttb
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> CBool
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-_pack_padded_sequence_ttb _input _lengths _batch_first =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::_pack_padded_sequence(
-    *$(at::Tensor* _input)
-  , *$(at::Tensor* _lengths)
-  , $(bool _batch_first)));
-  }|]
-
-_pack_padded_sequence_backward_tltb
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr Tensor
-  -> CBool
-  -> IO (Ptr Tensor)
-_pack_padded_sequence_backward_tltb _grad _input_size _batch_sizes _batch_first =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_pack_padded_sequence_backward(
-    *$(at::Tensor* _grad)
-  , *$(std::vector<int64_t>* _input_size)
-  , *$(at::Tensor* _batch_sizes)
-  , $(bool _batch_first)));
-  }|]
-
-_pad_packed_sequence_ttbsl
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> CBool
-  -> Ptr Scalar
-  -> Int64
-  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-_pad_packed_sequence_ttbsl _data _batch_sizes _batch_first _padding_value _total_length =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::_pad_packed_sequence(
-    *$(at::Tensor* _data)
-  , *$(at::Tensor* _batch_sizes)
-  , $(bool _batch_first)
-  , *$(at::Scalar* _padding_value)
-  , $(int64_t _total_length)));
-  }|]
-
-masked_fill_tts
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Scalar
-  -> IO (Ptr Tensor)
-masked_fill_tts _self _mask _value =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::masked_fill(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _mask)
-  , *$(at::Scalar* _value)));
-  }|]
-
-masked_fill_ttt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-masked_fill_ttt _self _mask _value =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::masked_fill(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _mask)
-  , *$(at::Tensor* _value)));
-  }|]
-
-masked_scatter_ttt
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-masked_scatter_ttt _self _mask _source =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::masked_scatter(
-    *$(at::Tensor* _self)
-  , *$(at::Tensor* _mask)
-  , *$(at::Tensor* _source)));
-  }|]
-
-index_add_tltt
-  :: Ptr Tensor
-  -> Int64
-  -> Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-index_add_tltt _self _dim _index _source =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::index_add(
-    *$(at::Tensor* _self)
-  , $(int64_t _dim)
-  , *$(at::Tensor* _index)
-  , *$(at::Tensor* _source)));
-  }|]
-
 index_add_tntt
   :: Ptr Tensor
   -> Ptr Dimname
@@ -1682,16 +1280,52 @@ take_tt _self _index =
   , *$(at::Tensor* _index)));
   }|]
 
-take_backward_ttt
+take_along_dim_out_tttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+take_along_dim_out_tttl _out _self _indices _dim =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::take_along_dim_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _indices)
+  , $(int64_t _dim)));
+  }|]
+
+take_along_dim_out_ttt
   :: Ptr Tensor
   -> Ptr Tensor
   -> Ptr Tensor
   -> IO (Ptr Tensor)
-take_backward_ttt _grad _input _index =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(at::take_backward(
-    *$(at::Tensor* _grad)
-  , *$(at::Tensor* _input)
-  , *$(at::Tensor* _index)));
+take_along_dim_out_ttt _out _self _indices =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::take_along_dim_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _indices)));
+  }|]
+
+take_along_dim_ttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+take_along_dim_ttl _self _indices _dim =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::take_along_dim(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _indices)
+  , $(int64_t _dim)));
+  }|]
+
+take_along_dim_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+take_along_dim_tt _self _indices =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::take_along_dim(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _indices)));
   }|]
 
 index_select_out_ttlt
@@ -2074,6 +1708,58 @@ addcdiv_ttt _self _tensor1 _tensor2 =
   , *$(at::Tensor* _tensor2)));
   }|]
 
+cross_entropy_loss_tttll
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> Int64
+  -> IO (Ptr Tensor)
+cross_entropy_loss_tttll _self _target _weight _reduction _ignore_index =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::cross_entropy_loss(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , *$(at::Tensor* _weight)
+  , $(int64_t _reduction)
+  , $(int64_t _ignore_index)));
+  }|]
+
+cross_entropy_loss_tttl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+cross_entropy_loss_tttl _self _target _weight _reduction =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::cross_entropy_loss(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , *$(at::Tensor* _weight)
+  , $(int64_t _reduction)));
+  }|]
+
+cross_entropy_loss_ttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+cross_entropy_loss_ttt _self _target _weight =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::cross_entropy_loss(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)
+  , *$(at::Tensor* _weight)));
+  }|]
+
+cross_entropy_loss_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+cross_entropy_loss_tt _self _target =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::cross_entropy_loss(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _target)));
+  }|]
+
 lstsq_out_tttt
   :: Ptr Tensor
   -> Ptr Tensor
@@ -2218,19 +1904,389 @@ triangular_solve_tt _self _A =
   , *$(at::Tensor* _A)));
   }|]
 
-_triangular_solve_helper_ttbbb
+symeig_out_tttbb
   :: Ptr Tensor
+  -> Ptr Tensor
   -> Ptr Tensor
   -> CBool
   -> CBool
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+symeig_out_tttbb _e _V _self _eigenvectors _upper =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::symeig_out(
+    *$(at::Tensor* _e)
+  , *$(at::Tensor* _V)
+  , *$(at::Tensor* _self)
+  , $(bool _eigenvectors)
+  , $(bool _upper)));
+  }|]
+
+symeig_out_tttb
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
   -> CBool
   -> IO (Ptr (StdTuple '(Tensor,Tensor)))
-_triangular_solve_helper_ttbbb _self _A _upper _transpose _unitriangular =
-  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::_triangular_solve_helper(
+symeig_out_tttb _e _V _self _eigenvectors =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::symeig_out(
+    *$(at::Tensor* _e)
+  , *$(at::Tensor* _V)
+  , *$(at::Tensor* _self)
+  , $(bool _eigenvectors)));
+  }|]
+
+symeig_out_ttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+symeig_out_ttt _e _V _self =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::symeig_out(
+    *$(at::Tensor* _e)
+  , *$(at::Tensor* _V)
+  , *$(at::Tensor* _self)));
+  }|]
+
+symeig_tbb
+  :: Ptr Tensor
+  -> CBool
+  -> CBool
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+symeig_tbb _self _eigenvectors _upper =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::symeig(
+    *$(at::Tensor* _self)
+  , $(bool _eigenvectors)
+  , $(bool _upper)));
+  }|]
+
+symeig_tb
+  :: Ptr Tensor
+  -> CBool
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+symeig_tb _self _eigenvectors =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::symeig(
+    *$(at::Tensor* _self)
+  , $(bool _eigenvectors)));
+  }|]
+
+symeig_t
+  :: Ptr Tensor
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+symeig_t _self =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::symeig(
+    *$(at::Tensor* _self)));
+  }|]
+
+_symeig_helper_tbb
+  :: Ptr Tensor
+  -> CBool
+  -> CBool
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+_symeig_helper_tbb _self _eigenvectors _upper =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::_symeig_helper(
+    *$(at::Tensor* _self)
+  , $(bool _eigenvectors)
+  , $(bool _upper)));
+  }|]
+
+eig_out_tttb
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> CBool
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+eig_out_tttb _e _v _self _eigenvectors =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::eig_out(
+    *$(at::Tensor* _e)
+  , *$(at::Tensor* _v)
+  , *$(at::Tensor* _self)
+  , $(bool _eigenvectors)));
+  }|]
+
+eig_out_ttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+eig_out_ttt _e _v _self =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::eig_out(
+    *$(at::Tensor* _e)
+  , *$(at::Tensor* _v)
+  , *$(at::Tensor* _self)));
+  }|]
+
+eig_tb
+  :: Ptr Tensor
+  -> CBool
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+eig_tb _self _eigenvectors =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::eig(
+    *$(at::Tensor* _self)
+  , $(bool _eigenvectors)));
+  }|]
+
+eig_t
+  :: Ptr Tensor
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+eig_t _self =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::eig(
+    *$(at::Tensor* _self)));
+  }|]
+
+svd_out_ttttbb
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> CBool
+  -> CBool
+  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor)))
+svd_out_ttttbb _U _S _V _self _some _compute_uv =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor>(at::svd_out(
+    *$(at::Tensor* _U)
+  , *$(at::Tensor* _S)
+  , *$(at::Tensor* _V)
+  , *$(at::Tensor* _self)
+  , $(bool _some)
+  , $(bool _compute_uv)));
+  }|]
+
+svd_out_ttttb
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> CBool
+  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor)))
+svd_out_ttttb _U _S _V _self _some =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor>(at::svd_out(
+    *$(at::Tensor* _U)
+  , *$(at::Tensor* _S)
+  , *$(at::Tensor* _V)
+  , *$(at::Tensor* _self)
+  , $(bool _some)));
+  }|]
+
+svd_out_tttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor)))
+svd_out_tttt _U _S _V _self =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor>(at::svd_out(
+    *$(at::Tensor* _U)
+  , *$(at::Tensor* _S)
+  , *$(at::Tensor* _V)
+  , *$(at::Tensor* _self)));
+  }|]
+
+svd_tbb
+  :: Ptr Tensor
+  -> CBool
+  -> CBool
+  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor)))
+svd_tbb _self _some _compute_uv =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor>(at::svd(
+    *$(at::Tensor* _self)
+  , $(bool _some)
+  , $(bool _compute_uv)));
+  }|]
+
+svd_tb
+  :: Ptr Tensor
+  -> CBool
+  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor)))
+svd_tb _self _some =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor>(at::svd(
+    *$(at::Tensor* _self)
+  , $(bool _some)));
+  }|]
+
+svd_t
+  :: Ptr Tensor
+  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor)))
+svd_t _self =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor>(at::svd(
+    *$(at::Tensor* _self)));
+  }|]
+
+_svd_helper_tbb
+  :: Ptr Tensor
+  -> CBool
+  -> CBool
+  -> IO (Ptr (StdTuple '(Tensor,Tensor,Tensor)))
+_svd_helper_tbb _self _some _compute_uv =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor>(at::_svd_helper(
+    *$(at::Tensor* _self)
+  , $(bool _some)
+  , $(bool _compute_uv)));
+  }|]
+
+swapaxes_tll
+  :: Ptr Tensor
+  -> Int64
+  -> Int64
+  -> IO (Ptr Tensor)
+swapaxes_tll _self _axis0 _axis1 =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::swapaxes(
+    *$(at::Tensor* _self)
+  , $(int64_t _axis0)
+  , $(int64_t _axis1)));
+  }|]
+
+swapdims_tll
+  :: Ptr Tensor
+  -> Int64
+  -> Int64
+  -> IO (Ptr Tensor)
+swapdims_tll _self _dim0 _dim1 =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::swapdims(
+    *$(at::Tensor* _self)
+  , $(int64_t _dim0)
+  , $(int64_t _dim1)));
+  }|]
+
+cholesky_out_ttb
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> CBool
+  -> IO (Ptr Tensor)
+cholesky_out_ttb _out _self _upper =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::cholesky_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , $(bool _upper)));
+  }|]
+
+cholesky_out_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+cholesky_out_tt _out _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::cholesky_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)));
+  }|]
+
+cholesky_tb
+  :: Ptr Tensor
+  -> CBool
+  -> IO (Ptr Tensor)
+cholesky_tb _self _upper =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::cholesky(
+    *$(at::Tensor* _self)
+  , $(bool _upper)));
+  }|]
+
+cholesky_t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+cholesky_t _self =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::cholesky(
+    *$(at::Tensor* _self)));
+  }|]
+
+cholesky_solve_out_tttb
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> CBool
+  -> IO (Ptr Tensor)
+cholesky_solve_out_tttb _out _self _input2 _upper =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::cholesky_solve_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _input2)
+  , $(bool _upper)));
+  }|]
+
+cholesky_solve_out_ttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+cholesky_solve_out_ttt _out _self _input2 =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::cholesky_solve_out(
+    *$(at::Tensor* _out)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _input2)));
+  }|]
+
+cholesky_solve_ttb
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> CBool
+  -> IO (Ptr Tensor)
+cholesky_solve_ttb _self _input2 _upper =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::cholesky_solve(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _input2)
+  , $(bool _upper)));
+  }|]
+
+cholesky_solve_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+cholesky_solve_tt _self _input2 =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::cholesky_solve(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _input2)));
+  }|]
+
+_cholesky_solve_helper_ttb
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> CBool
+  -> IO (Ptr Tensor)
+_cholesky_solve_helper_ttb _self _A _upper =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::_cholesky_solve_helper(
     *$(at::Tensor* _self)
   , *$(at::Tensor* _A)
-  , $(bool _upper)
-  , $(bool _transpose)
-  , $(bool _unitriangular)));
+  , $(bool _upper)));
+  }|]
+
+solve_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+solve_tt _self _A =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::solve(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _A)));
+  }|]
+
+solve_out_tttt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+solve_out_tttt _solution _lu _self _A =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::solve_out(
+    *$(at::Tensor* _solution)
+  , *$(at::Tensor* _lu)
+  , *$(at::Tensor* _self)
+  , *$(at::Tensor* _A)));
+  }|]
+
+_solve_helper_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+_solve_helper_tt _self _A =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>(at::_solve_helper(
+    *$(at::Tensor* _self)
+  , *$(at::Tensor* _A)));
+  }|]
+
+cholesky_inverse_tb
+  :: Ptr Tensor
+  -> CBool
+  -> IO (Ptr Tensor)
+cholesky_inverse_tb _self _upper =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(at::cholesky_inverse(
+    *$(at::Tensor* _self)
+  , $(bool _upper)));
   }|]
 

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/TensorFactories.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/TensorFactories.hs
@@ -190,36 +190,6 @@ blackman_window_lb _window_length _periodic =
   , $(bool _periodic)));
   }|]
 
-empty_meta_loM
-  :: Ptr IntArray
-  -> Ptr TensorOptions
-  -> MemoryFormat
-  -> IO (Ptr Tensor)
-empty_meta_loM _size _options _memory_format =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(torch::empty_meta(
-    *$(std::vector<int64_t>* _size)
-  , *$(at::TensorOptions* _options)
-  , $(at::MemoryFormat _memory_format)));
-  }|]
-
-empty_meta_lo
-  :: Ptr IntArray
-  -> Ptr TensorOptions
-  -> IO (Ptr Tensor)
-empty_meta_lo _size _options =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(torch::empty_meta(
-    *$(std::vector<int64_t>* _size)
-  , *$(at::TensorOptions* _options)));
-  }|]
-
-empty_meta_l
-  :: Ptr IntArray
-  -> IO (Ptr Tensor)
-empty_meta_l _size =
-  [C.throwBlock| at::Tensor* { return new at::Tensor(torch::empty_meta(
-    *$(std::vector<int64_t>* _size)));
-  }|]
-
 empty_lNoM
   :: Ptr IntArray
   -> Ptr DimnameList
@@ -1544,6 +1514,36 @@ zeros_like_t
 zeros_like_t _self =
   [C.throwBlock| at::Tensor* { return new at::Tensor(torch::zeros_like(
     *$(at::Tensor* _self)));
+  }|]
+
+_sparse_csr_tensor_tttlo
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr TensorOptions
+  -> IO (Ptr Tensor)
+_sparse_csr_tensor_tttlo _crow_indices _col_indices _values _size _options =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(torch::_sparse_csr_tensor(
+    *$(at::Tensor* _crow_indices)
+  , *$(at::Tensor* _col_indices)
+  , *$(at::Tensor* _values)
+  , *$(std::vector<int64_t>* _size)
+  , *$(at::TensorOptions* _options)));
+  }|]
+
+_sparse_csr_tensor_ttto
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr TensorOptions
+  -> IO (Ptr Tensor)
+_sparse_csr_tensor_ttto _crow_indices _col_indices _values _options =
+  [C.throwBlock| at::Tensor* { return new at::Tensor(torch::_sparse_csr_tensor(
+    *$(at::Tensor* _crow_indices)
+  , *$(at::Tensor* _col_indices)
+  , *$(at::Tensor* _values)
+  , *$(at::TensorOptions* _options)));
   }|]
 
 sparse_coo_tensor_lo

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Module.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Module.hs
@@ -472,14 +472,12 @@ dumpToStr ::
   CBool ->
   CBool ->
   CBool ->
-  CInt ->
   IO (Ptr StdString)
-dumpToStr obj print_method_bodies print_attr_values print_param_values level =
+dumpToStr obj print_method_bodies print_attr_values print_param_values =
   [C.throwBlock| std::string* {
     return new std::string($(torch::jit::script::Module* obj)->dump_to_str(
       $(bool print_method_bodies)
     , $(bool print_attr_values)
     , $(bool print_param_values)
-    , $(int level)
     ));
   }|]

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/StdVector.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/StdVector.hs
@@ -23,7 +23,11 @@ import Torch.Internal.Type
 
 C.context $ C.cppCtx <> mempty { C.ctxTypesTable = typeTable }
 
+C.include "<ATen/Scalar.h>"
 C.include "<vector>"
+
+newStdVectorScalar :: IO (Ptr (StdVector Scalar))
+newStdVectorScalar = [C.throwBlock| std::vector<at::Scalar>* { return new std::vector<at::Scalar>(); }|]
 
 newStdVectorDouble :: IO (Ptr (StdVector CDouble))
 newStdVectorDouble = [C.throwBlock| std::vector<double>* { return new std::vector<double>(); }|]
@@ -34,8 +38,8 @@ newStdVectorInt = [C.throwBlock| std::vector<int64_t>* { return new std::vector<
 newStdVectorBool :: IO (Ptr (StdVector CBool))
 newStdVectorBool = [C.throwBlock| std::vector<bool>* { return new std::vector<bool>(); }|]
 
-
-
+stdVectorScalar_empty :: Ptr (StdVector Scalar) -> IO (CBool)
+stdVectorScalar_empty _obj = [C.throwBlock| bool { return (*$(std::vector<at::Scalar>* _obj)).empty(); }|]
 
 stdVectorDouble_empty :: Ptr (StdVector CDouble) -> IO (CBool)
 stdVectorDouble_empty _obj = [C.throwBlock| bool { return (*$(std::vector<double>* _obj)).empty(); }|]
@@ -55,6 +59,9 @@ stdVectorInt_size _obj = [C.throwBlock| size_t { return (*$(std::vector<int64_t>
 stdVectorBool_size :: Ptr (StdVector CBool) -> IO (CSize)
 stdVectorBool_size _obj = [C.throwBlock| size_t { return (*$(std::vector<bool>* _obj)).size(); }|]
 
+stdVectorScalar_at :: Ptr (StdVector Scalar) -> CSize -> IO (Ptr Scalar)
+stdVectorScalar_at _obj _s = [C.throwBlock| at::Scalar* { return new at::Scalar((*$(std::vector<at::Scalar>* _obj))[$(size_t _s)]); }|]
+
 stdVectorDouble_at :: Ptr (StdVector CDouble) -> CSize -> IO CDouble
 stdVectorDouble_at _obj _s = [C.throwBlock| double { return (double)((*$(std::vector<double>* _obj))[$(size_t _s)]); }|]
 
@@ -63,6 +70,9 @@ stdVectorInt_at _obj _s = [C.throwBlock| int64_t { return (int64_t)((*$(std::vec
 
 stdVectorBool_at :: Ptr (StdVector CBool) -> CSize -> IO CBool
 stdVectorBool_at _obj _s = [C.throwBlock| bool { return ((*$(std::vector<bool>* _obj))[$(size_t _s)]); }|]
+
+stdVectorScalar_push_back :: Ptr (StdVector Scalar) -> Ptr Scalar -> IO ()
+stdVectorScalar_push_back _obj _v = [C.throwBlock| void {  (*$(std::vector<at::Scalar>* _obj)).push_back(*$(at::Scalar* _v)); }|]
 
 stdVectorDouble_push_back :: Ptr (StdVector CDouble) -> CDouble -> IO ()
 stdVectorDouble_push_back _obj _v = [C.throwBlock| void {  (*$(std::vector<double>* _obj)).push_back($(double _v)); }|]

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Tensor/Tensor0.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Tensor/Tensor0.hs
@@ -124,15 +124,6 @@ tensor_element_size _obj =
     );
   }|]
 
-tensor_fw_grad_L
-  :: Ptr Tensor
-  -> Word64
-  -> IO (Ptr Tensor)
-tensor_fw_grad_L _obj _level =
-  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).fw_grad(
-    $(uint64_t _level)));
-  }|]
-
 tensor_get_device
   :: Ptr Tensor
   -> IO (Int64)
@@ -506,19 +497,6 @@ tensor_scalar_type
 tensor_scalar_type _obj =
   [C.throwBlock| at::ScalarType { return (*$(at::Tensor* _obj)).scalar_type(
     );
-  }|]
-
-tensor_set_fw_grad_tLb
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Word64
-  -> CBool
-  -> IO (())
-tensor_set_fw_grad_tLb _obj _new_grad _level _is_inplace_op =
-  [C.throwBlock| void {  (*$(at::Tensor* _obj)).set_fw_grad(
-    *$(at::Tensor* _new_grad)
-  , $(uint64_t _level)
-  , $(bool _is_inplace_op));
   }|]
 
 tensor_set_requires_grad_b
@@ -1566,28 +1544,6 @@ tensor_chunk_ll _obj _chunks _dim =
   , $(int64_t _dim)));
   }|]
 
--- tensor_tensor_split_ll
---   :: Ptr Tensor
---   -> Int64
---   -> Int64
---   -> IO (Ptr TensorList)
--- tensor_tensor_split_ll _obj _sections _dim =
---   [C.throwBlock| std::vector<at::Tensor>* { return new std::vector<at::Tensor>((*$(at::Tensor* _obj)).tensor_split(
---     $(int64_t _sections)
---   , $(int64_t _dim)));
---   }|]
-
-tensor_tensor_split_ll
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> Int64
-  -> IO (Ptr TensorList)
-tensor_tensor_split_ll _obj _indices _dim =
-  [C.throwBlock| std::vector<at::Tensor>* { return new std::vector<at::Tensor>((*$(at::Tensor* _obj)).tensor_split(
-    *$(std::vector<int64_t>* _indices)
-  , $(int64_t _dim)));
-  }|]
-
 tensor_tensor_split_tl
   :: Ptr Tensor
   -> Ptr Tensor
@@ -1610,6 +1566,17 @@ tensor_clamp_ss _obj _min _max =
   , *$(at::Scalar* _max)));
   }|]
 
+tensor_clamp_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_clamp_tt _obj _min _max =
+  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).clamp(
+    *$(at::Tensor* _min)
+  , *$(at::Tensor* _max)));
+  }|]
+
 tensor_clamp__ss
   :: Ptr Tensor
   -> Ptr Scalar
@@ -1621,6 +1588,17 @@ tensor_clamp__ss _obj _min _max =
   , *$(at::Scalar* _max)));
   }|]
 
+tensor_clamp__tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_clamp__tt _obj _min _max =
+  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).clamp_(
+    *$(at::Tensor* _min)
+  , *$(at::Tensor* _max)));
+  }|]
+
 tensor_clamp_max_s
   :: Ptr Tensor
   -> Ptr Scalar
@@ -1628,6 +1606,15 @@ tensor_clamp_max_s
 tensor_clamp_max_s _obj _max =
   [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).clamp_max(
     *$(at::Scalar* _max)));
+  }|]
+
+tensor_clamp_max_t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_clamp_max_t _obj _max =
+  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).clamp_max(
+    *$(at::Tensor* _max)));
   }|]
 
 tensor_clamp_max__s
@@ -1639,6 +1626,15 @@ tensor_clamp_max__s _obj _max =
     *$(at::Scalar* _max)));
   }|]
 
+tensor_clamp_max__t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_clamp_max__t _obj _max =
+  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).clamp_max_(
+    *$(at::Tensor* _max)));
+  }|]
+
 tensor_clamp_min_s
   :: Ptr Tensor
   -> Ptr Scalar
@@ -1648,6 +1644,15 @@ tensor_clamp_min_s _obj _min =
     *$(at::Scalar* _min)));
   }|]
 
+tensor_clamp_min_t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_clamp_min_t _obj _min =
+  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).clamp_min(
+    *$(at::Tensor* _min)));
+  }|]
+
 tensor_clamp_min__s
   :: Ptr Tensor
   -> Ptr Scalar
@@ -1655,6 +1660,15 @@ tensor_clamp_min__s
 tensor_clamp_min__s _obj _min =
   [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).clamp_min_(
     *$(at::Scalar* _min)));
+  }|]
+
+tensor_clamp_min__t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_clamp_min__t _obj _min =
+  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).clamp_min_(
+    *$(at::Tensor* _min)));
   }|]
 
 tensor_clip_ss
@@ -1668,6 +1682,17 @@ tensor_clip_ss _obj _min _max =
   , *$(at::Scalar* _max)));
   }|]
 
+tensor_clip_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_clip_tt _obj _min _max =
+  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).clip(
+    *$(at::Tensor* _min)
+  , *$(at::Tensor* _max)));
+  }|]
+
 tensor_clip__ss
   :: Ptr Tensor
   -> Ptr Scalar
@@ -1677,6 +1702,17 @@ tensor_clip__ss _obj _min _max =
   [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).clip_(
     *$(at::Scalar* _min)
   , *$(at::Scalar* _max)));
+  }|]
+
+tensor_clip__tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_clip__tt _obj _min _max =
+  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).clip_(
+    *$(at::Tensor* _min)
+  , *$(at::Tensor* _max)));
   }|]
 
 tensor_contiguous_M
@@ -1730,24 +1766,6 @@ tensor_cosh_ _obj =
   [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).cosh_(
     ));
   }|]
-
-tensor_count_nonzero_l
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-tensor_count_nonzero_l _obj _dim =
-  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).count_nonzero(
-    *$(std::vector<int64_t>* _dim)));
-  }|]
-
--- tensor_count_nonzero_l
---   :: Ptr Tensor
---   -> Int64
---   -> IO (Ptr Tensor)
--- tensor_count_nonzero_l _obj _dim =
---   [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).count_nonzero(
---     $(int64_t _dim)));
---   }|]
 
 tensor_cummax_l
   :: Ptr Tensor

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Tensor/Tensor1.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Tensor/Tensor1.hs
@@ -1599,50 +1599,6 @@ tensor_permute_l _obj _dims =
     *$(std::vector<int64_t>* _dims)));
   }|]
 
-tensor_movedim_ll
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-tensor_movedim_ll _obj _source _destination =
-  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).movedim(
-    *$(std::vector<int64_t>* _source)
-  , *$(std::vector<int64_t>* _destination)));
-  }|]
-
--- tensor_movedim_ll
---   :: Ptr Tensor
---   -> Int64
---   -> Int64
---   -> IO (Ptr Tensor)
--- tensor_movedim_ll _obj _source _destination =
---   [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).movedim(
---     $(int64_t _source)
---   , $(int64_t _destination)));
---   }|]
-
-tensor_moveaxis_ll
-  :: Ptr Tensor
-  -> Ptr IntArray
-  -> Ptr IntArray
-  -> IO (Ptr Tensor)
-tensor_moveaxis_ll _obj _source _destination =
-  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).moveaxis(
-    *$(std::vector<int64_t>* _source)
-  , *$(std::vector<int64_t>* _destination)));
-  }|]
-
--- tensor_moveaxis_ll
---   :: Ptr Tensor
---   -> Int64
---   -> Int64
---   -> IO (Ptr Tensor)
--- tensor_moveaxis_ll _obj _source _destination =
---   [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).moveaxis(
---     $(int64_t _source)
---   , $(int64_t _destination)));
---   }|]
-
 tensor_numpy_T
   :: Ptr Tensor
   -> IO (Ptr Tensor)
@@ -1872,5 +1828,79 @@ tensor_hardshrink_s
 tensor_hardshrink_s _obj _lambd =
   [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).hardshrink(
     *$(at::Scalar* _lambd)));
+  }|]
+
+tensor_hardshrink_backward_ts
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_hardshrink_backward_ts _obj _self _lambd =
+  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).hardshrink_backward(
+    *$(at::Tensor* _self)
+  , *$(at::Scalar* _lambd)));
+  }|]
+
+tensor_rsqrt
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_rsqrt _obj =
+  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).rsqrt(
+    ));
+  }|]
+
+tensor_rsqrt_
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_rsqrt_ _obj =
+  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).rsqrt_(
+    ));
+  }|]
+
+tensor_select_nl
+  :: Ptr Tensor
+  -> Ptr Dimname
+  -> Int64
+  -> IO (Ptr Tensor)
+tensor_select_nl _obj _dim _index =
+  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).select(
+    *$(at::Dimname* _dim)
+  , $(int64_t _index)));
+  }|]
+
+tensor_select_ll
+  :: Ptr Tensor
+  -> Int64
+  -> Int64
+  -> IO (Ptr Tensor)
+tensor_select_ll _obj _dim _index =
+  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).select(
+    $(int64_t _dim)
+  , $(int64_t _index)));
+  }|]
+
+tensor_sigmoid
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_sigmoid _obj =
+  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).sigmoid(
+    ));
+  }|]
+
+tensor_sigmoid_
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_sigmoid_ _obj =
+  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).sigmoid_(
+    ));
+  }|]
+
+tensor_logit_d
+  :: Ptr Tensor
+  -> CDouble
+  -> IO (Ptr Tensor)
+tensor_logit_d _obj _eps =
+  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).logit(
+    $(double _eps)));
   }|]
 

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Tensor/Tensor2.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Tensor/Tensor2.hs
@@ -32,80 +32,6 @@ C.include "<vector>"
 
 
 
-tensor_hardshrink_backward_ts
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> Ptr Scalar
-  -> IO (Ptr Tensor)
-tensor_hardshrink_backward_ts _obj _self _lambd =
-  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).hardshrink_backward(
-    *$(at::Tensor* _self)
-  , *$(at::Scalar* _lambd)));
-  }|]
-
-tensor_rsqrt
-  :: Ptr Tensor
-  -> IO (Ptr Tensor)
-tensor_rsqrt _obj =
-  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).rsqrt(
-    ));
-  }|]
-
-tensor_rsqrt_
-  :: Ptr Tensor
-  -> IO (Ptr Tensor)
-tensor_rsqrt_ _obj =
-  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).rsqrt_(
-    ));
-  }|]
-
-tensor_select_nl
-  :: Ptr Tensor
-  -> Ptr Dimname
-  -> Int64
-  -> IO (Ptr Tensor)
-tensor_select_nl _obj _dim _index =
-  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).select(
-    *$(at::Dimname* _dim)
-  , $(int64_t _index)));
-  }|]
-
-tensor_select_ll
-  :: Ptr Tensor
-  -> Int64
-  -> Int64
-  -> IO (Ptr Tensor)
-tensor_select_ll _obj _dim _index =
-  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).select(
-    $(int64_t _dim)
-  , $(int64_t _index)));
-  }|]
-
-tensor_sigmoid
-  :: Ptr Tensor
-  -> IO (Ptr Tensor)
-tensor_sigmoid _obj =
-  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).sigmoid(
-    ));
-  }|]
-
-tensor_sigmoid_
-  :: Ptr Tensor
-  -> IO (Ptr Tensor)
-tensor_sigmoid_ _obj =
-  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).sigmoid_(
-    ));
-  }|]
-
-tensor_logit_d
-  :: Ptr Tensor
-  -> CDouble
-  -> IO (Ptr Tensor)
-tensor_logit_d _obj _eps =
-  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).logit(
-    $(double _eps)));
-  }|]
-
 tensor_logit__d
   :: Ptr Tensor
   -> CDouble
@@ -528,6 +454,19 @@ tensor_std_lbb _obj _dim _unbiased _keepdim =
   , $(bool _keepdim)));
   }|]
 
+tensor_std_llb
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Int64
+  -> CBool
+  -> IO (Ptr Tensor)
+tensor_std_llb _obj _dim _correction _keepdim =
+  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).std(
+    *$(std::vector<int64_t>* _dim)
+  , $(int64_t _correction)
+  , $(bool _keepdim)));
+  }|]
+
 tensor_std_Nbb
   :: Ptr Tensor
   -> Ptr DimnameList
@@ -538,6 +477,19 @@ tensor_std_Nbb _obj _dim _unbiased _keepdim =
   [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).std(
     *$(std::vector<at::Dimname>* _dim)
   , $(bool _unbiased)
+  , $(bool _keepdim)));
+  }|]
+
+tensor_std_Nlb
+  :: Ptr Tensor
+  -> Ptr DimnameList
+  -> Int64
+  -> CBool
+  -> IO (Ptr Tensor)
+tensor_std_Nlb _obj _dim _correction _keepdim =
+  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).std(
+    *$(std::vector<at::Dimname>* _dim)
+  , $(int64_t _correction)
   , $(bool _keepdim)));
   }|]
 
@@ -794,6 +746,19 @@ tensor_var_lbb _obj _dim _unbiased _keepdim =
   , $(bool _keepdim)));
   }|]
 
+tensor_var_llb
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Int64
+  -> CBool
+  -> IO (Ptr Tensor)
+tensor_var_llb _obj _dim _correction _keepdim =
+  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).var(
+    *$(std::vector<int64_t>* _dim)
+  , $(int64_t _correction)
+  , $(bool _keepdim)));
+  }|]
+
 tensor_var_Nbb
   :: Ptr Tensor
   -> Ptr DimnameList
@@ -804,6 +769,19 @@ tensor_var_Nbb _obj _dim _unbiased _keepdim =
   [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).var(
     *$(std::vector<at::Dimname>* _dim)
   , $(bool _unbiased)
+  , $(bool _keepdim)));
+  }|]
+
+tensor_var_Nlb
+  :: Ptr Tensor
+  -> Ptr DimnameList
+  -> Int64
+  -> CBool
+  -> IO (Ptr Tensor)
+tensor_var_Nlb _obj _dim _correction _keepdim =
+  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).var(
+    *$(std::vector<at::Dimname>* _dim)
+  , $(int64_t _correction)
   , $(bool _keepdim)));
   }|]
 
@@ -903,6 +881,14 @@ tensor_norm_sNb _obj _p _dim _keepdim =
   , $(bool _keepdim)));
   }|]
 
+tensor_frexp
+  :: Ptr Tensor
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+tensor_frexp _obj =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>((*$(at::Tensor* _obj)).frexp(
+    ));
+  }|]
+
 tensor_clone_M
   :: Ptr Tensor
   -> MemoryFormat
@@ -910,6 +896,14 @@ tensor_clone_M
 tensor_clone_M _obj _memory_format =
   [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).clone(
     $(at::MemoryFormat _memory_format)));
+  }|]
+
+tensor_positive
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_positive _obj =
+  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).positive(
+    ));
   }|]
 
 tensor_resize_as__tM
@@ -1205,6 +1199,22 @@ tensor_values
   -> IO (Ptr Tensor)
 tensor_values _obj =
   [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).values(
+    ));
+  }|]
+
+tensor_crow_indices
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_crow_indices _obj =
+  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).crow_indices(
+    ));
+  }|]
+
+tensor_col_indices
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_col_indices _obj =
+  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).col_indices(
     ));
   }|]
 
@@ -1533,6 +1543,19 @@ tensor_put__ttb _obj _index _source _accumulate =
   , $(bool _accumulate)));
   }|]
 
+tensor_put_ttb
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> CBool
+  -> IO (Ptr Tensor)
+tensor_put_ttb _obj _index _source _accumulate =
+  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).put(
+    *$(at::Tensor* _index)
+  , *$(at::Tensor* _source)
+  , $(bool _accumulate)));
+  }|]
+
 tensor_index_add__ltt
   :: Ptr Tensor
   -> Int64
@@ -1544,6 +1567,21 @@ tensor_index_add__ltt _obj _dim _index _source =
     $(int64_t _dim)
   , *$(at::Tensor* _index)
   , *$(at::Tensor* _source)));
+  }|]
+
+tensor_index_add__ltts
+  :: Ptr Tensor
+  -> Int64
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_index_add__ltts _obj _dim _index _source _alpha =
+  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).index_add_(
+    $(int64_t _dim)
+  , *$(at::Tensor* _index)
+  , *$(at::Tensor* _source)
+  , *$(at::Scalar* _alpha)));
   }|]
 
 tensor_index_add_ltt
@@ -1559,17 +1597,34 @@ tensor_index_add_ltt _obj _dim _index _source =
   , *$(at::Tensor* _source)));
   }|]
 
-tensor_index_add_ntt
+tensor_index_add_ltts
+  :: Ptr Tensor
+  -> Int64
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_index_add_ltts _obj _dim _index _source _alpha =
+  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).index_add(
+    $(int64_t _dim)
+  , *$(at::Tensor* _index)
+  , *$(at::Tensor* _source)
+  , *$(at::Scalar* _alpha)));
+  }|]
+
+tensor_index_add_ntts
   :: Ptr Tensor
   -> Ptr Dimname
   -> Ptr Tensor
   -> Ptr Tensor
+  -> Ptr Scalar
   -> IO (Ptr Tensor)
-tensor_index_add_ntt _obj _dim _index _source =
+tensor_index_add_ntts _obj _dim _index _source _alpha =
   [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).index_add(
     *$(at::Dimname* _dim)
   , *$(at::Tensor* _index)
-  , *$(at::Tensor* _source)));
+  , *$(at::Tensor* _source)
+  , *$(at::Scalar* _alpha)));
   }|]
 
 tensor_index_fill__lts
@@ -1965,14 +2020,5 @@ tensor___or___t
 tensor___or___t _obj _other =
   [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).__or__(
     *$(at::Tensor* _other)));
-  }|]
-
-tensor___ior___s
-  :: Ptr Tensor
-  -> Ptr Scalar
-  -> IO (Ptr Tensor)
-tensor___ior___s _obj _other =
-  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).__ior__(
-    *$(at::Scalar* _other)));
   }|]
 

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Tensor/Tensor3.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Tensor/Tensor3.hs
@@ -32,6 +32,15 @@ C.include "<vector>"
 
 
 
+tensor___ior___s
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor___ior___s _obj _other =
+  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).__ior__(
+    *$(at::Scalar* _other)));
+  }|]
+
 tensor___ior___t
   :: Ptr Tensor
   -> Ptr Tensor
@@ -185,15 +194,6 @@ tensor___irshift___t _obj _other =
     *$(at::Tensor* _other)));
   }|]
 
-tensor_atan2__t
-  :: Ptr Tensor
-  -> Ptr Tensor
-  -> IO (Ptr Tensor)
-tensor_atan2__t _obj _other =
-  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).atan2_(
-    *$(at::Tensor* _other)));
-  }|]
-
 tensor_tril__l
   :: Ptr Tensor
   -> Int64
@@ -218,15 +218,6 @@ tensor_digamma_
 tensor_digamma_ _obj =
   [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).digamma_(
     ));
-  }|]
-
-tensor_polygamma__l
-  :: Ptr Tensor
-  -> Int64
-  -> IO (Ptr Tensor)
-tensor_polygamma__l _obj _n =
-  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).polygamma_(
-    $(int64_t _n)));
   }|]
 
 tensor_renorm__sls
@@ -870,6 +861,17 @@ tensor_take_t _obj _index =
     *$(at::Tensor* _index)));
   }|]
 
+tensor_take_along_dim_tl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+tensor_take_along_dim_tl _obj _indices _dim =
+  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).take_along_dim(
+    *$(at::Tensor* _indices)
+  , $(int64_t _dim)));
+  }|]
+
 tensor_index_select_lt
   :: Ptr Tensor
   -> Int64
@@ -1208,14 +1210,14 @@ tensor_digamma _obj =
     ));
   }|]
 
--- tensor_polygamma_t
---   :: Ptr Tensor
---   -> Ptr Tensor
---   -> IO (Ptr Tensor)
--- tensor_polygamma_t _obj _self =
---   [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).polygamma(
---     *$(at::Tensor* _self)));
---   }|]
+tensor_polygamma__l
+  :: Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+tensor_polygamma__l _obj _n =
+  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).polygamma_(
+    $(int64_t _n)));
+  }|]
 
 tensor_erfinv
   :: Ptr Tensor
@@ -1282,6 +1284,15 @@ tensor_dist_ts _obj _other _p =
   [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).dist(
     *$(at::Tensor* _other)
   , *$(at::Scalar* _p)));
+  }|]
+
+tensor_atan2__t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_atan2__t _obj _other =
+  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).atan2_(
+    *$(at::Tensor* _other)));
   }|]
 
 tensor_atan2_t
@@ -1558,6 +1569,66 @@ tensor_nanquantile_tlb _obj _q _dim _keepdim =
   , $(bool _keepdim)));
   }|]
 
+tensor_quantile_dlbs
+  :: Ptr Tensor
+  -> CDouble
+  -> Int64
+  -> CBool
+  -> Ptr StdString
+  -> IO (Ptr Tensor)
+tensor_quantile_dlbs _obj _q _dim _keepdim _interpolation =
+  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).quantile(
+    $(double _q)
+  , $(int64_t _dim)
+  , $(bool _keepdim)
+  , *$(std::string* _interpolation)));
+  }|]
+
+tensor_quantile_tlbs
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> CBool
+  -> Ptr StdString
+  -> IO (Ptr Tensor)
+tensor_quantile_tlbs _obj _q _dim _keepdim _interpolation =
+  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).quantile(
+    *$(at::Tensor* _q)
+  , $(int64_t _dim)
+  , $(bool _keepdim)
+  , *$(std::string* _interpolation)));
+  }|]
+
+tensor_nanquantile_dlbs
+  :: Ptr Tensor
+  -> CDouble
+  -> Int64
+  -> CBool
+  -> Ptr StdString
+  -> IO (Ptr Tensor)
+tensor_nanquantile_dlbs _obj _q _dim _keepdim _interpolation =
+  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).nanquantile(
+    $(double _q)
+  , $(int64_t _dim)
+  , $(bool _keepdim)
+  , *$(std::string* _interpolation)));
+  }|]
+
+tensor_nanquantile_tlbs
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> CBool
+  -> Ptr StdString
+  -> IO (Ptr Tensor)
+tensor_nanquantile_tlbs _obj _q _dim _keepdim _interpolation =
+  [C.throwBlock| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).nanquantile(
+    *$(at::Tensor* _q)
+  , $(int64_t _dim)
+  , $(bool _keepdim)
+  , *$(std::string* _interpolation)));
+  }|]
+
 tensor_sort_lb
   :: Ptr Tensor
   -> Int64
@@ -1569,6 +1640,19 @@ tensor_sort_lb _obj _dim _descending =
   , $(bool _descending)));
   }|]
 
+tensor_sort_blb
+  :: Ptr Tensor
+  -> CBool
+  -> Int64
+  -> CBool
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+tensor_sort_blb _obj _stable _dim _descending =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>((*$(at::Tensor* _obj)).sort(
+    $(bool _stable)
+  , $(int64_t _dim)
+  , $(bool _descending)));
+  }|]
+
 tensor_sort_nb
   :: Ptr Tensor
   -> Ptr Dimname
@@ -1577,6 +1661,19 @@ tensor_sort_nb
 tensor_sort_nb _obj _dim _descending =
   [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>((*$(at::Tensor* _obj)).sort(
     *$(at::Dimname* _dim)
+  , $(bool _descending)));
+  }|]
+
+tensor_sort_bnb
+  :: Ptr Tensor
+  -> CBool
+  -> Ptr Dimname
+  -> CBool
+  -> IO (Ptr (StdTuple '(Tensor,Tensor)))
+tensor_sort_bnb _obj _stable _dim _descending =
+  [C.throwBlock| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>((*$(at::Tensor* _obj)).sort(
+    $(bool _stable)
+  , *$(at::Dimname* _dim)
   , $(bool _descending)));
   }|]
 

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -47,6 +47,18 @@
         "url": "https://github.com/tweag/jupyterWith/archive/35eb565c6d00f3c61ef5e74e7e41870cfa3926f7.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
+    "libtorch-nix": {
+        "branch": "main",
+        "description": "nix scripts for pytorch-related libraries",
+        "homepage": "https://pytorch.org/",
+        "owner": "hasktorch",
+        "repo": "libtorch-nix",
+        "rev": "dfbd8c9fc8ffa283d0b96fe7007190fb1a704c0f",
+        "sha256": "1sy7qy32fh3gqzd6y1x8hh19pydz53zp6xnz4jx8j7ac7g5x2zgs",
+        "type": "tarball",
+        "url": "https://github.com/hasktorch/libtorch-nix/archive/dfbd8c9fc8ffa283d0b96fe7007190fb1a704c0f.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "naersk": {
         "branch": "master",
         "description": "Build rust crates in Nix. No configuration, no code generation, no IFD. Sandbox friendly.",
@@ -57,18 +69,6 @@
         "sha256": "156fbnr5s2n1xxbbk2z9xa7c5g2z5fdpqmjjs6n9ipbr038n0z3s",
         "type": "tarball",
         "url": "https://github.com/nmattia/naersk/archive/b3b099d669fc8b18d361c249091c9fe95d57ebbb.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
-    "libtorch-nix": {
-        "branch": "main",
-        "description": "nix scripts for pytorch-related libraries",
-        "homepage": "https://pytorch.org/",
-        "owner": "hasktorch",
-        "repo": "libtorch-nix",
-        "rev": "d14b0fd10b96d192b92b8ccc7254ade4b3489331",
-        "sha256": "1k2xax64hfmaw5kzmx3w242z62xckjihraa75vvdz8v27in60zqi",
-        "type": "tarball",
-        "url": "https://github.com/hasktorch/libtorch-nix/archive/d14b0fd10b96d192b92b8ccc7254ade4b3489331.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {


### PR DESCRIPTION
- Add the new type of `at::ArrayRef<at::Scalar>`  in codegen.
- Fix the parser of `Declaration.yaml`. (Just remove the field of `matches_jit_signature`.)
- Add some APIs to blacklists of codegen due to duplicate definitions of suffix of functions and ambiguous overload of c++.
- Fix the arguments of `Torch.Internal.Unmanaged.Module.dumpToStr`
- Fix the doctests of `Torch.Typed.Functional` for deprecated APIs.