### PR TITLE
Change the apt source of libtorch to apt-hasktorch.com with cloudflare

### DIFF
--- a/.github/workflows/cabal-linux.yml
+++ b/.github/workflows/cabal-linux.yml
@@ -13,7 +13,7 @@ jobs:
         sudo apt update -qq
         sudo apt -y --allow-downgrades --allow-remove-essential --allow-change-held-packages install locales software-properties-common apt-transport-https
         sudo add-apt-repository -y ppa:hvr/ghc
-        sudo bash -c "echo deb [trusted=yes] https://github.com/hasktorch/libtorch-binary-for-ci/releases/download/apt ./ > /etc/apt/sources.list.d/libtorch.list"
+        sudo bash -c "echo deb [trusted=yes] https://apt-hasktorch.com/apt ./ > /etc/apt/sources.list.d/libtorch.list"
         sudo rm -f /etc/apt/sources.list.d/sbt.list
         sudo apt update -qq
         sudo apt -y purge ghc* cabal-install* php* || true


### PR DESCRIPTION
The files of github-releases become having short time token with redirect url.
Current apt of linux does not work with github-releases, because the query string of the redirect URL is processed incorrectly.
 We've decided to put the assets on our instance from github-releases.
The files of instance are cached in cloudflare.
