### PR TITLE
Add nms for a motivational example of Record Dot Syntax

### DIFF
--- a/hasktorch/src/Torch/Typed/Vision.hs
+++ b/hasktorch/src/Torch/Typed/Vision.hs
@@ -141,3 +141,75 @@ initMnist path = do
   testImagesBS <- decompressFile path "t10k-images-idx3-ubyte.gz"
   testLabelsBS <- decompressFile path "t10k-labels-idx1-ubyte.gz"
   return (MnistData imagesBS labelsBS, MnistData testImagesBS testLabelsBS)
+
+data Box a = Box
+  { x1 :: a,
+    y1 :: a,
+    x2 :: a,
+    y2 :: a,
+    score :: a
+  }
+  deriving (Show, Eq, Generic, Default)
+
+nms_cpu :: Num a => [Box a] -> a -> [Box a]
+nms_cpu dets = nms_cpu' (sortBy score dets)
+  where
+    nms_cpu' :: Num a => [Box a] -> a -> [Box a]
+    nms_cpu' [] _ = []
+    nms_cpu' (head_:tail_) iou_threshold = head_: nms_cpu filtered_boxes iou_threshold
+      where
+        head_area = (x2 head_ - x1 head_) *  (y2 head_ - y1 head_)
+        filtered_boxes = filter (\v ->
+                                   let 
+                                     xx1 = max (x1 head_) (x1 v) 
+                                     yy1 = max (y1 head_) (y1 v)
+                                     xx2 = min (x2 head_) (x2 v)
+                                     yy1 = min (y2 head_) (y2 v)
+                                     v_area = (xx2 - xx1) * (yy2 - yy1)
+                                     inter_area = (xx2 - xx1) * (yy2 - yy1)
+                                     iou = inter_area / (head_area + v_area - inter_area)
+                                   in iou < iou_threshold
+                                ) tail_
+
+-- THe reference code of nms
+-- https://github.com/rbgirshick/fast-rcnn/blob/master/lib/utils/nms.py
+
+nms :: NamedTensor device dtype '[Vector n, Box] -> Float -> NamedTensor device dtype '[Vector m, Box]
+nms dets iou_threshold = dets ! (loop sort_idxes 0)
+  where
+    sort_idxes = sortNamedDim @"score" dets
+    areas =
+      (dets ^. field @"x2" - dets ^. field @"x1") *
+      (dets ^. field @"y2" - dets ^. field @"y1")
+    loop sort_idxes i | length sort_idxes <= i = sort_idxes
+                      | otherwise =
+        let
+          idx = sort_idxes ! i
+          other_idxes = sort_idxes ! [slice|({i}+1):|]
+          xx1 = max (dets ! idx ^.field@"x1") ((dets ! other_idxes) ^. field @"x1")
+          xx2 = min (dets ! idx ^.field@"x2") ((dets ! other_idxes) ^. field @"x2")
+          yy1 = max (dets ! idx ^.field@"y1") ((dets ! other_idxes) ^. field @"y1")
+          yy2 = min (dets ! idx ^.field@"y2") ((dets ! other_idxes) ^. field @"y2")
+          inter_areas = (xx2 - xx1) * (yy2 - yy1)
+          iou = inter_areas / ((area ! idx) + (areas ! other_idxes) - inter_areas)
+        in loop (delete sort_idxes (iou >= iou_threshold)) (i+1)
+
+nms_with_dotsyntax :: NamedTensor device dtype '[Vector n, Box] -> Float -> NamedTensor device dtype '[Vector m, Box]
+nms_with_dotsyntax dets iou_threshold = dets ! (loop sort_idxes 0)
+  where
+    sort_idxes = sortNamedDim @"score" dets
+    areas =
+      (dets.x2 - dets.x1) *
+      (dets.y2 - dets.y1)
+    loop sort_idxes i | length sort_idxes <= i = sort_idxes
+                      | otherwise =
+        let
+          idx = sort_idxes ! i
+          other_idxes = sort_idxes ! [slice|({i}+1):|]
+          xx1 = max (dets ! i).x1 (dets ! other_idxes).x1
+          xx2 = min (dets ! i).x2 (dets ! other_idxes).x2
+          yy1 = max (dets ! i).y1 (dets ! other_idxes).y1
+          yy2 = min (dets ! i).y2 (dets ! other_idxes).y2
+          inter_areas = (xx2 - xx1) * (yy2 - yy1)
+          iou = inter_areas / ((area ! idx) + (areas ! other_idxes) - inter_areas)
+        in loop (delete sort_idxes (iou >= iou_threshold)) (i+1)

--- a/hasktorch/src/Torch/Typed/Vision.hs
+++ b/hasktorch/src/Torch/Typed/Vision.hs
@@ -151,8 +151,8 @@ data Box a = Box
   }
   deriving (Show, Eq, Generic, Default)
 
-nms_cpu :: Num a => [Box a] -> a -> [Box a]
-nms_cpu dets = nms_cpu' (sortBy score dets)
+nmsCpu :: Num a => [Box a] -> a -> [Box a]
+nmsCpu dets = nms_cpu' (sortBy score dets)
   where
     nms_cpu' :: Num a => [Box a] -> a -> [Box a]
     nms_cpu' [] _ = []
@@ -194,8 +194,33 @@ nms dets iou_threshold = dets ! (loop sort_idxes 0)
           iou = inter_areas / ((area ! idx) + (areas ! other_idxes) - inter_areas)
         in loop (delete sort_idxes (iou >= iou_threshold)) (i+1)
 
-nms_with_dotsyntax :: NamedTensor device dtype '[Vector n, Box] -> Float -> NamedTensor device dtype '[Vector m, Box]
-nms_with_dotsyntax dets iou_threshold = dets ! (loop sort_idxes 0)
+nmsWithDotsyntax :: NamedTensor device dtype '[Vector n, Box] -> Float -> NamedTensor device dtype '[Vector m, Box]
+nmsWithDotsyntax dets iou_threshold = dets ! (loop sort_idxes 0)
+  where
+    sort_idxes = sortNamedDim @"score" dets
+    areas =
+      (dets.x2 - dets.x1) *
+      (dets.y2 - dets.y1)
+    loop sort_idxes i | length sort_idxes <= i = sort_idxes
+                      | otherwise =
+        let
+          idx = sort_idxes ! i
+          other_idxes = sort_idxes ! [slice|({i}+1):|]
+          xx1 = max (dets ! i).x1 (dets ! other_idxes).x1
+          xx2 = min (dets ! i).x2 (dets ! other_idxes).x2
+          yy1 = max (dets ! i).y1 (dets ! other_idxes).y1
+          yy2 = min (dets ! i).y2 (dets ! other_idxes).y2
+          inter_areas = (xx2 - xx1) * (yy2 - yy1)
+          iou = inter_areas / ((area ! idx) + (areas ! other_idxes) - inter_areas)
+        in loop (delete sort_idxes (iou >= iou_threshold)) (i+1)
+
+genericNms :: ( HasField "x1" a
+              , HasField "x2" a
+              , HasField "y1" a
+              , HasField "y2" a
+              , HasField "score" a
+              ) => NamedTensor device dtype '[Vector n, a] -> Float -> NamedTensor device dtype '[Vector m, a]
+genericNms dets iou_threshold = dets ! (loop sort_idxes 0)
   where
     sort_idxes = sortNamedDim @"score" dets
     areas =


### PR DESCRIPTION
Is it possible to combine Record Dot Syntax and named tensor?
I make a motivational example for that.
The python code of nms below is concise enough, but I'm wondering if `Record Dot Syntax` would make it even easier for users to write codes.

```python
# https://github.com/rbgirshick/fast-rcnn/blob/master/lib/utils/nms.py#L8-L37
def nms(dets, thresh):
    x1 = dets[:, 0]
    y1 = dets[:, 1]
    x2 = dets[:, 2]
    y2 = dets[:, 3]
    scores = dets[:, 4]

    areas = (x2 - x1 + 1) * (y2 - y1 + 1)
    order = scores.argsort()[::-1]

    keep = []
    while order.size > 0:
        i = order[0]
        keep.append(i)
        xx1 = np.maximum(x1[i], x1[order[1:]])
        yy1 = np.maximum(y1[i], y1[order[1:]])
        xx2 = np.minimum(x2[i], x2[order[1:]])
        yy2 = np.minimum(y2[i], y2[order[1:]])

        w = np.maximum(0.0, xx2 - xx1 + 1)
        h = np.maximum(0.0, yy2 - yy1 + 1)
        inter = w * h
        ovr = inter / (areas[i] + areas[order[1:]] - inter)

        inds = np.where(ovr <= thresh)[0]
        order = order[inds + 1]

    return keep
```