### PR TITLE
Fix to cuda tensor

### DIFF
--- a/experimental/gradually-typed/src/Torch/GraduallyTyped/NN/Class.hs
+++ b/experimental/gradually-typed/src/Torch/GraduallyTyped/NN/Class.hs
@@ -46,7 +46,7 @@ import Foreign.ForeignPtr (ForeignPtr)
 import GHC.TypeLits (Nat, natVal, type (+))
 import Torch.GraduallyTyped.Device (Device, DeviceType)
 import Torch.GraduallyTyped.Random (Generator)
-import Torch.GraduallyTyped.Tensor.Type (SSetDevice (sSetDevice), SSetGradient (..), Tensor (..), TensorSpec (..), UncheckedTensor, sCheckedDataType, sCheckedLayout, sCheckedShape)
+import Torch.GraduallyTyped.Tensor.Type (sSetDevice, sSetGradient, Tensor (..), TensorSpec (..), UncheckedTensor, sCheckedDataType, sCheckedLayout, sCheckedShape)
 import qualified Torch.Internal.Type as ATen (Tensor)
 import qualified Torch.Script (IValue (..))
 import qualified Torch.Serialize (pickleLoad, pickleSave)
@@ -246,7 +246,6 @@ instance (HasStateDict a, HasStateDict b) => HasStateDict (a, b) where
 type instance ModelSpec (Tensor gradient layout device dataType shape) = TensorSpec gradient layout device dataType shape
 
 instance
-  (SSetGradient gradient, SSetDevice device) =>
   HasStateDict
     (Tensor gradient layout device dataType shape)
   where

--- a/experimental/gradually-typed/src/Torch/GraduallyTyped/NN/Normalization.hs
+++ b/experimental/gradually-typed/src/Torch/GraduallyTyped/NN/Normalization.hs
@@ -33,7 +33,7 @@ import Torch.GraduallyTyped.NN.Type (HasBias (..), SHasBias (..))
 import Torch.GraduallyTyped.RequiresGradient (Gradient, RequiresGradient (..), SGradient)
 import Torch.GraduallyTyped.Shape (Dim (..), Name (..), SShape (..), Shape (..), Size (..))
 import Torch.GraduallyTyped.Tensor.Creation (sOnes, sZeros)
-import Torch.GraduallyTyped.Tensor.Type (SGetShape, SSetGradient, Tensor, TensorSpec (..), SSetDevice)
+import Torch.GraduallyTyped.Tensor.Type (SGetShape, Tensor, TensorSpec (..))
 import Torch.GraduallyTyped.Unify (type (<+>), type (<|>))
 
 data
@@ -96,7 +96,6 @@ instance
      in pure . (LayerNormWithoutBias weight eps,)
 
 instance
-  (SSetGradient gradient, SSetDevice device) =>
   HasStateDict
     (LayerNorm hasBias gradient device dataType normalizedShape)
   where

--- a/experimental/gradually-typed/src/Torch/GraduallyTyped/NN/Sparse.hs
+++ b/experimental/gradually-typed/src/Torch/GraduallyTyped/NN/Sparse.hs
@@ -31,7 +31,7 @@ import Torch.GraduallyTyped.Prelude (Seq)
 import Torch.GraduallyTyped.RequiresGradient (Gradient (..), RequiresGradient (..), SGradient (..))
 import Torch.GraduallyTyped.Shape (Dim (..), Name, SDim (..), SShape (..), Shape (..), Size, pattern (:|:))
 import Torch.GraduallyTyped.Tensor.Creation (sRandn)
-import Torch.GraduallyTyped.Tensor.Type (SGetLayout, SSetDevice, SSetGradient, Tensor, TensorSpec (..))
+import Torch.GraduallyTyped.Tensor.Type (SGetLayout, Tensor, TensorSpec (..))
 import Torch.GraduallyTyped.Unify (type (<+>), type (<|>))
 
 data
@@ -94,7 +94,6 @@ instance
         >>>= ireturn . Embedding
 
 instance
-  (SSetGradient gradient, SSetDevice device) =>
   HasStateDict
     (Embedding gradient layout device dataType embedNumDim embedDim paddingIdx)
   where

--- a/experimental/gradually-typed/src/Torch/GraduallyTyped/Tensor/Type.hs
+++ b/experimental/gradually-typed/src/Torch/GraduallyTyped/Tensor/Type.hs
@@ -1395,8 +1395,10 @@ fromTensorRaw ::
   (TensorLike a dType dims, TensorLikeRaw a, SGetDims dims) =>
   Tensor gradient layout device ('DataType dType) ('Shape dims) ->
   a
-fromTensorRaw t = unsafePerformIO $
-  withTensor t $ \ptr -> tensorPeekElemOff ptr 0 (fromInteger . dimSize <$> getDims t)
+fromTensorRaw t =
+  unsafePerformIO $
+    sSetDevice (SDevice SCPU) t
+      >>= flip withTensor (\ptr -> tensorPeekElemOff ptr 0 $ fromInteger . dimSize <$> getDims t)
 
 instance TensorLike Bool 'Bool '[] where
   sToTensor = sToTensorRaw

--- a/experimental/gradually-typed/src/Torch/GraduallyTyped/Tensor/Type.hs
+++ b/experimental/gradually-typed/src/Torch/GraduallyTyped/Tensor/Type.hs
@@ -1386,9 +1386,9 @@ sToTensorRaw gradient' layout device x = do
       t <- UnsafeTensor <$> cast2 ATen.empty_lo dims' opts
       withTensor t $ \ptr ->
         tensorPokeElemOff ptr 0 dims' x
-      pure t
+      sSetDevice device t
   where
-    opts = tensorOptions gradient' layout device (sing @('DataType dType))
+    opts = tensorOptions gradient' layout (SDevice SCPU) (sing @('DataType dType))
 
 fromTensorRaw ::
   forall gradient layout device a dType dims.

--- a/experimental/gradually-typed/test/TensorSpec.hs
+++ b/experimental/gradually-typed/test/TensorSpec.hs
@@ -127,41 +127,41 @@ spec = describe "TensorLike" $ do
         let xs' = fromTensor t
         assert $ P.all (uncurry (~~)) $ V.zip xs' xs
 
-    it "Tensor" $ do
-      let t =
-            ones
-              @('Gradient 'WithoutGradient)
-              @('Layout 'Dense)
-              @('Device 'CPU)
-              @('DataType 'Int64)
-              @('Shape '[ 'Dim ('Name "*") ('Size 4), 'Dim ('Name "*") ('Size 8)])
-      t' <- toTensor @('Gradient 'WithoutGradient) @('Layout 'Dense) @('Device 'CPU) t
-      all' <- all $ t' ==. t
-      fromTensor all' `shouldBe` True
-      let t'' =
-            fromTensor
-              @( Tensor
-                   ('Gradient 'WithoutGradient)
-                   ('Layout 'Dense)
-                   ('Device 'CPU)
-                   ('DataType 'Int64)
-                   ('Shape '[ 'Dim ('Name "*") ('Size 4), 'Dim ('Name "*") ('Size 8)])
-               )
-              t'
-      all'' <- all $ t'' ==. t
-      fromTensor all'' `shouldBe` True
+  -- it "Tensor" $ do
+  --   let t =
+  --         ones
+  --           @('Gradient 'WithoutGradient)
+  --           @('Layout 'Dense)
+  --           @('Device 'CPU)
+  --           @('DataType 'Int64)
+  --           @('Shape '[ 'Dim ('Name "*") ('Size 4), 'Dim ('Name "*") ('Size 8)])
+  --   t' <- toTensor @('Gradient 'WithoutGradient) @('Layout 'Dense) @('Device 'CPU) t
+  --   all' <- all $ t' ==. t
+  --   fromTensor all' `shouldBe` True
+  --   let t'' =
+  --         fromTensor
+  --           @( Tensor
+  --                ('Gradient 'WithoutGradient)
+  --                ('Layout 'Dense)
+  --                ('Device 'CPU)
+  --                ('DataType 'Int64)
+  --                ('Shape '[ 'Dim ('Name "*") ('Size 4), 'Dim ('Name "*") ('Size 8)])
+  --            )
+  --           t'
+  --   all'' <- all $ t'' ==. t
+  --   fromTensor all'' `shouldBe` True
 
   it "dims ([[]] :: [[[Int]]]) = 1x0x0" $ do
     x <- toCPUTensor @[[[Int]]] [[]]
-    dims x `shouldBe` [Dim "*" 1, Dim "*" 0, Dim "*" 0]
+    getDims x `shouldBe` [Dim "*" 1, Dim "*" 0, Dim "*" 0]
 
   it "dims ([] :: [(Int, Int)]) = 0x2" $ do
     x <- toCPUTensor @[(Int, Int)] []
-    dims x `shouldBe` [Dim "*" 0, Dim "*" 2]
+    getDims x `shouldBe` [Dim "*" 0, Dim "*" 2]
 
   it "dims ([] :: [([Int], [Int])] = 0x2x0" $ do
     x <- toCPUTensor @[([Int], [Int])] []
-    dims x `shouldBe` [Dim "*" 0, Dim "*" 2, Dim "*" 0]
+    getDims x `shouldBe` [Dim "*" 0, Dim "*" 2, Dim "*" 0]
 
   it "lists having different length" $ do
     let mkT = toCPUTensor @[[Double]] [[1], [1, 2]]

--- a/experimental/gradually-typed/test/TransformerSpec.hs
+++ b/experimental/gradually-typed/test/TransformerSpec.hs
@@ -1,16 +1,14 @@
 module TransformerSpec where
 
 import Test.Hspec
-import Torch.GraduallyTyped.NN.Transformer.Block (testBlock)
-import Torch.GraduallyTyped.NN.Transformer.CrossAttention (testCA)
-import Torch.GraduallyTyped.NN.Transformer.Decoder (testDecoder)
-import Torch.GraduallyTyped.NN.Transformer.DecoderBlock (testDecoderBlock)
-import Torch.GraduallyTyped.NN.Transformer.DecoderStack (testDecoderStack)
-import Torch.GraduallyTyped.NN.Transformer.Encoder (testEncoder)
-import Torch.GraduallyTyped.NN.Transformer.MultiHeadAttention (testMHA)
-import Torch.GraduallyTyped.NN.Transformer.SelfAttention (testSA)
-import Torch.GraduallyTyped.NN.Transformer.SequenceToSequence (testSeqToSeq)
-import Torch.GraduallyTyped.NN.Transformer.Stack (testStack)
+import Torch.GraduallyTyped.NN.Transformer.GBlock (testEncoderBlock, testDecoderBlock)
+import Torch.GraduallyTyped.NN.Transformer.GCrossAttention (testCA)
+import Torch.GraduallyTyped.NN.Transformer.GTransformer (testEncoder, testDecoder)
+import Torch.GraduallyTyped.NN.Transformer.GMultiHeadAttention (testMHA)
+import Torch.GraduallyTyped.NN.Transformer.GSelfAttention (testSA)
+import Torch.GraduallyTyped.NN.Transformer.GEncoderDecoder (testEncoderDecoderTransformer)
+import Torch.GraduallyTyped.NN.Transformer.GStack (testEncoderStack, testDecoderStack)
+import Torch.GraduallyTyped.NN.Transformer.GLMHead (testLMHead)
 
 spec :: Spec
 spec = describe "Transformer" $ do
@@ -26,31 +24,35 @@ spec = describe "Transformer" $ do
     it "minimal" $ do
       _ <- testCA
       pure ()
-  context "block" $ do
+  context "encoder block" $ do
     it "minimal" $ do
-      _ <- testBlock
+      _ <- testEncoderBlock
       pure ()
   context "decoder block" $ do
     it "minimal" $ do
       _ <- testDecoderBlock
       pure ()
-  context "stack" $ do
+  context "encoder stack" $ do
     it "minimal" $ do
-      _ <- testStack
-      pure ()
-  context "encoder" $ do
-    it "minimal" $ do
-      _ <- testEncoder
+      _ <- testEncoderStack
       pure ()
   context "decoder stack" $ do
     it "minimal" $ do
       _ <- testDecoderStack
       pure ()
+  context "encoder" $ do
+    it "minimal" $ do
+      _ <- testEncoder
+      pure ()
   context "decoder" $ do
     it "minimal" $ do
       _ <- testDecoder
       pure ()
-  context "sequence-to-sequence" $ do
+  context "encoder-decoder" $ do
     it "minimal" $ do
-      _ <- testSeqToSeq
+      _ <- testEncoderDecoderTransformer
+      pure ()
+  context "lm-head" $ do
+    it "minimal" $ do
+      _ <- testLMHead
       pure ()


### PR DESCRIPTION
I had to comment the `TensorLike` instance for `Tensor`, because it would allow for switching gradients off or on from outside of `IO` which mustn't be allowed.