### PR TITLE
Add instances of complex numbers

### DIFF
--- a/hasktorch/hasktorch.cabal
+++ b/hasktorch/hasktorch.cabal
@@ -134,6 +134,7 @@ library
                     , vector-sized
                     , template-haskell
                     , megaparsec
+                    , half
 
  default-extensions:  Strict
                     , StrictData
@@ -200,6 +201,7 @@ test-suite spec
                     , vector-sized
                     , lens-family-core
                     , data-default-class
+                    , half
 
 test-suite doctests
   if os(darwin) || flag(disable-doctest)

--- a/hasktorch/src/Torch/DType.hs
+++ b/hasktorch/src/Torch/DType.hs
@@ -175,6 +175,24 @@ isIntegral QUInt8 = False
 isIntegral QInt32 = False
 isIntegral BFloat16 = False
 
+isComplex :: DType -> Bool
+isComplex Bool = False
+isComplex UInt8 = False
+isComplex Int8 = False
+isComplex Int16 = False
+isComplex Int32 = False
+isComplex Int64 = False
+isComplex Half = False
+isComplex Float = False
+isComplex Double = False
+isComplex ComplexHalf = True
+isComplex ComplexFloat = True
+isComplex ComplexDouble = True
+isComplex QInt8 = False
+isComplex QUInt8 = False
+isComplex QInt32 = False
+isComplex BFloat16 = False
+
 byteLength :: DType -> Int
 byteLength dtype =
   case dtype of

--- a/hasktorch/src/Torch/DType.hs
+++ b/hasktorch/src/Torch/DType.hs
@@ -5,6 +5,8 @@
 
 module Torch.DType where
 
+import Data.Complex
+import qualified Numeric.Half as N
 import Data.Int
 import Data.Reflection
 import Data.Word
@@ -83,6 +85,12 @@ instance Reifies Int64 DType where
 instance Reifies 'Int64 DType where
   reflect _ = Int64
 
+instance Reifies N.Half DType where
+  reflect _ = Half
+
+instance Reifies 'Half DType where
+  reflect _ = Half
+
 instance Reifies Float DType where
   reflect _ = Float
 
@@ -94,6 +102,24 @@ instance Reifies Double DType where
 
 instance Reifies 'Double DType where
   reflect _ = Double
+
+instance Reifies (Complex N.Half) DType where
+  reflect _ = ComplexHalf
+
+instance Reifies 'ComplexHalf DType where
+  reflect _ = ComplexHalf
+
+instance Reifies (Complex Float) DType where
+  reflect _ = ComplexFloat
+
+instance Reifies 'ComplexFloat DType where
+  reflect _ = ComplexFloat
+
+instance Reifies (Complex Double) DType where
+  reflect _ = ComplexDouble
+
+instance Reifies 'ComplexDouble DType where
+  reflect _ = ComplexDouble
 
 instance Castable DType ATen.ScalarType where
   cast Bool f = f ATen.kBool

--- a/hasktorch/test/TensorSpec.hs
+++ b/hasktorch/test/TensorSpec.hs
@@ -5,6 +5,8 @@ module TensorSpec (spec) where
 
 import Control.Arrow ((&&&))
 import Control.Exception.Safe
+import Numeric.Half
+import Data.Complex
 import Data.Int
 import Data.Word
 import Test.Hspec
@@ -14,6 +16,11 @@ import Torch.Functional
 import Torch.Tensor
 import Torch.TensorFactories
 import Torch.TensorOptions
+import Test.QuickCheck.Arbitrary
+
+instance Arbitrary Half where
+  arbitrary = arbitrarySizedFractional
+  shrink    = shrinkDecimal
 
 spec :: Spec
 spec = do
@@ -39,12 +46,24 @@ spec = do
     it "TensorLike Int64" $
       property $
         \x -> asValue (asTensor x) `shouldBe` (x :: Int64)
+    it "TensorLike Half" $
+      property $
+        \x -> asValue (asTensor x) `shouldBe` (x :: Half)
     it "TensorLike Float" $
       property $
         \x -> asValue (asTensor x) `shouldBe` (x :: Float)
     it "TensorLike Double" $
       property $
         \x -> asValue (asTensor x) `shouldBe` (x :: Double)
+    it "TensorLike ComplexHalf" $
+      property $
+        \x -> asValue (asTensor x) `shouldBe` (x :: Complex Half)
+    it "TensorLike Complex Float" $
+      property $
+        \x -> asValue (asTensor x) `shouldBe` (x :: Complex Float)
+    it "TensorLike Complex Double" $
+      property $
+        \x -> asValue (asTensor x) `shouldBe` (x :: Complex Double)
 
     it "Compare internal expression of c++ with Storable expression of haskell" $ do
       show (asTensor [True, False, True, False])
@@ -140,6 +159,16 @@ spec = do
           asValue (asTensor xx) `shouldBe` xx
           let xxx = replicate 3 xx
           asValue (asTensor xxx) `shouldBe` xxx
+    it "TensorLike [Half]" $
+      property $
+        \(NonEmpty (x :: [Half])) -> do
+          asValue (asTensor x) `shouldBe` x
+          toDouble (select 0 0 (asTensor x)) `shouldBe` realToFrac (head x)
+          shape (asTensor x) `shouldBe` [length x]
+          let xx = replicate 5 x
+          asValue (asTensor xx) `shouldBe` xx
+          let xxx = replicate 3 xx
+          asValue (asTensor xxx) `shouldBe` xxx
     it "TensorLike [Float]" $
       property $
         \(NonEmpty (x :: [Float])) -> do
@@ -155,6 +184,36 @@ spec = do
         \(NonEmpty (x :: [Double])) -> do
           asValue (asTensor x) `shouldBe` x
           toDouble (select 0 0 (asTensor x)) `shouldBe` realToFrac (head x)
+          shape (asTensor x) `shouldBe` [length x]
+          let xx = replicate 5 x
+          asValue (asTensor xx) `shouldBe` xx
+          let xxx = replicate 3 xx
+          asValue (asTensor xxx) `shouldBe` xxx
+    it "TensorLike [Complex Half]" $
+      property $
+        \(NonEmpty (x :: [Complex Half])) -> do
+          asValue (asTensor x) `shouldBe` x
+          asValue (select 0 0 (asTensor x)) `shouldBe` (head x)
+          shape (asTensor x) `shouldBe` [length x]
+          let xx = replicate 5 x
+          asValue (asTensor xx) `shouldBe` xx
+          let xxx = replicate 3 xx
+          asValue (asTensor xxx) `shouldBe` xxx
+    it "TensorLike [Complex Float]" $
+      property $
+        \(NonEmpty (x :: [Complex Float])) -> do
+          asValue (asTensor x) `shouldBe` x
+          asValue (select 0 0 (asTensor x)) `shouldBe` (head x)
+          shape (asTensor x) `shouldBe` [length x]
+          let xx = replicate 5 x
+          asValue (asTensor xx) `shouldBe` xx
+          let xxx = replicate 3 xx
+          asValue (asTensor xxx) `shouldBe` xxx
+    it "TensorLike [Complex Double]" $
+      property $
+        \(NonEmpty (x :: [Complex Double])) -> do
+          asValue (asTensor x) `shouldBe` x
+          asValue (select 0 0 (asTensor x)) `shouldBe` (head x)
           shape (asTensor x) `shouldBe` [length x]
           let xx = replicate 5 x
           asValue (asTensor xx) `shouldBe` xx


### PR DESCRIPTION
Add TensorLike instances for complex numbers to read and write them.

```
ghci> :m + Data.Complex
ghci> a = [1,2,3] :: [Complex Double]
ghci> b = asTensor a
ghci> b * b
Tensor ComplexDouble [3] [ 1.0000   ,  4.0000   ,  9.0000   ]
ghci> b + b
Tensor ComplexDouble [3] [ 2.0000   ,  4.0000   ,  6.0000   ]
ghci> b / b
Tensor ComplexDouble [3] [ 1.0000   ,  1.0000   ,  1.0000   ]
ghci> b - b
Tensor ComplexDouble [3] [ 0.0000,  0.0000,  0.0000]
ghci> a = [1 :+ 1 , 2:+2,3:+3] :: [Complex Double]
ghci> b = asTensor a
ghci> b
Tensor ComplexDouble [3] [Cannot show stacktrace
Exception: value cannot be converted to type double without overflow: (1,1); type: std::runtime_error
Cannot show stacktrace
Exception: value cannot be converted to type double without overflow: (1,1); type: std::runtime_error
*** Exception: CppStdException "Exception: value cannot be converted to type double without overflow: (1,1); type: std::runtime_error"
```
