### PR TITLE
To build gradually typed api, install the binary of libtokenizers

### DIFF
--- a/.github/workflows/cabal-linux.yml
+++ b/.github/workflows/cabal-linux.yml
@@ -18,7 +18,7 @@ jobs:
         sudo apt update -qq
         sudo apt -y purge ghc* cabal-install* php* || true
         sudo apt -y --allow-downgrades --allow-remove-essential --allow-change-held-packages install build-essential zlib1g-dev liblapack-dev libblas-dev ghc-8.10.2 cabal-install-3.4 devscripts debhelper python3-pip cmake curl wget unzip git libtinfo-dev python3 python3-yaml
-        sudo apt -y install libtorch=1.9.0+cpu-1 libtokenizers=0.1
+        sudo apt -y install libtorch=1.9.0+cpu-1 libtokenizers=0.1-1
     - name: Setup repos
       run: |
         git submodule init && git submodule update

--- a/.github/workflows/cabal-linux.yml
+++ b/.github/workflows/cabal-linux.yml
@@ -13,7 +13,7 @@ jobs:
         sudo apt update -qq
         sudo apt -y --allow-downgrades --allow-remove-essential --allow-change-held-packages install locales software-properties-common apt-transport-https
         sudo add-apt-repository -y ppa:hvr/ghc
-        sudo echo deb [trusted=yes] https://github.com/hasktorch/libtorch-binary-for-ci/releases/download/apt ./ > /etc/apt/sources.list.d/libtorch.list
+        sudo bash -c "echo deb [trusted=yes] https://github.com/hasktorch/libtorch-binary-for-ci/releases/download/apt ./ > /etc/apt/sources.list.d/libtorch.list"
         sudo rm -f /etc/apt/sources.list.d/sbt.list
         sudo apt update -qq
         sudo apt -y purge ghc* cabal-install* php* || true

--- a/.github/workflows/cabal-linux.yml
+++ b/.github/workflows/cabal-linux.yml
@@ -13,10 +13,12 @@ jobs:
         sudo apt update -qq
         sudo apt -y --allow-downgrades --allow-remove-essential --allow-change-held-packages install locales software-properties-common apt-transport-https
         sudo add-apt-repository -y ppa:hvr/ghc
+        sudo echo deb [trusted=yes] https://github.com/hasktorch/libtorch-binary-for-ci/releases/download/apt ./ > /etc/apt/sources.list.d/libtorch.list
         sudo rm -f /etc/apt/sources.list.d/sbt.list
         sudo apt update -qq
         sudo apt -y purge ghc* cabal-install* php* || true
         sudo apt -y --allow-downgrades --allow-remove-essential --allow-change-held-packages install build-essential zlib1g-dev liblapack-dev libblas-dev ghc-8.10.2 cabal-install-3.4 devscripts debhelper python3-pip cmake curl wget unzip git libtinfo-dev python3 python3-yaml
+        sudo apt -y install libtorch=1.9.0+cpu-1 libtokenizers=0.1
     - name: Setup repos
       run: |
         git submodule init && git submodule update
@@ -31,26 +33,16 @@ jobs:
       run: |
         export PATH=/opt/ghc/bin:$PATH
         source setenv
-        pushd deps/ ; ./get-deps.sh -a cpu -c; popd
+        #APT installs libtorch and libtokenizers.
+        #pushd deps/ ; ./get-deps.sh -a cpu -c; popd
         ./setup-cabal.sh
         cabal v2-update
         cabal v2-install hspec-discover
-        cabal v2-build --jobs=2 \
-          libtorch-ffi \
-          libtorch-ffi-helper \
-          hasktorch \
-          codegen \
-          examples \
-          bounding-box \
-          dataloader-cifar10 \
-          untyped-nlp
+        cabal v2-build --jobs=2 all
     - name: Test
       run: |
         export PATH=/opt/ghc/bin:$PATH
         source setenv
-        cabal v2-test --jobs=2 \
-          libtorch-ffi \
-          hasktorch \
-          codegen
+        cabal v2-test --jobs=2 all
         cabal v2-exec codegen-exe
         cabal exec xor-mlp

--- a/.github/workflows/cabal-linux.yml
+++ b/.github/workflows/cabal-linux.yml
@@ -25,7 +25,9 @@ jobs:
     - name: Cache .cabal
       uses: actions/cache@v2
       with:
-        path: ~/.cabal/store
+        path: |
+          ~/.cabal/store
+          dist-newstyle
         key: ${{ runner.os }}-cabal-${{ hashFiles('**/fallible.cabal') }}
         restore-keys: |
           ${{ runner.os }}-cabal-

--- a/.github/workflows/cabal-macos.yaml
+++ b/.github/workflows/cabal-macos.yaml
@@ -19,6 +19,8 @@ jobs:
         brew install cabal-install || true
         brew tap hasktorch/libtorch-prebuild https://github.com/hasktorch/homebrew-libtorch-prebuild || true
         brew install libtorch-prebuild@1.9 || true
+        brew tap hasktorch/tokenizers https://github.com/hasktorch/tokenizers || true
+        brew install libtokenizers || true
         #pushd deps/ ; ./get-deps.sh -a cpu -c ;popd
     - name: Build
       run: |
@@ -26,21 +28,10 @@ jobs:
         ./setup-cabal.sh
         cabal v2-update
         cabal v2-install hspec-discover
-        cabal v2-build --jobs=2 \
-          libtorch-ffi \
-          libtorch-ffi-helper \
-          hasktorch \
-          codegen \
-          examples \
-          bounding-box \
-          dataloader-cifar10 \
-          untyped-nlp
+        cabal v2-build --jobs=2 all
     - name: Test
       run: |
         #. setenv
-        cabal v2-test --jobs=2 \
-          libtorch-ffi \
-          hasktorch \
-          codegen
+        cabal v2-test --jobs=2 all
         cabal v2-exec codegen-exe
         cabal exec xor-mlp

--- a/.github/workflows/cabal-macos.yaml
+++ b/.github/workflows/cabal-macos.yaml
@@ -22,6 +22,15 @@ jobs:
         brew tap hasktorch/tokenizers https://github.com/hasktorch/tokenizers || true
         brew install libtokenizers || true
         #pushd deps/ ; ./get-deps.sh -a cpu -c ;popd
+    - name: Cache .cabal
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cabal/store
+          dist-newstyle
+        key: ${{ runner.os }}-cabal-${{ hashFiles('**/fallible.cabal') }}
+        restore-keys: |
+          ${{ runner.os }}-cabal-
     - name: Build
       run: |
         #. setenv

--- a/.github/workflows/stack-linux.yml
+++ b/.github/workflows/stack-linux.yml
@@ -30,7 +30,9 @@ jobs:
       id: cache-stack
       uses: actions/cache@v2
       with:
-        path: ~/.stack
+        path: |
+          ~/.stack
+          .stack-work
         key: "\
           ${{ runner.os }}-stack\
           -${{ hashFiles('**/stack.yaml.lock') }}\

--- a/.github/workflows/stack-macos.yaml
+++ b/.github/workflows/stack-macos.yaml
@@ -26,7 +26,9 @@ jobs:
       id: cache-stack
       uses: actions/cache@v2
       with:
-        path: ~/.stack
+        path: |
+          ~/.stack
+          .stack-work
         key: "\
           ${{ runner.os }}-stack\
           -${{ hashFiles('**/stack.yaml.lock') }}\

--- a/.github/workflows/stack-nix-linux.yml
+++ b/.github/workflows/stack-nix-linux.yml
@@ -33,7 +33,9 @@ jobs:
         id: cache-stack
         uses: actions/cache@v2
         with:
-          path: ~/.stack
+          path: |
+            ~/.stack
+            .stack-work
           key: "\
             ${{ runner.os }}-stack\
             -${{ hashFiles('**/stack.yaml.lock') }}\

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY . /hasktorch
 
 ENV PATH="/opt/ghc/bin:${PATH}"
 RUN cd deps/ && ./get-deps.sh -a cu101
-ENV LD_LIBRARY_PATH="/hasktorch/deps/libtorch/lib/:/hasktorch/deps/mklml/lib/:${LD_LIBRARY_PATH}"
+ENV LD_LIBRARY_PATH="/hasktorch/deps/libtorch/lib/:/hasktorch/deps/mklml/lib/:/hasktorch/deps/libtokenizers/lib/:${LD_LIBRARY_PATH}"
 RUN ./setup-cabal.sh
 RUN cabal v2-update
 RUN cabal v2-install hspec-discover

--- a/deps/get-deps.sh
+++ b/deps/get-deps.sh
@@ -113,6 +113,9 @@ if [ "$SKIP_DOWNLOAD" = 0 ] ; then
       rm -f mklml_mac_2019.0.1.20181227.tgz.1
       rm -rf mklml
       mv mklml_mac_2019.0.1.20181227 mklml
+
+      wget https://github.com/hasktorch/tokenizers/releases/download/libtokenizers-v0.1/libtokenizers-macos.zip
+      unzip libtokenizers-macos.zip
       ;;
     "Linux")
       if [ "$USE_NIGHTLY" = 1 ] ; then
@@ -143,6 +146,9 @@ if [ "$SKIP_DOWNLOAD" = 0 ] ; then
       rm -rf mklml
       mv mklml_lnx_2019.0.1.20181227 mklml
       ln -s libmklml_intel.so mklml/lib/libmklml.so
+
+      wget https://github.com/hasktorch/tokenizers/releases/download/libtokenizers-v0.1/libtokenizers-linux.zip
+      unzip libtokenizers-linux.zip
       ;;
   esac
 fi

--- a/experimental/gradually-typed/hasktorch-gradually-typed.cabal
+++ b/experimental/gradually-typed/hasktorch-gradually-typed.cabal
@@ -17,6 +17,11 @@ custom-setup
     , Cabal
     , cabal-doctest >=1.0.6 && <1.1
 
+Flag disable-doctest
+ Description: Disable doctest.
+ Default:     False
+ Manual:      True
+
 library
   exposed-modules:     Torch.GraduallyTyped
                      , Torch.GraduallyTyped.Prelude
@@ -196,6 +201,10 @@ test-suite spec
   build-tool-depends: hspec-discover:hspec-discover
 
 test-suite doctests
+  if os(darwin) || flag(disable-doctest)
+    Buildable: False
+  else
+    Buildable: True
   type:                exitcode-stdio-1.0
   main-is:             doctests.hs
   ghc-options:         -Wall -threaded -fplugin GHC.TypeLits.Normalise -fplugin GHC.TypeLits.KnownNat.Solver -fplugin GHC.TypeLits.Extra.Solver -fconstraint-solver-iterations=0

--- a/experimental/gradually-typed/hasktorch-gradually-typed.cabal
+++ b/experimental/gradually-typed/hasktorch-gradually-typed.cabal
@@ -103,6 +103,7 @@ library
                      , Torch.GraduallyTyped.NN.Functional.Loss
                      , Torch.GraduallyTyped.Internal.TensorOptions
                      , Torch.GraduallyTyped.Internal.Void
+                     , Torch.GraduallyTyped.Internal.Vector
                      , Torch.GraduallyTyped.Examples.LinearRegression
                      , Torch.GraduallyTyped.Examples.TwoLayerNetwork
                      , Torch.Language

--- a/experimental/gradually-typed/src/Torch/Data/Parser.hs
+++ b/experimental/gradually-typed/src/Torch/Data/Parser.hs
@@ -44,7 +44,7 @@ type Parser
   (a :: Type) =
   FreeT ((->) i) b a
 
-instance (Applicative f, MonadLogic b) => MonadLogic (FreeT f b) where
+instance (Applicative f, MonadLogic b, MonadPlus b) => MonadLogic (FreeT f b) where
   -- msplit :: FreeT f b a -> FreeT f b (Maybe (a, FreeT f b a))
   msplit (FreeT b) = FreeT $ go b []
     where

--- a/experimental/gradually-typed/src/Torch/GraduallyTyped/Internal/Vector.hs
+++ b/experimental/gradually-typed/src/Torch/GraduallyTyped/Internal/Vector.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE CPP #-}
+
+module Torch.GraduallyTyped.Internal.Vector where
+
+import qualified Data.Vector as V
+
+#if MIN_VERSION_vector(0,12,2)
+uncons :: V.Vector a -> Maybe (a, V.Vector a)
+uncons = V.uncons
+#else
+uncons :: V.Vector a -> Maybe (a, V.Vector a)
+uncons xs = flip (,) (V.unsafeTail xs) `fmap` (xs V.!? 0)
+#endif
+

--- a/experimental/gradually-typed/src/Torch/GraduallyTyped/NN/Class.hs
+++ b/experimental/gradually-typed/src/Torch/GraduallyTyped/NN/Class.hs
@@ -35,7 +35,8 @@ import Data.Singletons.TypeLits (SNat (..))
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Typeable (Typeable)
-import qualified Data.Vector as V
+import qualified Data.Vector as V hiding (uncons)
+import qualified Torch.GraduallyTyped.Internal.Vector as V
 import qualified Data.Vector.Generic.Sized.Internal as VGS
 import qualified Data.Vector.Sized as VS
 import Foreign.ForeignPtr (ForeignPtr)

--- a/experimental/gradually-typed/src/Torch/GraduallyTyped/NN/Transformer/GStack.hs
+++ b/experimental/gradually-typed/src/Torch/GraduallyTyped/NN/Transformer/GStack.hs
@@ -14,7 +14,8 @@ import Control.Monad.Indexed.State (IxStateT (..))
 import Data.Functor.Indexed ((<<$>>))
 import Data.Kind (Type)
 import Data.Singletons.TypeLits (SNat (..))
-import qualified Data.Vector as V
+import qualified Data.Vector as V hiding (uncons)
+import qualified Torch.GraduallyTyped.Internal.Vector as V
 import qualified Data.Vector.Generic.Sized.Internal as VGS
 import qualified Data.Vector.Sized as VS
 import GHC.TypeLits (type (+))

--- a/experimental/gradually-typed/src/Torch/GraduallyTyped/Tensor/IndexingSlicingJoining.hs
+++ b/experimental/gradually-typed/src/Torch/GraduallyTyped/Tensor/IndexingSlicingJoining.hs
@@ -59,32 +59,35 @@ class HasCat (selectDim :: SelectDim (By Symbol Nat)) k (c :: k -> Type) (a :: k
   -- >>> t <- ones @('Gradient 'WithGradient) @('Layout 'Dense) @('Device 'CPU) @('DataType 'Float) @('Shape '[ 'Dim ('Name "batch") ('Size 32), 'Dim ('Name "feature") ('Size 8)])
   -- >>> :type cat @('SelectDim ('ByName "feature")) [t]
   -- cat @('SelectDim ('ByName "feature")) [t]
-  --   :: Tensor
-  --        ('Gradient 'WithGradient)
-  --        ('Layout 'Dense)
-  --        ('Device 'CPU)
-  --        ('DataType 'Float)
-  --        ('Shape
-  --           '[ 'Dim ('Name "batch") ('Size 32),
-  --              'Dim 'UncheckedName 'UncheckedSize])
+  --   :: MonadThrow m =>
+  --      m (Tensor
+  --           ('Gradient 'WithGradient)
+  --           ('Layout 'Dense)
+  --           ('Device 'CPU)
+  --           ('DataType 'Float)
+  --           ('Shape
+  --              '[ 'Dim ('Name "batch") ('Size 32),
+  --                 'Dim 'UncheckedName 'UncheckedSize]))
   -- >>> :type cat @('SelectDim ( 'ByIndex 0)) [t]
   -- cat @('SelectDim ( 'ByIndex 0)) [t]
-  --   :: Tensor
-  --        ('Gradient 'WithGradient)
-  --        ('Layout 'Dense)
-  --        ('Device 'CPU)
-  --        ('DataType 'Float)
-  --        ('Shape
-  --           '[ 'Dim 'UncheckedName 'UncheckedSize,
-  --              'Dim ('Name "feature") ('Size 8)])
+  --   :: MonadThrow m =>
+  --      m (Tensor
+  --           ('Gradient 'WithGradient)
+  --           ('Layout 'Dense)
+  --           ('Device 'CPU)
+  --           ('DataType 'Float)
+  --           ('Shape
+  --              '[ 'Dim 'UncheckedName 'UncheckedSize,
+  --                 'Dim ('Name "feature") ('Size 8)]))
   -- >>> :type sCat (SUncheckedSelectDim (ByIndex 0)) [t]
   -- sCat (SUncheckedSelectDim (ByIndex 0)) [t]
-  --   :: Tensor
-  --        ('Gradient 'WithGradient)
-  --        ('Layout 'Dense)
-  --        ('Device 'CPU)
-  --        ('DataType 'Float)
-  --        'UncheckedShape
+  --   :: MonadThrow m =>
+  --      m (Tensor
+  --           ('Gradient 'WithGradient)
+  --           ('Layout 'Dense)
+  --           ('Device 'CPU)
+  --           ('DataType 'Float)
+  --           'UncheckedShape)
   sCat :: forall m. MonadThrow m => SSelectDim selectDim -> c a -> m (CatF selectDim a c)
 
   cat :: forall m. (SingI selectDim, MonadThrow m) => c a -> m (CatF selectDim a c)

--- a/experimental/gradually-typed/src/Torch/GraduallyTyped/Tensor/MathOperations/BlasLapack.hs
+++ b/experimental/gradually-typed/src/Torch/GraduallyTyped/Tensor/MathOperations/BlasLapack.hs
@@ -66,12 +66,13 @@ type family MatmulF (shape :: Shape [Dim (Name Symbol) (Size Nat)]) (shape' :: S
 --         >>> result = tensor1 `matmul` tensor2
 --         >>> :type result
 --         result
---           :: Tensor
---                ('Gradient 'WithGradient)
---                ('Layout 'Dense)
---                ('Device 'CPU)
---                ('DataType 'Float)
---                ('Shape '[])
+--           :: MonadThrow m =>
+--              m (Tensor
+--                   ('Gradient 'WithGradient)
+--                   ('Layout 'Dense)
+--                   ('Device 'CPU)
+--                   ('DataType 'Float)
+--                   ('Shape '[]))
 --
 --
 --     (2) If both arguments are 2-dimensional, the matrix-matrix product is returned:
@@ -81,12 +82,13 @@ type family MatmulF (shape :: Shape [Dim (Name Symbol) (Size Nat)]) (shape' :: S
 --         >>> result = tensor1 `matmul` tensor2
 --         >>> :type result
 --         result
---           :: Tensor
---                ('Gradient 'WithGradient)
---                ('Layout 'Dense)
---                ('Device 'CPU)
---                ('DataType 'Float)
---                ('Shape '[ 'Dim ('Name "*") ('Size 3), 'Dim ('Name "*") ('Size 7)])
+--           :: MonadThrow m =>
+--              m (Tensor
+--                   ('Gradient 'WithGradient)
+--                   ('Layout 'Dense)
+--                   ('Device 'CPU)
+--                   ('DataType 'Float)
+--                   ('Shape '[ 'Dim ('Name "*") ('Size 3), 'Dim ('Name "*") ('Size 7)]))
 --
 --
 --     (3) If the first argument is 1-dimensional and the second argument is 2-dimensional,
@@ -98,12 +100,13 @@ type family MatmulF (shape :: Shape [Dim (Name Symbol) (Size Nat)]) (shape' :: S
 --         >>> result = tensor1 `matmul` tensor2
 --         >>> :type result
 --         result
---           :: Tensor
---                ('Gradient 'WithGradient)
---                ('Layout 'Dense)
---                ('Device 'CPU)
---                ('DataType 'Float)
---                ('Shape '[ 'Dim ('Name "*") ('Size 7)])
+--           :: MonadThrow m =>
+--              m (Tensor
+--                   ('Gradient 'WithGradient)
+--                   ('Layout 'Dense)
+--                   ('Device 'CPU)
+--                   ('DataType 'Float)
+--                   ('Shape '[ 'Dim ('Name "*") ('Size 7)]))
 --
 --
 --     (4) If the first argument is 2-dimensional and the second argument is 1-dimensional,
@@ -114,12 +117,13 @@ type family MatmulF (shape :: Shape [Dim (Name Symbol) (Size Nat)]) (shape' :: S
 --         >>> result = tensor1 `matmul` tensor2
 --         >>> :type result
 --         result
---           :: Tensor
---                ('Gradient 'WithGradient)
---                ('Layout 'Dense)
---                ('Device 'CPU)
---                ('DataType 'Float)
---                ('Shape '[ 'Dim ('Name "*") ('Size 3)])
+--           :: MonadThrow m =>
+--              m (Tensor
+--                   ('Gradient 'WithGradient)
+--                   ('Layout 'Dense)
+--                   ('Device 'CPU)
+--                   ('DataType 'Float)
+--                   ('Shape '[ 'Dim ('Name "*") ('Size 3)]))
 --
 --
 --     (5) If both arguments are at least 1-dimensional and at least one argument is \(n\)-dimensional (where \(n > 2\)),
@@ -132,14 +136,15 @@ type family MatmulF (shape :: Shape [Dim (Name Symbol) (Size Nat)]) (shape' :: S
 --         >>> result = tensor1 `matmul` tensor2
 --         >>> :type result
 --         result
---           :: Tensor
---                ('Gradient 'WithGradient)
---                ('Layout 'Dense)
---                ('Device 'CPU)
---                ('DataType 'Float)
---                ('Shape
---                   '[ 'Dim ('Name "batch") ('Size 10), 'Dim ('Name "*") ('Size 3),
---                      'Dim ('Name "*") ('Size 7)])
+--           :: MonadThrow m =>
+--              m (Tensor
+--                   ('Gradient 'WithGradient)
+--                   ('Layout 'Dense)
+--                   ('Device 'CPU)
+--                   ('DataType 'Float)
+--                   ('Shape
+--                      '[ 'Dim ('Name "batch") ('Size 10), 'Dim ('Name "*") ('Size 3),
+--                         'Dim ('Name "*") ('Size 7)]))
 --
 --
 --     If the first argument is 1-dimensional,
@@ -150,13 +155,14 @@ type family MatmulF (shape :: Shape [Dim (Name Symbol) (Size Nat)]) (shape' :: S
 --         >>> result = tensor1 `matmul` tensor2
 --         >>> :type result
 --         result
---           :: Tensor
---                ('Gradient 'WithGradient)
---                ('Layout 'Dense)
---                ('Device 'CPU)
---                ('DataType 'Float)
---                ('Shape
---                   '[ 'Dim ('Name "batch") ('Size 10), 'Dim ('Name "*") ('Size 7)])
+--           :: MonadThrow m =>
+--              m (Tensor
+--                   ('Gradient 'WithGradient)
+--                   ('Layout 'Dense)
+--                   ('Device 'CPU)
+--                   ('DataType 'Float)
+--                   ('Shape
+--                      '[ 'Dim ('Name "batch") ('Size 10), 'Dim ('Name "*") ('Size 7)]))
 --
 --
 --     If the second argument is 1-dimensional,
@@ -167,13 +173,14 @@ type family MatmulF (shape :: Shape [Dim (Name Symbol) (Size Nat)]) (shape' :: S
 --         >>> result = tensor1 `matmul` tensor2
 --         >>> :type result
 --         result
---           :: Tensor
---                ('Gradient 'WithGradient)
---                ('Layout 'Dense)
---                ('Device 'CPU)
---                ('DataType 'Float)
---                ('Shape
---                   '[ 'Dim ('Name "batch") ('Size 10), 'Dim ('Name "*") ('Size 3)])
+--           :: MonadThrow m =>
+--              m (Tensor
+--                   ('Gradient 'WithGradient)
+--                   ('Layout 'Dense)
+--                   ('Device 'CPU)
+--                   ('DataType 'Float)
+--                   ('Shape
+--                      '[ 'Dim ('Name "batch") ('Size 10), 'Dim ('Name "*") ('Size 3)]))
 --
 --
 --     The non-matrix (i.e. batch) dimensions are broadcasted (and thus must be broadcastable).
@@ -185,14 +192,15 @@ type family MatmulF (shape :: Shape [Dim (Name Symbol) (Size Nat)]) (shape' :: S
 --         >>> result = tensor1 `matmul` tensor2
 --         >>> :type result
 --         result
---           :: Tensor
---                ('Gradient 'WithGradient)
---                ('Layout 'Dense)
---                ('Device 'CPU)
---                ('DataType 'Float)
---                ('Shape
---                   '[ 'Dim ('Name "batch") ('Size 10), 'Dim ('Name "*") ('Size 5),
---                      'Dim ('Name "*") ('Size 3), 'Dim ('Name "*") ('Size 7)])
+--           :: MonadThrow m =>
+--              m (Tensor
+--                   ('Gradient 'WithGradient)
+--                   ('Layout 'Dense)
+--                   ('Device 'CPU)
+--                   ('DataType 'Float)
+--                   ('Shape
+--                      '[ 'Dim ('Name "batch") ('Size 10), 'Dim ('Name "*") ('Size 5),
+--                         'Dim ('Name "*") ('Size 3), 'Dim ('Name "*") ('Size 7)]))
 matmul ::
   forall m gradient gradient' layout layout' device device' dataType dataType' shape shape'.
   MonadThrow m =>

--- a/experimental/gradually-typed/src/Torch/GraduallyTyped/Tensor/MathOperations/BlasLapack.hs
+++ b/experimental/gradually-typed/src/Torch/GraduallyTyped/Tensor/MathOperations/BlasLapack.hs
@@ -88,7 +88,8 @@ type family MatmulF (shape :: Shape [Dim (Name Symbol) (Size Nat)]) (shape' :: S
 --                   ('Layout 'Dense)
 --                   ('Device 'CPU)
 --                   ('DataType 'Float)
---                   ('Shape '[ 'Dim ('Name "*") ('Size 3), 'Dim ('Name "*") ('Size 7)]))
+--                   ('Shape
+--                      '[ 'Dim ('Name "*") ('Size 3), 'Dim ('Name "*") ('Size 7)]))
 --
 --
 --     (3) If the first argument is 1-dimensional and the second argument is 2-dimensional,

--- a/experimental/gradually-typed/src/Torch/GraduallyTyped/Tensor/Type.hs
+++ b/experimental/gradually-typed/src/Torch/GraduallyTyped/Tensor/Type.hs
@@ -43,7 +43,8 @@ import Data.Proxy (Proxy (..))
 import Data.Singletons (SingI (sing), fromSing)
 import Data.Singletons.Prelude.List (SList (..))
 import Data.Typeable (Typeable)
-import qualified Data.Vector as V
+import qualified Data.Vector as V hiding (uncons)
+import qualified Torch.GraduallyTyped.Internal.Vector as V
 import qualified Data.Vector.Generic.Sized.Internal as SVI
 import qualified Data.Vector.Sized as SV
 import Foreign (Ptr, Word8, castPtr, fromBool, peekElemOff, pokeElemOff, withForeignPtr)

--- a/setenv
+++ b/setenv
@@ -3,7 +3,7 @@
 # execute this command if needed when building on OSX if there are linker errors.
 # dylib files in extra-lib-dirs  don't get forwarded to ghc
 # in some versions of OSX. See https://github.com/commercialhaskell/stack/issues/1826
-HASKTORCH_LIB_PATH="$(pwd)/deps/libtorch/lib/:$(pwd)/deps/mklml/lib/"
+HASKTORCH_LIB_PATH="$(pwd)/deps/libtorch/lib/:$(pwd)/deps/mklml/lib/:$(pwd)/deps/libtokenizers/lib/"
 
 function add_vendor_lib_path {
     case "$(uname)" in

--- a/setup-cabal.sh
+++ b/setup-cabal.sh
@@ -32,6 +32,7 @@ package libtorch-ffi
 package *
   extra-lib-dirs: $(pwd)/deps/mklml/lib
   extra-lib-dirs: $(pwd)/deps/libtorch/lib
+  extra-lib-dirs: $(pwd)/deps/tokenizers/lib
 
 package libtorch-ffi
     ghc-options: -j${USED_NUM_CPU} +RTS -A128m -n2m -M${USED_MEM_GB} -RTS

--- a/stack.yaml
+++ b/stack.yaml
@@ -21,6 +21,7 @@ extra-include-dirs:
 extra-lib-dirs:
 - deps/libtorch/lib
 - deps/mklml/lib
+- deps/libtokenizers/lib
 
 extra-deps:
 - datasets-0.4.0@sha256:9bfd5b54c6c5e1e72384a890cf29bf85a02007e0a31c98753f7d225be3c7fa6a,4929
@@ -31,6 +32,10 @@ extra-deps:
 - require-0.4.10@sha256:41b096daaca0d6be49239add1149af9f34c84640d09a7ffa9b45c55f089b5dac,3759
 - git: https://github.com/mcwitt/tintin
   commit: cad1ab21e53a3c734e09143def4fe862ded9e67a
+- git: https://github.com/hasktorch/tokenizers
+  commit: e4208275b6e7d5e265d454819eec5ec626d4077b
+  subdirs:
+  - bindings/haskell/tokenizers-haskell
 
 allow-newer: true
 


### PR DESCRIPTION
This is to use gradually typed api in workflows other than nix.
I update get-deps.sh to install the shared library of libtokenizers_haskell.