### PR TITLE
Bump ghc to 9.0.2

### DIFF
--- a/.github/workflows/cabal-linux.yml
+++ b/.github/workflows/cabal-linux.yml
@@ -23,6 +23,7 @@ jobs:
         echo "$HOME/.ghcup/bin" >> $GITHUB_PATH
         curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
         ghcup install ghc 9.0.2
+        ghcup set ghc 9.0.2
         ghcup install cabal
     - name: Setup repos
       run: |

--- a/.github/workflows/cabal-linux.yml
+++ b/.github/workflows/cabal-linux.yml
@@ -12,13 +12,18 @@ jobs:
       run: |
         sudo apt update -qq
         sudo apt -y --allow-downgrades --allow-remove-essential --allow-change-held-packages install locales software-properties-common apt-transport-https
-        sudo add-apt-repository -y ppa:hvr/ghc
         sudo bash -c "echo deb [trusted=yes] https://apt-hasktorch.com/apt ./ > /etc/apt/sources.list.d/libtorch.list"
         sudo rm -f /etc/apt/sources.list.d/sbt.list
         sudo apt update -qq
         sudo apt -y purge ghc* cabal-install* php* || true
-        sudo apt -y --allow-downgrades --allow-remove-essential --allow-change-held-packages install build-essential zlib1g-dev liblapack-dev libblas-dev ghc-9.0.1 cabal-install-3.4 devscripts debhelper python3-pip cmake curl wget unzip git libtinfo-dev python3 python3-yaml
+        sudo apt -y --allow-downgrades --allow-remove-essential --allow-change-held-packages install build-essential zlib1g-dev liblapack-dev libblas-dev devscripts debhelper python3-pip cmake curl wget unzip git libtinfo-dev python3 python3-yaml
         sudo apt -y install libtorch=1.11.0+cpu-1 libtokenizers=0.1-1
+
+        echo "$HOME/.cabal/bin" >> $GITHUB_PATH
+        echo "$HOME/.ghcup/bin" >> $GITHUB_PATH
+        curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
+        ghcup install ghc 9.0.2
+        ghcup install cabal
     - name: Setup repos
       run: |
         git submodule init && git submodule update
@@ -33,7 +38,6 @@ jobs:
           ${{ runner.os }}-cabal-
     - name: Build
       run: |
-        export PATH=/opt/ghc/bin:$PATH
         source setenv
         #APT installs libtorch and libtokenizers.
         #pushd deps/ ; ./get-deps.sh -a cpu -c; popd
@@ -43,7 +47,6 @@ jobs:
         cabal v2-build --jobs=2 all
     - name: Test
       run: |
-        export PATH=/opt/ghc/bin:$PATH
         source setenv
         cabal v2-test --jobs=2 all
         cabal v2-exec codegen-exe

--- a/.github/workflows/cabal-macos.yaml
+++ b/.github/workflows/cabal-macos.yaml
@@ -27,6 +27,7 @@ jobs:
         echo "$HOME/.ghcup/bin" >> $GITHUB_PATH
         curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
         ghcup install ghc 9.0.2
+        ghcup set ghc 9.0.2
         ghcup install cabal
     - name: Cache .cabal
       uses: actions/cache@v2

--- a/.github/workflows/cabal-macos.yaml
+++ b/.github/workflows/cabal-macos.yaml
@@ -12,25 +12,31 @@ jobs:
         git submodule init && git submodule update
     - name: Setup tool-chains
       run: |
-        /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
         brew install libomp || true
         pip3 install pyyaml || true
-        brew install ghc@8.10 || true
-        brew install cabal-install || true
+        #brew install ghc@9.02 || true
+        #brew install cabal-install || true
         brew tap hasktorch/libtorch-prebuild https://github.com/hasktorch/homebrew-libtorch-prebuild || true
         brew install libtorch-prebuild@1.11 || true
         brew tap hasktorch/tokenizers https://github.com/hasktorch/tokenizers || true
         brew install libtokenizers || true
         #pushd deps/ ; ./get-deps.sh -a cpu -c ;popd
+
+        echo "$HOME/.cabal/bin" >> $GITHUB_PATH
+        echo "$HOME/.ghcup/bin" >> $GITHUB_PATH
+        curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
+        ghcup install ghc 9.0.2
+        ghcup install cabal
     - name: Cache .cabal
       uses: actions/cache@v2
       with:
         path: |
           ~/.cabal/store
           dist-newstyle
-        key: ${{ runner.os }}-cabal-ghc8107-${{ hashFiles('**/fallible.cabal') }}
+        key: ${{ runner.os }}-cabal-ghc902-${{ hashFiles('**/fallible.cabal') }}
         restore-keys: |
-          ${{ runner.os }}-cabal-ghc8107-
+          ${{ runner.os }}-cabal-ghc902-
     - name: Build
       run: |
         #. setenv

--- a/.github/workflows/nix-haddock-linux.yml
+++ b/.github/workflows/nix-haddock-linux.yml
@@ -27,8 +27,6 @@ jobs:
           experimental-features = nix-command flakes
         nix_path: nixpkgs=channel:nixos-unstable
     - run: nix-env -iA cachix -f https://cachix.org/api/v1/install
-    - run: |
-        .github/workflows/setup-iohk-cache.sh
     - run: cachix use hasktorch
     - run: |
         nix build .#haddocks-join -L -j 1

--- a/.github/workflows/nix-haddock-linux.yml
+++ b/.github/workflows/nix-haddock-linux.yml
@@ -5,6 +5,9 @@ name: nix-haddock-linux
 
 on: [push, pull_request]
 
+env:
+  NIX_OPTIONS: -L -j 1 --impure
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -29,7 +32,7 @@ jobs:
     - run: nix-env -iA cachix -f https://cachix.org/api/v1/install
     - run: cachix use hasktorch
     - run: |
-        nix build .#haddocks-join -L -j 1
+        nix build .#haddocks-join $NIX_OPTIONS
         pwd
         find result/ |head
         mkdir public

--- a/.github/workflows/nix-linux-cu10.yml
+++ b/.github/workflows/nix-linux-cu10.yml
@@ -53,10 +53,6 @@ jobs:
           name: hasktorch
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
       - run: |
-          .github/workflows/setup-iohk-cache.sh
-          sed -i -e 's/"x86_64-linux" "x86_64-darwin"/"x86_64-linux"/g' flake.nix
-          nix flake show
-      - run: |
           ps -aux
           free
           export NIX_BUILD_CORES=1

--- a/.github/workflows/nix-linux-cu10.yml
+++ b/.github/workflows/nix-linux-cu10.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
 
+env:
+  NIX_OPTIONS: -L -j 1 --impure
+
 jobs:
   # tests:
   #   runs-on: ubuntu-latest
@@ -57,49 +60,49 @@ jobs:
           free
           export NIX_BUILD_CORES=1
 
-          nix build '.#codegen:test:doctests' -L -j 1
-          nix build '.#checks.x86_64-linux.codegen:test:spec' -L -j 1
-          nix build '.#hasktorch-cuda-10:test:doctests' -L -j 1
-          nix build '.#checks.x86_64-linux.hasktorch-cuda-10:test:spec' -L -j 1
-          nix build '.#hasktorch-gradually-typed-cuda-10:test:doctests' -L -j 1
-          nix build '.#checks.x86_64-linux.hasktorch-gradually-typed-cuda-10:test:spec' -L -j 1
-          nix build '.#libtorch-ffi-cuda-10:test:spec' -L -j 1
-          nix build '.#checks.x86_64-linux.libtorch-ffi-cuda-10:test:spec' -L -j 1
+          nix build '.#codegen:test:doctests' $NIX_OPTIONS
+          nix build '.#checks.x86_64-linux.codegen:test:spec' $NIX_OPTIONS
+          nix build '.#hasktorch-cuda-10:test:doctests' $NIX_OPTIONS
+          nix build '.#checks.x86_64-linux.hasktorch-cuda-10:test:spec' $NIX_OPTIONS
+          nix build '.#hasktorch-gradually-typed-cuda-10:test:doctests' $NIX_OPTIONS
+          nix build '.#checks.x86_64-linux.hasktorch-gradually-typed-cuda-10:test:spec' $NIX_OPTIONS
+          nix build '.#libtorch-ffi-cuda-10:test:spec' $NIX_OPTIONS
+          nix build '.#checks.x86_64-linux.libtorch-ffi-cuda-10:test:spec' $NIX_OPTIONS
 
       - run: |
           ps -aux
           free
           export NIX_BUILD_CORES=1
 
-          nix build '.#bounding-box-cuda-10:exe:bounding-box' -L -j 1
-          nix build '.#codegen:exe:codegen-exe' -L -j 1
-          nix build '.#dataloader-cifar10-cuda-10:exe:dataloader-cifar10' -L -j 1
-          nix build '.#examples-cuda-10:exe:alexNet' -L -j 1
-          nix build '.#examples-cuda-10:exe:autograd' -L -j 1
-          nix build '.#examples-cuda-10:exe:distill' -L -j 1
-          nix build '.#examples-cuda-10:exe:gaussian-process' -L -j 1
-          nix build '.#examples-cuda-10:exe:gd-field' -L -j 1
-          nix build '.#examples-cuda-10:exe:image-processing' -L -j 1
-          nix build '.#examples-cuda-10:exe:iris-classification' -L -j 1
-          nix build '.#examples-cuda-10:exe:load-torchscript' -L -j 1
-          nix build '.#examples-cuda-10:exe:matrix-factorization' -L -j 1
-          nix build '.#examples-cuda-10:exe:minimal-text-example' -L -j 1
-          nix build '.#examples-cuda-10:exe:mnist-mixed-precision' -L -j 1
-          nix build '.#examples-cuda-10:exe:mnist-mlp' -L -j 1
-          nix build '.#examples-cuda-10:exe:optimizers' -L -j 1
-          nix build '.#examples-cuda-10:exe:optimizers-cpp' -L -j 1
-          nix build '.#examples-cuda-10:exe:optimizers-cpp-typed' -L -j 1
-          nix build '.#examples-cuda-10:exe:regression' -L -j 1
-          nix build '.#examples-cuda-10:exe:regularization' -L -j 1
-          nix build '.#examples-cuda-10:exe:rnn' -L -j 1
-          nix build '.#examples-cuda-10:exe:serialization' -L -j 1
-          nix build '.#examples-cuda-10:exe:static-mnist-cnn' -L -j 1
-          nix build '.#examples-cuda-10:exe:static-mnist-mlp' -L -j 1
-          nix build '.#examples-cuda-10:exe:static-xor-mlp' -L -j 1
-          nix build '.#examples-cuda-10:exe:typed-transformer' -L -j 1
-          nix build '.#examples-cuda-10:exe:vae' -L -j 1
-          nix build '.#examples-cuda-10:exe:xor-mlp' -L -j 1
-          nix build '.#hasktorch-gradually-typed-cuda-10:exe:linear-regression' -L -j 1
-          nix build '.#hasktorch-gradually-typed-cuda-10:exe:neural-interpreter' -L -j 1
-          nix build '.#hasktorch-gradually-typed-cuda-10:exe:two-layer-network' -L -j 1
-          nix build '.#untyped-nlp-cuda-10:exe:untyped-nlp' -L -j 1
+          nix build '.#bounding-box-cuda-10:exe:bounding-box' $NIX_OPTIONS
+          nix build '.#codegen:exe:codegen-exe' $NIX_OPTIONS
+          nix build '.#dataloader-cifar10-cuda-10:exe:dataloader-cifar10' $NIX_OPTIONS
+          nix build '.#examples-cuda-10:exe:alexNet' $NIX_OPTIONS
+          nix build '.#examples-cuda-10:exe:autograd' $NIX_OPTIONS
+          nix build '.#examples-cuda-10:exe:distill' $NIX_OPTIONS
+          nix build '.#examples-cuda-10:exe:gaussian-process' $NIX_OPTIONS
+          nix build '.#examples-cuda-10:exe:gd-field' $NIX_OPTIONS
+          nix build '.#examples-cuda-10:exe:image-processing' $NIX_OPTIONS
+          nix build '.#examples-cuda-10:exe:iris-classification' $NIX_OPTIONS
+          nix build '.#examples-cuda-10:exe:load-torchscript' $NIX_OPTIONS
+          nix build '.#examples-cuda-10:exe:matrix-factorization' $NIX_OPTIONS
+          nix build '.#examples-cuda-10:exe:minimal-text-example' $NIX_OPTIONS
+          nix build '.#examples-cuda-10:exe:mnist-mixed-precision' $NIX_OPTIONS
+          nix build '.#examples-cuda-10:exe:mnist-mlp' $NIX_OPTIONS
+          nix build '.#examples-cuda-10:exe:optimizers' $NIX_OPTIONS
+          nix build '.#examples-cuda-10:exe:optimizers-cpp' $NIX_OPTIONS
+          nix build '.#examples-cuda-10:exe:optimizers-cpp-typed' $NIX_OPTIONS
+          nix build '.#examples-cuda-10:exe:regression' $NIX_OPTIONS
+          nix build '.#examples-cuda-10:exe:regularization' $NIX_OPTIONS
+          nix build '.#examples-cuda-10:exe:rnn' $NIX_OPTIONS
+          nix build '.#examples-cuda-10:exe:serialization' $NIX_OPTIONS
+          nix build '.#examples-cuda-10:exe:static-mnist-cnn' $NIX_OPTIONS
+          nix build '.#examples-cuda-10:exe:static-mnist-mlp' $NIX_OPTIONS
+          nix build '.#examples-cuda-10:exe:static-xor-mlp' $NIX_OPTIONS
+          nix build '.#examples-cuda-10:exe:typed-transformer' $NIX_OPTIONS
+          nix build '.#examples-cuda-10:exe:vae' $NIX_OPTIONS
+          nix build '.#examples-cuda-10:exe:xor-mlp' $NIX_OPTIONS
+          nix build '.#hasktorch-gradually-typed-cuda-10:exe:linear-regression' $NIX_OPTIONS
+          nix build '.#hasktorch-gradually-typed-cuda-10:exe:neural-interpreter' $NIX_OPTIONS
+          nix build '.#hasktorch-gradually-typed-cuda-10:exe:two-layer-network' $NIX_OPTIONS
+          nix build '.#untyped-nlp-cuda-10:exe:untyped-nlp' $NIX_OPTIONS

--- a/.github/workflows/nix-linux-cu11.yml
+++ b/.github/workflows/nix-linux-cu11.yml
@@ -53,10 +53,6 @@ jobs:
           name: hasktorch
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
       - run: |
-          .github/workflows/setup-iohk-cache.sh
-          sed -i -e 's/"x86_64-linux" "x86_64-darwin"/"x86_64-linux"/g' flake.nix
-          nix flake show
-      - run: |
           ps -aux
           free
           export NIX_BUILD_CORES=1

--- a/.github/workflows/nix-linux-cu11.yml
+++ b/.github/workflows/nix-linux-cu11.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
 
+env:
+  NIX_OPTIONS: -L -j 1 --impure
+
 jobs:
   # tests:
   #   runs-on: ubuntu-latest
@@ -57,49 +60,49 @@ jobs:
           free
           export NIX_BUILD_CORES=1
 
-          nix build '.#codegen:test:doctests' -L -j 1
-          nix build '.#checks.x86_64-linux.codegen:test:spec' -L -j 1
-          nix build '.#hasktorch-cuda-11:test:doctests' -L -j 1
-          nix build '.#checks.x86_64-linux.hasktorch-cuda-11:test:spec' -L -j 1
-          nix build '.#hasktorch-gradually-typed-cuda-11:test:doctests' -L -j 1
-          nix build '.#checks.x86_64-linux.hasktorch-gradually-typed-cuda-11:test:spec' -L -j 1
-          nix build '.#libtorch-ffi-cuda-11:test:spec' -L -j 1
-          nix build '.#checks.x86_64-linux.libtorch-ffi-cuda-11:test:spec' -L -j 1
+          nix build '.#codegen:test:doctests' $NIX_OPTIONS
+          nix build '.#checks.x86_64-linux.codegen:test:spec' $NIX_OPTIONS
+          nix build '.#hasktorch-cuda-11:test:doctests' $NIX_OPTIONS
+          nix build '.#checks.x86_64-linux.hasktorch-cuda-11:test:spec' $NIX_OPTIONS
+          nix build '.#hasktorch-gradually-typed-cuda-11:test:doctests' $NIX_OPTIONS
+          nix build '.#checks.x86_64-linux.hasktorch-gradually-typed-cuda-11:test:spec' $NIX_OPTIONS
+          nix build '.#libtorch-ffi-cuda-11:test:spec' $NIX_OPTIONS
+          nix build '.#checks.x86_64-linux.libtorch-ffi-cuda-11:test:spec' $NIX_OPTIONS
 
       - run: |
           ps -aux
           free
           export NIX_BUILD_CORES=1
 
-          nix build '.#bounding-box-cuda-11:exe:bounding-box' -L -j 1
-          nix build '.#codegen:exe:codegen-exe' -L -j 1
-          nix build '.#dataloader-cifar10-cuda-11:exe:dataloader-cifar10' -L -j 1
-          nix build '.#examples-cuda-11:exe:alexNet' -L -j 1
-          nix build '.#examples-cuda-11:exe:autograd' -L -j 1
-          nix build '.#examples-cuda-11:exe:distill' -L -j 1
-          nix build '.#examples-cuda-11:exe:gaussian-process' -L -j 1
-          nix build '.#examples-cuda-11:exe:gd-field' -L -j 1
-          nix build '.#examples-cuda-11:exe:image-processing' -L -j 1
-          nix build '.#examples-cuda-11:exe:iris-classification' -L -j 1
-          nix build '.#examples-cuda-11:exe:load-torchscript' -L -j 1
-          nix build '.#examples-cuda-11:exe:matrix-factorization' -L -j 1
-          nix build '.#examples-cuda-11:exe:minimal-text-example' -L -j 1
-          nix build '.#examples-cuda-11:exe:mnist-mixed-precision' -L -j 1
-          nix build '.#examples-cuda-11:exe:mnist-mlp' -L -j 1
-          nix build '.#examples-cuda-11:exe:optimizers' -L -j 1
-          nix build '.#examples-cuda-11:exe:optimizers-cpp' -L -j 1
-          nix build '.#examples-cuda-11:exe:optimizers-cpp-typed' -L -j 1
-          nix build '.#examples-cuda-11:exe:regression' -L -j 1
-          nix build '.#examples-cuda-11:exe:regularization' -L -j 1
-          nix build '.#examples-cuda-11:exe:rnn' -L -j 1
-          nix build '.#examples-cuda-11:exe:serialization' -L -j 1
-          nix build '.#examples-cuda-11:exe:static-mnist-cnn' -L -j 1
-          nix build '.#examples-cuda-11:exe:static-mnist-mlp' -L -j 1
-          nix build '.#examples-cuda-11:exe:static-xor-mlp' -L -j 1
-          nix build '.#examples-cuda-11:exe:typed-transformer' -L -j 1
-          nix build '.#examples-cuda-11:exe:vae' -L -j 1
-          nix build '.#examples-cuda-11:exe:xor-mlp' -L -j 1
-          nix build '.#hasktorch-gradually-typed-cuda-11:exe:linear-regression' -L -j 1
-          nix build '.#hasktorch-gradually-typed-cuda-11:exe:neural-interpreter' -L -j 1
-          nix build '.#hasktorch-gradually-typed-cuda-11:exe:two-layer-network' -L -j 1
-          nix build '.#untyped-nlp-cuda-11:exe:untyped-nlp' -L -j 1
+          nix build '.#bounding-box-cuda-11:exe:bounding-box' $NIX_OPTIONS
+          nix build '.#codegen:exe:codegen-exe' $NIX_OPTIONS
+          nix build '.#dataloader-cifar10-cuda-11:exe:dataloader-cifar10' $NIX_OPTIONS
+          nix build '.#examples-cuda-11:exe:alexNet' $NIX_OPTIONS
+          nix build '.#examples-cuda-11:exe:autograd' $NIX_OPTIONS
+          nix build '.#examples-cuda-11:exe:distill' $NIX_OPTIONS
+          nix build '.#examples-cuda-11:exe:gaussian-process' $NIX_OPTIONS
+          nix build '.#examples-cuda-11:exe:gd-field' $NIX_OPTIONS
+          nix build '.#examples-cuda-11:exe:image-processing' $NIX_OPTIONS
+          nix build '.#examples-cuda-11:exe:iris-classification' $NIX_OPTIONS
+          nix build '.#examples-cuda-11:exe:load-torchscript' $NIX_OPTIONS
+          nix build '.#examples-cuda-11:exe:matrix-factorization' $NIX_OPTIONS
+          nix build '.#examples-cuda-11:exe:minimal-text-example' $NIX_OPTIONS
+          nix build '.#examples-cuda-11:exe:mnist-mixed-precision' $NIX_OPTIONS
+          nix build '.#examples-cuda-11:exe:mnist-mlp' $NIX_OPTIONS
+          nix build '.#examples-cuda-11:exe:optimizers' $NIX_OPTIONS
+          nix build '.#examples-cuda-11:exe:optimizers-cpp' $NIX_OPTIONS
+          nix build '.#examples-cuda-11:exe:optimizers-cpp-typed' $NIX_OPTIONS
+          nix build '.#examples-cuda-11:exe:regression' $NIX_OPTIONS
+          nix build '.#examples-cuda-11:exe:regularization' $NIX_OPTIONS
+          nix build '.#examples-cuda-11:exe:rnn' $NIX_OPTIONS
+          nix build '.#examples-cuda-11:exe:serialization' $NIX_OPTIONS
+          nix build '.#examples-cuda-11:exe:static-mnist-cnn' $NIX_OPTIONS
+          nix build '.#examples-cuda-11:exe:static-mnist-mlp' $NIX_OPTIONS
+          nix build '.#examples-cuda-11:exe:static-xor-mlp' $NIX_OPTIONS
+          nix build '.#examples-cuda-11:exe:typed-transformer' $NIX_OPTIONS
+          nix build '.#examples-cuda-11:exe:vae' $NIX_OPTIONS
+          nix build '.#examples-cuda-11:exe:xor-mlp' $NIX_OPTIONS
+          nix build '.#hasktorch-gradually-typed-cuda-11:exe:linear-regression' $NIX_OPTIONS
+          nix build '.#hasktorch-gradually-typed-cuda-11:exe:neural-interpreter' $NIX_OPTIONS
+          nix build '.#hasktorch-gradually-typed-cuda-11:exe:two-layer-network' $NIX_OPTIONS
+          nix build '.#untyped-nlp-cuda-11:exe:untyped-nlp' $NIX_OPTIONS

--- a/.github/workflows/nix-linux.yml
+++ b/.github/workflows/nix-linux.yml
@@ -2,6 +2,9 @@ name: nix-linux
 
 on: [push, pull_request]
 
+env:
+  NIX_OPTIONS: -L -j 1 --impure
+
 jobs:
   # tests:
   #   runs-on: ubuntu-latest
@@ -54,49 +57,49 @@ jobs:
           free
           export NIX_BUILD_CORES=1
 
-          nix build '.#codegen:test:doctests' -L -j 1
-          nix build '.#checks.x86_64-linux.codegen:test:spec' -L -j 1
-          nix build '.#hasktorch-cpu:test:doctests' -L -j 1
-          nix build '.#checks.x86_64-linux.hasktorch-cpu:test:spec' -L -j 1
-          nix build '.#hasktorch-gradually-typed-cpu:test:doctests' -L -j 1
-          nix build '.#checks.x86_64-linux.hasktorch-gradually-typed-cpu:test:spec' -L -j 1
-          nix build '.#libtorch-ffi-cpu:test:spec' -L -j 1
-          nix build '.#checks.x86_64-linux.libtorch-ffi-cpu:test:spec' -L -j 1
+          nix build '.#codegen:test:doctests' $NIX_OPTIONS
+          nix build '.#checks.x86_64-linux.codegen:test:spec' $NIX_OPTIONS
+          nix build '.#hasktorch-cpu:test:doctests' $NIX_OPTIONS
+          nix build '.#checks.x86_64-linux.hasktorch-cpu:test:spec' $NIX_OPTIONS
+          nix build '.#hasktorch-gradually-typed-cpu:test:doctests' $NIX_OPTIONS
+          nix build '.#checks.x86_64-linux.hasktorch-gradually-typed-cpu:test:spec' $NIX_OPTIONS
+          nix build '.#libtorch-ffi-cpu:test:spec' $NIX_OPTIONS
+          nix build '.#checks.x86_64-linux.libtorch-ffi-cpu:test:spec' $NIX_OPTIONS
 
       - run: |
           ps -aux
           free
           export NIX_BUILD_CORES=1
 
-          nix build '.#bounding-box-cpu:exe:bounding-box' -L -j 1
-          nix build '.#codegen:exe:codegen-exe' -L -j 1
-          nix build '.#dataloader-cifar10-cpu:exe:dataloader-cifar10' -L -j 1
-          nix build '.#examples-cpu:exe:alexNet' -L -j 1
-          nix build '.#examples-cpu:exe:autograd' -L -j 1
-          nix build '.#examples-cpu:exe:distill' -L -j 1
-          nix build '.#examples-cpu:exe:gaussian-process' -L -j 1
-          nix build '.#examples-cpu:exe:gd-field' -L -j 1
-          nix build '.#examples-cpu:exe:image-processing' -L -j 1
-          nix build '.#examples-cpu:exe:iris-classification' -L -j 1
-          nix build '.#examples-cpu:exe:load-torchscript' -L -j 1
-          nix build '.#examples-cpu:exe:matrix-factorization' -L -j 1
-          nix build '.#examples-cpu:exe:minimal-text-example' -L -j 1
-          nix build '.#examples-cpu:exe:mnist-mixed-precision' -L -j 1
-          nix build '.#examples-cpu:exe:mnist-mlp' -L -j 1
-          nix build '.#examples-cpu:exe:optimizers' -L -j 1
-          nix build '.#examples-cpu:exe:optimizers-cpp' -L -j 1
-          nix build '.#examples-cpu:exe:optimizers-cpp-typed' -L -j 1
-          nix build '.#examples-cpu:exe:regression' -L -j 1
-          nix build '.#examples-cpu:exe:regularization' -L -j 1
-          nix build '.#examples-cpu:exe:rnn' -L -j 1
-          nix build '.#examples-cpu:exe:serialization' -L -j 1
-          nix build '.#examples-cpu:exe:static-mnist-cnn' -L -j 1
-          nix build '.#examples-cpu:exe:static-mnist-mlp' -L -j 1
-          nix build '.#examples-cpu:exe:static-xor-mlp' -L -j 1
-          nix build '.#examples-cpu:exe:typed-transformer' -L -j 1
-          nix build '.#examples-cpu:exe:vae' -L -j 1
-          nix build '.#examples-cpu:exe:xor-mlp' -L -j 1
-          nix build '.#hasktorch-gradually-typed-cpu:exe:linear-regression' -L -j 1
-          nix build '.#hasktorch-gradually-typed-cpu:exe:neural-interpreter' -L -j 1
-          nix build '.#hasktorch-gradually-typed-cpu:exe:two-layer-network' -L -j 1
-          nix build '.#untyped-nlp-cpu:exe:untyped-nlp' -L -j 1
+          nix build '.#bounding-box-cpu:exe:bounding-box' $NIX_OPTIONS
+          nix build '.#codegen:exe:codegen-exe' $NIX_OPTIONS
+          nix build '.#dataloader-cifar10-cpu:exe:dataloader-cifar10' $NIX_OPTIONS
+          nix build '.#examples-cpu:exe:alexNet' $NIX_OPTIONS
+          nix build '.#examples-cpu:exe:autograd' $NIX_OPTIONS
+          nix build '.#examples-cpu:exe:distill' $NIX_OPTIONS
+          nix build '.#examples-cpu:exe:gaussian-process' $NIX_OPTIONS
+          nix build '.#examples-cpu:exe:gd-field' $NIX_OPTIONS
+          nix build '.#examples-cpu:exe:image-processing' $NIX_OPTIONS
+          nix build '.#examples-cpu:exe:iris-classification' $NIX_OPTIONS
+          nix build '.#examples-cpu:exe:load-torchscript' $NIX_OPTIONS
+          nix build '.#examples-cpu:exe:matrix-factorization' $NIX_OPTIONS
+          nix build '.#examples-cpu:exe:minimal-text-example' $NIX_OPTIONS
+          nix build '.#examples-cpu:exe:mnist-mixed-precision' $NIX_OPTIONS
+          nix build '.#examples-cpu:exe:mnist-mlp' $NIX_OPTIONS
+          nix build '.#examples-cpu:exe:optimizers' $NIX_OPTIONS
+          nix build '.#examples-cpu:exe:optimizers-cpp' $NIX_OPTIONS
+          nix build '.#examples-cpu:exe:optimizers-cpp-typed' $NIX_OPTIONS
+          nix build '.#examples-cpu:exe:regression' $NIX_OPTIONS
+          nix build '.#examples-cpu:exe:regularization' $NIX_OPTIONS
+          nix build '.#examples-cpu:exe:rnn' $NIX_OPTIONS
+          nix build '.#examples-cpu:exe:serialization' $NIX_OPTIONS
+          nix build '.#examples-cpu:exe:static-mnist-cnn' $NIX_OPTIONS
+          nix build '.#examples-cpu:exe:static-mnist-mlp' $NIX_OPTIONS
+          nix build '.#examples-cpu:exe:static-xor-mlp' $NIX_OPTIONS
+          nix build '.#examples-cpu:exe:typed-transformer' $NIX_OPTIONS
+          nix build '.#examples-cpu:exe:vae' $NIX_OPTIONS
+          nix build '.#examples-cpu:exe:xor-mlp' $NIX_OPTIONS
+          nix build '.#hasktorch-gradually-typed-cpu:exe:linear-regression' $NIX_OPTIONS
+          nix build '.#hasktorch-gradually-typed-cpu:exe:neural-interpreter' $NIX_OPTIONS
+          nix build '.#hasktorch-gradually-typed-cpu:exe:two-layer-network' $NIX_OPTIONS
+          nix build '.#untyped-nlp-cpu:exe:untyped-nlp' $NIX_OPTIONS

--- a/.github/workflows/nix-linux.yml
+++ b/.github/workflows/nix-linux.yml
@@ -50,10 +50,6 @@ jobs:
           name: hasktorch
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
       - run: |
-          .github/workflows/setup-iohk-cache.sh
-          sed -i -e 's/"x86_64-linux" "x86_64-darwin"/"x86_64-linux"/g' flake.nix
-          nix flake show
-      - run: |
           ps -aux
           free
           export NIX_BUILD_CORES=1

--- a/.github/workflows/nix-macos.yml
+++ b/.github/workflows/nix-macos.yml
@@ -2,6 +2,9 @@ name: nix-macos
 
 on: [push, pull_request]
 
+env:
+  NIX_OPTIONS: -L -j 1 --impure
+
 jobs:
   # tests:
   #   runs-on: macOS-latest
@@ -31,15 +34,15 @@ jobs:
           #sed -i -e 's/"x86_64-linux"//g' flake.nix
           #nix flake show
       - run: |
-          nix build '.#codegen:test:doctests' -L -j 1
-          nix build '.#checks.x86_64-darwin.codegen:test:spec' -L -j 1
-          nix build '.#checks.x86_64-darwin.hasktorch-cpu:test:spec' -L -j 1
-          nix build '.#checks.x86_64-darwin.hasktorch-gradually-typed-cpu:test:spec' -L -j 1
-          nix build '.#libtorch-ffi-cpu:test:spec' -L -j 1
-          nix build '.#checks.x86_64-darwin.libtorch-ffi-cpu:test:spec' -L -j 1
+          nix build '.#codegen:test:doctests' $NIX_OPTIONS
+          nix build '.#checks.x86_64-darwin.codegen:test:spec' $NIX_OPTIONS
+          nix build '.#checks.x86_64-darwin.hasktorch-cpu:test:spec' $NIX_OPTIONS
+          nix build '.#checks.x86_64-darwin.hasktorch-gradually-typed-cpu:test:spec' $NIX_OPTIONS
+          nix build '.#libtorch-ffi-cpu:test:spec' $NIX_OPTIONS
+          nix build '.#checks.x86_64-darwin.libtorch-ffi-cpu:test:spec' $NIX_OPTIONS
 
           run-nix-build () {
-            nix build $@ --derivation && nix build $@ -L
+            nix build $@ --derivation && nix build $@ $NIX_OPTIONS
           }
           run-nix-build '.#bounding-box-cpu:exe:bounding-box'
           run-nix-build '.#codegen:exe:codegen-exe'

--- a/.github/workflows/nix-macos.yml
+++ b/.github/workflows/nix-macos.yml
@@ -33,7 +33,7 @@ jobs:
           nix --version
           #sed -i -e 's/"x86_64-linux"//g' flake.nix
           #nix flake show
-      - uses: mxschmitt/action-tmate@v3
+#      - uses: mxschmitt/action-tmate@v3
 #        timeout-minutes: 15
       - run: |
           nix build '.#codegen:test:doctests' $NIX_OPTIONS

--- a/.github/workflows/nix-macos.yml
+++ b/.github/workflows/nix-macos.yml
@@ -34,7 +34,7 @@ jobs:
           #sed -i -e 's/"x86_64-linux"//g' flake.nix
           #nix flake show
       - uses: mxschmitt/action-tmate@v3
-        timeout-minutes: 15
+#        timeout-minutes: 15
       - run: |
           nix build '.#codegen:test:doctests' $NIX_OPTIONS
           nix build '.#checks.x86_64-darwin.codegen:test:spec' $NIX_OPTIONS

--- a/.github/workflows/nix-macos.yml
+++ b/.github/workflows/nix-macos.yml
@@ -33,6 +33,8 @@ jobs:
           nix --version
           #sed -i -e 's/"x86_64-linux"//g' flake.nix
           #nix flake show
+      - uses: mxschmitt/action-tmate@v3
+        timeout-minutes: 15
       - run: |
           nix build '.#codegen:test:doctests' $NIX_OPTIONS
           nix build '.#checks.x86_64-darwin.codegen:test:spec' $NIX_OPTIONS

--- a/.github/workflows/stack-macos.yaml
+++ b/.github/workflows/stack-macos.yaml
@@ -12,7 +12,7 @@ jobs:
         git submodule init && git submodule update
     - name: Setup tool-chains
       run: |
-        /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
         brew install libomp || true
         pip3 install pyyaml || true
         #wget -qO- https://get.haskellstack.org/ | sed -e 's/^STACK_VERSION=.*/STACK_VERSION="1.9.3"/g' | sh || true

--- a/flake.lock
+++ b/flake.lock
@@ -20,10 +20,10 @@
       "flake": false,
       "locked": {
         "lastModified": 1603716527,
-        "narHash": "sha256-sDbrmur9Zfp4mPKohCD8IDZfXJ0Tjxpmr2R+kg5PpSY=",
+        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
         "owner": "haskell",
         "repo": "cabal",
-        "rev": "94aaa8e4720081f9c75497e2735b90f6a819b08e",
+        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
         "type": "github"
       },
       "original": {
@@ -36,16 +36,33 @@
     "cabal-34": {
       "flake": false,
       "locked": {
-        "lastModified": 1622475795,
-        "narHash": "sha256-chwTL304Cav+7p38d9mcb+egABWmxo2Aq+xgVBgEb/U=",
+        "lastModified": 1640353650,
+        "narHash": "sha256-N1t6M3/wqj90AEdRkeC8i923gQYUpzSr8b40qVOZ1Rk=",
         "owner": "haskell",
         "repo": "cabal",
-        "rev": "b086c1995cdd616fc8d91f46a21e905cc50a1049",
+        "rev": "942639c18c0cd8ec53e0a6f8d120091af35312cd",
         "type": "github"
       },
       "original": {
         "owner": "haskell",
         "ref": "3.4",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-36": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1641652457,
+        "narHash": "sha256-BlFPKP4C4HRUJeAbdembX1Rms1LD380q9s0qVDeoAak=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "f27667f8ec360c475027dcaee0138c937477b070",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.6",
         "repo": "cabal",
         "type": "github"
       }
@@ -81,13 +98,29 @@
         "type": "github"
       }
     },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1635892615,
+        "narHash": "sha256-harGbMZr4hzat2BWBU+Y5OYXlu+fVz7E4WeQzHi5o8A=",
+        "owner": "input-output-hk",
+        "repo": "flake-compat",
+        "rev": "eca47d3377946315596da653862d341ee5341318",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
-        "lastModified": 1623875721,
-        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
         "type": "github"
       },
       "original": {
@@ -98,11 +131,11 @@
     },
     "flake-utils_2": {
       "locked": {
-        "lastModified": 1619345332,
-        "narHash": "sha256-qHnQkEp1uklKTpx3MvKtY6xzgcqXDsz5nLilbbuL+3A=",
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "2ebf2558e5bf978c7fb8ea927dfaed8fefab2e28",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
         "type": "github"
       },
       "original": {
@@ -131,11 +164,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1635037915,
-        "narHash": "sha256-I+mPG1w2homLMzqwbs32IsSlmJtLaoer3n5jczWl65o=",
+        "lastModified": 1664673254,
+        "narHash": "sha256-ND5oi8LQf9lyLI2XS9Ig8zVJArt/Jja8a5SIJJhdUEM=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "38dc0a55e3efd065c7e9f0c5e7ff2d056e421fe7",
+        "rev": "e83134e6ed9e1d9a112457dda1f5b99d4bbe1ed7",
         "type": "github"
       },
       "original": {
@@ -149,28 +182,32 @@
         "HTTP": "HTTP",
         "cabal-32": "cabal-32",
         "cabal-34": "cabal-34",
+        "cabal-36": "cabal-36",
         "cardano-shell": "cardano-shell",
+        "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
         "hackage": "hackage",
         "hpc-coveralls": "hpc-coveralls",
+        "hydra": "hydra",
         "nix-tools": "nix-tools",
         "nixpkgs": [
           "nixpkgs"
         ],
         "nixpkgs-2003": "nixpkgs-2003",
-        "nixpkgs-2009": "nixpkgs-2009",
         "nixpkgs-2105": "nixpkgs-2105",
+        "nixpkgs-2111": "nixpkgs-2111",
+        "nixpkgs-2205": "nixpkgs-2205",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "old-ghc-nix": "old-ghc-nix",
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1635038099,
-        "narHash": "sha256-ULhJ/nsZ1bvy99VASxNIAXSm8SePnANInTuHGZbgOg4=",
+        "lastModified": 1664673368,
+        "narHash": "sha256-oIsI79VqmNmNTNT8re8UI55EK+5xn5syt+pJgmpbHlc=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "c4e4d8dd7c23cb66df5ecc8ceb0733b27e9d1525",
+        "rev": "1fbe8f674b30354b5a8b45245e05c54a5c77fc13",
         "type": "github"
       },
       "original": {
@@ -195,6 +232,29 @@
         "type": "github"
       }
     },
+    "hydra": {
+      "inputs": {
+        "nix": "nix",
+        "nixpkgs": [
+          "haskell-nix",
+          "hydra",
+          "nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1646878427,
+        "narHash": "sha256-KtbrofMtN8GlM7D+n90kixr7QpSlVmdN+vK5CA/aRzc=",
+        "owner": "NixOS",
+        "repo": "hydra",
+        "rev": "28b682b85b7efc5cf7974065792a1f22203a5927",
+        "type": "github"
+      },
+      "original": {
+        "id": "hydra",
+        "type": "indirect"
+      }
+    },
     "iohkNix": {
       "inputs": {
         "nixpkgs": [
@@ -202,11 +262,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1633964277,
-        "narHash": "sha256-7G/BK514WiMRr90EswNBthe8SmH9tjPaTBba/RW/VA8=",
+        "lastModified": 1663072120,
+        "narHash": "sha256-npRp5ULHI8/dvDAkBvudLybz0/vVBHg0p7ps7myxKgk=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "1e51437aac8a0e49663cb21e781f34163c81ebfb",
+        "rev": "e936cc0972fceb544dd7847e39fbcace1c9c00de",
         "type": "github"
       },
       "original": {
@@ -240,9 +300,25 @@
         "type": "github"
       }
     },
+    "lowdown-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1633514407,
+        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "type": "github"
+      }
+    },
     "naersk": {
       "inputs": {
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
         "lastModified": 1629707199,
@@ -258,33 +334,52 @@
         "type": "github"
       }
     },
-    "nix-tools": {
-      "flake": false,
+    "nix": {
+      "inputs": {
+        "lowdown-src": "lowdown-src",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-regression": "nixpkgs-regression"
+      },
       "locked": {
-        "lastModified": 1627889534,
-        "narHash": "sha256-9eEbK2nrRp6rYGQoBv6LO9IA/ANZpofwAkxMuGBD45Y=",
-        "owner": "input-output-hk",
-        "repo": "nix-tools",
-        "rev": "15d2e4b61cb63ff351f3c490c12c4d89eafd31a1",
+        "lastModified": 1643066034,
+        "narHash": "sha256-xEPeMcNJVOeZtoN+d+aRwolpW8mFSEQx76HTRdlhPhg=",
+        "owner": "NixOS",
+        "repo": "nix",
+        "rev": "a1cd7e58606a41fcf62bf8637804cf8306f17f62",
         "type": "github"
       },
       "original": {
-        "owner": "input-output-hk",
-        "repo": "nix-tools",
+        "owner": "NixOS",
+        "ref": "2.6.0",
+        "repo": "nix",
         "type": "github"
+      }
+    },
+    "nix-tools": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1,
+        "narHash": "sha256-pqNsBhQkO/nT991ASoSXsn07P7lNqpTP0wIV85wft30=",
+        "path": "./nix-tools",
+        "type": "path"
+      },
+      "original": {
+        "path": "./nix-tools",
+        "type": "path"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1619531122,
-        "narHash": "sha256-ovm5bo6PkZzNKh2YGXbRKYIjega0EjiEP0YDwyeXEYU=",
+        "lastModified": 1632864508,
+        "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bb80d578e8ad3cb5a607f468ac00cc546d0396dc",
+        "rev": "82891b5e2c2359d7e58d08849e4c89511ab94234",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
+        "ref": "nixos-21.05-small",
         "type": "indirect"
       }
     },
@@ -304,29 +399,13 @@
         "type": "github"
       }
     },
-    "nixpkgs-2009": {
-      "locked": {
-        "lastModified": 1624271064,
-        "narHash": "sha256-qns/uRW7MR2EfVf6VEeLgCsCp7pIOjDeR44JzTF09MA=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "46d1c3f28ca991601a53e9a14fdd53fcd3dd8416",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-20.09-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs-2105": {
       "locked": {
-        "lastModified": 1630481079,
-        "narHash": "sha256-leWXLchbAbqOlLT6tju631G40SzQWPqaAXQG3zH1Imw=",
+        "lastModified": 1659914493,
+        "narHash": "sha256-lkA5X3VNMKirvA+SUzvEhfA7XquWLci+CGi505YFAIs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "110a2c9ebbf5d4a94486854f18a37a938cfacbbb",
+        "rev": "022caabb5f2265ad4006c1fa5b1ebe69fb0c3faf",
         "type": "github"
       },
       "original": {
@@ -336,13 +415,60 @@
         "type": "github"
       }
     },
-    "nixpkgs-unstable": {
+    "nixpkgs-2111": {
       "locked": {
-        "lastModified": 1628785280,
-        "narHash": "sha256-2B5eMrEr6O8ff2aQNeVxTB+9WrGE80OB4+oM6T7fOcc=",
+        "lastModified": 1659446231,
+        "narHash": "sha256-hekabNdTdgR/iLsgce5TGWmfIDZ86qjPhxDg/8TlzhE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6525bbc06a39f26750ad8ee0d40000ddfdc24acb",
+        "rev": "eabc38219184cc3e04a974fe31857d8e0eac098d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2205": {
+      "locked": {
+        "lastModified": 1663981975,
+        "narHash": "sha256-TKaxWAVJR+a5JJauKZqibmaM5e/Pi5tBDx9s8fl/kSE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "309faedb8338d3ae8ad8f1043b3ccf48c9cc2970",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-22.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-regression": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1663905476,
+        "narHash": "sha256-0CSwRKaYravh9v6qSlBpM0gNg0UhKT2lL7Yn6Zbx7UM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e14f9fb57315f0d4abde222364f19f88c77d2b79",
         "type": "github"
       },
       "original": {
@@ -353,6 +479,20 @@
       }
     },
     "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1645655918,
+        "narHash": "sha256-ZfbEFRW7o237+A1P7eTKhXje435FCAoe0blj2n20Was=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "77a7a4197740213879b9a1d2e1788c6c8ade4274",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_3": {
       "locked": {
         "lastModified": 1630084536,
         "narHash": "sha256-ZFO/c1n5NNzHdY848Lfrbh8QN8MdP6oajbj4Z55rVXs=",
@@ -366,7 +506,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_3": {
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1630084536,
         "narHash": "sha256-ZFO/c1n5NNzHdY848Lfrbh8QN8MdP6oajbj4Z55rVXs=",
@@ -400,14 +540,14 @@
     "pre-commit-hooks": {
       "inputs": {
         "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1634595438,
-        "narHash": "sha256-hV9D41fqTateTligwNd9dmJKQ0R0w6RpCN92xR3LhHk=",
+        "lastModified": 1664573419,
+        "narHash": "sha256-bVjsFPOF4t5/G9ir/qNqmQWxRKooG86ctOH78yaarkc=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "06fa80325b6fe3b28d136071dd0ce55d4817e9fd",
+        "rev": "2a4f1cfaa01b8b31edc7d3004454c4a0c38d50d8",
         "type": "github"
       },
       "original": {
@@ -436,11 +576,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1635038033,
-        "narHash": "sha256-3AliGUxmwAhWIlsA5oAj1PsGpytq4CWEKAnyZSpjfwU=",
+        "lastModified": 1664586901,
+        "narHash": "sha256-ROUeTRTJ0Yktjqg+vXOYCXKWjIqutJl4rw5KsFZ0kCo=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "248b1a35980778c95543fbdc38841bb4a1a6385c",
+        "rev": "f1abb218b94cc1e94bc52185dab499f6705b6edd",
         "type": "github"
       },
       "original": {
@@ -452,7 +592,7 @@
     "tokenizers": {
       "inputs": {
         "naersk": "naersk",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs_4",
         "utils": [
           "haskell-nix",
           "flake-utils"

--- a/flake.lock
+++ b/flake.lock
@@ -16,7 +16,40 @@
         "type": "github"
       }
     },
+    "HTTP_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1451647621,
+        "narHash": "sha256-oHIyw3x0iKBexEo49YeUDV1k74ZtyYKGR2gNJXXRxts=",
+        "owner": "phadej",
+        "repo": "HTTP",
+        "rev": "9bc0996d412fef1787449d841277ef663ad9a915",
+        "type": "github"
+      },
+      "original": {
+        "owner": "phadej",
+        "repo": "HTTP",
+        "type": "github"
+      }
+    },
     "cabal-32": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1603716527,
+        "narHash": "sha256-sDbrmur9Zfp4mPKohCD8IDZfXJ0Tjxpmr2R+kg5PpSY=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "94aaa8e4720081f9c75497e2735b90f6a819b08e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.2",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-32_2": {
       "flake": false,
       "locked": {
         "lastModified": 1603716527,
@@ -36,6 +69,23 @@
     "cabal-34": {
       "flake": false,
       "locked": {
+        "lastModified": 1622475795,
+        "narHash": "sha256-chwTL304Cav+7p38d9mcb+egABWmxo2Aq+xgVBgEb/U=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "b086c1995cdd616fc8d91f46a21e905cc50a1049",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.4",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-34_2": {
+      "flake": false,
+      "locked": {
         "lastModified": 1640353650,
         "narHash": "sha256-N1t6M3/wqj90AEdRkeC8i923gQYUpzSr8b40qVOZ1Rk=",
         "owner": "haskell",
@@ -53,6 +103,23 @@
     "cabal-36": {
       "flake": false,
       "locked": {
+        "lastModified": 1662482775,
+        "narHash": "sha256-thO83914M6xxtwyPjoy73DDUOeEYZukHUU6hRqh7lbA=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "507001ab445f1c00726593c073351d2cdf0b240d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.6",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-36_2": {
+      "flake": false,
+      "locked": {
         "lastModified": 1641652457,
         "narHash": "sha256-BlFPKP4C4HRUJeAbdembX1Rms1LD380q9s0qVDeoAak=",
         "owner": "haskell",
@@ -68,6 +135,22 @@
       }
     },
     "cardano-shell": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1608537748,
+        "narHash": "sha256-PulY1GfiMgKVnBci3ex4ptk2UNYMXqGjJOxcPy2KYT4=",
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "rev": "9392c75087cb9a3d453998f4230930dea3a95725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "type": "github"
+      }
+    },
+    "cardano-shell_2": {
       "flake": false,
       "locked": {
         "lastModified": 1608537748,
@@ -114,7 +197,53 @@
         "type": "github"
       }
     },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1635892615,
+        "narHash": "sha256-harGbMZr4hzat2BWBU+Y5OYXlu+fVz7E4WeQzHi5o8A=",
+        "owner": "input-output-hk",
+        "repo": "flake-compat",
+        "rev": "eca47d3377946315596da653862d341ee5341318",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
+      "locked": {
+        "lastModified": 1623875721,
+        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
       "locked": {
         "lastModified": 1644229661,
         "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
@@ -129,13 +258,13 @@
         "type": "github"
       }
     },
-    "flake-utils_2": {
+    "flake-utils_4": {
       "locked": {
-        "lastModified": 1644229661,
-        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "lastModified": 1619345332,
+        "narHash": "sha256-qHnQkEp1uklKTpx3MvKtY6xzgcqXDsz5nLilbbuL+3A=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "rev": "2ebf2558e5bf978c7fb8ea927dfaed8fefab2e28",
         "type": "github"
       },
       "original": {
@@ -161,14 +290,47 @@
         "type": "github"
       }
     },
+    "ghc-8.6.5-iohk_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1600920045,
+        "narHash": "sha256-DO6kxJz248djebZLpSzTGD6s8WRpNI9BTwUeOf5RwY8=",
+        "owner": "input-output-hk",
+        "repo": "ghc",
+        "rev": "95713a6ecce4551240da7c96b6176f980af75cae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "release/8.6.5-iohk",
+        "repo": "ghc",
+        "type": "github"
+      }
+    },
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1664673254,
-        "narHash": "sha256-ND5oi8LQf9lyLI2XS9Ig8zVJArt/Jja8a5SIJJhdUEM=",
+        "lastModified": 1635037915,
+        "narHash": "sha256-I+mPG1w2homLMzqwbs32IsSlmJtLaoer3n5jczWl65o=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "e83134e6ed9e1d9a112457dda1f5b99d4bbe1ed7",
+        "rev": "38dc0a55e3efd065c7e9f0c5e7ff2d056e421fe7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackage_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1664759632,
+        "narHash": "sha256-SirBVxqVonZ0VhSJKqXdnoInhbpIOtN9gXESV6Mlt0k=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "a9acd50aefb3711dce5d1eb7f746b07562312b37",
         "type": "github"
       },
       "original": {
@@ -192,7 +354,51 @@
         "hydra": "hydra",
         "nix-tools": "nix-tools",
         "nixpkgs": [
-          "nixpkgs"
+          "haskell-nix",
+          "nixpkgs-unstable"
+        ],
+        "nixpkgs-2003": "nixpkgs-2003_2",
+        "nixpkgs-2105": "nixpkgs-2105_2",
+        "nixpkgs-2111": "nixpkgs-2111_2",
+        "nixpkgs-2205": "nixpkgs-2205_2",
+        "nixpkgs-unstable": "nixpkgs-unstable_2",
+        "old-ghc-nix": "old-ghc-nix_2",
+        "stackage": "stackage_2"
+      },
+      "locked": {
+        "lastModified": 1664764787,
+        "narHash": "sha256-jscXUkqtN7Ivc/x6jT/d7vV435lgTK/4MdvRZVsKD9g=",
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "rev": "ec0c59e2de05053c21301bc959a27df92fe93376",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "rev": "ec0c59e2de05053c21301bc959a27df92fe93376",
+        "type": "github"
+      }
+    },
+    "haskellNix": {
+      "inputs": {
+        "HTTP": "HTTP_2",
+        "cabal-32": "cabal-32_2",
+        "cabal-34": "cabal-34_2",
+        "cabal-36": "cabal-36_2",
+        "cardano-shell": "cardano-shell_2",
+        "flake-compat": "flake-compat_2",
+        "flake-utils": "flake-utils_3",
+        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_2",
+        "hackage": "hackage_2",
+        "hpc-coveralls": "hpc-coveralls_2",
+        "hydra": "hydra_2",
+        "nix-tools": "nix-tools_2",
+        "nixpkgs": [
+          "haskell-nix",
+          "nix-tools",
+          "haskellNix",
+          "nixpkgs-unstable"
         ],
         "nixpkgs-2003": "nixpkgs-2003",
         "nixpkgs-2105": "nixpkgs-2105",
@@ -203,11 +409,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1664673368,
-        "narHash": "sha256-oIsI79VqmNmNTNT8re8UI55EK+5xn5syt+pJgmpbHlc=",
+        "lastModified": 1664764787,
+        "narHash": "sha256-jscXUkqtN7Ivc/x6jT/d7vV435lgTK/4MdvRZVsKD9g=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "1fbe8f674b30354b5a8b45245e05c54a5c77fc13",
+        "rev": "ec0c59e2de05053c21301bc959a27df92fe93376",
         "type": "github"
       },
       "original": {
@@ -217,6 +423,22 @@
       }
     },
     "hpc-coveralls": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1607498076,
+        "narHash": "sha256-8uqsEtivphgZWYeUo5RDUhp6bO9j2vaaProQxHBltQk=",
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "rev": "14df0f7d229f4cd2e79f8eabb1a740097fdfa430",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "type": "github"
+      }
+    },
+    "hpc-coveralls_2": {
       "flake": false,
       "locked": {
         "lastModified": 1607498076,
@@ -243,6 +465,31 @@
         ]
       },
       "locked": {
+        "lastModified": 1664546346,
+        "narHash": "sha256-BEXvLgBRK38Z2f4v5OXvTgywkvU+n0PHyjvOepa+GXk=",
+        "owner": "NixOS",
+        "repo": "hydra",
+        "rev": "8f05b797e96197b9ddaec63331b58b6a98aa5c0a",
+        "type": "github"
+      },
+      "original": {
+        "id": "hydra",
+        "type": "indirect"
+      }
+    },
+    "hydra_2": {
+      "inputs": {
+        "nix": "nix_2",
+        "nixpkgs": [
+          "haskell-nix",
+          "nix-tools",
+          "haskellNix",
+          "hydra",
+          "nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
         "lastModified": 1646878427,
         "narHash": "sha256-KtbrofMtN8GlM7D+n90kixr7QpSlVmdN+vK5CA/aRzc=",
         "owner": "NixOS",
@@ -262,11 +509,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1663072120,
-        "narHash": "sha256-npRp5ULHI8/dvDAkBvudLybz0/vVBHg0p7ps7myxKgk=",
+        "lastModified": 1633964277,
+        "narHash": "sha256-7G/BK514WiMRr90EswNBthe8SmH9tjPaTBba/RW/VA8=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "e936cc0972fceb544dd7847e39fbcace1c9c00de",
+        "rev": "1e51437aac8a0e49663cb21e781f34163c81ebfb",
         "type": "github"
       },
       "original": {
@@ -316,9 +563,25 @@
         "type": "github"
       }
     },
+    "lowdown-src_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1633514407,
+        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "type": "github"
+      }
+    },
     "naersk": {
       "inputs": {
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": "nixpkgs_4"
       },
       "locked": {
         "lastModified": 1629707199,
@@ -341,6 +604,62 @@
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
+        "lastModified": 1661606874,
+        "narHash": "sha256-9+rpYzI+SmxJn+EbYxjGv68Ucp22bdFUSy/4LkHkkDQ=",
+        "owner": "NixOS",
+        "repo": "nix",
+        "rev": "11e45768b34fdafdcf019ddbd337afa16127ff0f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "2.11.0",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
+    "nix-tools": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "haskellNix": "haskellNix",
+        "nixpkgs": [
+          "haskell-nix",
+          "nix-tools",
+          "haskellNix",
+          "nixpkgs-unstable"
+        ]
+      },
+      "locked": {
+        "lastModified": 1,
+        "narHash": "sha256-IVlPOoFDRn7b9gfvNb8agit97toR2GzAwU8HDvu3crY=",
+        "path": "./nix-tools",
+        "type": "path"
+      },
+      "original": {
+        "path": "./nix-tools",
+        "type": "path"
+      }
+    },
+    "nix-tools_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1,
+        "narHash": "sha256-pqNsBhQkO/nT991ASoSXsn07P7lNqpTP0wIV85wft30=",
+        "path": "./nix-tools",
+        "type": "path"
+      },
+      "original": {
+        "path": "./nix-tools",
+        "type": "path"
+      }
+    },
+    "nix_2": {
+      "inputs": {
+        "lowdown-src": "lowdown-src_2",
+        "nixpkgs": "nixpkgs_2",
+        "nixpkgs-regression": "nixpkgs-regression_2"
+      },
+      "locked": {
         "lastModified": 1643066034,
         "narHash": "sha256-xEPeMcNJVOeZtoN+d+aRwolpW8mFSEQx76HTRdlhPhg=",
         "owner": "NixOS",
@@ -355,35 +674,39 @@
         "type": "github"
       }
     },
-    "nix-tools": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1,
-        "narHash": "sha256-pqNsBhQkO/nT991ASoSXsn07P7lNqpTP0wIV85wft30=",
-        "path": "./nix-tools",
-        "type": "path"
-      },
-      "original": {
-        "path": "./nix-tools",
-        "type": "path"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1632864508,
-        "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
+        "lastModified": 1657693803,
+        "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "82891b5e2c2359d7e58d08849e4c89511ab94234",
+        "rev": "365e1b3a859281cf11b94f87231adeabbdd878a2",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "ref": "nixos-21.05-small",
-        "type": "indirect"
+        "owner": "NixOS",
+        "ref": "nixos-22.05-small",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "nixpkgs-2003": {
+      "locked": {
+        "lastModified": 1620055814,
+        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-20.03-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2003_2": {
       "locked": {
         "lastModified": 1620055814,
         "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
@@ -415,7 +738,39 @@
         "type": "github"
       }
     },
+    "nixpkgs-2105_2": {
+      "locked": {
+        "lastModified": 1630481079,
+        "narHash": "sha256-leWXLchbAbqOlLT6tju631G40SzQWPqaAXQG3zH1Imw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "110a2c9ebbf5d4a94486854f18a37a938cfacbbb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-2111": {
+      "locked": {
+        "lastModified": 1659446231,
+        "narHash": "sha256-hekabNdTdgR/iLsgce5TGWmfIDZ86qjPhxDg/8TlzhE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "eabc38219184cc3e04a974fe31857d8e0eac098d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2111_2": {
       "locked": {
         "lastModified": 1659446231,
         "narHash": "sha256-hekabNdTdgR/iLsgce5TGWmfIDZ86qjPhxDg/8TlzhE=",
@@ -447,7 +802,39 @@
         "type": "github"
       }
     },
+    "nixpkgs-2205_2": {
+      "locked": {
+        "lastModified": 1664158485,
+        "narHash": "sha256-OJjPilaj2R0yAwjg4O96iJLWKoW2+TeLlDpk0yF73xE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "058d97782ed561787a6b2186854d29c94fd4fc0c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-22.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-regression": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      }
+    },
+    "nixpkgs-regression_2": {
       "locked": {
         "lastModified": 1643052045,
         "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
@@ -478,27 +865,44 @@
         "type": "github"
       }
     },
+    "nixpkgs-unstable_2": {
+      "locked": {
+        "lastModified": 1628785280,
+        "narHash": "sha256-2B5eMrEr6O8ff2aQNeVxTB+9WrGE80OB4+oM6T7fOcc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6525bbc06a39f26750ad8ee0d40000ddfdc24acb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1645655918,
-        "narHash": "sha256-ZfbEFRW7o237+A1P7eTKhXje435FCAoe0blj2n20Was=",
-        "owner": "nixos",
+        "lastModified": 1632864508,
+        "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "77a7a4197740213879b9a1d2e1788c6c8ade4274",
+        "rev": "82891b5e2c2359d7e58d08849e4c89511ab94234",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
+        "ref": "nixos-21.05-small",
         "type": "indirect"
       }
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1630084536,
-        "narHash": "sha256-ZFO/c1n5NNzHdY848Lfrbh8QN8MdP6oajbj4Z55rVXs=",
+        "lastModified": 1619531122,
+        "narHash": "sha256-ovm5bo6PkZzNKh2YGXbRKYIjega0EjiEP0YDwyeXEYU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "40f337454d6c76bc12500564f4553d6853e83aeb",
+        "rev": "bb80d578e8ad3cb5a607f468ac00cc546d0396dc",
         "type": "github"
       },
       "original": {
@@ -537,17 +941,34 @@
         "type": "github"
       }
     },
+    "old-ghc-nix_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1631092763,
+        "narHash": "sha256-sIKgO+z7tj4lw3u6oBZxqIhDrzSkvpHtv0Kki+lh9Fg=",
+        "owner": "angerman",
+        "repo": "old-ghc-nix",
+        "rev": "af48a7a7353e418119b6dfe3cd1463a657f342b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "angerman",
+        "ref": "master",
+        "repo": "old-ghc-nix",
+        "type": "github"
+      }
+    },
     "pre-commit-hooks": {
       "inputs": {
-        "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs_2"
+        "flake-utils": "flake-utils_4",
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1664573419,
-        "narHash": "sha256-bVjsFPOF4t5/G9ir/qNqmQWxRKooG86ctOH78yaarkc=",
+        "lastModified": 1634595438,
+        "narHash": "sha256-hV9D41fqTateTligwNd9dmJKQ0R0w6RpCN92xR3LhHk=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "2a4f1cfaa01b8b31edc7d3004454c4a0c38d50d8",
+        "rev": "06fa80325b6fe3b28d136071dd0ce55d4817e9fd",
         "type": "github"
       },
       "original": {
@@ -589,10 +1010,28 @@
         "type": "github"
       }
     },
+    "stackage_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1635038033,
+        "narHash": "sha256-3AliGUxmwAhWIlsA5oAj1PsGpytq4CWEKAnyZSpjfwU=",
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "rev": "248b1a35980778c95543fbdc38841bb4a1a6385c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "type": "github"
+      }
+    },
     "tokenizers": {
       "inputs": {
         "naersk": "naersk",
-        "nixpkgs": "nixpkgs_4",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
         "utils": [
           "haskell-nix",
           "flake-utils"

--- a/flake.lock
+++ b/flake.lock
@@ -16,40 +16,7 @@
         "type": "github"
       }
     },
-    "HTTP_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1451647621,
-        "narHash": "sha256-oHIyw3x0iKBexEo49YeUDV1k74ZtyYKGR2gNJXXRxts=",
-        "owner": "phadej",
-        "repo": "HTTP",
-        "rev": "9bc0996d412fef1787449d841277ef663ad9a915",
-        "type": "github"
-      },
-      "original": {
-        "owner": "phadej",
-        "repo": "HTTP",
-        "type": "github"
-      }
-    },
     "cabal-32": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1603716527,
-        "narHash": "sha256-sDbrmur9Zfp4mPKohCD8IDZfXJ0Tjxpmr2R+kg5PpSY=",
-        "owner": "haskell",
-        "repo": "cabal",
-        "rev": "94aaa8e4720081f9c75497e2735b90f6a819b08e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "3.2",
-        "repo": "cabal",
-        "type": "github"
-      }
-    },
-    "cabal-32_2": {
       "flake": false,
       "locked": {
         "lastModified": 1603716527,
@@ -69,23 +36,6 @@
     "cabal-34": {
       "flake": false,
       "locked": {
-        "lastModified": 1622475795,
-        "narHash": "sha256-chwTL304Cav+7p38d9mcb+egABWmxo2Aq+xgVBgEb/U=",
-        "owner": "haskell",
-        "repo": "cabal",
-        "rev": "b086c1995cdd616fc8d91f46a21e905cc50a1049",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "3.4",
-        "repo": "cabal",
-        "type": "github"
-      }
-    },
-    "cabal-34_2": {
-      "flake": false,
-      "locked": {
         "lastModified": 1640353650,
         "narHash": "sha256-N1t6M3/wqj90AEdRkeC8i923gQYUpzSr8b40qVOZ1Rk=",
         "owner": "haskell",
@@ -101,23 +51,6 @@
       }
     },
     "cabal-36": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1662482775,
-        "narHash": "sha256-thO83914M6xxtwyPjoy73DDUOeEYZukHUU6hRqh7lbA=",
-        "owner": "haskell",
-        "repo": "cabal",
-        "rev": "507001ab445f1c00726593c073351d2cdf0b240d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "3.6",
-        "repo": "cabal",
-        "type": "github"
-      }
-    },
-    "cabal-36_2": {
       "flake": false,
       "locked": {
         "lastModified": 1641652457,
@@ -150,54 +83,7 @@
         "type": "github"
       }
     },
-    "cardano-shell_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1608537748,
-        "narHash": "sha256-PulY1GfiMgKVnBci3ex4ptk2UNYMXqGjJOxcPy2KYT4=",
-        "owner": "input-output-hk",
-        "repo": "cardano-shell",
-        "rev": "9392c75087cb9a3d453998f4230930dea3a95725",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "cardano-shell",
-        "type": "github"
-      }
-    },
-    "devshell": {
-      "locked": {
-        "lastModified": 1625086391,
-        "narHash": "sha256-IpNPv1v8s4L3CoxhwcgZIitGpcrnNgnj09X7TA0QV3k=",
-        "owner": "numtide",
-        "repo": "devshell",
-        "rev": "4b5ac7cf7d9a1cc60b965bb51b59922f2210cbc7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "devshell",
-        "type": "github"
-      }
-    },
     "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1635892615,
-        "narHash": "sha256-harGbMZr4hzat2BWBU+Y5OYXlu+fVz7E4WeQzHi5o8A=",
-        "owner": "input-output-hk",
-        "repo": "flake-compat",
-        "rev": "eca47d3377946315596da653862d341ee5341318",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_2": {
       "flake": false,
       "locked": {
         "lastModified": 1635892615,
@@ -215,36 +101,6 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1623875721,
-        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
-      "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_3": {
-      "locked": {
         "lastModified": 1644229661,
         "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
         "owner": "numtide",
@@ -258,13 +114,13 @@
         "type": "github"
       }
     },
-    "flake-utils_4": {
+    "flake-utils_2": {
       "locked": {
-        "lastModified": 1619345332,
-        "narHash": "sha256-qHnQkEp1uklKTpx3MvKtY6xzgcqXDsz5nLilbbuL+3A=",
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "2ebf2558e5bf978c7fb8ea927dfaed8fefab2e28",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
         "type": "github"
       },
       "original": {
@@ -290,40 +146,7 @@
         "type": "github"
       }
     },
-    "ghc-8.6.5-iohk_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1600920045,
-        "narHash": "sha256-DO6kxJz248djebZLpSzTGD6s8WRpNI9BTwUeOf5RwY8=",
-        "owner": "input-output-hk",
-        "repo": "ghc",
-        "rev": "95713a6ecce4551240da7c96b6176f980af75cae",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "ref": "release/8.6.5-iohk",
-        "repo": "ghc",
-        "type": "github"
-      }
-    },
     "hackage": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1635037915,
-        "narHash": "sha256-I+mPG1w2homLMzqwbs32IsSlmJtLaoer3n5jczWl65o=",
-        "owner": "input-output-hk",
-        "repo": "hackage.nix",
-        "rev": "38dc0a55e3efd065c7e9f0c5e7ff2d056e421fe7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "hackage.nix",
-        "type": "github"
-      }
-    },
-    "hackage_2": {
       "flake": false,
       "locked": {
         "lastModified": 1664759632,
@@ -357,49 +180,6 @@
           "haskell-nix",
           "nixpkgs-unstable"
         ],
-        "nixpkgs-2003": "nixpkgs-2003_2",
-        "nixpkgs-2105": "nixpkgs-2105_2",
-        "nixpkgs-2111": "nixpkgs-2111_2",
-        "nixpkgs-2205": "nixpkgs-2205_2",
-        "nixpkgs-unstable": "nixpkgs-unstable_2",
-        "old-ghc-nix": "old-ghc-nix_2",
-        "stackage": "stackage_2"
-      },
-      "locked": {
-        "lastModified": 1664764787,
-        "narHash": "sha256-jscXUkqtN7Ivc/x6jT/d7vV435lgTK/4MdvRZVsKD9g=",
-        "owner": "input-output-hk",
-        "repo": "haskell.nix",
-        "rev": "ec0c59e2de05053c21301bc959a27df92fe93376",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "haskell.nix",
-        "rev": "ec0c59e2de05053c21301bc959a27df92fe93376",
-        "type": "github"
-      }
-    },
-    "haskellNix": {
-      "inputs": {
-        "HTTP": "HTTP_2",
-        "cabal-32": "cabal-32_2",
-        "cabal-34": "cabal-34_2",
-        "cabal-36": "cabal-36_2",
-        "cardano-shell": "cardano-shell_2",
-        "flake-compat": "flake-compat_2",
-        "flake-utils": "flake-utils_3",
-        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_2",
-        "hackage": "hackage_2",
-        "hpc-coveralls": "hpc-coveralls_2",
-        "hydra": "hydra_2",
-        "nix-tools": "nix-tools_2",
-        "nixpkgs": [
-          "haskell-nix",
-          "nix-tools",
-          "haskellNix",
-          "nixpkgs-unstable"
-        ],
         "nixpkgs-2003": "nixpkgs-2003",
         "nixpkgs-2105": "nixpkgs-2105",
         "nixpkgs-2111": "nixpkgs-2111",
@@ -419,26 +199,11 @@
       "original": {
         "owner": "input-output-hk",
         "repo": "haskell.nix",
+        "rev": "ec0c59e2de05053c21301bc959a27df92fe93376",
         "type": "github"
       }
     },
     "hpc-coveralls": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1607498076,
-        "narHash": "sha256-8uqsEtivphgZWYeUo5RDUhp6bO9j2vaaProQxHBltQk=",
-        "owner": "sevanspowell",
-        "repo": "hpc-coveralls",
-        "rev": "14df0f7d229f4cd2e79f8eabb1a740097fdfa430",
-        "type": "github"
-      },
-      "original": {
-        "owner": "sevanspowell",
-        "repo": "hpc-coveralls",
-        "type": "github"
-      }
-    },
-    "hpc-coveralls_2": {
       "flake": false,
       "locked": {
         "lastModified": 1607498076,
@@ -465,31 +230,6 @@
         ]
       },
       "locked": {
-        "lastModified": 1664546346,
-        "narHash": "sha256-BEXvLgBRK38Z2f4v5OXvTgywkvU+n0PHyjvOepa+GXk=",
-        "owner": "NixOS",
-        "repo": "hydra",
-        "rev": "8f05b797e96197b9ddaec63331b58b6a98aa5c0a",
-        "type": "github"
-      },
-      "original": {
-        "id": "hydra",
-        "type": "indirect"
-      }
-    },
-    "hydra_2": {
-      "inputs": {
-        "nix": "nix_2",
-        "nixpkgs": [
-          "haskell-nix",
-          "nix-tools",
-          "haskellNix",
-          "hydra",
-          "nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
         "lastModified": 1646878427,
         "narHash": "sha256-KtbrofMtN8GlM7D+n90kixr7QpSlVmdN+vK5CA/aRzc=",
         "owner": "NixOS",
@@ -509,41 +249,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1633964277,
-        "narHash": "sha256-7G/BK514WiMRr90EswNBthe8SmH9tjPaTBba/RW/VA8=",
+        "lastModified": 1663072120,
+        "narHash": "sha256-npRp5ULHI8/dvDAkBvudLybz0/vVBHg0p7ps7myxKgk=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "1e51437aac8a0e49663cb21e781f34163c81ebfb",
+        "rev": "e936cc0972fceb544dd7847e39fbcace1c9c00de",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "type": "github"
-      }
-    },
-    "libtorch-nix": {
-      "inputs": {
-        "devshell": "devshell",
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "utils": [
-          "haskell-nix",
-          "flake-utils"
-        ]
-      },
-      "locked": {
-        "lastModified": 1647710908,
-        "narHash": "sha256-Q087FfbOn5vehzENnpPftp2Fy/vwwighCT3jTVG7nIg=",
-        "owner": "hasktorch",
-        "repo": "libtorch-nix",
-        "rev": "fbf5bb828c5f1eff0f4cf0c88c6eb436845273b3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hasktorch",
-        "repo": "libtorch-nix",
         "type": "github"
       }
     },
@@ -563,25 +278,9 @@
         "type": "github"
       }
     },
-    "lowdown-src_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1633514407,
-        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
-        "owner": "kristapsdz",
-        "repo": "lowdown",
-        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "kristapsdz",
-        "repo": "lowdown",
-        "type": "github"
-      }
-    },
     "naersk": {
       "inputs": {
-        "nixpkgs": "nixpkgs_4"
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
         "lastModified": 1629707199,
@@ -604,62 +303,6 @@
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1661606874,
-        "narHash": "sha256-9+rpYzI+SmxJn+EbYxjGv68Ucp22bdFUSy/4LkHkkDQ=",
-        "owner": "NixOS",
-        "repo": "nix",
-        "rev": "11e45768b34fdafdcf019ddbd337afa16127ff0f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "2.11.0",
-        "repo": "nix",
-        "type": "github"
-      }
-    },
-    "nix-tools": {
-      "inputs": {
-        "flake-utils": "flake-utils_2",
-        "haskellNix": "haskellNix",
-        "nixpkgs": [
-          "haskell-nix",
-          "nix-tools",
-          "haskellNix",
-          "nixpkgs-unstable"
-        ]
-      },
-      "locked": {
-        "lastModified": 1,
-        "narHash": "sha256-IVlPOoFDRn7b9gfvNb8agit97toR2GzAwU8HDvu3crY=",
-        "path": "./nix-tools",
-        "type": "path"
-      },
-      "original": {
-        "path": "./nix-tools",
-        "type": "path"
-      }
-    },
-    "nix-tools_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1,
-        "narHash": "sha256-pqNsBhQkO/nT991ASoSXsn07P7lNqpTP0wIV85wft30=",
-        "path": "./nix-tools",
-        "type": "path"
-      },
-      "original": {
-        "path": "./nix-tools",
-        "type": "path"
-      }
-    },
-    "nix_2": {
-      "inputs": {
-        "lowdown-src": "lowdown-src_2",
-        "nixpkgs": "nixpkgs_2",
-        "nixpkgs-regression": "nixpkgs-regression_2"
-      },
-      "locked": {
         "lastModified": 1643066034,
         "narHash": "sha256-xEPeMcNJVOeZtoN+d+aRwolpW8mFSEQx76HTRdlhPhg=",
         "owner": "NixOS",
@@ -674,39 +317,35 @@
         "type": "github"
       }
     },
+    "nix-tools": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1,
+        "narHash": "sha256-pqNsBhQkO/nT991ASoSXsn07P7lNqpTP0wIV85wft30=",
+        "path": "./nix-tools",
+        "type": "path"
+      },
+      "original": {
+        "path": "./nix-tools",
+        "type": "path"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1657693803,
-        "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
+        "lastModified": 1632864508,
+        "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "365e1b3a859281cf11b94f87231adeabbdd878a2",
+        "rev": "82891b5e2c2359d7e58d08849e4c89511ab94234",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixos-22.05-small",
-        "repo": "nixpkgs",
-        "type": "github"
+        "id": "nixpkgs",
+        "ref": "nixos-21.05-small",
+        "type": "indirect"
       }
     },
     "nixpkgs-2003": {
-      "locked": {
-        "lastModified": 1620055814,
-        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-20.03-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2003_2": {
       "locked": {
         "lastModified": 1620055814,
         "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
@@ -738,39 +377,7 @@
         "type": "github"
       }
     },
-    "nixpkgs-2105_2": {
-      "locked": {
-        "lastModified": 1630481079,
-        "narHash": "sha256-leWXLchbAbqOlLT6tju631G40SzQWPqaAXQG3zH1Imw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "110a2c9ebbf5d4a94486854f18a37a938cfacbbb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-21.05-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs-2111": {
-      "locked": {
-        "lastModified": 1659446231,
-        "narHash": "sha256-hekabNdTdgR/iLsgce5TGWmfIDZ86qjPhxDg/8TlzhE=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "eabc38219184cc3e04a974fe31857d8e0eac098d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-21.11-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2111_2": {
       "locked": {
         "lastModified": 1659446231,
         "narHash": "sha256-hekabNdTdgR/iLsgce5TGWmfIDZ86qjPhxDg/8TlzhE=",
@@ -802,39 +409,7 @@
         "type": "github"
       }
     },
-    "nixpkgs-2205_2": {
-      "locked": {
-        "lastModified": 1664158485,
-        "narHash": "sha256-OJjPilaj2R0yAwjg4O96iJLWKoW2+TeLlDpk0yF73xE=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "058d97782ed561787a6b2186854d29c94fd4fc0c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-22.05-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs-regression": {
-      "locked": {
-        "lastModified": 1643052045,
-        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "github"
-      }
-    },
-    "nixpkgs-regression_2": {
       "locked": {
         "lastModified": 1643052045,
         "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
@@ -865,52 +440,21 @@
         "type": "github"
       }
     },
-    "nixpkgs-unstable_2": {
-      "locked": {
-        "lastModified": 1628785280,
-        "narHash": "sha256-2B5eMrEr6O8ff2aQNeVxTB+9WrGE80OB4+oM6T7fOcc=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "6525bbc06a39f26750ad8ee0d40000ddfdc24acb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1632864508,
-        "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
-        "owner": "NixOS",
+        "lastModified": 1645655918,
+        "narHash": "sha256-ZfbEFRW7o237+A1P7eTKhXje435FCAoe0blj2n20Was=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "82891b5e2c2359d7e58d08849e4c89511ab94234",
+        "rev": "77a7a4197740213879b9a1d2e1788c6c8ade4274",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixos-21.05-small",
         "type": "indirect"
       }
     },
     "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1619531122,
-        "narHash": "sha256-ovm5bo6PkZzNKh2YGXbRKYIjega0EjiEP0YDwyeXEYU=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "bb80d578e8ad3cb5a607f468ac00cc546d0396dc",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_4": {
       "locked": {
         "lastModified": 1630084536,
         "narHash": "sha256-ZFO/c1n5NNzHdY848Lfrbh8QN8MdP6oajbj4Z55rVXs=",
@@ -941,34 +485,17 @@
         "type": "github"
       }
     },
-    "old-ghc-nix_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1631092763,
-        "narHash": "sha256-sIKgO+z7tj4lw3u6oBZxqIhDrzSkvpHtv0Kki+lh9Fg=",
-        "owner": "angerman",
-        "repo": "old-ghc-nix",
-        "rev": "af48a7a7353e418119b6dfe3cd1463a657f342b8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "angerman",
-        "ref": "master",
-        "repo": "old-ghc-nix",
-        "type": "github"
-      }
-    },
     "pre-commit-hooks": {
       "inputs": {
-        "flake-utils": "flake-utils_4",
-        "nixpkgs": "nixpkgs_3"
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1634595438,
-        "narHash": "sha256-hV9D41fqTateTligwNd9dmJKQ0R0w6RpCN92xR3LhHk=",
+        "lastModified": 1664708386,
+        "narHash": "sha256-aCD8UUGNYb5nYzRmtsq/0yP9gFOQQHr/Lsb5vW+mucw=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "06fa80325b6fe3b28d136071dd0ce55d4817e9fd",
+        "rev": "2e4a708918e14fdbd534cc94aaa9470cd19b2464",
         "type": "github"
       },
       "original": {
@@ -981,7 +508,6 @@
       "inputs": {
         "haskell-nix": "haskell-nix",
         "iohkNix": "iohkNix",
-        "libtorch-nix": "libtorch-nix",
         "nixpkgs": [
           "haskell-nix",
           "nixpkgs-unstable"
@@ -1002,22 +528,6 @@
         "owner": "input-output-hk",
         "repo": "stackage.nix",
         "rev": "f1abb218b94cc1e94bc52185dab499f6705b6edd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "stackage.nix",
-        "type": "github"
-      }
-    },
-    "stackage_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1635038033,
-        "narHash": "sha256-3AliGUxmwAhWIlsA5oAj1PsGpytq4CWEKAnyZSpjfwU=",
-        "owner": "input-output-hk",
-        "repo": "stackage.nix",
-        "rev": "248b1a35980778c95543fbdc38841bb4a1a6385c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,14 +3,17 @@
 
   nixConfig = {
     substituters = [
-      https://cache.nixos.org
-      https://cache.iog.io
-      https://hasktorch.cachix.org
+      "https://cache.nixos.org"
     ];
-    trusted-public-keys = [
-      hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
-      hasktorch.cachix.org-1:wLjNS6HuFVpmzbmv01lxwjdCOtWRD8pQVR3Zr/wVoQc=
+    extra-substituters = [
+      "https://cache.iog.io"
+      "https://hasktorch.cachix.org"
     ];
+    extra-trusted-public-keys = [
+      "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
+      "hasktorch.cachix.org-1:wLjNS6HuFVpmzbmv01lxwjdCOtWRD8pQVR3Zr/wVoQc="
+    ];
+    allow-import-from-derivation = "true";
     bash-prompt = "\\[\\033[1m\\][dev-hasktorch$(__git_ps1 \" (%s)\")]\\[\\033\[m\\]\\040\\w$\\040";
     
   };
@@ -96,7 +99,7 @@
             (hasktorch.overlays.hasktorch-project ty)
           ];
         in
-          { pkgs = import nixpkgs { inherit system overlays; };
+          { pkgs = import nixpkgs { inherit system overlays; inherit (haskell-nix) config;};
             legacyPkgs = haskell-nix.legacyPackages.${system}.appendOverlays overlays;
           };
 

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
   nixConfig = {
     substituters = [
       https://cache.nixos.org
-      https://hydra.iohk.io
+      https://cache.iog.io
       https://hasktorch.cachix.org
     ];
     trusted-public-keys = [
@@ -15,11 +15,10 @@
   };
 
   inputs = {
-    nixpkgs.follows = "haskell-nix/nixpkgs-unstable";
     haskell-nix = {
-      url = "github:input-output-hk/haskell.nix";
-      inputs.nixpkgs.follows = "nixpkgs";
+      url = "github:input-output-hk/haskell.nix?rev=ec0c59e2de05053c21301bc959a27df92fe93376";
     };
+    nixpkgs.follows = "haskell-nix/nixpkgs-unstable";
     utils.follows = "haskell-nix/flake-utils";
     iohkNix = {
       url = "github:input-output-hk/iohk-nix";
@@ -33,6 +32,7 @@
     tokenizers = {
       url = "github:hasktorch/tokenizers/flakes";
       inputs.utils.follows = "haskell-nix/flake-utils";
+      inputs.nixpkgs.follows = "nixpkgs";
     };
     pre-commit-hooks.url = "github:cachix/pre-commit-hooks.nix";
   };

--- a/flake.nix
+++ b/flake.nix
@@ -70,7 +70,7 @@
         hasktorch-project = final: prev: {
           hasktorchProject = import ./nix/haskell.nix ({
             pkgs = prev;
-            compiler-nix-name = "ghc8107";
+            compiler-nix-name = "ghc902";
             inherit (prev) lib;
             inherit (prev.hasktorch-config) profiling cudaSupport;
           });

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,8 @@
       hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
       hasktorch.cachix.org-1:wLjNS6HuFVpmzbmv01lxwjdCOtWRD8pQVR3Zr/wVoQc=
     ];
-    bash-prompt = "\\[\\033[1m\\][dev-hasktorch]\\[\\033\[m\\]\\040\\w$\\040";
+    bash-prompt = "\\[\\033[1m\\][dev-hasktorch$(__git_ps1 \" (%s)\")]\\[\\033\[m\\]\\040\\w$\\040";
+    
   };
 
   inputs = {

--- a/hasktorch/test/ScriptSpec.hs
+++ b/hasktorch/test/ScriptSpec.hs
@@ -7,19 +7,12 @@ module ScriptSpec (spec) where
 
 import Control.Exception.Safe (catch, throwIO)
 import GHC.Generics
-import Language.C.Inline.Cpp.Exceptions (CppException (..))
 import Test.Hspec
 import Torch hiding (forward)
 import Torch.Autograd
 import Torch.NN
 import Torch.Script
 import Prelude hiding (abs, exp, floor, log, max, min)
-
-prettyException :: IO a -> IO a
-prettyException func =
-  func `catch` \a@(CppStdException message) -> do
-    putStrLn message
-    throwIO (CppStdException "")
 
 data MLPSpec = MLPSpec
   { inputFeatures :: Int,

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -80,9 +80,9 @@ let
         packages.libtorch-ffi = {
           preConfigure = setupNumCores "libtorch-ffi";
           configureFlags = [
-            "--extra-lib-dirs=${pkgs.torch}/lib"
-            "--extra-include-dirs=${pkgs.torch}/include"
-            "--extra-include-dirs=${pkgs.torch}/include/torch/csrc/api/include"
+            "--extra-lib-dirs=${pkgs.torch.out}/lib"
+            "--extra-include-dirs=${pkgs.torch.dev}/include"
+            "--extra-include-dirs=${pkgs.torch.dev}/include/torch/csrc/api/include"
           ];
           flags = {
             cuda = cudaSupport;

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -47,8 +47,8 @@ let
       # Enable profiling
       (lib.optionalAttrs profiling {
         enableLibraryProfiling = true;
-        packages.examples.enableExecutableProfiling = true;
-        packages.hasktorch-gradually-typed.enableExecutableProfiling = true;
+#        packages.examples.enableExecutableProfiling = true;
+#        packages.hasktorch-gradually-typed.enableExecutableProfiling = true;
       })
 
       # Fix for "exceptions" build problem with ghc 9.0.1 (https://github.com/input-output-hk/haskell.nix/issues/1177)

--- a/nix/libtorch-binary-hashes.nix
+++ b/nix/libtorch-binary-hashes.nix
@@ -1,0 +1,24 @@
+version : builtins.getAttr version {
+  "1.11.0" = {
+    x86_64-darwin-cpu = {
+      name = "libtorch-macos-1.11.0.zip";
+      url = "https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.11.0.zip";
+      hash = "sha256-oTbvPjrREXPQanSjxzHbgJOtY5Yzb9FFgQsUG78o6eQ=";
+    };
+    x86_64-linux-cpu = {
+      name = "libtorch-cxx11-abi-shared-with-deps-1.11.0-cpu.zip";
+      url = "https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.11.0%2Bcpu.zip";
+      hash = "sha256-zC3lyeQrZJAkwingIbbjTkLXngsEaVv6VCl3QbAjOMQ=";
+    };
+    x86_64-linux-cuda-10 = {
+      name = "libtorch-cxx11-abi-shared-with-deps-1.11.0-cu113.zip";
+      url = "https://download.pytorch.org/libtorch/cu113/libtorch-cxx11-abi-shared-with-deps-1.11.0%2Bcu102.zip";
+      hash = "1qznvi3yjlpf0vxf9hnr59ajin17xfz85w3axrsc9xnmpkyhi6p8";
+    };
+    x86_64-linux-cuda-11 = {
+      name = "libtorch-cxx11-abi-shared-with-deps-1.11.0-cu113.zip";
+      url = "https://download.pytorch.org/libtorch/cu113/libtorch-cxx11-abi-shared-with-deps-1.11.0%2Bcu113.zip";
+      hash = "11zjggaw2qi4fh7v36ygb0pqlbphihq46yfvbgrv93a7x6f857ld";
+    };
+  };
+}

--- a/nix/libtorch-binary-hashes.nix
+++ b/nix/libtorch-binary-hashes.nix
@@ -11,14 +11,14 @@ version : builtins.getAttr version {
       hash = "sha256-zC3lyeQrZJAkwingIbbjTkLXngsEaVv6VCl3QbAjOMQ=";
     };
     x86_64-linux-cuda-10 = {
-      name = "libtorch-cxx11-abi-shared-with-deps-1.11.0-cu113.zip";
-      url = "https://download.pytorch.org/libtorch/cu113/libtorch-cxx11-abi-shared-with-deps-1.11.0%2Bcu102.zip";
-      hash = "1qznvi3yjlpf0vxf9hnr59ajin17xfz85w3axrsc9xnmpkyhi6p8";
+      name = "libtorch-cxx11-abi-shared-with-deps-1.11.0-cu102.zip";
+      url = "https://download.pytorch.org/libtorch/cu102/libtorch-cxx11-abi-shared-with-deps-1.11.0%2Bcu102.zip";
+      hash = "sha256-0IYyWOOuDuzl15YOE6zoXK8fvhKcS+RRPJHvm1V9s58=";
     };
     x86_64-linux-cuda-11 = {
       name = "libtorch-cxx11-abi-shared-with-deps-1.11.0-cu113.zip";
       url = "https://download.pytorch.org/libtorch/cu113/libtorch-cxx11-abi-shared-with-deps-1.11.0%2Bcu113.zip";
-      hash = "11zjggaw2qi4fh7v36ygb0pqlbphihq46yfvbgrv93a7x6f857ld";
+      hash = "sha256-0J2X76XeWaDn0SaptehYsFVInMTwyzgYxAdshn4wZXM=";
     };
   };
 }

--- a/nix/libtorch.nix
+++ b/nix/libtorch.nix
@@ -1,0 +1,103 @@
+{ callPackage
+, stdenv
+, fetchzip
+, lib
+, libcxx
+
+, addOpenGLRunpath
+, patchelf
+, fixDarwinDylibNames
+
+, cudaSupport
+, device
+}:
+
+let
+  # The binary libtorch distribution statically links the CUDA
+  # toolkit. This means that we do not need to provide CUDA to
+  # this derivation. However, we should ensure on version bumps
+  # that the CUDA toolkit for `passthru.tests` is still
+  # up-to-date.
+  version = "1.11.0";
+  srcs = import ./libtorch-binary-hashes.nix version;
+  unavailable = throw "libtorch is not available for this platform";
+  libcxx-for-libtorch = if stdenv.hostPlatform.system == "x86_64-darwin" then libcxx else stdenv.cc.cc.lib;
+in stdenv.mkDerivation {
+  inherit version;
+  pname = "libtorch";
+
+  src = fetchzip srcs."${stdenv.targetPlatform.system}-${device}" or unavailable;
+
+  nativeBuildInputs =
+    if stdenv.isDarwin then [ fixDarwinDylibNames ]
+    else [ patchelf ] ++ lib.optionals cudaSupport [ addOpenGLRunpath ];
+
+  dontBuild = true;
+  dontConfigure = true;
+  dontStrip = true;
+
+  installPhase = ''
+    # Copy headers and CMake files.
+    mkdir -p $dev
+    cp -r include $dev
+    cp -r share $dev
+
+    install -Dm755 -t $out/lib lib/*${stdenv.hostPlatform.extensions.sharedLibrary}*
+
+    # We do not care about Java support...
+    rm -f $out/lib/lib*jni* 2> /dev/null || true
+
+    # Fix up library paths for split outputs
+    substituteInPlace $dev/share/cmake/Torch/TorchConfig.cmake \
+      --replace \''${TORCH_INSTALL_PREFIX}/lib "$out/lib" \
+
+    substituteInPlace \
+      $dev/share/cmake/Caffe2/Caffe2Targets-release.cmake \
+      --replace \''${_IMPORT_PREFIX}/lib "$out/lib" \
+  '';
+
+  postFixup = let
+    rpath = lib.makeLibraryPath [ stdenv.cc.cc.lib ];
+  in lib.optionalString stdenv.isLinux ''
+    find $out/lib -type f \( -name '*.so' -or -name '*.so.*' \) | while read lib; do
+      echo "setting rpath for $lib..."
+      patchelf --set-rpath "${rpath}:$out/lib" "$lib"
+      ${lib.optionalString cudaSupport ''
+        addOpenGLRunpath "$lib"
+      ''}
+    done
+  '' + lib.optionalString stdenv.isDarwin ''
+    for f in $out/lib/*.dylib; do
+        otool -L $f
+    done
+    for f in $out/lib/*.dylib; do
+      install_name_tool -id $out/lib/$(basename $f) $f || true
+      for rpath in $(otool -L $f | grep rpath | awk '{print $1}');do
+        install_name_tool -change $rpath $out/lib/$(basename $rpath) $f
+      done
+      if otool -L $f | grep /usr/lib/libc++ >& /dev/null; then
+        install_name_tool -change /usr/lib/libc++.1.dylib ${libcxx-for-libtorch.outPath}/lib/libc++.1.0.dylib $f
+      fi
+    done
+    for f in $out/lib/*.dylib; do
+        otool -L $f
+    done
+  '';
+
+  outputs = [ "out" "dev" ];
+
+  passthru.tests.cmake = callPackage ./test {
+    inherit cudaSupport;
+  };
+
+  meta = with lib; {
+    description = "C++ API of the PyTorch machine learning framework";
+    homepage = "https://pytorch.org/";
+    # Includes CUDA and Intel MKL, but redistributions of the binary are not limited.
+    # https://docs.nvidia.com/cuda/eula/index.html
+    # https://www.intel.com/content/www/us/en/developer/articles/license/onemkl-license-faq.html
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ junjihashimoto ];
+    platforms = platforms.unix;
+  };
+}

--- a/nix/stack-shell.nix
+++ b/nix/stack-shell.nix
@@ -37,7 +37,7 @@ let
     name = "hasktorch-stack-dev-shell";
 
     extraArgs = [
-      "--extra-include-dirs=${pkgs.torch}/include/torch/csrc/api/include"
+      "--extra-include-dirs=${pkgs.torch.dev}/include/torch/csrc/api/include"
     ];
 
     inherit buildInputs;

--- a/setup-cabal.sh
+++ b/setup-cabal.sh
@@ -2,8 +2,8 @@
 
 set -xe
 
-if ghc --version | grep 9.0.1 ; then
-curl https://www.stackage.org/nightly-2022-03-17/cabal.config |\
+if ghc --version | grep 9.0.. ; then
+curl https://www.stackage.org/lts-19.25/cabal.config |\
 sed -e 's/with-compiler: .*$//g' |\
 sed -e 's/.*inline-c-cpp.*//g' > cabal.project.freeze
 else
@@ -45,6 +45,9 @@ package libtorch-ffi
     ghc-options: -j${USED_NUM_CPU} +RTS -A128m -n2m -M${USED_MEM_GB} -RTS
 
 package hasktorch
+    ghc-options: -j${USED_NUM_CPU} +RTS -A128m -n2m -M${USED_MEMX2_GB} -RTS
+
+package vector
     ghc-options: -j${USED_NUM_CPU} +RTS -A128m -n2m -M${USED_MEMX2_GB} -RTS
 
 EOF

--- a/setup-cabal.sh
+++ b/setup-cabal.sh
@@ -1,15 +1,11 @@
 #!/usr/bin/env bash
 
 set -xe
+ghc --version
 
-if ghc --version | grep 9.0.. ; then
 curl https://www.stackage.org/lts-19.25/cabal.config |\
 sed -e 's/with-compiler: .*$//g' |\
 sed -e 's/.*inline-c-cpp.*//g' > cabal.project.freeze
-else
-curl https://www.stackage.org/lts-17.2/cabal.config |\
-sed -e 's/with-compiler: .*$//g' > cabal.project.freeze
-fi
 
 case "$(uname)" in
   "Darwin")

--- a/stack.yaml
+++ b/stack.yaml
@@ -35,7 +35,7 @@ extra-deps:
 - term-rewriting-0.4.0.2@sha256:5412f6aa29c5756634ee30e8df923c83ab9f012a4b8797c460af3d7078466764,2740
 - type-errors-pretty-0.0.1.2@sha256:9042b64d1ac2f69aa55690576504a2397ebea8a6a55332242c88f54027c7eb57,2781
 - git: https://github.com/hasktorch/tintin
-  commit: 3bbe6a3797e43c92e61a2a4bdc26d5732cd5e7fd
+  commit: 0d5afba586da01e0a54e598745676c5c56189178
 - git: https://github.com/hasktorch/tokenizers
   commit: 9d25f0ba303193e97f8b22b9c93cbc84725886c3
   subdirs:
@@ -52,6 +52,7 @@ allow-newer: true
 
 nix:
   shell-file: nix/stack-shell.nix
+  pure: false
 
 # ghc-options:
 #   libtorch-ffi: -j +RTS -A128m -n2m -RTS

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-18.14
+resolver: lts-19.25
 
 #compiler: ghc-8.10.7
 


### PR DESCRIPTION
The ghc and lts we are using are a little old.
We can not resolve package dependencies in macos,  so upgrade them.