### PR TITLE
Expose in Functional and add layers for all conv-nd and convTranspose-nd 

### DIFF
--- a/hasktorch/src/Torch/Functional.hs
+++ b/hasktorch/src/Torch/Functional.hs
@@ -1852,6 +1852,19 @@ conv1d weight bias stride padding dilation groups input =
       dilation
       groups
 
+conv1d' :: 
+  -- | weight
+  Tensor ->
+  -- | bias
+  Tensor ->
+  -- | strides
+  Int ->
+  -- | padding
+  Int ->
+  -- | input
+  Tensor ->
+  -- | output
+  Tensor
 conv1d' weight bias stride padding = conv1d weight bias stride padding 1 1
 
 -- | Applies a 2D convolution over an input signal composed of several input planes.
@@ -1905,6 +1918,216 @@ conv2d' weight bias stride padding =
     padding
     (1, 1) -- dilation
     (1 :: Int) -- groups
+
+-- | Applies a 2D convolution over an input signal composed of several input planes.
+conv3d ::
+  -- | weight
+  Tensor ->
+  -- | bias
+  Tensor ->
+  -- | strides
+  (Int, Int, Int) ->
+  -- | padding
+  (Int, Int, Int) ->
+  -- | dilation
+  (Int, Int, Int) ->
+  -- | groups
+  Int ->
+  -- | input
+  Tensor ->
+  -- | output
+  Tensor
+conv3d weight bias (stride0, stride1, stride2) (padding0, padding1, padding2) (dilation0, dilation1, dilation2) groups input =
+  unsafePerformIO $
+    cast7
+      ATen.conv3d_tttllll
+      input
+      weight
+      bias
+      ([stride0, stride1, stride2] :: [Int])
+      ([padding0, padding1, padding2] :: [Int])
+      ([dilation0, dilation1, dilation2] :: [Int])
+      groups
+
+conv3d' ::
+  -- | weight
+  Tensor ->
+  -- | bias
+  Tensor ->
+  -- | strides
+  (Int, Int, Int) ->
+  -- | padding
+  (Int, Int, Int) ->
+  -- | input
+  Tensor ->
+  -- | output
+  Tensor
+conv3d' weight bias stride padding =
+  conv3d
+    weight
+    bias
+    stride
+    padding
+    (1, 1, 1) -- dilation
+    (1 :: Int) -- groups
+
+convTranspose1d ::
+  -- | weight
+  Tensor ->
+  -- | bias
+  Tensor ->
+  -- | strides
+  Int ->
+  -- | padding
+  Int ->
+  -- | output padding
+  Int -> 
+  -- | groups
+  Int ->
+  -- | input
+  Tensor ->
+  -- | output
+  Tensor
+
+convTranspose1d weight bias stride padding outPadding groups input =
+    unsafePerformIO $
+        cast7
+            ATen.conv_transpose1d_tttllll
+            input
+            weight
+            bias
+            (stride :: Int)
+            (padding :: Int)
+            (outPadding :: Int)
+            groups
+
+convTranspose1d' ::
+  -- | weight
+  Tensor ->
+  -- | bias
+  Tensor ->
+  -- | strides
+  Int ->
+  -- | padding
+  Int ->
+  -- | input
+  Tensor ->
+  -- | output
+  Tensor
+convTranspose1d' weight bias stride padding = 
+    convTranspose1d
+        weight
+        bias
+        stride
+        padding
+        0
+        (1 :: Int)
+
+convTranspose2d ::
+  -- | weight
+  Tensor ->
+  -- | bias
+  Tensor ->
+  -- | strides
+  (Int, Int) ->
+  -- | padding
+  (Int, Int) ->
+  -- | output padding
+  (Int, Int) -> 
+  -- | groups
+  Int ->
+  -- | input
+  Tensor ->
+  -- | output
+  Tensor
+
+convTranspose2d weight bias (stride0, stride1) (padding0, padding1) (outPadding0, outPadding1) groups input =
+    unsafePerformIO $
+        cast7
+            ATen.conv_transpose2d_tttllll
+            input
+            weight
+            bias
+            ([stride0, stride1] :: [Int])
+            ([padding0, padding1] :: [Int])
+            ([outPadding0, outPadding1] :: [Int])
+            groups
+
+convTranspose2d' ::
+  -- | weight
+  Tensor ->
+  -- | bias
+  Tensor ->
+  -- | strides
+  (Int, Int) ->
+  -- | padding
+  (Int, Int) ->
+  -- | input
+  Tensor ->
+  -- | output
+  Tensor
+convTranspose2d' weight bias stride padding = 
+    convTranspose2d
+        weight
+        bias
+        stride
+        padding
+        (0, 0)
+        (1 :: Int)
+
+convTranspose3d ::
+  -- | weight
+  Tensor ->
+  -- | bias
+  Tensor ->
+  -- | strides
+  (Int, Int, Int) ->
+  -- | padding
+  (Int, Int, Int) ->
+  -- | output padding
+  (Int, Int, Int) -> 
+  -- | groups
+  Int ->
+  -- | input
+  Tensor ->
+  -- | output
+  Tensor
+
+convTranspose3d weight bias (stride0, stride1, stride2) (padding0, padding1, padding2) (outPadding0, outPadding1, outPadding2) groups input =
+    unsafePerformIO $
+        cast7
+            ATen.conv_transpose3d_tttllll
+            input
+            weight
+            bias
+            ([stride0, stride1, stride2] :: [Int])
+            ([padding0, padding1, padding2] :: [Int])
+            ([outPadding0, outPadding1, outPadding2] :: [Int])
+            groups
+
+convTranspose3d' ::
+  -- | weight
+  Tensor ->
+  -- | bias
+  Tensor ->
+  -- | strides
+  (Int, Int, Int) ->
+  -- | padding
+  (Int, Int, Int) ->
+  -- | input
+  Tensor ->
+  -- | output
+  Tensor
+convTranspose3d' weight bias stride padding = 
+    convTranspose3d
+        weight
+        bias
+        stride
+        padding
+        (0, 0, 0)
+        (1 :: Int)
+
+
 
 -- | Returns a new tensor with the signs of the elements of @input@
 sign ::
@@ -2908,6 +3131,39 @@ batchNorm weight bias running_mean running_var training momentum eps input =
   unsafePerformIO $
     cast9
       ATen.batch_norm_tttttbddb
+      input
+      weight
+      bias
+      running_mean
+      running_var
+      training
+      momentum
+      eps
+      True
+
+instanceNorm ::
+  -- | weight
+  Tensor ->
+  -- | bias
+  Tensor ->
+  -- | running_mean
+  Tensor ->
+  -- | running_var
+  Tensor ->
+  -- | training
+  Bool ->
+  -- | momentum
+  Double ->
+  -- | eps
+  Double ->
+  -- | input
+  Tensor ->
+  -- | output
+  Tensor
+instanceNorm weight bias running_mean running_var training momentum eps input =
+  unsafePerformIO $
+    cast9
+      ATen.instance_norm_tttttbddb
       input
       weight
       bias

--- a/hasktorch/src/Torch/NN.hs
+++ b/hasktorch/src/Torch/NN.hs
@@ -258,16 +258,80 @@ instance Randomizable LinearSpec Linear where
           ( subScalar bound $ mulScalar (bound * 2.0) init
           )
     return $ Linear w b
+--
+-- Conv1d
+--
+data Conv1dSpec = Conv1dSpec
+  {  inputChannelSize1d :: Int,
+     outputChannelSize1d :: Int,
+     kernelSize :: Int
+  }
+  deriving (Show, Eq)
+
+data Conv1d = Conv1d
+  { conv1dWeight :: Parameter,
+    conv1dBias :: Parameter
+  }
+  deriving (Show, Generic, Parameterized)
+
+conv1dForward :: 
+  -- | layer
+  Conv1d ->
+  -- | stride
+  Int ->
+  -- | padding
+  Int ->
+  -- | input
+  Tensor ->
+  -- | output
+  Tensor
+
+conv1dForward layer = Torch.Functional.conv1d' w b
+  where
+    w = toDependent (conv1dWeight layer)
+    b = toDependent (conv1dBias layer)
+
+instance Randomizable Conv1dSpec Conv1d where
+  sample Conv1dSpec {..} = do
+    w <-
+      makeIndependent
+        =<< kaimingUniform
+          FanIn
+          (LeakyRelu $ Prelude.sqrt (5.0 :: Float))
+          [ outputChannelSize1d,
+            inputChannelSize1d,
+            kernelSize
+          ]
+    init <- randIO' [outputChannelSize1d]
+    let bound =
+          (1 :: Float)
+            / Prelude.sqrt
+              ( fromIntegral
+                  ( getter FanIn $
+                      calculateFan
+                        [ outputChannelSize1d,
+                          inputChannelSize1d,
+                          kernelSize
+                        ]
+                  ) ::
+                  Float
+              )
+    b <-
+      makeIndependent
+        =<< pure
+          ( subScalar bound $ mulScalar (bound * 2.0) init
+          )
+    return $ Conv1d w b
 
 --
 -- Conv2d
 --
 
 data Conv2dSpec = Conv2dSpec
-  { inputChannelSize :: Int,
-    outputChannelSize :: Int,
-    kernelHeight :: Int,
-    kernelWidth :: Int
+  { inputChannelSize2d :: Int,
+    outputChannelSize2d :: Int,
+    kernelHeight2d :: Int,
+    kernelWidth2d :: Int
   }
   deriving (Show, Eq)
 
@@ -300,22 +364,22 @@ instance Randomizable Conv2dSpec Conv2d where
         =<< kaimingUniform
           FanIn
           (LeakyRelu $ Prelude.sqrt (5.0 :: Float))
-          [ outputChannelSize,
-            inputChannelSize,
-            kernelHeight,
-            kernelWidth
+          [ outputChannelSize2d,
+            inputChannelSize2d,
+            kernelHeight2d,
+            kernelWidth2d
           ]
-    init <- randIO' [outputChannelSize]
+    init <- randIO' [outputChannelSize2d]
     let bound =
           (1 :: Float)
             / Prelude.sqrt
               ( fromIntegral
                   ( getter FanIn $
                       calculateFan
-                        [ outputChannelSize,
-                          inputChannelSize,
-                          kernelHeight,
-                          kernelWidth
+                        [ outputChannelSize2d,
+                          inputChannelSize2d,
+                          kernelHeight2d,
+                          kernelWidth2d
                         ]
                   ) ::
                   Float
@@ -326,6 +390,284 @@ instance Randomizable Conv2dSpec Conv2d where
           ( subScalar bound $ mulScalar (bound * 2.0) init
           )
     return $ Conv2d w b
+
+--
+-- Conv3d
+--
+
+data Conv3dSpec = Conv3dSpec
+  { inputChannelSize3d :: Int,
+    outputChannelSize3d :: Int,
+    kernelHeight3d :: Int,
+    kernelWidth3d :: Int,
+    kernelDepth3d :: Int
+  }
+  deriving (Show, Eq)
+
+data Conv3d = Conv3d
+  { conv3dWeight :: Parameter,
+    conv3dBias :: Parameter
+  }
+  deriving (Show, Generic, Parameterized)
+
+conv3dForward ::
+  -- | layer
+  Conv3d ->
+  -- | stride
+  (Int, Int, Int) ->
+  -- | padding
+  (Int, Int, Int) ->
+  -- | input
+  Tensor ->
+  -- | output
+  Tensor
+conv3dForward layer = Torch.Functional.conv3d' w b
+  where
+    w = toDependent (conv3dWeight layer)
+    b = toDependent (conv3dBias layer)
+
+instance Randomizable Conv3dSpec Conv3d where
+  sample Conv3dSpec {..} = do
+    w <-
+      makeIndependent
+        =<< kaimingUniform
+          FanIn
+          (LeakyRelu $ Prelude.sqrt (5.0 :: Float))
+          [ outputChannelSize3d,
+            inputChannelSize3d,
+            kernelHeight3d,
+            kernelWidth3d,
+            kernelDepth3d
+          ]
+    init <- randIO' [outputChannelSize3d]
+    let bound =
+          (1 :: Float)
+            / Prelude.sqrt
+              ( fromIntegral
+                  ( getter FanIn $
+                      calculateFan
+                        [ outputChannelSize3d,
+                          inputChannelSize3d,
+                          kernelHeight3d,
+                          kernelWidth3d,
+                          kernelDepth3d
+                        ]
+                  ) ::
+                  Float
+              )
+    b <-
+      makeIndependent
+        =<< pure
+          ( subScalar bound $ mulScalar (bound * 2.0) init
+          )
+    return $ Conv3d w b
+
+-- 
+-- ConvTranspose1d
+--
+
+data ConvTranspose1dSpec = ConvTranspose1dSpec
+  { trInputChannelSize1d :: Int,
+    trOutputChannelSize1d :: Int,
+    trKernelSize :: Int
+  }
+  deriving (Show, Eq)
+
+data ConvTranspose1d = ConvTranspose1d
+  { convTranspose1dWeight :: Parameter,
+    convTranspose1dBias :: Parameter
+  }
+  deriving (Show, Generic, Parameterized)
+
+convTranspose1dForward ::
+  -- | layer
+  ConvTranspose1d -> 
+  -- | stride
+  Int -> 
+  -- | padding
+  Int -> 
+  -- | input
+  Tensor -> 
+  -- | output
+  Tensor 
+
+convTranspose1dForward layer = convTranspose1d' w b
+  where
+    w = toDependent (convTranspose1dWeight layer)
+    b = toDependent (convTranspose1dBias layer)
+
+instance Randomizable ConvTranspose1dSpec ConvTranspose1d where
+  sample ConvTranspose1dSpec {..} = do
+    w <-
+      makeIndependent
+        =<< kaimingUniform
+          FanIn
+          (LeakyRelu $ Prelude.sqrt (5.0 :: Float))
+          [ trInputChannelSize1d, 
+            trOutputChannelSize1d,
+            trKernelSize
+          ]
+    init <- randIO' [trOutputChannelSize1d]
+    let bound =
+          (1 :: Float)
+            / Prelude.sqrt
+              ( fromIntegral
+                  ( getter FanIn $
+                      calculateFan
+                        [ trInputChannelSize1d,
+                          trOutputChannelSize1d,
+                          trKernelSize
+                        ]
+                  ) ::
+                  Float
+              )
+    b <-
+      makeIndependent
+        =<< pure
+          ( subScalar bound $ mulScalar (bound * 2.0) init
+          )
+    return $ ConvTranspose1d w b
+
+-- 
+-- ConvTranspose2d
+--
+
+data ConvTranspose2dSpec = ConvTranspose2dSpec
+  { trInputChannelSize2d :: Int,
+    trOutputChannelSize2d :: Int,
+    trKernelHeight2d :: Int,
+    trKernelWidth2d :: Int
+  }
+  deriving (Show, Eq)
+
+data ConvTranspose2d = ConvTranspose2d
+  { convTranspose2dWeight :: Parameter,
+    convTranspose2dBias :: Parameter
+  }
+  deriving (Show, Generic, Parameterized)
+
+convTranspose2dForward ::
+  -- | layer
+  ConvTranspose2d -> 
+  -- | stride
+  (Int, Int) -> 
+  -- | padding
+  (Int, Int) -> 
+  -- | input
+  Tensor -> 
+  -- | output
+  Tensor 
+
+convTranspose2dForward layer = convTranspose2d' w b
+  where
+    w = toDependent (convTranspose2dWeight layer)
+    b = toDependent (convTranspose2dBias layer)
+
+instance Randomizable ConvTranspose2dSpec ConvTranspose2d where
+  sample ConvTranspose2dSpec {..} = do
+    w <-
+      makeIndependent
+        =<< kaimingUniform
+          FanIn
+          (LeakyRelu $ Prelude.sqrt (5.0 :: Float))
+          [ trInputChannelSize2d, 
+            trOutputChannelSize2d,
+            trKernelHeight2d,
+            trKernelWidth2d
+          ]
+    init <- randIO' [trOutputChannelSize2d]
+    let bound =
+          (1 :: Float)
+            / Prelude.sqrt
+              ( fromIntegral
+                  ( getter FanIn $
+                      calculateFan
+                        [ trInputChannelSize2d,
+                          trOutputChannelSize2d,
+                          trKernelHeight2d,
+                          trKernelWidth2d
+                        ]
+                  ) ::
+                  Float
+              )
+    b <-
+      makeIndependent
+        =<< pure
+          ( subScalar bound $ mulScalar (bound * 2.0) init
+          )
+    return $ ConvTranspose2d w b
+
+-- 
+-- ConvTranspose2d
+--
+
+data ConvTranspose3dSpec = ConvTranspose3dSpec
+  { trInputChannelSize3d :: Int,
+    trOutputChannelSize3d :: Int,
+    trKernelHeight3d :: Int,
+    trKernelWidth3d :: Int,
+    trKernelDepth3d :: Int
+  }
+  deriving (Show, Eq)
+
+data ConvTranspose3d = ConvTranspose3d
+  { convTranspose3dWeight :: Parameter,
+    convTranspose3dBias :: Parameter
+  }
+  deriving (Show, Generic, Parameterized)
+
+convTranspose3dForward ::
+  -- | layer
+  ConvTranspose3d -> 
+  -- | stride
+  (Int, Int, Int) -> 
+  -- | padding
+  (Int, Int, Int) -> 
+  -- | input
+  Tensor -> 
+  -- | output
+  Tensor 
+
+convTranspose3dForward layer = convTranspose3d' w b
+  where
+    w = toDependent (convTranspose3dWeight layer)
+    b = toDependent (convTranspose3dBias layer)
+
+instance Randomizable ConvTranspose3dSpec ConvTranspose3d where
+  sample ConvTranspose3dSpec {..} = do
+    w <-
+      makeIndependent
+        =<< kaimingUniform
+          FanIn
+          (LeakyRelu $ Prelude.sqrt (5.0 :: Float))
+          [ trInputChannelSize3d, 
+            trOutputChannelSize3d,
+            trKernelHeight3d,
+            trKernelWidth3d,
+            trKernelDepth3d
+          ]
+    init <- randIO' [trOutputChannelSize3d]
+    let bound =
+          (1 :: Float)
+            / Prelude.sqrt
+              ( fromIntegral
+                  ( getter FanIn $
+                      calculateFan
+                        [ trInputChannelSize3d,
+                          trOutputChannelSize3d,
+                          trKernelHeight3d,
+                          trKernelWidth3d,
+                          trKernelDepth3d
+                        ]
+                  ) ::
+                  Float
+              )
+    b <-
+      makeIndependent
+        =<< pure
+          ( subScalar bound $ mulScalar (bound * 2.0) init
+          )
+    return $ ConvTranspose3d w b
 
 data BatchNormSpec = BatchNormSpec
   { numFeatures :: Int
@@ -359,6 +701,39 @@ instance Randomizable BatchNormSpec BatchNorm where
     mean <- toDependent <$> makeIndependentWithRequiresGrad (zeros' [numFeatures]) False
     var <- toDependent <$> makeIndependentWithRequiresGrad (ones' [numFeatures]) False
     return $ BatchNorm w b mean var
+
+data InstanceNormSpec = InstanceNormSpec
+  { iNumFeatures :: Int
+  }
+  deriving (Show, Eq)
+
+data InstanceNorm = InstanceNorm
+  { instanceNormWeight :: Parameter,
+    instanceNormBias :: Parameter,
+    iRunningMean :: Tensor,
+    iRunningVar :: Tensor
+  }
+  deriving (Show, Generic)
+
+instanceNormForward :: InstanceNorm -> Bool -> Double -> Double -> Tensor -> Tensor
+instanceNormForward InstanceNorm {..} train momentum eps input =
+  Torch.Functional.instanceNorm
+    (toDependent instanceNormWeight)
+    (toDependent instanceNormBias)
+    iRunningMean
+    iRunningVar
+    train
+    momentum
+    eps
+    input
+
+instance Randomizable InstanceNormSpec InstanceNorm where
+  sample InstanceNormSpec {..} = do
+    w <- makeIndependent (ones' [iNumFeatures])
+    b <- makeIndependent (zeros' [iNumFeatures])
+    mean <- toDependent <$> makeIndependentWithRequiresGrad (zeros' [iNumFeatures]) False
+    var <- toDependent <$> makeIndependentWithRequiresGrad (ones' [iNumFeatures]) False
+    return $ InstanceNorm w b mean var
 
 data UpSampleSpec = UpSampleSpec
   { upsampleInputFilters :: Int,

--- a/hasktorch/src/Torch/Typed/NN/Convolution.hs
+++ b/hasktorch/src/Torch/Typed/NN/Convolution.hs
@@ -272,3 +272,247 @@ instance
   where
   sample Conv3dSpec =
     Conv3d <$> (makeIndependent =<< randn) <*> (makeIndependent =<< randn)
+
+
+data
+  ConvTranspose1dSpec
+    (inputChannelSize :: Nat)
+    (outputChannelSize :: Nat)
+    (kernelSize :: Nat)
+    (dtype :: D.DType)
+    (device :: (D.DeviceType, Nat))
+  = ConvTranspose1dSpec
+  deriving (Show, Eq)
+
+data
+  ConvTranspose1d
+    (inputChannelSize :: Nat)
+    (outputChannelSize :: Nat)
+    (kernelSize :: Nat)
+    (dtype :: D.DType)
+    (device :: (D.DeviceType, Nat)) where
+  ConvTranspose1d ::
+    forall inputChannelSize outputChannelSize kernelSize dtype device.
+    { convTranspose1dWeight :: Parameter device dtype '[inputChannelSize, outputChannelSize, kernelSize],
+      convTranspose1dBias :: Parameter device dtype '[outputChannelSize]
+    } ->
+    ConvTranspose1d inputChannelSize outputChannelSize kernelSize dtype
+      device
+  deriving (Show, Generic, Parameterized)
+
+-- | convTranspose1d
+-- The constraints on this one are _very_ involved, so the partial signatures
+-- make the code significantly cleaner.
+convTranspose1dForward ::
+  forall stride padding.
+  _ =>
+  ConvTranspose1d _ _ _ _ _ ->
+  Tensor _ _ _ ->
+  Tensor _ _ _
+convTranspose1dForward ConvTranspose1d {..} input =
+  convTranspose1d @stride @padding
+    (toDependent convTranspose1dWeight)
+    (toDependent convTranspose1dBias)
+    input
+
+instance
+  ( All KnownNat
+      '[ stride,
+         padding,
+         inputChannelSize,
+         outputChannelSize,
+         kernelSize,
+         inputSize,
+         batchSize,
+         outputSize
+       ],
+    ConvSideCheck inputSize kernelSize stride padding outputSize
+  ) =>
+  HasForward (ConvTranspose1d inputChannelSize outputChannelSize kernelSize dtype device) (Tensor device dtype '[batchSize, inputChannelSize, inputSize], Proxy stride, Proxy padding) (Tensor device dtype '[batchSize, outputChannelSize, outputSize])
+  where
+  forward model (input, Proxy, Proxy) = convTranspose1dForward @stride @padding model input
+  forwardStoch = (pure .) . forward
+
+instance
+  ( KnownNat inputChannelSize,
+    KnownNat outputChannelSize,
+    KnownNat kernelSize,
+    KnownDType dtype,
+    KnownDevice device,
+    RandDTypeIsValid device dtype
+  ) =>
+  Randomizable (ConvTranspose1dSpec inputChannelSize outputChannelSize kernelSize dtype device)
+    (ConvTranspose1d inputChannelSize outputChannelSize kernelSize dtype device)
+  where
+  sample ConvTranspose1dSpec =
+    ConvTranspose1d <$> (makeIndependent =<< randn) <*> (makeIndependent =<< randn)
+
+data
+  ConvTranspose2dSpec
+    (inputChannelSize :: Nat)
+    (outputChannelSize :: Nat)
+    (kernelSize0 :: Nat)
+    (kernelSize1 :: Nat)
+    (dtype :: D.DType)
+    (device :: (D.DeviceType, Nat))
+  = ConvTranspose2dSpec
+  deriving (Show, Eq)
+
+data
+  ConvTranspose2d
+    (inputChannelSize :: Nat)
+    (outputChannelSize :: Nat)
+    (kernelSize0 :: Nat)
+    (kernelSize1 :: Nat)
+    (dtype :: D.DType)
+    (device :: (D.DeviceType, Nat)) where
+  ConvTranspose2d ::
+    forall inputChannelSize outputChannelSize kernelSize0 kernelSize1 dtype device.
+    { convTranspose2dWeight :: Parameter device dtype '[inputChannelSize, outputChannelSize, kernelSize0, kernelSize1],
+      convTranspose2dBias :: Parameter device dtype '[outputChannelSize]
+    } ->
+    ConvTranspose2d inputChannelSize outputChannelSize kernelSize0 kernelSize1 dtype
+      device
+  deriving (Show, Generic, Parameterized)
+
+-- | convTranspose2d
+-- The constraints on this one are _very_ involved, so the partial signatures
+-- make the code significantly cleaner.
+convTranspose2dForward ::
+  forall stride padding.
+  _ =>
+  ConvTranspose2d _ _ _ _ _ _ ->
+  Tensor _ _ _ ->
+  Tensor _ _ _
+convTranspose2dForward ConvTranspose2d {..} input =
+  convTranspose2d @stride @padding
+    (toDependent convTranspose2dWeight)
+    (toDependent convTranspose2dBias)
+    input
+
+instance
+  ( All KnownNat
+      '[ Torch.Typed.Aux.Fst stride,
+         Torch.Typed.Aux.Snd stride,
+         Torch.Typed.Aux.Fst padding,
+         Torch.Typed.Aux.Snd padding,
+         inputChannelSize,
+         outputChannelSize,
+         kernelSize0,
+         kernelSize1,
+         inputSize0,
+         inputSize1,
+         batchSize,
+         outputSize0,
+         outputSize1
+       ],
+    ConvSideCheck inputSize0 kernelSize0 (Torch.Typed.Aux.Fst stride) (Torch.Typed.Aux.Fst padding) outputSize0,
+    ConvSideCheck inputSize1 kernelSize1 (Torch.Typed.Aux.Snd stride) (Torch.Typed.Aux.Snd padding) outputSize1
+  ) =>
+  HasForward (ConvTranspose2d inputChannelSize outputChannelSize kernelSize0 kernelSize1 dtype device) (Tensor device dtype '[batchSize, inputChannelSize, inputSize0, inputSize1], Proxy stride, Proxy padding) (Tensor device dtype '[batchSize, outputChannelSize, outputSize0, outputSize1])
+  where
+  forward model (input, Proxy, Proxy) = convTranspose2dForward @stride @padding model input
+  forwardStoch = (pure .) . forward
+
+instance
+  ( KnownNat inputChannelSize,
+    KnownNat outputChannelSize,
+    KnownNat kernelSize0,
+    KnownNat kernelSize1,
+    KnownDType dtype,
+    KnownDevice device,
+    RandDTypeIsValid device dtype
+  ) =>
+  Randomizable (ConvTranspose2dSpec inputChannelSize outputChannelSize kernelSize0 kernelSize1 dtype device)
+    (ConvTranspose2d inputChannelSize outputChannelSize kernelSize0 kernelSize1 dtype device)
+  where
+  sample ConvTranspose2dSpec =
+    ConvTranspose2d <$> (makeIndependent =<< randn) <*> (makeIndependent =<< randn)
+
+data
+  ConvTranspose3dSpec
+    (inputChannelSize :: Nat)
+    (outputChannelSize :: Nat)
+    (kernelSize0 :: Nat)
+    (kernelSize1 :: Nat)
+    (kernelSize2 :: Nat)
+    (dtype :: D.DType)
+    (device :: (D.DeviceType, Nat))
+  = ConvTranspose3dSpec
+  deriving (Show, Eq)
+
+data
+  ConvTranspose3d
+    (inputChannelSize :: Nat)
+    (outputChannelSize :: Nat)
+    (kernelSize0 :: Nat)
+    (kernelSize1 :: Nat)
+    (kernelSize2 :: Nat)
+    (dtype :: D.DType)
+    (device :: (D.DeviceType, Nat)) where
+  ConvTranspose3d ::
+    forall inputChannelSize outputChannelSize kernelSize0 kernelSize1 kernelSize2 dtype device.
+    { convTranspose3dWeight :: Parameter device dtype '[inputChannelSize, outputChannelSize, kernelSize0, kernelSize1, kernelSize2],
+      convTranspose3dBias :: Parameter device dtype '[outputChannelSize]
+    } ->
+    ConvTranspose3d inputChannelSize outputChannelSize kernelSize0 kernelSize1 kernelSize2 dtype
+      device
+  deriving (Show, Generic, Parameterized)
+
+-- | convTranspose3d
+-- The constraints on this one are _very_ involved, so the partial signatures
+-- make the code significantly cleaner.
+convTranspose3dForward ::
+  forall stride padding.
+  _ =>
+  ConvTranspose3d _ _ _ _ _ _ _ ->
+  Tensor _ _ _ ->
+  Tensor _ _ _
+convTranspose3dForward ConvTranspose3d {..} input =
+  convTranspose3d @stride @padding
+    (toDependent convTranspose3dWeight)
+    (toDependent convTranspose3dBias)
+    input
+
+instance
+  ( All KnownNat
+      '[ Fst3 stride,
+         Snd3 stride,
+         Trd3 stride,
+         Fst3 padding,
+         Snd3 padding,
+         Trd3 padding,
+         inputChannelSize,
+         outputChannelSize,
+         kernelSize0,
+         kernelSize1,
+         kernelSize2,
+         inputSize0,
+         inputSize1,
+         inputSize2,
+         batchSize
+       ],
+    ConvSideCheck inputSize0 kernelSize0 (Fst3 stride) (Fst3 padding) outputSize0,
+    ConvSideCheck inputSize1 kernelSize1 (Snd3 stride) (Snd3 padding) outputSize1,
+    ConvSideCheck inputSize2 kernelSize2 (Trd3 stride) (Trd3 padding) outputSize2
+  ) =>
+  HasForward (ConvTranspose3d inputChannelSize outputChannelSize kernelSize0 kernelSize1 kernelSize2 dtype device) (Tensor device dtype '[batchSize, inputChannelSize, inputSize0, inputSize1, inputSize2], Proxy stride, Proxy padding) (Tensor device dtype '[batchSize, outputChannelSize, outputSize0, outputSize1, outputSize2])
+  where
+  forward model (input, Proxy, Proxy) = convTranspose3dForward @stride @padding model input
+  forwardStoch = (pure .) . forward
+
+instance
+  ( KnownNat inputChannelSize,
+    KnownNat outputChannelSize,
+    KnownNat kernelSize0,
+    KnownNat kernelSize1,
+    KnownNat kernelSize2,
+    KnownDType dtype,
+    KnownDevice device,
+    RandDTypeIsValid device dtype
+  ) =>
+  Randomizable (ConvTranspose3dSpec inputChannelSize outputChannelSize kernelSize0 kernelSize1 kernelSize2 dtype device)
+    (ConvTranspose3d inputChannelSize outputChannelSize kernelSize0 kernelSize1 kernelSize2 dtype device)
+  where
+  sample ConvTranspose3dSpec =
+    ConvTranspose3d <$> (makeIndependent =<< randn) <*> (makeIndependent =<< randn)

--- a/hasktorch/test/FunctionalSpec.hs
+++ b/hasktorch/test/FunctionalSpec.hs
@@ -183,11 +183,11 @@ spec = do
         input0 = 5
         input1 = 6
         input2 = 7
-        x = conv2d'
+        x = conv3d'
               (ones' [out_channel, in_channel, kernel0, kernel1, kernel2])
               (ones' [out_channel])
-              (1,1)
-              (0,0)
+              (1,1,1)
+              (0,0,0)
               (ones' [batch, in_channel, input0, input1, input2])
     shape x `shouldBe` [batch, out_channel, input0, input1, input2]
   it "convTranspose1d" $ do

--- a/hasktorch/test/FunctionalSpec.hs
+++ b/hasktorch/test/FunctionalSpec.hs
@@ -145,6 +145,19 @@ spec = do
   it "inverse of an identity matrix is an identity matrix" $ do
     let soln = eq (inverse $ eye' 3 3) (eye' 3 3)
     all soln `shouldBe` True
+  it "conv1d" $ do
+    let batch = 10
+        in_channel = 3
+        out_channel = 10
+        kernel = 1
+        input = 5
+        x = conv1d' 
+              (ones' [out_channel, in_channel, kernel])
+              (ones' [out_channel])
+              1
+              0
+              (ones' [batch, in_channel, input])
+    shape x `shouldBe` [batch, out_channel, input]
   it "conv2d" $ do
     let batch = 10
         in_channel = 3
@@ -160,6 +173,68 @@ spec = do
               (0,0)
               (ones' [batch, in_channel, input0, input1])
     shape x `shouldBe` [batch, out_channel, input0, input1]
+  it "conv3d" $ do
+    let batch = 10
+        in_channel = 3
+        out_channel = 10
+        kernel0 = 1
+        kernel1 = 1
+        kernel2 = 1
+        input0 = 5
+        input1 = 6
+        input2 = 7
+        x = conv2d'
+              (ones' [out_channel, in_channel, kernel0, kernel1, kernel2])
+              (ones' [out_channel])
+              (1,1)
+              (0,0)
+              (ones' [batch, in_channel, input0, input1, input2])
+    shape x `shouldBe` [batch, out_channel, input0, input1, input2]
+  it "convTranspose1d" $ do
+    let batch = 10
+        in_channel = 3
+        out_channel = 10
+        kernel = 1
+        input = 5
+        x = convTranspose1d' 
+              (ones' [in_channel, out_channel, kernel])
+              (ones' [out_channel])
+              1
+              0
+              (ones' [batch, in_channel, input])
+    shape x `shouldBe` [batch, out_channel, input]
+  it "convTranspose2d" $ do
+    let batch = 10
+        in_channel = 3
+        out_channel = 10
+        kernel0 = 1
+        kernel1 = 1
+        input0 = 5
+        input1 = 6
+        x = convTranspose2d'
+              (ones' [in_channel, out_channel, kernel0, kernel1])
+              (ones' [out_channel])
+              (1,1)
+              (0,0)
+              (ones' [batch, in_channel, input0, input1])
+    shape x `shouldBe` [batch, out_channel, input0, input1]
+  it "convTranspose3d" $ do
+    let batch = 10
+        in_channel = 3
+        out_channel = 10
+        kernel0 = 1
+        kernel1 = 1
+        kernel2 = 1
+        input0 = 5
+        input1 = 6
+        input2 = 7
+        x = convTranspose3d'
+              (ones' [in_channel, out_channel, kernel0, kernel1, kernel2])
+              (ones' [out_channel])
+              (1,1,1)
+              (0,0,0)
+              (ones' [batch, in_channel, input0, input1, input2])
+    shape x `shouldBe` [batch, out_channel, input0, input1, input2]
   it "elu (pos)" $ do
     let x = elu (0.5::Float) $ 5 * ones' [4]
     (toDouble $ select 0 0 x) `shouldBe` 5.0


### PR DESCRIPTION
Typed and Untyped convolution and transposed convolution functions and layers. Specs added in Untyped to match the existing conv2d test. Would like to add a Torch.GraduallyTyped.NN.Convolution, but I haven't looked into or worked with GraduallyTyped more than in passing. Typed and Untyped seem to behave and test as expected so far which makes sense given they were an expansion built off of existing scaffolding. 

Also includes `InstanceNorm`. I followed the convention set by `BatchNorm` of not having any Parameterized instance, but I could see it being helpful to have one for working with full models that use the layers, especially with serialization and deserialization. 

Hope this all looks good, and I'd be glad for any feedback or suggestions! 