### PR TITLE
Fix c++-optimizer to converge loss with CUDA

### DIFF
--- a/hasktorch/src/Torch/Autograd.hs
+++ b/hasktorch/src/Torch/Autograd.hs
@@ -28,6 +28,9 @@ grad y inputs = unsafePerformIO $ cast2 Torch.Internal.Managed.Autograd.grad y (
 requiresGrad :: Tensor -> Bool
 requiresGrad t = unsafePerformIO $ cast1 ATen.tensor_requires_grad t
 
+setRequiresGrad :: Bool -> Tensor -> Tensor
+setRequiresGrad flag t = unsafePerformIO $ cast2 ATen.tensor_set_requires_grad_b t flag
+
 makeIndependent :: Tensor -> IO IndependentTensor
 makeIndependent tensor = makeIndependentWithRequiresGrad tensor True
 

--- a/hasktorch/src/Torch/Optim/CppOptim.hs
+++ b/hasktorch/src/Torch/Optim/CppOptim.hs
@@ -61,7 +61,7 @@ class CppOptimizer option where
   initOptimizer :: Parameterized model => option -> model -> IO (CppOptimizerState option)
   unsafeStep :: Parameterized model => model -> CppOptimizerState option -> Tensor -> IO (model, CppOptimizerState option)
   unsafeStep model o@(CppOptimizerState _ optimizer) loss = do
-    v <- cast3 LibTorch.unsafeStep optimizer (map toDependent $ flattenParameters model) loss
+    v <- cast2 LibTorch.unsafeStep optimizer loss
     let newModel = replaceParameters model $ map (IndependentTensor . Unsafe) v
     return (newModel, o)
 

--- a/hasktorch/src/Torch/Typed/Optim/CppOptim.hs
+++ b/hasktorch/src/Torch/Typed/Optim/CppOptim.hs
@@ -81,12 +81,12 @@ class CppOptimizer option where
     Tensor dev dtype lossShape ->
     IO (model, CppOptimizerState option (Parameters model))
   unsafeStep model o@(CppOptimizerState _ optimizer) loss = do
-    let deps :: HList tensors
-        deps = hmap' ToDependent $ flattenParameters model
+    -- let deps :: HList tensors
+    --    deps = hmap' ToDependent $ flattenParameters model
 
     -- Debug.traceIO $ "Tensors in: "
     -- cast deps (Debug.traceIO . show . map (TD.shape . TD.Unsafe))
-    v :: [TD.ATenTensor] <- cast3 LibTorch.unsafeStep optimizer deps loss
+    v :: [TD.ATenTensor] <- cast2 LibTorch.unsafeStep optimizer loss
     -- Debug.traceIO $ "Params returned by unsafeStep: "<>show (length v)
 
     newParamTensors :: HList tensors <- uncast v pure

--- a/libtorch-ffi/src/Torch/Internal/Managed/Optim.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Optim.hs
@@ -140,8 +140,8 @@ stepWithGenerator optimizer generator loss = do
       return $ unsafeForeignPtrToPtr ret
 
 
-unsafeStep :: ForeignPtr Optimizer -> ForeignPtr TensorList -> ForeignPtr Tensor -> IO (ForeignPtr TensorList)
-unsafeStep = cast3 Unmanaged.unsafeStep
+unsafeStep :: ForeignPtr Optimizer -> ForeignPtr Tensor -> IO (ForeignPtr TensorList)
+unsafeStep = cast2 Unmanaged.unsafeStep
 
 save :: ForeignPtr Optimizer -> ForeignPtr StdString -> IO ()
 save = cast2 Unmanaged.save

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Optim.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Optim.hs
@@ -313,14 +313,13 @@ stepWithGenerator optimizer generator lossFunc =
     lossFunc' :: Ptr () -> Ptr () -> IO (Ptr ())
     lossFunc' params generator = castPtr <$> lossFunc (castPtr params) (castPtr generator)
 
--- After this function is called, params(TensorList) of input is updated.
--- TensorList of output is the same as input's params(TensorList).
-unsafeStep :: Ptr Optimizer -> Ptr TensorList -> Ptr Tensor -> IO (Ptr TensorList)
-unsafeStep optimizer params loss =
+-- After this function is called, params(TensorList) of optimizer is updated.
+-- TensorList of output is the same as optimizer's params(TensorList).
+unsafeStep :: Ptr Optimizer -> Ptr Tensor -> IO (Ptr TensorList)
+unsafeStep optimizer loss =
   [C.throwBlock| std::vector<at::Tensor>* {
     auto optimizer = $(torch::optim::Optimizer* optimizer);
     auto loss = $(at::Tensor* loss);
-    optimizer->param_groups().at(0).params() = *$(std::vector<at::Tensor>* params);
     optimizer->zero_grad();
     loss->backward();
     optimizer->step();


### PR DESCRIPTION
https://github.com/hasktorch/hasktorch/issues/639
In case of CUDA, requies-grad-property of `unsafeStep`'s parameters is deleted.
We can avoid this problem by using the parameters set in the optimizer at initialization as they are, so delete the list of parameters from `unsafeStep` function.