### PR TITLE
Rename Aux to Auxiliary

### DIFF
--- a/hasktorch/hasktorch.cabal
+++ b/hasktorch/hasktorch.cabal
@@ -51,14 +51,14 @@ library
                     , Torch.HList
                     , Torch.Lens
                     , Torch.Typed
-                    , Torch.Typed.Aux
+                    , Torch.Typed.Auxiliary
                     , Torch.Typed.Factories
                     , Torch.Typed.Functional
                     , Torch.Typed.NN
                     , Torch.Typed.NN.Convolution
                     , Torch.Typed.NN.Normalization
                     , Torch.Typed.NN.Recurrent
-                    , Torch.Typed.NN.Recurrent.Aux
+                    , Torch.Typed.NN.Recurrent.Auxiliary
                     , Torch.Typed.NN.Recurrent.Cell.LSTM
                     , Torch.Typed.NN.Recurrent.Cell.GRU
                     , Torch.Typed.NN.Recurrent.LSTM
@@ -154,7 +154,7 @@ test-suite spec
                     , NNSpec
                     , DimnameSpec
                     , PipelineSpec
-                    , Torch.Typed.AuxSpec
+                    , Torch.Typed.AuxiliarySpec
                     , Torch.Typed.TensorSpec0
                     , Torch.Typed.TensorSpec1
                     , Torch.Typed.FactoriesSpec

--- a/hasktorch/src/Torch/Typed.hs
+++ b/hasktorch/src/Torch/Typed.hs
@@ -2,7 +2,7 @@ module Torch.Typed
   ( module Torch.HList,
     module Torch.Typed,
     module Torch.Data,
-    module Torch.Typed.Aux,
+    module Torch.Typed.Auxiliary,
     module Torch.Typed.Autograd,
     module Torch.Typed.Device,
     module Torch.Typed.DType,
@@ -30,7 +30,7 @@ import Torch.Functional (Reduction (..), Tri (..))
 import Torch.HList
 import Torch.Scalar (Scalar (..))
 import Torch.Typed.Autograd
-import Torch.Typed.Aux
+import Torch.Typed.Auxiliary
 import Torch.Typed.DType
 import Torch.Typed.Device
 import Torch.Typed.Factories

--- a/hasktorch/src/Torch/Typed/Auxiliary.hs
+++ b/hasktorch/src/Torch/Typed/Auxiliary.hs
@@ -10,7 +10,7 @@
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-module Torch.Typed.Aux where
+module Torch.Typed.Auxiliary where
 
 import qualified Data.Int as I
 import Data.Kind
@@ -28,10 +28,10 @@ natValInt16 :: forall n. KnownNat n => I.Int16
 natValInt16 = fromIntegral $ natVal $ Proxy @n
 
 type family Fst (t :: (a, b)) :: a where
-  Torch.Typed.Aux.Fst '(x, _) = x
+  Torch.Typed.Auxiliary.Fst '(x, _) = x
 
 type family Snd (t :: (a, b)) :: b where
-  Torch.Typed.Aux.Snd '(_, x) = x
+  Torch.Typed.Auxiliary.Snd '(_, x) = x
 
 type family Fst3 (t :: (a, b, c)) :: a where
   Fst3 '(x, _, _) = x

--- a/hasktorch/src/Torch/Typed/Device.hs
+++ b/hasktorch/src/Torch/Typed/Device.hs
@@ -27,7 +27,7 @@ import qualified Torch.Internal.Cast as ATen
 import qualified Torch.Internal.Class as ATen
 import qualified Torch.Internal.Managed.Autograd as LibTorch
 import qualified Torch.Tensor as D
-import Torch.Typed.Aux
+import Torch.Typed.Auxiliary
 import Torch.Typed.Functional
 import Torch.Typed.Parameter
 import Torch.Typed.Tensor

--- a/hasktorch/src/Torch/Typed/Factories.hs
+++ b/hasktorch/src/Torch/Typed/Factories.hs
@@ -33,7 +33,7 @@ import qualified Torch.Scalar as D
 import qualified Torch.Tensor as D
 import qualified Torch.TensorFactories as D
 import qualified Torch.TensorOptions as D
-import Torch.Typed.Aux
+import Torch.Typed.Auxiliary
 import Torch.Typed.Tensor
 import Prelude hiding (sin)
 

--- a/hasktorch/src/Torch/Typed/Functional.hs
+++ b/hasktorch/src/Torch/Typed/Functional.hs
@@ -58,7 +58,7 @@ import qualified Torch.Scalar as D
 import qualified Torch.Tensor as D
 import qualified Torch.TensorFactories as D
 import qualified Torch.TensorOptions as D
-import Torch.Typed.Aux
+import Torch.Typed.Auxiliary
 import Torch.Typed.Factories
 import Torch.Typed.Tensor
 import Prelude hiding
@@ -2411,16 +2411,16 @@ cudnnIsAcceptable input =
 
 constantPadNd1d ::
   forall (pad :: (Nat, Nat)) n dtype device.
-  (All KnownNat '[Torch.Typed.Aux.Fst pad, Torch.Typed.Aux.Snd pad, n]) =>
+  (All KnownNat '[Torch.Typed.Auxiliary.Fst pad, Torch.Typed.Auxiliary.Snd pad, n]) =>
   Float ->
   Tensor device dtype '[n] ->
-  Tensor device dtype '[n + Torch.Typed.Aux.Fst pad + Torch.Typed.Aux.Snd pad]
+  Tensor device dtype '[n + Torch.Typed.Auxiliary.Fst pad + Torch.Typed.Auxiliary.Snd pad]
 constantPadNd1d value input =
   unsafePerformIO $
     ATen.cast3
       ATen.Managed.constant_pad_nd_tls
       input
-      ([natValI @(Torch.Typed.Aux.Fst pad), natValI @(Torch.Typed.Aux.Snd pad)] :: [Int])
+      ([natValI @(Torch.Typed.Auxiliary.Fst pad), natValI @(Torch.Typed.Auxiliary.Snd pad)] :: [Int])
       value
 
 -- convolution :: Tensor device dtype shape -> Tensor device dtype shape -> Tensor device dtype shape -> [Int] -> [Int] -> [Int] -> Bool -> [Int] -> Int -> Tensor device dtype shape
@@ -2525,10 +2525,10 @@ conv2d ::
     device.
   ( All
       KnownNat
-      '[ Torch.Typed.Aux.Fst stride,
-         Torch.Typed.Aux.Snd stride,
-         Torch.Typed.Aux.Fst padding,
-         Torch.Typed.Aux.Snd padding,
+      '[ Torch.Typed.Auxiliary.Fst stride,
+         Torch.Typed.Auxiliary.Snd stride,
+         Torch.Typed.Auxiliary.Fst padding,
+         Torch.Typed.Auxiliary.Snd padding,
          inputChannelSize,
          outputChannelSize,
          kernelSize0,
@@ -2539,8 +2539,8 @@ conv2d ::
          outputSize0,
          outputSize1
        ],
-    ConvSideCheck inputSize0 kernelSize0 (Torch.Typed.Aux.Fst stride) (Torch.Typed.Aux.Fst padding) outputSize0,
-    ConvSideCheck inputSize1 kernelSize1 (Torch.Typed.Aux.Snd stride) (Torch.Typed.Aux.Snd padding) outputSize1
+    ConvSideCheck inputSize0 kernelSize0 (Torch.Typed.Auxiliary.Fst stride) (Torch.Typed.Auxiliary.Fst padding) outputSize0,
+    ConvSideCheck inputSize1 kernelSize1 (Torch.Typed.Auxiliary.Snd stride) (Torch.Typed.Auxiliary.Snd padding) outputSize1
   ) =>
   -- | weight
   Tensor device dtype '[outputChannelSize, inputChannelSize, kernelSize0, kernelSize1] ->
@@ -2557,8 +2557,8 @@ conv2d weight bias input =
       input
       weight
       bias
-      ([natValI @(Torch.Typed.Aux.Fst stride), natValI @(Torch.Typed.Aux.Snd stride)] :: [Int])
-      ([natValI @(Torch.Typed.Aux.Fst padding), natValI @(Torch.Typed.Aux.Snd padding)] :: [Int])
+      ([natValI @(Torch.Typed.Auxiliary.Fst stride), natValI @(Torch.Typed.Auxiliary.Snd stride)] :: [Int])
+      ([natValI @(Torch.Typed.Auxiliary.Fst padding), natValI @(Torch.Typed.Auxiliary.Snd padding)] :: [Int])
       ([1, 1] :: [Int])
       (1 :: Int)
 
@@ -2728,10 +2728,10 @@ convTranspose2d ::
     device.
   ( All
       KnownNat
-      '[ Torch.Typed.Aux.Fst stride,
-         Torch.Typed.Aux.Snd stride,
-         Torch.Typed.Aux.Fst padding,
-         Torch.Typed.Aux.Snd padding,
+      '[ Torch.Typed.Auxiliary.Fst stride,
+         Torch.Typed.Auxiliary.Snd stride,
+         Torch.Typed.Auxiliary.Fst padding,
+         Torch.Typed.Auxiliary.Snd padding,
          inputChannelSize,
          outputChannelSize,
          kernelSize0,
@@ -2742,8 +2742,8 @@ convTranspose2d ::
          outputSize0,
          outputSize1
        ],
-    ConvSideCheck inputSize0 kernelSize0 (Torch.Typed.Aux.Fst stride) (Torch.Typed.Aux.Fst padding) outputSize0,
-    ConvSideCheck inputSize1 kernelSize1 (Torch.Typed.Aux.Snd stride) (Torch.Typed.Aux.Snd padding) outputSize1
+    ConvSideCheck inputSize0 kernelSize0 (Torch.Typed.Auxiliary.Fst stride) (Torch.Typed.Auxiliary.Fst padding) outputSize0,
+    ConvSideCheck inputSize1 kernelSize1 (Torch.Typed.Auxiliary.Snd stride) (Torch.Typed.Auxiliary.Snd padding) outputSize1
   ) =>
   -- | weight
   Tensor device dtype '[inputChannelSize, outputChannelSize, kernelSize0, kernelSize1] ->
@@ -2760,8 +2760,8 @@ convTranspose2d weight bias input =
       input
       weight
       bias
-      ([natValI @(Torch.Typed.Aux.Fst stride), natValI @(Torch.Typed.Aux.Snd stride)] :: [Int])
-      ([natValI @(Torch.Typed.Aux.Fst padding), natValI @(Torch.Typed.Aux.Snd padding)] :: [Int])
+      ([natValI @(Torch.Typed.Auxiliary.Fst stride), natValI @(Torch.Typed.Auxiliary.Snd stride)] :: [Int])
+      ([natValI @(Torch.Typed.Auxiliary.Fst padding), natValI @(Torch.Typed.Auxiliary.Snd padding)] :: [Int])
       ([0, 0] :: [Int])
       (1 :: Int)
 
@@ -3710,19 +3710,19 @@ maxPool2d ::
   forall kernelSize stride padding channelSize inputSize0 inputSize1 batchSize outputSize0 outputSize1 dtype device.
   ( All
       KnownNat
-      '[ Torch.Typed.Aux.Fst kernelSize,
-         Torch.Typed.Aux.Snd kernelSize,
-         Torch.Typed.Aux.Fst stride,
-         Torch.Typed.Aux.Snd stride,
-         Torch.Typed.Aux.Fst padding,
-         Torch.Typed.Aux.Snd padding,
+      '[ Torch.Typed.Auxiliary.Fst kernelSize,
+         Torch.Typed.Auxiliary.Snd kernelSize,
+         Torch.Typed.Auxiliary.Fst stride,
+         Torch.Typed.Auxiliary.Snd stride,
+         Torch.Typed.Auxiliary.Fst padding,
+         Torch.Typed.Auxiliary.Snd padding,
          channelSize,
          inputSize0,
          inputSize1,
          batchSize
        ],
-    ConvSideCheck inputSize0 (Torch.Typed.Aux.Fst kernelSize) (Torch.Typed.Aux.Fst stride) (Torch.Typed.Aux.Fst padding) outputSize0,
-    ConvSideCheck inputSize1 (Torch.Typed.Aux.Snd kernelSize) (Torch.Typed.Aux.Snd stride) (Torch.Typed.Aux.Snd padding) outputSize1
+    ConvSideCheck inputSize0 (Torch.Typed.Auxiliary.Fst kernelSize) (Torch.Typed.Auxiliary.Fst stride) (Torch.Typed.Auxiliary.Fst padding) outputSize0,
+    ConvSideCheck inputSize1 (Torch.Typed.Auxiliary.Snd kernelSize) (Torch.Typed.Auxiliary.Snd stride) (Torch.Typed.Auxiliary.Snd padding) outputSize1
   ) =>
   -- | input
   Tensor device dtype '[batchSize, channelSize, inputSize0, inputSize1] ->
@@ -3733,9 +3733,9 @@ maxPool2d input =
     ATen.cast6
       ATen.Managed.max_pool2d_tllllb
       input
-      ([natValI @(Torch.Typed.Aux.Fst kernelSize), natValI @(Torch.Typed.Aux.Snd kernelSize)] :: [Int])
-      ([natValI @(Torch.Typed.Aux.Fst stride), natValI @(Torch.Typed.Aux.Snd stride)] :: [Int])
-      ([natValI @(Torch.Typed.Aux.Fst padding), natValI @(Torch.Typed.Aux.Snd padding)] :: [Int])
+      ([natValI @(Torch.Typed.Auxiliary.Fst kernelSize), natValI @(Torch.Typed.Auxiliary.Snd kernelSize)] :: [Int])
+      ([natValI @(Torch.Typed.Auxiliary.Fst stride), natValI @(Torch.Typed.Auxiliary.Snd stride)] :: [Int])
+      ([natValI @(Torch.Typed.Auxiliary.Fst padding), natValI @(Torch.Typed.Auxiliary.Snd padding)] :: [Int])
       ([1, 1] :: [Int])
       False
 
@@ -3752,19 +3752,19 @@ mkldnnMaxPool2d ::
   forall kernelSize stride padding channelSize inputSize0 inputSize1 batchSize outputSize0 outputSize1 dtype device.
   ( All
       KnownNat
-      '[ Torch.Typed.Aux.Fst kernelSize,
-         Torch.Typed.Aux.Snd kernelSize,
-         Torch.Typed.Aux.Fst stride,
-         Torch.Typed.Aux.Snd stride,
-         Torch.Typed.Aux.Fst padding,
-         Torch.Typed.Aux.Snd padding,
+      '[ Torch.Typed.Auxiliary.Fst kernelSize,
+         Torch.Typed.Auxiliary.Snd kernelSize,
+         Torch.Typed.Auxiliary.Fst stride,
+         Torch.Typed.Auxiliary.Snd stride,
+         Torch.Typed.Auxiliary.Fst padding,
+         Torch.Typed.Auxiliary.Snd padding,
          channelSize,
          inputSize0,
          inputSize1,
          batchSize
        ],
-    ConvSideCheck inputSize0 (Torch.Typed.Aux.Fst kernelSize) (Torch.Typed.Aux.Fst stride) (Torch.Typed.Aux.Fst padding) outputSize0,
-    ConvSideCheck inputSize1 (Torch.Typed.Aux.Snd kernelSize) (Torch.Typed.Aux.Snd stride) (Torch.Typed.Aux.Snd padding) outputSize1
+    ConvSideCheck inputSize0 (Torch.Typed.Auxiliary.Fst kernelSize) (Torch.Typed.Auxiliary.Fst stride) (Torch.Typed.Auxiliary.Fst padding) outputSize0,
+    ConvSideCheck inputSize1 (Torch.Typed.Auxiliary.Snd kernelSize) (Torch.Typed.Auxiliary.Snd stride) (Torch.Typed.Auxiliary.Snd padding) outputSize1
   ) =>
   -- | input
   Tensor device dtype '[batchSize, channelSize, inputSize0, inputSize1] ->
@@ -3775,9 +3775,9 @@ mkldnnMaxPool2d input =
     ATen.cast6
       ATen.Managed.mkldnn_max_pool2d_tllllb
       input
-      ([natValI @(Torch.Typed.Aux.Fst kernelSize), natValI @(Torch.Typed.Aux.Snd kernelSize)] :: [Int])
-      ([natValI @(Torch.Typed.Aux.Fst stride), natValI @(Torch.Typed.Aux.Snd stride)] :: [Int])
-      ([natValI @(Torch.Typed.Aux.Fst padding), natValI @(Torch.Typed.Aux.Snd padding)] :: [Int])
+      ([natValI @(Torch.Typed.Auxiliary.Fst kernelSize), natValI @(Torch.Typed.Auxiliary.Snd kernelSize)] :: [Int])
+      ([natValI @(Torch.Typed.Auxiliary.Fst stride), natValI @(Torch.Typed.Auxiliary.Snd stride)] :: [Int])
+      ([natValI @(Torch.Typed.Auxiliary.Fst padding), natValI @(Torch.Typed.Auxiliary.Snd padding)] :: [Int])
       ([1, 1] :: [Int])
       False
 
@@ -3793,19 +3793,19 @@ quantizedMaxPool2d ::
   forall kernelSize stride padding channelSize inputSize0 inputSize1 batchSize outputSize0 outputSize1 dtype device.
   ( All
       KnownNat
-      '[ Torch.Typed.Aux.Fst kernelSize,
-         Torch.Typed.Aux.Snd kernelSize,
-         Torch.Typed.Aux.Fst stride,
-         Torch.Typed.Aux.Snd stride,
-         Torch.Typed.Aux.Fst padding,
-         Torch.Typed.Aux.Snd padding,
+      '[ Torch.Typed.Auxiliary.Fst kernelSize,
+         Torch.Typed.Auxiliary.Snd kernelSize,
+         Torch.Typed.Auxiliary.Fst stride,
+         Torch.Typed.Auxiliary.Snd stride,
+         Torch.Typed.Auxiliary.Fst padding,
+         Torch.Typed.Auxiliary.Snd padding,
          channelSize,
          inputSize0,
          inputSize1,
          batchSize
        ],
-    ConvSideCheck inputSize0 (Torch.Typed.Aux.Fst kernelSize) (Torch.Typed.Aux.Fst stride) (Torch.Typed.Aux.Fst padding) outputSize0,
-    ConvSideCheck inputSize1 (Torch.Typed.Aux.Snd kernelSize) (Torch.Typed.Aux.Snd stride) (Torch.Typed.Aux.Snd padding) outputSize1
+    ConvSideCheck inputSize0 (Torch.Typed.Auxiliary.Fst kernelSize) (Torch.Typed.Auxiliary.Fst stride) (Torch.Typed.Auxiliary.Fst padding) outputSize0,
+    ConvSideCheck inputSize1 (Torch.Typed.Auxiliary.Snd kernelSize) (Torch.Typed.Auxiliary.Snd stride) (Torch.Typed.Auxiliary.Snd padding) outputSize1
   ) =>
   -- | input
   Tensor device dtype '[batchSize, channelSize, inputSize0, inputSize1] ->
@@ -3816,9 +3816,9 @@ quantizedMaxPool2d input =
     ATen.cast5
       ATen.Managed.quantized_max_pool2d_tllll
       input
-      ([natValI @(Torch.Typed.Aux.Fst kernelSize), natValI @(Torch.Typed.Aux.Snd kernelSize)] :: [Int])
-      ([natValI @(Torch.Typed.Aux.Fst stride), natValI @(Torch.Typed.Aux.Snd stride)] :: [Int])
-      ([natValI @(Torch.Typed.Aux.Fst padding), natValI @(Torch.Typed.Aux.Snd padding)] :: [Int])
+      ([natValI @(Torch.Typed.Auxiliary.Fst kernelSize), natValI @(Torch.Typed.Auxiliary.Snd kernelSize)] :: [Int])
+      ([natValI @(Torch.Typed.Auxiliary.Fst stride), natValI @(Torch.Typed.Auxiliary.Snd stride)] :: [Int])
+      ([natValI @(Torch.Typed.Auxiliary.Fst padding), natValI @(Torch.Typed.Auxiliary.Snd padding)] :: [Int])
       ([1, 1] :: [Int])
 
 -- | maxPool3d
@@ -5684,20 +5684,20 @@ adaptiveAvgPool2d ::
          inputSize0,
          inputSize1,
          batchSize,
-         Torch.Typed.Aux.Fst outputSize,
-         Torch.Typed.Aux.Snd outputSize
+         Torch.Typed.Auxiliary.Fst outputSize,
+         Torch.Typed.Auxiliary.Snd outputSize
        ]
   ) =>
   -- | input
   Tensor device dtype '[batchSize, channelSize, inputSize0, inputSize1] ->
   -- | output
-  Tensor device dtype '[batchSize, channelSize, Torch.Typed.Aux.Fst outputSize, Torch.Typed.Aux.Snd outputSize]
+  Tensor device dtype '[batchSize, channelSize, Torch.Typed.Auxiliary.Fst outputSize, Torch.Typed.Auxiliary.Snd outputSize]
 adaptiveAvgPool2d input =
   unsafePerformIO $
     ATen.cast2
       ATen.Managed.adaptive_avg_pool2d_tl
       input
-      ([natValI @(Torch.Typed.Aux.Fst outputSize), natValI @(Torch.Typed.Aux.Snd outputSize)] :: [Int])
+      ([natValI @(Torch.Typed.Auxiliary.Fst outputSize), natValI @(Torch.Typed.Auxiliary.Snd outputSize)] :: [Int])
 
 -- | MKLDNN adaptive averaged 2-D pooling
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -5719,20 +5719,20 @@ mkldnnAdaptiveAvgPool2d ::
          inputSize0,
          inputSize1,
          batchSize,
-         Torch.Typed.Aux.Fst outputSize,
-         Torch.Typed.Aux.Snd outputSize
+         Torch.Typed.Auxiliary.Fst outputSize,
+         Torch.Typed.Auxiliary.Snd outputSize
        ]
   ) =>
   -- | input
   Tensor device dtype '[batchSize, channelSize, inputSize0, inputSize1] ->
   -- | output
-  Tensor device dtype '[batchSize, channelSize, Torch.Typed.Aux.Fst outputSize, Torch.Typed.Aux.Snd outputSize]
+  Tensor device dtype '[batchSize, channelSize, Torch.Typed.Auxiliary.Fst outputSize, Torch.Typed.Auxiliary.Snd outputSize]
 mkldnnAdaptiveAvgPool2d input =
   unsafePerformIO $
     ATen.cast2
       ATen.Managed.adaptive_avg_pool2d_tl
       input
-      ([natValI @(Torch.Typed.Aux.Fst outputSize), natValI @(Torch.Typed.Aux.Snd outputSize)] :: [Int])
+      ([natValI @(Torch.Typed.Auxiliary.Fst outputSize), natValI @(Torch.Typed.Auxiliary.Snd outputSize)] :: [Int])
 
 -- | adaptive averaged 3-D pooling
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -5796,22 +5796,22 @@ adaptiveMaxPool2d ::
          inputSize0,
          inputSize1,
          batchSize,
-         Torch.Typed.Aux.Fst outputSize,
-         Torch.Typed.Aux.Snd outputSize
+         Torch.Typed.Auxiliary.Fst outputSize,
+         Torch.Typed.Auxiliary.Snd outputSize
        ]
   ) =>
   -- | input
   Tensor device dtype '[batchSize, channelSize, inputSize0, inputSize1] ->
   -- | output
-  ( Tensor device dtype '[batchSize, channelSize, Torch.Typed.Aux.Fst outputSize, Torch.Typed.Aux.Snd outputSize],
-    Tensor device 'D.Int64 '[batchSize, channelSize, Torch.Typed.Aux.Fst outputSize, Torch.Typed.Aux.Snd outputSize]
+  ( Tensor device dtype '[batchSize, channelSize, Torch.Typed.Auxiliary.Fst outputSize, Torch.Typed.Auxiliary.Snd outputSize],
+    Tensor device 'D.Int64 '[batchSize, channelSize, Torch.Typed.Auxiliary.Fst outputSize, Torch.Typed.Auxiliary.Snd outputSize]
   )
 adaptiveMaxPool2d input =
   unsafePerformIO $
     ATen.cast2
       ATen.Managed.adaptive_max_pool2d_tl
       input
-      ([natValI @(Torch.Typed.Aux.Fst outputSize), natValI @(Torch.Typed.Aux.Snd outputSize)] :: [Int])
+      ([natValI @(Torch.Typed.Auxiliary.Fst outputSize), natValI @(Torch.Typed.Auxiliary.Snd outputSize)] :: [Int])
 
 -- | adaptive 3-D max-pool
 -- TODO: probably only defined for floating point tensors, or maybe numeric type is lifted?
@@ -5883,19 +5883,19 @@ avgPool2d ::
     device.
   ( All
       KnownNat
-      '[ Torch.Typed.Aux.Fst kernelSize,
-         Torch.Typed.Aux.Snd kernelSize,
-         Torch.Typed.Aux.Fst stride,
-         Torch.Typed.Aux.Snd stride,
-         Torch.Typed.Aux.Fst padding,
-         Torch.Typed.Aux.Snd padding,
+      '[ Torch.Typed.Auxiliary.Fst kernelSize,
+         Torch.Typed.Auxiliary.Snd kernelSize,
+         Torch.Typed.Auxiliary.Fst stride,
+         Torch.Typed.Auxiliary.Snd stride,
+         Torch.Typed.Auxiliary.Fst padding,
+         Torch.Typed.Auxiliary.Snd padding,
          channelSize,
          inputSize0,
          inputSize1,
          batchSize
        ],
-    ConvSideCheck inputSize0 (Torch.Typed.Aux.Fst kernelSize) (Torch.Typed.Aux.Fst stride) (Torch.Typed.Aux.Fst padding) outputSize0,
-    ConvSideCheck inputSize1 (Torch.Typed.Aux.Snd kernelSize) (Torch.Typed.Aux.Snd stride) (Torch.Typed.Aux.Snd padding) outputSize1
+    ConvSideCheck inputSize0 (Torch.Typed.Auxiliary.Fst kernelSize) (Torch.Typed.Auxiliary.Fst stride) (Torch.Typed.Auxiliary.Fst padding) outputSize0,
+    ConvSideCheck inputSize1 (Torch.Typed.Auxiliary.Snd kernelSize) (Torch.Typed.Auxiliary.Snd stride) (Torch.Typed.Auxiliary.Snd padding) outputSize1
   ) =>
   -- | input
   Tensor device dtype '[batchSize, channelSize, inputSize0, inputSize1] ->
@@ -5906,9 +5906,9 @@ avgPool2d input =
     ATen.cast7
       ATen.Managed.avg_pool2d_tlllbbl
       input
-      ([natValI @(Torch.Typed.Aux.Fst kernelSize), natValI @(Torch.Typed.Aux.Snd kernelSize)] :: [Int])
-      ([natValI @(Torch.Typed.Aux.Fst stride), natValI @(Torch.Typed.Aux.Snd stride)] :: [Int])
-      ([natValI @(Torch.Typed.Aux.Fst padding), natValI @(Torch.Typed.Aux.Snd padding)] :: [Int])
+      ([natValI @(Torch.Typed.Auxiliary.Fst kernelSize), natValI @(Torch.Typed.Auxiliary.Snd kernelSize)] :: [Int])
+      ([natValI @(Torch.Typed.Auxiliary.Fst stride), natValI @(Torch.Typed.Auxiliary.Snd stride)] :: [Int])
+      ([natValI @(Torch.Typed.Auxiliary.Fst padding), natValI @(Torch.Typed.Auxiliary.Snd padding)] :: [Int])
       False
       True
       (1 :: Int)

--- a/hasktorch/src/Torch/Typed/Lens.hs
+++ b/hasktorch/src/Torch/Typed/Lens.hs
@@ -34,7 +34,7 @@ import qualified Torch.Functional.Internal as I
 import qualified Torch.Internal.Managed.Type.TensorIndex as ATen
 import Torch.Lens (Lens, Lens', Traversal, Traversal')
 import qualified Torch.Tensor as T
-import Torch.Typed.Aux hiding (If)
+import Torch.Typed.Auxiliary hiding (If)
 import Torch.Typed.Tensor
 
 class HasName (name :: Type -> Type) shape where

--- a/hasktorch/src/Torch/Typed/NN/Convolution.hs
+++ b/hasktorch/src/Torch/Typed/NN/Convolution.hs
@@ -24,7 +24,7 @@ import GHC.TypeLits
 import qualified Torch.DType as D
 import qualified Torch.Device as D
 import Torch.NN (HasForward (..), Randomizable (..))
-import Torch.Typed.Aux
+import Torch.Typed.Auxiliary
 import Torch.Typed.Factories
 import Torch.Typed.Functional
 import Torch.Typed.Parameter
@@ -162,10 +162,10 @@ conv2dForward Conv2d {..} input =
 instance
   ( All
       KnownNat
-      '[ Torch.Typed.Aux.Fst stride,
-         Torch.Typed.Aux.Snd stride,
-         Torch.Typed.Aux.Fst padding,
-         Torch.Typed.Aux.Snd padding,
+      '[ Torch.Typed.Auxiliary.Fst stride,
+         Torch.Typed.Auxiliary.Snd stride,
+         Torch.Typed.Auxiliary.Fst padding,
+         Torch.Typed.Auxiliary.Snd padding,
          inputChannelSize,
          outputChannelSize,
          kernelSize0,
@@ -176,8 +176,8 @@ instance
          outputSize0,
          outputSize1
        ],
-    ConvSideCheck inputSize0 kernelSize0 (Torch.Typed.Aux.Fst stride) (Torch.Typed.Aux.Fst padding) outputSize0,
-    ConvSideCheck inputSize1 kernelSize1 (Torch.Typed.Aux.Snd stride) (Torch.Typed.Aux.Snd padding) outputSize1
+    ConvSideCheck inputSize0 kernelSize0 (Torch.Typed.Auxiliary.Fst stride) (Torch.Typed.Auxiliary.Fst padding) outputSize0,
+    ConvSideCheck inputSize1 kernelSize1 (Torch.Typed.Auxiliary.Snd stride) (Torch.Typed.Auxiliary.Snd padding) outputSize1
   ) =>
   HasForward (Conv2d inputChannelSize outputChannelSize kernelSize0 kernelSize1 dtype device) (Tensor device dtype '[batchSize, inputChannelSize, inputSize0, inputSize1], Proxy stride, Proxy padding) (Tensor device dtype '[batchSize, outputChannelSize, outputSize0, outputSize1])
   where
@@ -429,10 +429,10 @@ convTranspose2dForward ConvTranspose2d {..} input =
 instance
   ( All
       KnownNat
-      '[ Torch.Typed.Aux.Fst stride,
-         Torch.Typed.Aux.Snd stride,
-         Torch.Typed.Aux.Fst padding,
-         Torch.Typed.Aux.Snd padding,
+      '[ Torch.Typed.Auxiliary.Fst stride,
+         Torch.Typed.Auxiliary.Snd stride,
+         Torch.Typed.Auxiliary.Fst padding,
+         Torch.Typed.Auxiliary.Snd padding,
          inputChannelSize,
          outputChannelSize,
          kernelSize0,
@@ -443,8 +443,8 @@ instance
          outputSize0,
          outputSize1
        ],
-    ConvSideCheck inputSize0 kernelSize0 (Torch.Typed.Aux.Fst stride) (Torch.Typed.Aux.Fst padding) outputSize0,
-    ConvSideCheck inputSize1 kernelSize1 (Torch.Typed.Aux.Snd stride) (Torch.Typed.Aux.Snd padding) outputSize1
+    ConvSideCheck inputSize0 kernelSize0 (Torch.Typed.Auxiliary.Fst stride) (Torch.Typed.Auxiliary.Fst padding) outputSize0,
+    ConvSideCheck inputSize1 kernelSize1 (Torch.Typed.Auxiliary.Snd stride) (Torch.Typed.Auxiliary.Snd padding) outputSize1
   ) =>
   HasForward (ConvTranspose2d inputChannelSize outputChannelSize kernelSize0 kernelSize1 dtype device) (Tensor device dtype '[batchSize, inputChannelSize, inputSize0, inputSize1], Proxy stride, Proxy padding) (Tensor device dtype '[batchSize, outputChannelSize, outputSize0, outputSize1])
   where

--- a/hasktorch/src/Torch/Typed/NN/Normalization.hs
+++ b/hasktorch/src/Torch/Typed/NN/Normalization.hs
@@ -15,7 +15,7 @@ import GHC.TypeLits
 import qualified Torch.DType as D
 import qualified Torch.Device as D
 import Torch.NN (HasForward (..), Randomizable (..))
-import Torch.Typed.Aux
+import Torch.Typed.Auxiliary
 import Torch.Typed.Factories
 import Torch.Typed.Functional
 import Torch.Typed.Parameter

--- a/hasktorch/src/Torch/Typed/NN/Recurrent.hs
+++ b/hasktorch/src/Torch/Typed/NN/Recurrent.hs
@@ -1,6 +1,6 @@
 module Torch.Typed.NN.Recurrent
   ( module Torch.Typed.NN.Recurrent,
-    module Torch.Typed.NN.Recurrent.Aux,
+    module Torch.Typed.NN.Recurrent.Auxiliary,
     module Torch.Typed.NN.Recurrent.GRU,
     module Torch.Typed.NN.Recurrent.LSTM,
     module Torch.Typed.NN.Recurrent.Cell.GRU,
@@ -8,7 +8,7 @@ module Torch.Typed.NN.Recurrent
   )
 where
 
-import Torch.Typed.NN.Recurrent.Aux
+import Torch.Typed.NN.Recurrent.Auxiliary
 import Torch.Typed.NN.Recurrent.Cell.GRU
 import Torch.Typed.NN.Recurrent.Cell.LSTM
 import Torch.Typed.NN.Recurrent.GRU

--- a/hasktorch/src/Torch/Typed/NN/Recurrent/Auxiliary.hs
+++ b/hasktorch/src/Torch/Typed/NN/Recurrent/Auxiliary.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 
-module Torch.Typed.NN.Recurrent.Aux where
+module Torch.Typed.NN.Recurrent.Auxiliary where
 
 import GHC.Generics
 import Torch.Functional (mulScalar, subScalar)

--- a/hasktorch/src/Torch/Typed/NN/Recurrent/GRU.hs
+++ b/hasktorch/src/Torch/Typed/NN/Recurrent/GRU.hs
@@ -52,7 +52,7 @@ import qualified Torch.TensorFactories as D
 import Torch.Typed.Factories
 import Torch.Typed.Functional hiding (sqrt)
 import Torch.Typed.NN.Dropout
-import Torch.Typed.NN.Recurrent.Aux
+import Torch.Typed.NN.Recurrent.Auxiliary
 import Torch.Typed.Parameter
 import Torch.Typed.Tensor
 import Prelude hiding (tanh)

--- a/hasktorch/src/Torch/Typed/NN/Recurrent/LSTM.hs
+++ b/hasktorch/src/Torch/Typed/NN/Recurrent/LSTM.hs
@@ -51,7 +51,7 @@ import qualified Torch.TensorFactories as D
 import Torch.Typed.Factories
 import Torch.Typed.Functional hiding (sqrt)
 import Torch.Typed.NN.Dropout
-import Torch.Typed.NN.Recurrent.Aux
+import Torch.Typed.NN.Recurrent.Auxiliary
 import Torch.Typed.Parameter
 import Torch.Typed.Tensor
 import Prelude hiding (tanh)

--- a/hasktorch/src/Torch/Typed/NN/Sparse.hs
+++ b/hasktorch/src/Torch/Typed/NN/Sparse.hs
@@ -20,7 +20,7 @@ import qualified Torch.DType as D
 import qualified Torch.Device as D
 import Torch.HList
 import Torch.NN (HasForward (..), Randomizable (..))
-import Torch.Typed.Aux
+import Torch.Typed.Auxiliary
 import Torch.Typed.Factories
 import Torch.Typed.Functional
 import Torch.Typed.Parameter

--- a/hasktorch/src/Torch/Typed/NN/Transformer.hs
+++ b/hasktorch/src/Torch/Typed/NN/Transformer.hs
@@ -27,7 +27,7 @@ import qualified Torch.Device as D
 import Torch.HList
 import Torch.NN (HasForward (..))
 import qualified Torch.NN as A
-import Torch.Typed.Aux
+import Torch.Typed.Auxiliary
 import Torch.Typed.Factories
 import Torch.Typed.Functional hiding (linear, log)
 import Torch.Typed.NN.Dropout

--- a/hasktorch/src/Torch/Typed/Optim.hs
+++ b/hasktorch/src/Torch/Typed/Optim.hs
@@ -26,7 +26,7 @@ import qualified Torch.Internal.Class as ATen
 import Torch.Internal.GC (mallocTrim)
 import qualified Torch.Tensor as D
 import Torch.Typed.Autograd
-import Torch.Typed.Aux
+import Torch.Typed.Auxiliary
 import Torch.Typed.Factories
 import Torch.Typed.Functional
 import Torch.Typed.Parameter

--- a/hasktorch/src/Torch/Typed/Parameter.hs
+++ b/hasktorch/src/Torch/Typed/Parameter.hs
@@ -35,7 +35,7 @@ import Torch.Device (DeviceType)
 import Torch.HList
 import qualified Torch.NN (Parameter, Randomizable (..), sample)
 import qualified Torch.Tensor (toType, _toDevice)
-import Torch.Typed.Aux
+import Torch.Typed.Auxiliary
 import Torch.Typed.Factories
 import Torch.Typed.Functional
 import Torch.Typed.Tensor

--- a/hasktorch/src/Torch/Typed/Tensor.hs
+++ b/hasktorch/src/Torch/Typed/Tensor.hs
@@ -52,7 +52,7 @@ import Torch.Internal.Class
 import qualified Torch.Internal.Type as ATen
 import qualified Torch.Tensor as D
 import qualified Torch.TensorFactories as D
-import Torch.Typed.Aux
+import Torch.Typed.Auxiliary
 import Prelude hiding (id, (.))
 
 class KnownShape (shape :: [Nat]) where

--- a/hasktorch/src/Torch/Typed/Vision.hs
+++ b/hasktorch/src/Torch/Typed/Vision.hs
@@ -28,7 +28,7 @@ import Torch.Internal.Cast
 import qualified Torch.Internal.Managed.TensorFactories as LibTorch
 import qualified Torch.Tensor as D
 import qualified Torch.TensorOptions as D
-import Torch.Typed.Aux
+import Torch.Typed.Auxiliary
 import Torch.Typed.Functional
 import Torch.Typed.Tensor
 

--- a/hasktorch/test/Spec.hs
+++ b/hasktorch/test/Spec.hs
@@ -21,7 +21,7 @@ import qualified Torch.Distributions.BernoulliSpec
 import qualified Torch.Distributions.CategoricalSpec
 import qualified Torch.Distributions.ConstraintsSpec
 import qualified Torch.Typed.AutogradSpec
-import qualified Torch.Typed.AuxSpec
+import qualified Torch.Typed.AuxiliarySpec
 import qualified Torch.Typed.FactoriesSpec
 import qualified Torch.Typed.FunctionalSpec0
 import qualified Torch.Typed.FunctionalSpec1
@@ -60,7 +60,7 @@ main = hspec $ do
   Torch.Distributions.CategoricalSpec.spec
   Torch.Distributions.ConstraintsSpec.spec
   Torch.Typed.AutogradSpec.spec
-  Torch.Typed.AuxSpec.spec
+  Torch.Typed.AuxiliarySpec.spec
   Torch.Typed.FactoriesSpec.spec
   Torch.Typed.FunctionalSpec0.spec
   Torch.Typed.FunctionalSpec1.spec

--- a/hasktorch/test/Torch/Typed/AutogradSpec.hs
+++ b/hasktorch/test/Torch/Typed/AutogradSpec.hs
@@ -38,7 +38,7 @@ import Test.QuickCheck ()
 import Torch (ATenTensor)
 import Torch.Internal.Class (Castable)
 import Torch.Typed
-import Torch.Typed.AuxSpec
+import Torch.Typed.AuxiliarySpec
 import Prelude hiding
   ( all,
     cos,

--- a/hasktorch/test/Torch/Typed/AuxiliarySpec.hs
+++ b/hasktorch/test/Torch/Typed/AuxiliarySpec.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -Wno-partial-type-signatures #-}
 
-module Torch.Typed.AuxSpec where
+module Torch.Typed.AuxiliarySpec where
 
 import Data.Proxy
 import System.IO.Unsafe

--- a/hasktorch/test/Torch/Typed/FactoriesSpec.hs
+++ b/hasktorch/test/Torch/Typed/FactoriesSpec.hs
@@ -15,7 +15,7 @@ import Data.Proxy
 import Test.Hspec (Spec, describe, it)
 import Test.QuickCheck ()
 import Torch.Typed
-import Torch.Typed.AuxSpec
+import Torch.Typed.AuxiliarySpec
 
 data SimpleFactoriesSpec = ZerosSpec | OnesSpec | FullSpec
 

--- a/hasktorch/test/Torch/Typed/FunctionalSpec0.hs
+++ b/hasktorch/test/Torch/Typed/FunctionalSpec0.hs
@@ -20,7 +20,7 @@ import Test.Hspec (Spec, before_, describe, it)
 import Test.QuickCheck ()
 import Torch.Internal.Managed.Type.Context (get_manual_seed)
 import Torch.Typed
-import Torch.Typed.AuxSpec
+import Torch.Typed.AuxiliarySpec
 import Prelude hiding
   ( abs,
     acos,

--- a/hasktorch/test/Torch/Typed/FunctionalSpec1.hs
+++ b/hasktorch/test/Torch/Typed/FunctionalSpec1.hs
@@ -20,7 +20,7 @@ import Test.Hspec (Spec, before_, describe, it)
 import Test.QuickCheck ()
 import Torch.Internal.Managed.Type.Context (get_manual_seed)
 import Torch.Typed
-import Torch.Typed.AuxSpec
+import Torch.Typed.AuxiliarySpec
 import Prelude hiding
   ( abs,
     acos,

--- a/hasktorch/test/Torch/Typed/FunctionalSpec2.hs
+++ b/hasktorch/test/Torch/Typed/FunctionalSpec2.hs
@@ -20,7 +20,7 @@ import Test.Hspec (Spec, before_, describe, it)
 import Test.QuickCheck ()
 import Torch.Internal.Managed.Type.Context (get_manual_seed)
 import Torch.Typed
-import Torch.Typed.AuxSpec
+import Torch.Typed.AuxiliarySpec
 import Prelude hiding
   ( abs,
     acos,

--- a/hasktorch/test/Torch/Typed/NN/Recurrent/GRUSpec.hs
+++ b/hasktorch/test/Torch/Typed/NN/Recurrent/GRUSpec.hs
@@ -14,7 +14,7 @@ import qualified Torch.NN as A
 import Torch.Typed.Factories
 import Torch.Typed.Functional
 import Torch.Typed.NN
-import Torch.Typed.NN.Recurrent.Aux
+import Torch.Typed.NN.Recurrent.Auxiliary
 import Torch.Typed.NN.Recurrent.GRU
 import Torch.Typed.Parameter
 

--- a/hasktorch/test/Torch/Typed/NN/Recurrent/LSTMSpec.hs
+++ b/hasktorch/test/Torch/Typed/NN/Recurrent/LSTMSpec.hs
@@ -14,7 +14,7 @@ import qualified Torch.NN as A
 import Torch.Typed.Factories
 import Torch.Typed.Functional
 import Torch.Typed.NN
-import Torch.Typed.NN.Recurrent.Aux
+import Torch.Typed.NN.Recurrent.Auxiliary
 import Torch.Typed.NN.Recurrent.LSTM
 import Torch.Typed.Parameter
 

--- a/hasktorch/test/Torch/Typed/OptimSpec.hs
+++ b/hasktorch/test/Torch/Typed/OptimSpec.hs
@@ -29,7 +29,7 @@ import Torch (ATenTensor)
 import Torch.Internal.Class (Castable)
 import Torch.Internal.Managed.Type.Context (manual_seed_L)
 import Torch.Typed
-import Torch.Typed.AuxSpec
+import Torch.Typed.AuxiliarySpec
 import Prelude hiding
   ( cos,
     exp,

--- a/hasktorch/test/Torch/Typed/TensorSpec0.hs
+++ b/hasktorch/test/Torch/Typed/TensorSpec0.hs
@@ -21,7 +21,7 @@ import Test.QuickCheck ()
 import qualified Torch as Torch
 import Torch.Internal.Class (Castable (cast), uncast)
 import Torch.Typed
-import Torch.Typed.AuxSpec
+import Torch.Typed.AuxiliarySpec
 
 data BinarySpec = AddSpec | SubSpec | MulSpec
 

--- a/hasktorch/test/Torch/Typed/TensorSpec1.hs
+++ b/hasktorch/test/Torch/Typed/TensorSpec1.hs
@@ -21,7 +21,7 @@ import Test.QuickCheck ()
 import qualified Torch as Torch
 import Torch.Internal.Class (Castable (cast), uncast)
 import Torch.Typed
-import Torch.Typed.AuxSpec
+import Torch.Typed.AuxiliarySpec
 
 data BinaryCmpSpec = GTSpec | LTSpec | GESpec | LESpec | EQSpec | NESpec
 


### PR DESCRIPTION
In windows, some tools can not clone `Aux.hs` file.
So this pr renames `Aux.hs` to `Auxiliary.hs`.