### PR TITLE
Add cache.nixos.org to substituters

### DIFF
--- a/.github/workflows/nix-haddock-linux.yml
+++ b/.github/workflows/nix-haddock-linux.yml
@@ -19,7 +19,7 @@ jobs:
         sudo apt autoclean -y || true
         docker rmi $(docker image ls -aq)
         df -h
-    - uses: cachix/install-nix-action@v13
+    - uses: cachix/install-nix-action@v16
       with:
         install_url: https://nixos-nix-install-tests.cachix.org/serve/i6laym9jw3wg9mw6ncyrk6gjx4l34vvx/install
         install_options: '--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve'

--- a/.github/workflows/nix-linux-cu10.yml
+++ b/.github/workflows/nix-linux-cu10.yml
@@ -41,7 +41,7 @@ jobs:
           df -h
           cat /proc/cpuinfo
           cat /proc/meminfo
-      - uses: cachix/install-nix-action@v13
+      - uses: cachix/install-nix-action@v16
         with:
           install_url: https://nixos-nix-install-tests.cachix.org/serve/i6laym9jw3wg9mw6ncyrk6gjx4l34vvx/install
           install_options: '--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve'

--- a/.github/workflows/nix-linux-cu11.yml
+++ b/.github/workflows/nix-linux-cu11.yml
@@ -41,7 +41,7 @@ jobs:
           df -h
           cat /proc/cpuinfo
           cat /proc/meminfo
-      - uses: cachix/install-nix-action@v13
+      - uses: cachix/install-nix-action@v16
         with:
           install_url: https://nixos-nix-install-tests.cachix.org/serve/i6laym9jw3wg9mw6ncyrk6gjx4l34vvx/install
           install_options: '--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve'

--- a/.github/workflows/nix-linux.yml
+++ b/.github/workflows/nix-linux.yml
@@ -38,7 +38,7 @@ jobs:
           df -h
           cat /proc/cpuinfo
           cat /proc/meminfo
-      - uses: cachix/install-nix-action@v13
+      - uses: cachix/install-nix-action@v16
         with:
           install_url: https://nixos-nix-install-tests.cachix.org/serve/i6laym9jw3wg9mw6ncyrk6gjx4l34vvx/install
           install_options: '--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve'

--- a/.github/workflows/nix-macos.yml
+++ b/.github/workflows/nix-macos.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: macOS-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: cachix/install-nix-action@v13
+      - uses: cachix/install-nix-action@v16
         with:
           install_url: https://nixos-nix-install-tests.cachix.org/serve/i6laym9jw3wg9mw6ncyrk6gjx4l34vvx/install
           install_options: '--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve'

--- a/.github/workflows/stack-nix-linux.yml
+++ b/.github/workflows/stack-nix-linux.yml
@@ -22,7 +22,7 @@ jobs:
           sudo apt update -qq
           sudo apt -y --allow-downgrades --allow-remove-essential --allow-change-held-packages install cmake curl wget unzip git libtinfo-dev python3 python3-yaml
           (wget -qO- https://get.haskellstack.org/ | sh) || true
-      - uses: cachix/install-nix-action@v14
+      - uses: cachix/install-nix-action@v16
         with:
           install_url: https://nixos-nix-install-tests.cachix.org/serve/vij683ly7sl95nnhb67bdjjfabclr85m/install
           install_options: '--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve'

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,7 @@
 
   nixConfig = {
     substituters = [
+      https://cache.nixos.org
       https://hydra.iohk.io
       https://hasktorch.cachix.org
     ];


### PR DESCRIPTION
It seems that nix-flake only searches substituters in flake.nix.