### PR TITLE
Replaced *weight and *bias with RecordDotSyntax.

### DIFF
--- a/examples/distill/Model.hs
+++ b/examples/distill/Model.hs
@@ -4,6 +4,8 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 
 module Model where
 
@@ -127,7 +129,7 @@ instance HasForward CNN Tensor Tensor where
       . reshape [batchSize, 1, 28, 28]
       $ input
     where
-      channels = (shape (toDependent . conv2dWeight $ cnnConv0)) !! 0
+      channels = (shape (toDependent cnnConv0.weight)) !! 0
       batchSize = Prelude.div (product (shape input)) 784
   forwardStoch = (pure .) . forward
 

--- a/examples/distill/Regularization.hs
+++ b/examples/distill/Regularization.hs
@@ -2,6 +2,8 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 
 module Main where
 
@@ -53,8 +55,8 @@ regularizationTest mnistData = do
   let pruneSpec =
         PruneSpec
           { selectWeights = \m ->
-              [ toDependent . weight . cnnFC0 $ m,
-                toDependent . weight . cnnFC1 $ m
+              [ toDependent $ m.cnnFC0.weight,
+                toDependent $ m.cnnFC1.weight
               ],
             pruneWeights = undefined
           }
@@ -82,15 +84,15 @@ regularizationTest mnistData = do
       mnistData
       initRefL2
 
-  plt <- strip (toDependent . weight . cnnFC0 $ initRef)
+  plt <- strip (toDependent initRef.cnnFC0.weight)
   toHtmlFile "plotInit.html" plt
   system "open plotInit.html"
   print "weights0 l1"
-  plt <- strip (toDependent . weight . cnnFC0 $ l1Model)
+  plt <- strip (toDependent l1Model.cnnFC0.weight)
   toHtmlFile "plot0l1.html" plt
   system "open plot0l1.html"
   print "weights0 l2"
-  plt <- strip (toDependent . weight . cnnFC0 $ l2Model)
+  plt <- strip (toDependent l2Model.cnnFC0.weight)
   toHtmlFile "plot0l2.html" plt
   system "open plot0l2.html"
 

--- a/examples/regression/Main.hs
+++ b/examples/regression/Main.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 
 module Main where
 
@@ -17,8 +19,8 @@ groundTruth t = squeezeAll $ matmul t weight + bias
 
 printParams :: Linear -> IO ()
 printParams trained = do
-  putStrLn $ "Parameters:\n" ++ (show $ toDependent $ weight trained)
-  putStrLn $ "Bias:\n" ++ (show $ toDependent $ bias trained)
+  putStrLn $ "Parameters:\n" ++ (show $ toDependent $ trained.weight)
+  putStrLn $ "Bias:\n" ++ (show $ toDependent $ trained.bias)
 
 main :: IO ()
 main = do

--- a/examples/serialization/Main.hs
+++ b/examples/serialization/Main.hs
@@ -5,6 +5,8 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 
 module Main where
 
@@ -43,8 +45,8 @@ asFloats = (asValue :: Tensor -> [Float]) . toDependent
 
 areSame :: Linear -> Linear -> Bool
 areSame trained trained' =
-  (asFloats (bias trained) == asFloats (bias trained'))
-    && (asFloats (weight trained) == asFloats (weight trained'))
+  (asFloats (trained.bias) == asFloats (trained'.bias))
+    && (asFloats (trained.weight) == asFloats (trained'.weight))
 
 main :: IO ()
 main = do

--- a/hasktorch/src/Torch/NN.hs
+++ b/hasktorch/src/Torch/NN.hs
@@ -11,6 +11,8 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 
 module Torch.NN where
 
@@ -221,8 +223,8 @@ linear :: Linear -> Tensor -> Tensor
 linear layer input = linear' input w b
   where
     linear' input weight bias = unsafePerformIO $ cast3 ATen.linear_ttt input weight bias
-    w = toDependent (weight layer)
-    b = toDependent (bias layer)
+    w = toDependent (layer.weight)
+    b = toDependent (layer.bias)
 
 linearForward :: Linear -> Tensor -> Tensor
 linearForward = linear -- temporary alias until dependencies are updated
@@ -270,8 +272,8 @@ data Conv1dSpec = Conv1dSpec
   deriving (Show, Eq)
 
 data Conv1d = Conv1d
-  { conv1dWeight :: Parameter,
-    conv1dBias :: Parameter
+  { weight :: Parameter,
+    bias :: Parameter
   }
   deriving (Show, Generic, Parameterized)
 
@@ -288,8 +290,8 @@ conv1dForward ::
   Tensor
 conv1dForward layer = Torch.Functional.conv1d' w b
   where
-    w = toDependent (conv1dWeight layer)
-    b = toDependent (conv1dBias layer)
+    w = toDependent (layer.weight)
+    b = toDependent (layer.bias)
 
 instance Randomizable Conv1dSpec Conv1d where
   sample Conv1dSpec {..} = do
@@ -336,8 +338,8 @@ data Conv2dSpec = Conv2dSpec
   deriving (Show, Eq)
 
 data Conv2d = Conv2d
-  { conv2dWeight :: Parameter,
-    conv2dBias :: Parameter
+  { weight :: Parameter,
+    bias :: Parameter
   }
   deriving (Show, Generic, Parameterized)
 
@@ -354,8 +356,8 @@ conv2dForward ::
   Tensor
 conv2dForward layer = Torch.Functional.conv2d' w b
   where
-    w = toDependent (conv2dWeight layer)
-    b = toDependent (conv2dBias layer)
+    w = toDependent (layer.weight)
+    b = toDependent (layer.bias)
 
 instance Randomizable Conv2dSpec Conv2d where
   sample Conv2dSpec {..} = do
@@ -405,8 +407,8 @@ data Conv3dSpec = Conv3dSpec
   deriving (Show, Eq)
 
 data Conv3d = Conv3d
-  { conv3dWeight :: Parameter,
-    conv3dBias :: Parameter
+  { weight :: Parameter,
+    bias :: Parameter
   }
   deriving (Show, Generic, Parameterized)
 
@@ -423,8 +425,8 @@ conv3dForward ::
   Tensor
 conv3dForward layer = Torch.Functional.conv3d' w b
   where
-    w = toDependent (conv3dWeight layer)
-    b = toDependent (conv3dBias layer)
+    w = toDependent (layer.weight)
+    b = toDependent (layer.bias)
 
 instance Randomizable Conv3dSpec Conv3d where
   sample Conv3dSpec {..} = do
@@ -474,8 +476,8 @@ data ConvTranspose1dSpec = ConvTranspose1dSpec
   deriving (Show, Eq)
 
 data ConvTranspose1d = ConvTranspose1d
-  { convTranspose1dWeight :: Parameter,
-    convTranspose1dBias :: Parameter
+  { weight :: Parameter,
+    bias :: Parameter
   }
   deriving (Show, Generic, Parameterized)
 
@@ -492,8 +494,8 @@ convTranspose1dForward ::
   Tensor
 convTranspose1dForward layer = convTranspose1d' w b
   where
-    w = toDependent (convTranspose1dWeight layer)
-    b = toDependent (convTranspose1dBias layer)
+    w = toDependent (layer.weight)
+    b = toDependent (layer.bias)
 
 instance Randomizable ConvTranspose1dSpec ConvTranspose1d where
   sample ConvTranspose1dSpec {..} = do
@@ -540,8 +542,8 @@ data ConvTranspose2dSpec = ConvTranspose2dSpec
   deriving (Show, Eq)
 
 data ConvTranspose2d = ConvTranspose2d
-  { convTranspose2dWeight :: Parameter,
-    convTranspose2dBias :: Parameter
+  { weight :: Parameter,
+    bias :: Parameter
   }
   deriving (Show, Generic, Parameterized)
 
@@ -558,8 +560,8 @@ convTranspose2dForward ::
   Tensor
 convTranspose2dForward layer = convTranspose2d' w b
   where
-    w = toDependent (convTranspose2dWeight layer)
-    b = toDependent (convTranspose2dBias layer)
+    w = toDependent (layer.weight)
+    b = toDependent (layer.bias)
 
 instance Randomizable ConvTranspose2dSpec ConvTranspose2d where
   sample ConvTranspose2dSpec {..} = do
@@ -609,8 +611,8 @@ data ConvTranspose3dSpec = ConvTranspose3dSpec
   deriving (Show, Eq)
 
 data ConvTranspose3d = ConvTranspose3d
-  { convTranspose3dWeight :: Parameter,
-    convTranspose3dBias :: Parameter
+  { weight :: Parameter,
+    bias :: Parameter
   }
   deriving (Show, Generic, Parameterized)
 
@@ -627,8 +629,8 @@ convTranspose3dForward ::
   Tensor
 convTranspose3dForward layer = convTranspose3d' w b
   where
-    w = toDependent (convTranspose3dWeight layer)
-    b = toDependent (convTranspose3dBias layer)
+    w = toDependent (layer.weight)
+    b = toDependent (layer.bias)
 
 instance Randomizable ConvTranspose3dSpec ConvTranspose3d where
   sample ConvTranspose3dSpec {..} = do
@@ -672,20 +674,20 @@ data BatchNormSpec = BatchNormSpec
   deriving (Show, Eq)
 
 data BatchNorm = BatchNorm
-  { batchNormWeight :: Parameter,
-    batchNormBias :: Parameter,
+  { weight :: Parameter,
+    bias :: Parameter,
     runningMean :: Tensor,
     runningVar :: Tensor
   }
   deriving (Show, Generic)
 
 batchNormForward :: BatchNorm -> Bool -> Double -> Double -> Tensor -> Tensor
-batchNormForward BatchNorm {..} train momentum eps input =
+batchNormForward params train momentum eps input =
   Torch.Functional.batchNorm
-    (toDependent batchNormWeight)
-    (toDependent batchNormBias)
-    runningMean
-    runningVar
+    (toDependent params.weight)
+    (toDependent params.bias)
+    params.runningMean
+    params.runningVar
     train
     momentum
     eps
@@ -705,20 +707,20 @@ data InstanceNormSpec = InstanceNormSpec
   deriving (Show, Eq)
 
 data InstanceNorm = InstanceNorm
-  { instanceNormWeight :: Parameter,
-    instanceNormBias :: Parameter,
+  { weight :: Parameter,
+    bias :: Parameter,
     iRunningMean :: Tensor,
     iRunningVar :: Tensor
   }
   deriving (Show, Generic)
 
 instanceNormForward :: InstanceNorm -> Bool -> Double -> Double -> Tensor -> Tensor
-instanceNormForward InstanceNorm {..} train momentum eps input =
+instanceNormForward params train momentum eps input =
   Torch.Functional.instanceNorm
-    (toDependent instanceNormWeight)
-    (toDependent instanceNormBias)
-    iRunningMean
-    iRunningVar
+    (toDependent params.weight)
+    (toDependent params.bias)
+    params.iRunningMean
+    params.iRunningVar
     train
     momentum
     eps

--- a/hasktorch/src/Torch/Typed/NN/Convolution.hs
+++ b/hasktorch/src/Torch/Typed/NN/Convolution.hs
@@ -14,6 +14,8 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeInType #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# OPTIONS_GHC -Wno-partial-type-signatures #-}
 
 module Torch.Typed.NN.Convolution where
@@ -50,8 +52,8 @@ data
   where
   Conv1d ::
     forall inputChannelSize outputChannelSize kernelSize dtype device.
-    { conv1dWeight :: Parameter device dtype '[outputChannelSize, inputChannelSize, kernelSize],
-      conv1dBias :: Parameter device dtype '[outputChannelSize]
+    { weight :: Parameter device dtype '[outputChannelSize, inputChannelSize, kernelSize],
+      bias :: Parameter device dtype '[outputChannelSize]
     } ->
     Conv1d
       inputChannelSize
@@ -72,8 +74,8 @@ conv1dForward ::
   Tensor _ _ _
 conv1dForward Conv1d {..} input =
   conv1d @stride @padding
-    (toDependent conv1dWeight)
-    (toDependent conv1dBias)
+    (toDependent weight)
+    (toDependent bias)
     input
 
 instance
@@ -132,8 +134,8 @@ data
   where
   Conv2d ::
     forall inputChannelSize outputChannelSize kernelSize0 kernelSize1 dtype device.
-    { conv2dWeight :: Parameter device dtype '[outputChannelSize, inputChannelSize, kernelSize0, kernelSize1],
-      conv2dBias :: Parameter device dtype '[outputChannelSize]
+    { weight :: Parameter device dtype '[outputChannelSize, inputChannelSize, kernelSize0, kernelSize1],
+      bias :: Parameter device dtype '[outputChannelSize]
     } ->
     Conv2d
       inputChannelSize
@@ -155,8 +157,8 @@ conv2dForward ::
   Tensor _ _ _
 conv2dForward Conv2d {..} input =
   conv2d @stride @padding
-    (toDependent conv2dWeight)
-    (toDependent conv2dBias)
+    (toDependent weight)
+    (toDependent bias)
     input
 
 instance
@@ -224,8 +226,8 @@ data
   where
   Conv3d ::
     forall inputChannelSize outputChannelSize kernelSize0 kernelSize1 kernelSize2 dtype device.
-    { conv3dWeight :: Parameter device dtype '[outputChannelSize, inputChannelSize, kernelSize0, kernelSize1, kernelSize2],
-      conv3dBias :: Parameter device dtype '[outputChannelSize]
+    { weight :: Parameter device dtype '[outputChannelSize, inputChannelSize, kernelSize0, kernelSize1, kernelSize2],
+      bias :: Parameter device dtype '[outputChannelSize]
     } ->
     Conv3d
       inputChannelSize
@@ -248,8 +250,8 @@ conv3dForward ::
   Tensor _ _ _
 conv3dForward Conv3d {..} input =
   conv3d @stride @padding
-    (toDependent conv3dWeight)
-    (toDependent conv3dBias)
+    (toDependent weight)
+    (toDependent bias)
     input
 
 instance
@@ -317,8 +319,8 @@ data
   where
   ConvTranspose1d ::
     forall inputChannelSize outputChannelSize kernelSize dtype device.
-    { convTranspose1dWeight :: Parameter device dtype '[inputChannelSize, outputChannelSize, kernelSize],
-      convTranspose1dBias :: Parameter device dtype '[outputChannelSize]
+    { weight :: Parameter device dtype '[inputChannelSize, outputChannelSize, kernelSize],
+      bias :: Parameter device dtype '[outputChannelSize]
     } ->
     ConvTranspose1d
       inputChannelSize
@@ -339,8 +341,8 @@ convTranspose1dForward ::
   Tensor _ _ _
 convTranspose1dForward ConvTranspose1d {..} input =
   convTranspose1d @stride @padding
-    (toDependent convTranspose1dWeight)
-    (toDependent convTranspose1dBias)
+    (toDependent weight)
+    (toDependent bias)
     input
 
 instance
@@ -399,8 +401,8 @@ data
   where
   ConvTranspose2d ::
     forall inputChannelSize outputChannelSize kernelSize0 kernelSize1 dtype device.
-    { convTranspose2dWeight :: Parameter device dtype '[inputChannelSize, outputChannelSize, kernelSize0, kernelSize1],
-      convTranspose2dBias :: Parameter device dtype '[outputChannelSize]
+    { weight :: Parameter device dtype '[inputChannelSize, outputChannelSize, kernelSize0, kernelSize1],
+      bias :: Parameter device dtype '[outputChannelSize]
     } ->
     ConvTranspose2d
       inputChannelSize
@@ -422,8 +424,8 @@ convTranspose2dForward ::
   Tensor _ _ _
 convTranspose2dForward ConvTranspose2d {..} input =
   convTranspose2d @stride @padding
-    (toDependent convTranspose2dWeight)
-    (toDependent convTranspose2dBias)
+    (toDependent weight)
+    (toDependent bias)
     input
 
 instance
@@ -491,8 +493,8 @@ data
   where
   ConvTranspose3d ::
     forall inputChannelSize outputChannelSize kernelSize0 kernelSize1 kernelSize2 dtype device.
-    { convTranspose3dWeight :: Parameter device dtype '[inputChannelSize, outputChannelSize, kernelSize0, kernelSize1, kernelSize2],
-      convTranspose3dBias :: Parameter device dtype '[outputChannelSize]
+    { weight :: Parameter device dtype '[inputChannelSize, outputChannelSize, kernelSize0, kernelSize1, kernelSize2],
+      bias :: Parameter device dtype '[outputChannelSize]
     } ->
     ConvTranspose3d
       inputChannelSize
@@ -515,8 +517,8 @@ convTranspose3dForward ::
   Tensor _ _ _
 convTranspose3dForward ConvTranspose3d {..} input =
   convTranspose3d @stride @padding
-    (toDependent convTranspose3dWeight)
-    (toDependent convTranspose3dBias)
+    (toDependent weight)
+    (toDependent bias)
     input
 
 instance

--- a/hasktorch/src/Torch/Typed/NN/Linear.hs
+++ b/hasktorch/src/Torch/Typed/NN/Linear.hs
@@ -8,6 +8,8 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# OPTIONS_GHC -Wno-partial-type-signatures #-}
 
 module Torch.Typed.NN.Linear where
@@ -40,8 +42,8 @@ data
   where
   Linear ::
     forall inputFeatures outputFeatures dtype device.
-    { linearWeight :: Parameter device dtype '[outputFeatures, inputFeatures],
-      linearBias :: Parameter device dtype '[outputFeatures]
+    { weight :: Parameter device dtype '[outputFeatures, inputFeatures],
+      bias :: Parameter device dtype '[outputFeatures]
     } ->
     Linear inputFeatures outputFeatures dtype device
   deriving (Show, Generic, Parameterized)
@@ -54,7 +56,7 @@ linearForward ::
   Linear _ _ _ _ ->
   Tensor _ _ _ ->
   Tensor _ _ _
-linearForward Linear {..} input = linear' (toDependent linearWeight) (toDependent linearBias) input
+linearForward Linear {..} input = linear' (toDependent weight) (toDependent bias) input
 
 instance
   ( shape'' ~ MatMul shape '[inputFeatures, outputFeatures],


### PR DESCRIPTION
Replaced *weight and *bias with RecordDotSyntax.
Until now, there were many *weight data field definitions like linearWeight and conv2dWeight, and it was necessary to define different names for each data. 
By RecordDotSyntax, we can just use weight and bias to access the fields.