### PR TITLE
Fix IOHK's cache

### DIFF
--- a/.github/workflows/nix-haddock-linux.yml
+++ b/.github/workflows/nix-haddock-linux.yml
@@ -21,7 +21,8 @@ jobs:
         df -h
     - uses: cachix/install-nix-action@v12
     - run: nix-env -iA cachix -f https://cachix.org/api/v1/install
-    - run: cachix use iohk
+    - run: |
+        ./setup-iohk-cache.sh
     - run: cachix use hasktorch
     - run: |
         nix-build -A combined-haddock

--- a/.github/workflows/nix-haddock-linux.yml
+++ b/.github/workflows/nix-haddock-linux.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: cachix/install-nix-action@v12
     - run: nix-env -iA cachix -f https://cachix.org/api/v1/install
     - run: |
-        ./setup-iohk-cache.sh
+        .github/workflows/setup-iohk-cache.sh
     - run: cachix use hasktorch
     - run: |
         nix-build -A combined-haddock

--- a/.github/workflows/nix-jupyterlab.yml
+++ b/.github/workflows/nix-jupyterlab.yml
@@ -22,6 +22,6 @@ jobs:
         name: hasktorch
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
     - run: |
-        ./setup-iohk-cache.sh
+        .github/workflows/setup-iohk-cache.sh
         export NIX_BUILD_CORES=1
         nix-shell nix/jupyter-shell.nix -j 1 --option sandbox false --command echo

--- a/.github/workflows/nix-jupyterlab.yml
+++ b/.github/workflows/nix-jupyterlab.yml
@@ -22,6 +22,6 @@ jobs:
         name: hasktorch
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
     - run: |
-        cachix use iohk
+        ./setup-iohk-cache.sh
         export NIX_BUILD_CORES=1
         nix-shell nix/jupyter-shell.nix -j 1 --option sandbox false --command echo

--- a/.github/workflows/nix-linux-cu10.yml
+++ b/.github/workflows/nix-linux-cu10.yml
@@ -46,7 +46,8 @@ jobs:
         with:
           name: hasktorch
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
-      - run: cachix use iohk
+      - run: |
+          ./setup-iohk-cache.sh
       - run: |
           nix-build -j 2 --arg cudaSupport true --argstr cudaMajorVersion 10 -A haskellPackages.libtorch-ffi.checks.spec
           nix-build -j 1 --arg cudaSupport true --argstr cudaMajorVersion 10 -A haskellPackages.hasktorch.checks.spec

--- a/.github/workflows/nix-linux-cu10.yml
+++ b/.github/workflows/nix-linux-cu10.yml
@@ -47,7 +47,7 @@ jobs:
           name: hasktorch
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
       - run: |
-          ./setup-iohk-cache.sh
+          .github/workflows/setup-iohk-cache.sh
       - run: |
           nix-build -j 2 --arg cudaSupport true --argstr cudaMajorVersion 10 -A haskellPackages.libtorch-ffi.checks.spec
           nix-build -j 1 --arg cudaSupport true --argstr cudaMajorVersion 10 -A haskellPackages.hasktorch.checks.spec

--- a/.github/workflows/nix-linux-cu11.yml
+++ b/.github/workflows/nix-linux-cu11.yml
@@ -47,7 +47,7 @@ jobs:
           name: hasktorch
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
       - run: |
-          ./setup-iohk-cache.sh
+          .github/workflows/setup-iohk-cache.sh
       - run: |
           nix-build -j 2 --arg cudaSupport true --argstr cudaMajorVersion 11 -A haskellPackages.libtorch-ffi.checks.spec
           nix-build -j 1 --arg cudaSupport true --argstr cudaMajorVersion 11 -A haskellPackages.hasktorch.checks.spec

--- a/.github/workflows/nix-linux-cu11.yml
+++ b/.github/workflows/nix-linux-cu11.yml
@@ -46,7 +46,8 @@ jobs:
         with:
           name: hasktorch
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
-      - run: cachix use iohk
+      - run: |
+          ./setup-iohk-cache.sh
       - run: |
           nix-build -j 2 --arg cudaSupport true --argstr cudaMajorVersion 11 -A haskellPackages.libtorch-ffi.checks.spec
           nix-build -j 1 --arg cudaSupport true --argstr cudaMajorVersion 11 -A haskellPackages.hasktorch.checks.spec

--- a/.github/workflows/nix-linux.yml
+++ b/.github/workflows/nix-linux.yml
@@ -45,7 +45,8 @@ jobs:
         with:
           name: hasktorch
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
-      - run: cachix use iohk
+      - run: |
+          ./setup-iohk-cache.sh
       - run: |
           ps -aux
           free

--- a/.github/workflows/nix-linux.yml
+++ b/.github/workflows/nix-linux.yml
@@ -46,7 +46,7 @@ jobs:
           name: hasktorch
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
       - run: |
-          ./setup-iohk-cache.sh
+          .github/workflows/setup-iohk-cache.sh
       - run: |
           ps -aux
           free

--- a/.github/workflows/nix-macos.yml
+++ b/.github/workflows/nix-macos.yml
@@ -24,7 +24,8 @@ jobs:
         with:
           name: hasktorch
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
-      - run: cachix use iohk
+      - run: |
+          ./setup-iohk-cache.sh
       - run: |
           nix-build -j 2 -A haskellPackages.libtorch-ffi.checks.spec
           nix-build -j 1 -A haskellPackages.hasktorch.checks.spec

--- a/.github/workflows/nix-macos.yml
+++ b/.github/workflows/nix-macos.yml
@@ -25,7 +25,7 @@ jobs:
           name: hasktorch
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
       - run: |
-          ./setup-iohk-cache.sh
+          .github/workflows/setup-iohk-cache.sh
       - run: |
           nix-build -j 2 -A haskellPackages.libtorch-ffi.checks.spec
           nix-build -j 1 -A haskellPackages.hasktorch.checks.spec

--- a/.github/workflows/setup-iohk-cache.sh
+++ b/.github/workflows/setup-iohk-cache.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
+cachix use iohk
+
 if ! grep hydra.iohk.io ~/.config/nix/nix.conf >& /dev/null; then
     sed -i -e 's/^\(substituters.*\)$/\1 https:\/\/hydra.iohk.io/g' ~/.config/nix/nix.conf
     sed -i -e 's/^\(trusted-public-keys.*\)$/\1 hydra.iohk.io:f\/Ea+s+dFdN+3Y\/G+FDgSq+a5NEWhJGzdjvKNGv0\/EQ=/g' ~/.config/nix/nix.conf
 else
     echo hydra.iohk.io is already set.
 fi
-
-cachix use iohk

--- a/.github/workflows/stack-nix-linux.yml
+++ b/.github/workflows/stack-nix-linux.yml
@@ -28,7 +28,8 @@ jobs:
           name: hasktorch
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
       - run: nix-env -iA cachix -f https://cachix.org/api/v1/install
-      - run: cachix use iohk
+      - run: |
+          ./setup-iohk-cache.sh
       - name: Cache .stack
         id: cache-stack
         uses: actions/cache@v2

--- a/.github/workflows/stack-nix-linux.yml
+++ b/.github/workflows/stack-nix-linux.yml
@@ -29,7 +29,7 @@ jobs:
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
       - run: nix-env -iA cachix -f https://cachix.org/api/v1/install
       - run: |
-          ./setup-iohk-cache.sh
+          .github/workflows/setup-iohk-cache.sh
       - name: Cache .stack
         id: cache-stack
         uses: actions/cache@v2

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ $ stack run static-mnist-cnn     # Run the MNIST CNN example.
 
 ```sh
 $ nix-env -iA cachix -f https://cachix.org/api/v1/install  # (Optional) Install Cachix.
-$ cachix use iohk                                          # (Optional) Use IOHK's cache.
+$ ./setup-iohk-cache.sh                                    # (Optional) Use IOHK's cache.
 $ cachix use hasktorch                                     # (Optional) Use hasktorch's cache.
 ```
 
@@ -277,7 +277,7 @@ $ cabal run static-mnist-cnn    # Run the MNIST CNN example.
 
 ```sh
 $ nix-env -iA cachix -f https://cachix.org/api/v1/install  # (Optional) Install Cachix.
-$ cachix use iohk                                          # (Optional) Use IOHK's cache.
+$ ./setup-iohk-cache.sh                                    # (Optional) Use IOHK's cache.
 $ cachix use hasktorch                                     # (Optional) Use hasktorch's cache.
 ```
 

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ $ stack run static-mnist-cnn     # Run the MNIST CNN example.
 
 ```sh
 $ nix-env -iA cachix -f https://cachix.org/api/v1/install  # (Optional) Install Cachix.
-$ ./setup-iohk-cache.sh                                    # (Optional) Use IOHK's cache.
+# (Optional) Use IOHK's cache. See https://input-output-hk.github.io/haskell.nix/tutorials/getting-started/#setting-up-the-binary-cache
 $ cachix use hasktorch                                     # (Optional) Use hasktorch's cache.
 ```
 
@@ -277,7 +277,7 @@ $ cabal run static-mnist-cnn    # Run the MNIST CNN example.
 
 ```sh
 $ nix-env -iA cachix -f https://cachix.org/api/v1/install  # (Optional) Install Cachix.
-$ ./setup-iohk-cache.sh                                    # (Optional) Use IOHK's cache.
+# (Optional) Use IOHK's cache. See https://input-output-hk.github.io/haskell.nix/tutorials/getting-started/#setting-up-the-binary-cache
 $ cachix use hasktorch                                     # (Optional) Use hasktorch's cache.
 ```
 

--- a/setup-iohk-cache.sh
+++ b/setup-iohk-cache.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+if ! grep hydra.iohk.io ~/.config/nix/nix.conf >& /dev/null; then
+    sed -i -e 's/^\(substituters.*\)$/\1 https:\/\/hydra.iohk.io/g' ~/.config/nix/nix.conf
+    sed -i -e 's/^\(trusted-public-keys.*\)$/\1 hydra.iohk.io:f\/Ea+s+dFdN+3Y\/G+FDgSq+a5NEWhJGzdjvKNGv0\/EQ=/g' ~/.config/nix/nix.conf
+else
+    echo hydra.iohk.io is already set.
+fi
+
+cachix use iohk


### PR DESCRIPTION
To use cached ghc of IOHK, update substituters of nix.

https://input-output-hk.github.io/haskell.nix/tutorials/getting-started/

Both cachix and hydra are set in the plutus-community documentation, so both are set in the same way.
https://docs.plutus-community.com/docs/setup/Ubuntu.html
