### PR TITLE
Fix batchNorm from pure-function to impure-function

### DIFF
--- a/hasktorch/src/Torch/Functional.hs
+++ b/hasktorch/src/Torch/Functional.hs
@@ -3111,9 +3111,9 @@ batchNormIO ::
   -- | bias
   Tensor ->
   -- | running_mean
-  Tensor ->
+  MutableTensor ->
   -- | running_var
-  Tensor ->
+  MutableTensor ->
   -- | training
   Bool ->
   -- | momentum
@@ -3124,7 +3124,7 @@ batchNormIO ::
   Tensor ->
   -- | output
   IO Tensor
-batchNormIO weight bias running_mean running_var training momentum eps input =
+batchNormIO weight bias (MutableTensor running_mean) (MutableTensor running_var) training momentum eps input =
   cast9
     ATen.batch_norm_tttttbddb
     input
@@ -3143,9 +3143,9 @@ instanceNormIO ::
   -- | bias
   Tensor ->
   -- | running_mean
-  Tensor ->
+  MutableTensor ->
   -- | running_var
-  Tensor ->
+  MutableTensor ->
   -- | training
   Bool ->
   -- | momentum
@@ -3156,7 +3156,7 @@ instanceNormIO ::
   Tensor ->
   -- | output
   IO Tensor
-instanceNormIO weight bias running_mean running_var training momentum eps input =
+instanceNormIO weight bias (MutableTensor running_mean) (MutableTensor running_var) training momentum eps input =
   cast9
     ATen.instance_norm_tttttbddb
     input

--- a/hasktorch/src/Torch/Functional.hs
+++ b/hasktorch/src/Torch/Functional.hs
@@ -3105,7 +3105,7 @@ repeat ::
   Tensor
 repeat a t = unsafePerformIO $ (cast2 ATen.tensor_repeat_l) t a
 
-batchNorm ::
+batchNormIO ::
   -- | weight
   Tensor ->
   -- | bias
@@ -3123,22 +3123,21 @@ batchNorm ::
   -- | input
   Tensor ->
   -- | output
-  Tensor
-batchNorm weight bias running_mean running_var training momentum eps input =
-  unsafePerformIO $
-    cast9
-      ATen.batch_norm_tttttbddb
-      input
-      weight
-      bias
-      running_mean
-      running_var
-      training
-      momentum
-      eps
-      True
+  IO Tensor
+batchNormIO weight bias running_mean running_var training momentum eps input =
+  cast9
+    ATen.batch_norm_tttttbddb
+    input
+    weight
+    bias
+    running_mean
+    running_var
+    training
+    momentum
+    eps
+    True
 
-instanceNorm ::
+instanceNormIO ::
   -- | weight
   Tensor ->
   -- | bias
@@ -3156,20 +3155,19 @@ instanceNorm ::
   -- | input
   Tensor ->
   -- | output
-  Tensor
-instanceNorm weight bias running_mean running_var training momentum eps input =
-  unsafePerformIO $
-    cast9
-      ATen.instance_norm_tttttbddb
-      input
-      weight
-      bias
-      running_mean
-      running_var
-      training
-      momentum
-      eps
-      True
+  IO Tensor
+instanceNormIO weight bias running_mean running_var training momentum eps input =
+  cast9
+    ATen.instance_norm_tttttbddb
+    input
+    weight
+    bias
+    running_mean
+    running_var
+    training
+    momentum
+    eps
+    True
 
 repeatInterleaveRange ::
   -- | repeats

--- a/hasktorch/src/Torch/NN.hs
+++ b/hasktorch/src/Torch/NN.hs
@@ -681,9 +681,9 @@ data BatchNorm = BatchNorm
   }
   deriving (Show, Generic)
 
-batchNormForward :: BatchNorm -> Bool -> Double -> Double -> Tensor -> Tensor
-batchNormForward params train momentum eps input =
-  Torch.Functional.batchNorm
+batchNormForwardIO :: BatchNorm -> Bool -> Double -> Double -> Tensor -> IO Tensor
+batchNormForwardIO params train momentum eps input =
+  Torch.Functional.batchNormIO
     (toDependent params.weight)
     (toDependent params.bias)
     params.runningMean
@@ -709,18 +709,18 @@ data InstanceNormSpec = InstanceNormSpec
 data InstanceNorm = InstanceNorm
   { weight :: Parameter,
     bias :: Parameter,
-    iRunningMean :: Tensor,
-    iRunningVar :: Tensor
+    runningMean :: Tensor,
+    runningVar :: Tensor
   }
   deriving (Show, Generic)
 
-instanceNormForward :: InstanceNorm -> Bool -> Double -> Double -> Tensor -> Tensor
-instanceNormForward params train momentum eps input =
-  Torch.Functional.instanceNorm
+instanceNormForwardIO :: InstanceNorm -> Bool -> Double -> Double -> Tensor -> IO Tensor
+instanceNormForwardIO params train momentum eps input =
+  Torch.Functional.instanceNormIO
     (toDependent params.weight)
     (toDependent params.bias)
-    params.iRunningMean
-    params.iRunningVar
+    params.runningMean
+    params.runningVar
     train
     momentum
     eps

--- a/hasktorch/src/Torch/NN.hs
+++ b/hasktorch/src/Torch/NN.hs
@@ -676,8 +676,8 @@ data BatchNormSpec = BatchNormSpec
 data BatchNorm = BatchNorm
   { weight :: Parameter,
     bias :: Parameter,
-    runningMean :: Tensor,
-    runningVar :: Tensor
+    runningMean :: MutableTensor,
+    runningVar :: MutableTensor
   }
   deriving (Show, Generic)
 
@@ -697,8 +697,8 @@ instance Randomizable BatchNormSpec BatchNorm where
   sample BatchNormSpec {..} = do
     w <- makeIndependent (ones' [numFeatures])
     b <- makeIndependent (zeros' [numFeatures])
-    mean <- toDependent <$> makeIndependentWithRequiresGrad (zeros' [numFeatures]) False
-    var <- toDependent <$> makeIndependentWithRequiresGrad (ones' [numFeatures]) False
+    mean <- MutableTensor <$> toDependent <$> makeIndependentWithRequiresGrad (zeros' [numFeatures]) False
+    var <- MutableTensor <$> toDependent <$> makeIndependentWithRequiresGrad (ones' [numFeatures]) False
     return $ BatchNorm w b mean var
 
 data InstanceNormSpec = InstanceNormSpec
@@ -709,8 +709,8 @@ data InstanceNormSpec = InstanceNormSpec
 data InstanceNorm = InstanceNorm
   { weight :: Parameter,
     bias :: Parameter,
-    runningMean :: Tensor,
-    runningVar :: Tensor
+    runningMean :: MutableTensor,
+    runningVar :: MutableTensor
   }
   deriving (Show, Generic)
 
@@ -730,8 +730,8 @@ instance Randomizable InstanceNormSpec InstanceNorm where
   sample InstanceNormSpec {..} = do
     w <- makeIndependent (ones' [iNumFeatures])
     b <- makeIndependent (zeros' [iNumFeatures])
-    mean <- toDependent <$> makeIndependentWithRequiresGrad (zeros' [iNumFeatures]) False
-    var <- toDependent <$> makeIndependentWithRequiresGrad (ones' [iNumFeatures]) False
+    mean <- MutableTensor <$> toDependent <$> makeIndependentWithRequiresGrad (zeros' [numFeatures]) False
+    var <- MutableTensor <$> toDependent <$> makeIndependentWithRequiresGrad (ones' [numFeatures]) False
     return $ InstanceNorm w b mean var
 
 data UpSampleSpec = UpSampleSpec

--- a/hasktorch/src/Torch/NN.hs
+++ b/hasktorch/src/Torch/NN.hs
@@ -702,7 +702,7 @@ instance Randomizable BatchNormSpec BatchNorm where
     return $ BatchNorm w b mean var
 
 data InstanceNormSpec = InstanceNormSpec
-  { iNumFeatures :: Int
+  { numFeatures :: Int
   }
   deriving (Show, Eq)
 
@@ -728,8 +728,8 @@ instanceNormForwardIO params train momentum eps input =
 
 instance Randomizable InstanceNormSpec InstanceNorm where
   sample InstanceNormSpec {..} = do
-    w <- makeIndependent (ones' [iNumFeatures])
-    b <- makeIndependent (zeros' [iNumFeatures])
+    w <- makeIndependent (ones' [numFeatures])
+    b <- makeIndependent (zeros' [numFeatures])
     mean <- MutableTensor <$> toDependent <$> makeIndependentWithRequiresGrad (zeros' [numFeatures]) False
     var <- MutableTensor <$> toDependent <$> makeIndependentWithRequiresGrad (ones' [numFeatures]) False
     return $ InstanceNorm w b mean var

--- a/hasktorch/src/Torch/Tensor.hs
+++ b/hasktorch/src/Torch/Tensor.hs
@@ -60,6 +60,14 @@ instance Castable Tensor ATenTensor where
   cast (Unsafe aten_tensor) f = f aten_tensor
   uncast aten_tensor f = f $ Unsafe aten_tensor
 
+newtype MutableTensor = MutableTensor Tensor deriving Show
+
+newMutableTensor :: Tensor -> IO MutableTensor
+newMutableTensor tensor = MutableTensor <$> cast1 ATen.detach_t tensor
+
+toImmutable :: MutableTensor -> IO Tensor
+toImmutable (MutableTensor tensor) = cast1 ATen.detach_t tensor
+
 --------------------------------------------------------------------------------
 -- Basic tensor properties
 --------------------------------------------------------------------------------


### PR DESCRIPTION
batchNorm is not  a pure function.
It updates the argument of runningMean and runningVar.
This PR changes batchNorm from a pure function to an impure function.
