### PR TITLE
Improve FFI performance

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -25,6 +25,20 @@ source-repository-package
     --sha256: 0sdw3ga7gbffyywpyx7xn8ghdw9gzsy4l68cas41hwfbkrwxwdg6
     tag: 32d7abec6a21c42a5f960d7f4133d604e8be79ec
 
+source-repository-package
+    type: git
+    location: https://github.com/hasktorch/inline-c
+    --sha256: 0hi4s3p0whf0ndsxn8qrfc3a7qndsgac0vz7n23kp3rx69yp0yr1
+    tag: 5b1a54e81f4c726faf35c15a8e39a4d86c52c6ba
+    subdir: inline-c
+
+source-repository-package
+    type: git
+    location: https://github.com/hasktorch/inline-c
+    --sha256: 0hi4s3p0whf0ndsxn8qrfc3a7qndsgac0vz7n23kp3rx69yp0yr1
+    tag: 5b1a54e81f4c726faf35c15a8e39a4d86c52c6ba
+    subdir: inline-c-cpp
+
 write-ghc-environment-files: always
 tests: true
 documentation: false

--- a/cabal.project
+++ b/cabal.project
@@ -27,16 +27,16 @@ source-repository-package
 
 source-repository-package
     type: git
-    location: https://github.com/hasktorch/inline-c
+    location: https://github.com/fpco/inline-c
     --sha256: 0hi4s3p0whf0ndsxn8qrfc3a7qndsgac0vz7n23kp3rx69yp0yr1
-    tag: 5b1a54e81f4c726faf35c15a8e39a4d86c52c6ba
+    tag: 2d0fe9b2f0aa0e1aefc7bfed95a501e59486afb0
     subdir: inline-c
 
 source-repository-package
     type: git
-    location: https://github.com/hasktorch/inline-c
+    location: https://github.com/fpco/inline-c
     --sha256: 0hi4s3p0whf0ndsxn8qrfc3a7qndsgac0vz7n23kp3rx69yp0yr1
-    tag: 5b1a54e81f4c726faf35c15a8e39a4d86c52c6ba
+    tag: 2d0fe9b2f0aa0e1aefc7bfed95a501e59486afb0
     subdir: inline-c-cpp
 
 write-ghc-environment-files: always

--- a/hasktorch/bench/Runtime.hs
+++ b/hasktorch/bench/Runtime.hs
@@ -111,43 +111,49 @@ main = do
       vT' = T.asTensor vList
 
     C.defaultMain [
-        C.env (pure (aH', bH', subH', vH')) $ \ ~(aH, bH, subH, vH) ->
-            C.bgroup "Hmatrix" [ 
-                             C.bench "multiplication" $ C.nf ((<>) aH) bH,
-                             C.bench "repeated multiplication" $ C.nf ( H.sumElements . flip (H.?) [1] . (<>) bH . (<>) aH . (<>) aH) bH,
-                             C.bench "multiplicationV" $ C.nf ((H.#>) aH) subH,
-                             -- C.bench "qr factorization" $ C.nf H.qr aH,
-                             C.bench "transpose" $ C.nf H.tr aH,
-                             C.bench "norm" $ C.nf H.norm_2 vH,
-                             C.bench "row" $ C.nf ((H.?) aH) [0],
-                             C.bench "column" $ C.nf ((H.¿) aH) [0], 
-                             C.bench "identity" $ C.nf identH n,
-                             C.bench "diag" $ C.nf H.diag subH,
-                             C.bench "map const 0" $ C.nf (mapH elemZero) aH,
-                             C.bench "map sqr" $ C.nf (mapH elemSqr) aH,
-                             C.bench "size" $ C.nf H.size aH
-                           ],
+        -- C.env (pure (aH', bH', subH', vH')) $ \ ~(aH, bH, subH, vH) ->
+        --     C.bgroup "Hmatrix" [ 
+        --                      C.bench "multiplication" $ C.nf ((<>) aH) bH,
+        --                      C.bench "repeated multiplication" $ C.nf ( H.sumElements . flip (H.?) [1] . (<>) bH . (<>) aH . (<>) aH) bH,
+        --                      C.bench "multiplicationV" $ C.nf ((H.#>) aH) subH,
+        --                      -- C.bench "qr factorization" $ C.nf H.qr aH,
+        --                      C.bench "transpose" $ C.nf H.tr aH,
+        --                      C.bench "norm" $ C.nf H.norm_2 vH,
+        --                      C.bench "row" $ C.nf ((H.?) aH) [0],
+        --                      C.bench "column" $ C.nf ((H.¿) aH) [0], 
+        --                      C.bench "identity" $ C.nf identH n,
+        --                      C.bench "diag" $ C.nf H.diag subH,
+        --                      C.bench "map const 0" $ C.nf (mapH elemZero) aH,
+        --                      C.bench "map sqr" $ C.nf (mapH elemSqr) aH,
+        --                      C.bench "size" $ C.nf H.size aH
+        --                    ],
 
         C.env (pure (aT', bT', subT', vT')) $ \ ~(aT, bT, subT, vT) ->
             C.bgroup "Hasktorch" [ 
-                             C.bench "multiplication" $ C.nf (T.matmul aT) bT,
-                             C.bench "repeated multiplication" $ C.nf ( T.sumAll . T.matmul bT . T.matmul aT . T.matmul aT) bT,
-                             C.bench "multiplicationV" $ C.nf (T.matmul aT) subT,
-                             -- C.bench "qr factorization" $ C.nf (\v -> TI.qr v True) aT,
-                             C.bench "transpose" $ C.nf TI.t aT,
-                             C.bench "norm" $ C.nf (\v -> TI.normAll v 2) vT,
-                             C.bench "row" $ C.nf ((T.!) aT) (0::Int),
-                             C.bench "column" $ C.nf ((T.!) aT) [T.slice|...,0|],
-                             C.bench "identity" $ C.nf (\i -> T.eye' i i) n,
-                             C.bench "diag" $ C.nf (T.diag (T.Diag 0)) subT,
-                             C.bench "map const 0" $ C.nf (\v -> T.maskedFill v  [T.slice|...|] 0) aT,
-                             C.bench "map sqr" $ C.nf (\v -> v * v) aT,
+                             -- C.bench "multiplication" $ C.nf (T.matmul aT) bT,
+                             -- C.bench "repeated multiplication" $ C.nf ( T.sumAll . T.matmul bT . T.matmul aT . T.matmul aT) bT,
+                             -- C.bench "multiplicationV" $ C.nf (T.matmul aT) subT,
+                             -- -- C.bench "qr factorization" $ C.nf (\v -> TI.qr v True) aT,
+                             -- C.bench "transpose" $ C.nf TI.t aT,
+                             -- C.bench "norm" $ C.nf (\v -> TI.normAll v 2) vT,
+                             -- C.bench "row" $ C.nf ((T.!) aT) (0::Int),
+                             -- C.bench "column" $ C.nf ((T.!) aT) [T.slice|...,0|],
+                             -- C.bench "identity" $ C.nf (\i -> T.eye' i i) n,
+                             -- C.bench "diag" $ C.nf (T.diag (T.Diag 0)) subT,
+                             -- C.bench "map const 0" $ C.nf (\v -> T.maskedFill v  [T.slice|...|] 0) aT,
+                             -- C.bench "map sqr" $ C.nf (\v -> v * v) aT,
                              C.bench "shape" $ C.nf T.shape aT,
                              C.bench "shape(managed)" $ C.nf (\(T.Unsafe v) -> unsafePerformIO $ TIM.tensor_sizes v) aT,
                              C.bench "shape(unmanaged)" $ C.nf (\(T.Unsafe v) -> unsafePerformIO $ withForeignPtr v $ \ptr -> TIU.tensor_sizes ptr) aT,
                              C.bench "dim" $ C.nf T.dim aT,
                              C.bench "dim(managed)" $ C.nf (\(T.Unsafe v) -> unsafePerformIO $ TIM.tensor_dim v) aT,
-                             C.bench "dim(unmanaged)" $ C.nf (\(T.Unsafe v) -> unsafePerformIO $ withForeignPtr v $ \ptr -> TIU.tensor_dim ptr) aT
+                             C.bench "dim(unmanaged)" $ C.nf (\(T.Unsafe v) -> unsafePerformIO $ withForeignPtr v $ \ptr -> TIU.tensor_dim ptr) aT,
+                             C.bench "dim(unsafe)" $ C.nf T.dimUnsafe aT,
+                             C.bench "dim(unsafe/managed)" $ C.nf (\(T.Unsafe v) -> unsafePerformIO $ TIM.tensor_dim_unsafe v) aT,
+                             C.bench "dim(unsafe/unmanaged)" $ C.nf (\(T.Unsafe v) -> unsafePerformIO $ withForeignPtr v $ \ptr -> TIU.tensor_dim_unsafe ptr) aT,
+                             C.bench "dim(unsafe-c)" $ C.nf T.dimCUnsafe aT,
+                             C.bench "dim(unsafe-c/managed)" $ C.nf (\(T.Unsafe v) -> unsafePerformIO $ TIM.tensor_dim_c_unsafe v) aT,
+                             C.bench "dim(unsafe-c/unmanaged)" $ C.nf (\(T.Unsafe v) -> unsafePerformIO $ withForeignPtr v $ \ptr -> TIU.tensor_dim_c_unsafe ptr) aT
                            ]
                ]
 

--- a/hasktorch/bench/Runtime.hs
+++ b/hasktorch/bench/Runtime.hs
@@ -111,37 +111,37 @@ main = do
       vT' = T.asTensor vList
 
     C.defaultMain [
-        -- C.env (pure (aH', bH', subH', vH')) $ \ ~(aH, bH, subH, vH) ->
-        --     C.bgroup "Hmatrix" [ 
-        --                      C.bench "multiplication" $ C.nf ((<>) aH) bH,
-        --                      C.bench "repeated multiplication" $ C.nf ( H.sumElements . flip (H.?) [1] . (<>) bH . (<>) aH . (<>) aH) bH,
-        --                      C.bench "multiplicationV" $ C.nf ((H.#>) aH) subH,
-        --                      -- C.bench "qr factorization" $ C.nf H.qr aH,
-        --                      C.bench "transpose" $ C.nf H.tr aH,
-        --                      C.bench "norm" $ C.nf H.norm_2 vH,
-        --                      C.bench "row" $ C.nf ((H.?) aH) [0],
-        --                      C.bench "column" $ C.nf ((H.¿) aH) [0], 
-        --                      C.bench "identity" $ C.nf identH n,
-        --                      C.bench "diag" $ C.nf H.diag subH,
-        --                      C.bench "map const 0" $ C.nf (mapH elemZero) aH,
-        --                      C.bench "map sqr" $ C.nf (mapH elemSqr) aH,
-        --                      C.bench "size" $ C.nf H.size aH
-        --                    ],
+        C.env (pure (aH', bH', subH', vH')) $ \ ~(aH, bH, subH, vH) ->
+            C.bgroup "Hmatrix" [ 
+                             C.bench "multiplication" $ C.nf ((<>) aH) bH,
+                             C.bench "repeated multiplication" $ C.nf ( H.sumElements . flip (H.?) [1] . (<>) bH . (<>) aH . (<>) aH) bH,
+                             C.bench "multiplicationV" $ C.nf ((H.#>) aH) subH,
+                             -- C.bench "qr factorization" $ C.nf H.qr aH,
+                             C.bench "transpose" $ C.nf H.tr aH,
+                             C.bench "norm" $ C.nf H.norm_2 vH,
+                             C.bench "row" $ C.nf ((H.?) aH) [0],
+                             C.bench "column" $ C.nf ((H.¿) aH) [0], 
+                             C.bench "identity" $ C.nf identH n,
+                             C.bench "diag" $ C.nf H.diag subH,
+                             C.bench "map const 0" $ C.nf (mapH elemZero) aH,
+                             C.bench "map sqr" $ C.nf (mapH elemSqr) aH,
+                             C.bench "size" $ C.nf H.size aH
+                           ],
 
         C.env (pure (aT', bT', subT', vT')) $ \ ~(aT, bT, subT, vT) ->
             C.bgroup "Hasktorch" [ 
-                             -- C.bench "multiplication" $ C.nf (T.matmul aT) bT,
-                             -- C.bench "repeated multiplication" $ C.nf ( T.sumAll . T.matmul bT . T.matmul aT . T.matmul aT) bT,
-                             -- C.bench "multiplicationV" $ C.nf (T.matmul aT) subT,
-                             -- -- C.bench "qr factorization" $ C.nf (\v -> TI.qr v True) aT,
-                             -- C.bench "transpose" $ C.nf TI.t aT,
-                             -- C.bench "norm" $ C.nf (\v -> TI.normAll v 2) vT,
-                             -- C.bench "row" $ C.nf ((T.!) aT) (0::Int),
-                             -- C.bench "column" $ C.nf ((T.!) aT) [T.slice|...,0|],
-                             -- C.bench "identity" $ C.nf (\i -> T.eye' i i) n,
-                             -- C.bench "diag" $ C.nf (T.diag (T.Diag 0)) subT,
-                             -- C.bench "map const 0" $ C.nf (\v -> T.maskedFill v  [T.slice|...|] 0) aT,
-                             -- C.bench "map sqr" $ C.nf (\v -> v * v) aT,
+                             C.bench "multiplication" $ C.nf (T.matmul aT) bT,
+                             C.bench "repeated multiplication" $ C.nf ( T.sumAll . T.matmul bT . T.matmul aT . T.matmul aT) bT,
+                             C.bench "multiplicationV" $ C.nf (T.matmul aT) subT,
+                             -- C.bench "qr factorization" $ C.nf (\v -> TI.qr v True) aT,
+                             C.bench "transpose" $ C.nf TI.t aT,
+                             C.bench "norm" $ C.nf (\v -> TI.normAll v 2) vT,
+                             C.bench "row" $ C.nf ((T.!) aT) (0::Int),
+                             C.bench "column" $ C.nf ((T.!) aT) [T.slice|...,0|],
+                             C.bench "identity" $ C.nf (\i -> T.eye' i i) n,
+                             C.bench "diag" $ C.nf (T.diag (T.Diag 0)) subT,
+                             C.bench "map const 0" $ C.nf (\v -> T.maskedFill v  [T.slice|...|] 0) aT,
+                             C.bench "map sqr" $ C.nf (\v -> v * v) aT,
                              C.bench "shape" $ C.nf T.shape aT,
                              C.bench "shape(managed)" $ C.nf (\(T.Unsafe v) -> unsafePerformIO $ TIM.tensor_sizes v) aT,
                              C.bench "shape(unmanaged)" $ C.nf (\(T.Unsafe v) -> unsafePerformIO $ withForeignPtr v $ \ptr -> TIU.tensor_sizes ptr) aT,

--- a/hasktorch/src/Torch/Tensor.hs
+++ b/hasktorch/src/Torch/Tensor.hs
@@ -97,6 +97,22 @@ dim ::
   Int
 dim t = unsafePerformIO $ (cast1 ATen.tensor_dim) t
 
+-- | Returns the dimensions of the input tensor
+dimUnsafe ::
+  -- | input
+  Tensor ->
+  -- | output
+  Int
+dimUnsafe t = unsafePerformIO $ (cast1 ATen.tensor_dim_unsafe) t
+
+-- | Returns the dimensions of the input tensor
+dimCUnsafe ::
+  -- | input
+  Tensor ->
+  -- | output
+  Int
+dimCUnsafe t = unsafePerformIO $ (cast1 ATen.tensor_dim_c_unsafe) t
+
 -- | Returns the device on which the tensor is currently allocated
 device ::
   -- | input

--- a/libtorch-ffi/libtorch-ffi.cabal
+++ b/libtorch-ffi/libtorch-ffi.cabal
@@ -138,7 +138,7 @@ library
  hs-source-dirs: src
  default-language: Haskell2010
  build-depends:       base >= 4.7 && < 5
-                    , inline-c-cpp >= 0.4.0.0 && < 0.5.0.0
+                    , inline-c-cpp >= 0.5.0.0 && < 0.6.0.0
                     , inline-c >= 0.9.0.0
                     , optparse-applicative >= 0.14.3.0
                     , containers

--- a/libtorch-ffi/src/Torch/Internal/Cast.hs
+++ b/libtorch-ffi/src/Torch/Internal/Cast.hs
@@ -42,71 +42,103 @@ import Torch.Internal.GC
 
 instance Castable a a where
   cast x f = f x
+  {-# INLINE cast #-}
   uncast x f = f x
+  {-# INLINE uncast #-}
 
 instance Castable Bool CBool where
   cast x f = f (if x then 1 else 0)
+  {-# INLINE cast #-}
   uncast x f = f (x /= 0)
+  {-# INLINE uncast #-}
 
 instance Castable Int CInt where
   cast x f = f (fromIntegral x)
+  {-# INLINE cast #-}
   uncast x f = f (fromIntegral x)
+  {-# INLINE uncast#-}
 
 instance Castable Int Int64 where
   cast x f = f (fromIntegral x)
+  {-# INLINE cast #-}
   -- TODO: Int64 might have a wider range than Int
   uncast x f = f (fromIntegral x)
+  {-# INLINE uncast #-}
 
 instance Castable Int16 CShort where
   cast x f = f (fromIntegral x)
+  {-# INLINE cast #-}
   uncast x f = f (fromIntegral x)
+  {-# INLINE uncast #-}
 
 instance Castable Int8 CChar where
   cast x f = f (fromIntegral x)
+  {-# INLINE cast #-}
   uncast x f = f (fromIntegral x)
+  {-# INLINE uncast #-}
 
 instance Castable Word CUInt where
   cast x f = f (fromIntegral x)
+  {-# INLINE cast #-}
   uncast x f = f (fromIntegral x)
+  {-# INLINE uncast #-}
 
 instance Castable Word8 CChar where
   cast x f = f (fromIntegral x)
+  {-# INLINE cast #-}
   uncast x f = f (fromIntegral x)
+  {-# INLINE uncast #-}
 
 instance Castable Double CDouble where
   cast x f = f (realToFrac x)
+  {-# INLINE cast #-}
   uncast x f = f (realToFrac x)
+  {-# INLINE uncast #-}
 
 instance Castable [Double] (Ptr CDouble) where
   cast xs f = newArray (map realToFrac xs) >>= f
+  {-# INLINE cast #-}
   uncast xs f = undefined
+  {-# INLINE uncast #-}
 
 instance Castable [Int] (Ptr CInt) where
   cast xs f = newArray (map fromIntegral xs) >>= f
+  {-# INLINE cast #-}
   uncast xs f = undefined
+  {-# INLINE uncast #-}
 
 instance Castable ByteString CString where
   cast x f = useAsCString x f
+  {-# INLINE cast #-}
   uncast x f = packCString x >>= f
+  {-# INLINE uncast #-}
 
 instance Castable [ByteString] (Ptr CString) where
   cast xs f = do ys <- mapM (\x -> useAsCString x return) xs
                  withArray ys $ \cptr -> f cptr
+  {-# INLINE cast #-}
   uncast xs f = undefined
+  {-# INLINE uncast #-}
 
 instance Castable String CString where
   cast x f = withCString x f
+  {-# INLINE cast #-}
   uncast x f = peekCString x >>= f
+  {-# INLINE uncast #-}
 
 instance (Castable a a') => Castable (Maybe a) (Maybe a') where
   cast Nothing f = f Nothing
   cast (Just v) f = cast v (\v -> f (Just v))
+  {-# INLINE cast #-}
   uncast Nothing f = f Nothing
   uncast (Just v) f = uncast v (\v -> f (Just v)) 
+  {-# INLINE uncast #-}
 
 instance (CppObject a) => Castable (ForeignPtr a) (Ptr a) where
   cast x f = withForeignPtr x f
+  {-# INLINE cast #-}
   uncast x f = fromPtr x >>= f
+  {-# INLINE uncast #-}
 
 --------------------------------------------------------------------------------
 -- Tuples of Castable
@@ -121,6 +153,8 @@ instance (Castable a a', Castable b b') => Castable (a,b) (a',b') where
     t0' <- uncast t0 return
     t1' <- uncast t1 return
     f (t0',t1')
+  {-# INLINE cast #-}
+  {-# INLINE uncast #-}
 
 instance (Castable a a', Castable b b', Castable c c') => Castable (a,b,c) (a',b',c') where
   cast (t0,t1,t2) f = do
@@ -133,6 +167,8 @@ instance (Castable a a', Castable b b', Castable c c') => Castable (a,b,c) (a',b
     t1' <- uncast t1 return
     t2' <- uncast t2 return
     f (t0',t1',t2')
+  {-# INLINE cast #-}
+  {-# INLINE uncast #-}
 
 instance (Castable a a', Castable b b', Castable c c', Castable d d') => Castable (a,b,c,d) (a',b',c',d') where
   cast (t0,t1,t2,t3) f = do
@@ -147,6 +183,8 @@ instance (Castable a a', Castable b b', Castable c c', Castable d d') => Castabl
     t2' <- uncast t2 return
     t3' <- uncast t3 return
     f (t0',t1',t2',t3')
+  {-# INLINE cast #-}
+  {-# INLINE uncast #-}
 
 instance (Castable a a', Castable b b', Castable c c', Castable d d', Castable e e') => Castable (a,b,c,d,e) (a',b',c',d',e') where
   cast (t0,t1,t2,t3,t4) f = do
@@ -163,6 +201,8 @@ instance (Castable a a', Castable b b', Castable c c', Castable d d', Castable e
     t3' <- uncast t3 return
     t4' <- uncast t4 return
     f (t0',t1',t2',t3',t4')
+  {-# INLINE cast #-}
+  {-# INLINE uncast #-}
 
 instance (Castable a a', Castable b b', Castable c c',
           Castable d d', Castable e e', Castable f f') => Castable (a,b,c,d,e,f) (a',b',c',d',e',f') where
@@ -182,6 +222,8 @@ instance (Castable a a', Castable b b', Castable c c',
     t4' <- uncast t4 return
     t5' <- uncast t5 return
     f (t0',t1',t2',t3',t4',t5')
+  {-# INLINE cast #-}
+  {-# INLINE uncast #-}
 
 --------------------------------------------------------------------------------
 -- These casts convert the value from C++ Tuple(CppTuple) to Haskell Tuple.
@@ -199,6 +241,8 @@ instance (CppTuple2 c, Castable a (A c), Castable b (B c)) => Castable (a,b) c w
     t0' <- uncast t0 return
     t1' <- uncast t1 return
     f (t0',t1')
+  {-# INLINE cast #-}
+  {-# INLINE uncast #-}
 
 instance (CppTuple3 d, Castable a (A d), Castable b (B d), Castable c (C d)) => Castable (a,b,c) d where
   cast _ _ = error "Attempted to cast a 3-tuple from Haskell to C++, this is not supported."
@@ -210,6 +254,8 @@ instance (CppTuple3 d, Castable a (A d), Castable b (B d), Castable c (C d)) => 
     t1' <- uncast t1 return
     t2' <- uncast t2 return
     f (t0',t1',t2')
+  {-# INLINE cast #-}
+  {-# INLINE uncast #-}
 
 instance (CppTuple4 e, Castable a (A e), Castable b (B e), Castable c (C e), Castable d (D e)) => Castable (a,b,c,d) e where
   cast _ _ = error "Attempted to cast a 4-tuple from Haskell to C++, this is not supported."
@@ -223,6 +269,8 @@ instance (CppTuple4 e, Castable a (A e), Castable b (B e), Castable c (C e), Cas
     t2' <- uncast t2 return
     t3' <- uncast t3 return
     f (t0',t1',t2',t3')
+  {-# INLINE cast #-}
+  {-# INLINE uncast #-}
 
 instance (CppTuple5 f, Castable a (A f), Castable b (B f), Castable c (C f), Castable d (D f), Castable e (E f)) => Castable (a,b,c,d,e) f where
   cast _ _ = error "Attempted to cast a 5-tuple from Haskell to C++, this is not supported."
@@ -238,6 +286,8 @@ instance (CppTuple5 f, Castable a (A f), Castable b (B f), Castable c (C f), Cas
     t3' <- uncast t3 return
     t4' <- uncast t4 return
     f (t0',t1',t2',t3',t4')
+  {-# INLINE cast #-}
+  {-# INLINE uncast #-}
 
 instance (CppTuple6 g,
           Castable a (A g), Castable b (B g), Castable c (C g),
@@ -257,30 +307,32 @@ instance (CppTuple6 g,
     t4' <- uncast t4 return
     t5' <- uncast t5 return
     f (t0',t1',t2',t3',t4',t5')
+  {-# INLINE cast #-}
+  {-# INLINE uncast #-}
 
 --------------------------------------------------------------------------------
--- Cast functions for various numbers of arguments
+-- Cast functions for various numbers of arguments without retryWithGC
 --------------------------------------------------------------------------------
 
 cast0 :: (Castable a ca) => (IO ca) -> IO a
-cast0 f = retryWithGC (f) >>= \ca -> uncast ca return
+cast0 f = (f) >>= \ca -> uncast ca return
 
 cast1 :: (Castable a ca, Castable y cy)
        => (ca -> IO cy) -> a -> IO y
-cast1 f a = cast a $ \ca -> retryWithGC (f ca) >>= \cy -> uncast cy return
+cast1 f a = cast a $ \ca -> (f ca) >>= \cy -> uncast cy return
 
 cast2 :: (Castable a ca, Castable x1 cx1, Castable y cy)
        => (ca -> cx1 -> IO cy) -> a -> x1 -> IO y
 cast2 f a x1 = cast a $ \ca ->
                   cast x1 $ \cx1 ->
-                    retryWithGC (f ca cx1) >>= \cy -> uncast cy return
+                    (f ca cx1) >>= \cy -> uncast cy return
 
 cast3 :: (Castable a ca, Castable x1 cx1, Castable x2 cx2, Castable y cy)
        => (ca -> cx1 -> cx2 -> IO cy) -> a -> x1 -> x2-> IO y
 cast3 f a x1 x2 = cast a $ \ca ->
                      cast x1 $ \cx1 ->
                        cast x2 $ \cx2 ->
-                         retryWithGC (f ca cx1 cx2) >>= \cy -> uncast cy return
+                         (f ca cx1 cx2) >>= \cy -> uncast cy return
 
 cast4 :: (Castable a ca, Castable x1 cx1, Castable x2 cx2, Castable x3 cx3, Castable y cy)
        => (ca -> cx1 -> cx2 -> cx3 -> IO cy) -> a -> x1 -> x2 -> x3 -> IO y
@@ -288,7 +340,7 @@ cast4 f a x1 x2 x3 = cast a $ \ca ->
                         cast x1 $ \cx1 ->
                           cast x2 $ \cx2 ->
                             cast x3 $ \cx3 ->
-                              retryWithGC (f ca cx1 cx2 cx3) >>= \cy -> uncast cy return
+                              (f ca cx1 cx2 cx3) >>= \cy -> uncast cy return
 
 cast5 :: (Castable a ca, Castable x1 cx1, Castable x2 cx2, Castable x3 cx3, Castable x4 cx4, Castable y cy)
        => (ca -> cx1 -> cx2 -> cx3 -> cx4 -> IO cy) -> a -> x1 -> x2 -> x3 -> x4 -> IO y
@@ -298,7 +350,7 @@ cast5 f a x1 x2 x3 x4 =
       cast x2 $ \cx2 ->
         cast x3 $ \cx3 ->
           cast x4 $ \cx4 ->
-            retryWithGC (f ca cx1 cx2 cx3 cx4) >>= \cy -> uncast cy return
+            (f ca cx1 cx2 cx3 cx4) >>= \cy -> uncast cy return
 
 
 cast6 :: (Castable a ca, Castable x1 cx1, Castable x2 cx2, Castable x3 cx3, Castable x4 cx4,
@@ -311,7 +363,7 @@ cast6 f a x1 x2 x3 x4 x5 =
         cast x3 $ \cx3 ->
           cast x4 $ \cx4 ->
             cast x5 $ \cx5 ->
-              retryWithGC (f ca cx1 cx2 cx3 cx4 cx5) >>= \cy -> uncast cy return
+              (f ca cx1 cx2 cx3 cx4 cx5) >>= \cy -> uncast cy return
 
 cast7 :: (Castable a ca, Castable x1 cx1, Castable x2 cx2, Castable x3 cx3, Castable x4 cx4,
            Castable x5 cx5, Castable x6 cx6, Castable y cy)
@@ -325,7 +377,7 @@ cast7 f a x1 x2 x3 x4 x5 x6 =
           cast x4 $ \cx4 ->
             cast x5 $ \cx5 ->
               cast x6 $ \cx6 ->
-                retryWithGC (f ca cx1 cx2 cx3 cx4 cx5 cx6) >>= \cy -> uncast cy return
+                (f ca cx1 cx2 cx3 cx4 cx5 cx6) >>= \cy -> uncast cy return
 
 cast8 :: (Castable a ca, Castable x1 cx1, Castable x2 cx2, Castable x3 cx3, Castable x4 cx4,
            Castable x5 cx5, Castable x6 cx6, Castable x7 cx7, Castable y cy)
@@ -340,7 +392,7 @@ cast8 f a x1 x2 x3 x4 x5 x6 x7 =
             cast x5 $ \cx5 ->
               cast x6 $ \cx6 ->
                 cast x7 $ \cx7 ->
-                  retryWithGC (f ca cx1 cx2 cx3 cx4 cx5 cx6 cx7) >>= \cy -> uncast cy return
+                  (f ca cx1 cx2 cx3 cx4 cx5 cx6 cx7) >>= \cy -> uncast cy return
 
 
 cast9 :: (Castable a ca, Castable x1 cx1, Castable x2 cx2, Castable x3 cx3, Castable x4 cx4,
@@ -357,7 +409,7 @@ cast9 f a x1 x2 x3 x4 x5 x6 x7 x8 =
               cast x6 $ \cx6 ->
                 cast x7 $ \cx7 ->
                   cast x8 $ \cx8 ->
-                    retryWithGC (f ca cx1 cx2 cx3 cx4 cx5 cx6 cx7 cx8) >>= \cy -> uncast cy return
+                    (f ca cx1 cx2 cx3 cx4 cx5 cx6 cx7 cx8) >>= \cy -> uncast cy return
 
 cast10 :: (Castable a ca, Castable x1 cx1, Castable x2 cx2, Castable x3 cx3, Castable x4 cx4,
            Castable x5 cx5, Castable x6 cx6, Castable x7 cx7, Castable x8 cx8, Castable x9 cx9,
@@ -375,7 +427,7 @@ cast10 f a x1 x2 x3 x4 x5 x6 x7 x8 x9 =
                 cast x7 $ \cx7 ->
                   cast x8 $ \cx8 ->
                     cast x9 $ \cx9 ->
-                      retryWithGC (f ca cx1 cx2 cx3 cx4 cx5 cx6 cx7 cx8 cx9) >>= \cy -> uncast cy return
+                      (f ca cx1 cx2 cx3 cx4 cx5 cx6 cx7 cx8 cx9) >>= \cy -> uncast cy return
 
 cast11 :: (Castable a ca, Castable x1 cx1, Castable x2 cx2, Castable x3 cx3, Castable x4 cx4,
             Castable x5 cx5, Castable x6 cx6, Castable x7 cx7, Castable x8 cx8, Castable x9 cx9,
@@ -394,7 +446,7 @@ cast11 f a x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 =
                   cast x8 $ \cx8 ->
                     cast x9 $ \cx9 ->
                       cast x10 $ \cx10 ->
-                        retryWithGC (f ca cx1 cx2 cx3 cx4 cx5 cx6 cx7 cx8 cx9 cx10) >>= \cy -> uncast cy return
+                        (f ca cx1 cx2 cx3 cx4 cx5 cx6 cx7 cx8 cx9 cx10) >>= \cy -> uncast cy return
 
 cast12 :: (Castable a ca, Castable x1 cx1, Castable x2 cx2, Castable x3 cx3, Castable x4 cx4,
             Castable x5 cx5, Castable x6 cx6, Castable x7 cx7, Castable x8 cx8, Castable x9 cx9,
@@ -414,7 +466,7 @@ cast12 f a x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 =
                     cast x9 $ \cx9 ->
                       cast x10 $ \cx10 ->
                         cast x11 $ \cx11 ->
-                         retryWithGC (f ca cx1 cx2 cx3 cx4 cx5 cx6 cx7 cx8 cx9 cx10 cx11) >>= \cy -> uncast cy return
+                         (f ca cx1 cx2 cx3 cx4 cx5 cx6 cx7 cx8 cx9 cx10 cx11) >>= \cy -> uncast cy return
 
 
 cast13 :: (Castable a ca, Castable x1 cx1, Castable x2 cx2, Castable x3 cx3, Castable x4 cx4,
@@ -436,7 +488,7 @@ cast13 f a x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 =
                       cast x10 $ \cx10 ->
                         cast x11 $ \cx11 ->
                           cast x12 $ \cx12 ->
-                            retryWithGC (f ca cx1 cx2 cx3 cx4 cx5 cx6 cx7 cx8 cx9 cx10 cx11 cx12) >>= \cy -> uncast cy return
+                            (f ca cx1 cx2 cx3 cx4 cx5 cx6 cx7 cx8 cx9 cx10 cx11 cx12) >>= \cy -> uncast cy return
 
 cast14 :: (Castable a ca, Castable x1 cx1, Castable x2 cx2, Castable x3 cx3, Castable x4 cx4,
             Castable x5 cx5, Castable x6 cx6, Castable x7 cx7, Castable x8 cx8, Castable x9 cx9,
@@ -458,7 +510,7 @@ cast14 f a x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 =
                         cast x11 $ \cx11 ->
                           cast x12 $ \cx12 ->
                           cast x13 $ \cx13 ->
-                            retryWithGC (f ca cx1 cx2 cx3 cx4 cx5 cx6 cx7 cx8 cx9 cx10 cx11 cx12 cx13) >>= \cy -> uncast cy return
+                            (f ca cx1 cx2 cx3 cx4 cx5 cx6 cx7 cx8 cx9 cx10 cx11 cx12 cx13) >>= \cy -> uncast cy return
 
 
 cast15 :: (Castable a ca, Castable x1 cx1, Castable x2 cx2, Castable x3 cx3, Castable x4 cx4,
@@ -482,7 +534,7 @@ cast15 f a x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 =
                           cast x12 $ \cx12 ->
                           cast x13 $ \cx13 ->
                           cast x14 $ \cx14 ->
-                            retryWithGC (f ca cx1 cx2 cx3 cx4 cx5 cx6 cx7 cx8 cx9 cx10 cx11 cx12 cx13 cx14) >>= \cy -> uncast cy return
+                            (f ca cx1 cx2 cx3 cx4 cx5 cx6 cx7 cx8 cx9 cx10 cx11 cx12 cx13 cx14) >>= \cy -> uncast cy return
 
 
 cast16 :: (Castable a ca, Castable x1 cx1, Castable x2 cx2, Castable x3 cx3, Castable x4 cx4,
@@ -507,7 +559,7 @@ cast16 f a x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 =
                           cast x13 $ \cx13 ->
                           cast x14 $ \cx14 ->
                           cast x15 $ \cx15 ->
-                            retryWithGC (f ca cx1 cx2 cx3 cx4 cx5 cx6 cx7 cx8 cx9 cx10 cx11 cx12 cx13 cx14 cx15) >>= \cy -> uncast cy return
+                            (f ca cx1 cx2 cx3 cx4 cx5 cx6 cx7 cx8 cx9 cx10 cx11 cx12 cx13 cx14 cx15) >>= \cy -> uncast cy return
 
 cast17 :: (Castable a ca, Castable x1 cx1, Castable x2 cx2, Castable x3 cx3, Castable x4 cx4,
             Castable x5 cx5, Castable x6 cx6, Castable x7 cx7, Castable x8 cx8, Castable x9 cx9,
@@ -534,7 +586,7 @@ cast17 f a x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 =
                           cast x14 $ \cx14 ->
                           cast x15 $ \cx15 ->
                           cast x16 $ \cx16 ->
-                            retryWithGC (f ca cx1 cx2 cx3 cx4 cx5 cx6 cx7 cx8 cx9 cx10 cx11 cx12 cx13 cx14 cx15 cx16) >>= \cy -> uncast cy return
+                            (f ca cx1 cx2 cx3 cx4 cx5 cx6 cx7 cx8 cx9 cx10 cx11 cx12 cx13 cx14 cx15 cx16) >>= \cy -> uncast cy return
 
 cast21 :: (Castable a ca, Castable x1 cx1, Castable x2 cx2, Castable x3 cx3, Castable x4 cx4,
             Castable x5 cx5, Castable x6 cx6, Castable x7 cx7, Castable x8 cx8, Castable x9 cx9,
@@ -568,7 +620,7 @@ cast21 f a x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 x19 x2
                           cast x18 $ \cx18 ->
                           cast x19 $ \cx19 ->
                           cast x20 $ \cx20 ->
-                            retryWithGC (f ca cx1 cx2 cx3 cx4 cx5 cx6 cx7 cx8 cx9
+                            (f ca cx1 cx2 cx3 cx4 cx5 cx6 cx7 cx8 cx9
                               cx10 cx11 cx12 cx13 cx14 cx15 cx16 cx17 cx18 cx19
                               cx20) >>= \cy -> uncast cy return
 
@@ -607,7 +659,403 @@ cast22 f a x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 x19 x2
                           cast x19 $ \cx19 ->
                           cast x20 $ \cx20 ->
                           cast x21 $ \cx21 ->
+                            (f ca cx1 cx2 cx3 cx4 cx5 cx6 cx7 cx8 cx9
+                              cx10 cx11 cx12 cx13 cx14 cx15 cx16 cx17 cx18 cx19
+                              cx20 cx21) >>= \cy -> uncast cy return
+
+
+{-# INLINE cast0 #-}
+{-# INLINE cast1 #-}
+{-# INLINE cast2 #-}
+{-# INLINE cast3 #-}
+{-# INLINE cast4 #-}
+{-# INLINE cast5 #-}
+{-# INLINE cast6 #-}
+{-# INLINE cast7 #-}
+{-# INLINE cast8 #-}
+{-# INLINE cast9 #-}
+{-# INLINE cast10 #-}
+{-# INLINE cast11 #-}
+{-# INLINE cast12 #-}
+{-# INLINE cast13 #-}
+{-# INLINE cast14 #-}
+{-# INLINE cast15 #-}
+{-# INLINE cast16 #-}
+{-# INLINE cast17 #-}
+{-# INLINE cast21 #-}
+{-# INLINE cast22 #-}
+
+--------------------------------------------------------------------------------
+-- Cast functions with retryWithGC
+--------------------------------------------------------------------------------
+
+_cast0 :: (Castable a ca) => (IO ca) -> IO a
+_cast0 f = retryWithGC (f) >>= \ca -> uncast ca return
+
+_cast1 :: (Castable a ca, Castable y cy)
+       => (ca -> IO cy) -> a -> IO y
+_cast1 f a = cast a $ \ca -> retryWithGC (f ca) >>= \cy -> uncast cy return
+
+_cast2 :: (Castable a ca, Castable x1 cx1, Castable y cy)
+       => (ca -> cx1 -> IO cy) -> a -> x1 -> IO y
+_cast2 f a x1 = cast a $ \ca ->
+                  cast x1 $ \cx1 ->
+                    retryWithGC (f ca cx1) >>= \cy -> uncast cy return
+
+_cast3 :: (Castable a ca, Castable x1 cx1, Castable x2 cx2, Castable y cy)
+       => (ca -> cx1 -> cx2 -> IO cy) -> a -> x1 -> x2-> IO y
+_cast3 f a x1 x2 = cast a $ \ca ->
+                     cast x1 $ \cx1 ->
+                       cast x2 $ \cx2 ->
+                         retryWithGC (f ca cx1 cx2) >>= \cy -> uncast cy return
+
+_cast4 :: (Castable a ca, Castable x1 cx1, Castable x2 cx2, Castable x3 cx3, Castable y cy)
+       => (ca -> cx1 -> cx2 -> cx3 -> IO cy) -> a -> x1 -> x2 -> x3 -> IO y
+_cast4 f a x1 x2 x3 = cast a $ \ca ->
+                        cast x1 $ \cx1 ->
+                          cast x2 $ \cx2 ->
+                            cast x3 $ \cx3 ->
+                              retryWithGC (f ca cx1 cx2 cx3) >>= \cy -> uncast cy return
+
+_cast5 :: (Castable a ca, Castable x1 cx1, Castable x2 cx2, Castable x3 cx3, Castable x4 cx4, Castable y cy)
+       => (ca -> cx1 -> cx2 -> cx3 -> cx4 -> IO cy) -> a -> x1 -> x2 -> x3 -> x4 -> IO y
+_cast5 f a x1 x2 x3 x4 =
+  cast a $ \ca ->
+    cast x1 $ \cx1 ->
+      cast x2 $ \cx2 ->
+        cast x3 $ \cx3 ->
+          cast x4 $ \cx4 ->
+            retryWithGC (f ca cx1 cx2 cx3 cx4) >>= \cy -> uncast cy return
+
+
+_cast6 :: (Castable a ca, Castable x1 cx1, Castable x2 cx2, Castable x3 cx3, Castable x4 cx4,
+           Castable x5 cx5, Castable y cy)
+       => (ca -> cx1 -> cx2 -> cx3 -> cx4 -> cx5 -> IO cy) -> a -> x1 -> x2 -> x3 -> x4 -> x5 -> IO y
+_cast6 f a x1 x2 x3 x4 x5 =
+  cast a $ \ca ->
+    cast x1 $ \cx1 ->
+      cast x2 $ \cx2 ->
+        cast x3 $ \cx3 ->
+          cast x4 $ \cx4 ->
+            cast x5 $ \cx5 ->
+              retryWithGC (f ca cx1 cx2 cx3 cx4 cx5) >>= \cy -> uncast cy return
+
+_cast7 :: (Castable a ca, Castable x1 cx1, Castable x2 cx2, Castable x3 cx3, Castable x4 cx4,
+           Castable x5 cx5, Castable x6 cx6, Castable y cy)
+       => (ca -> cx1 -> cx2 -> cx3 -> cx4 -> cx5 -> cx6 -> IO cy)
+          -> a -> x1 -> x2 -> x3 -> x4 -> x5 -> x6 -> IO y
+_cast7 f a x1 x2 x3 x4 x5 x6 =
+  cast a $ \ca ->
+    cast x1 $ \cx1 ->
+      cast x2 $ \cx2 ->
+        cast x3 $ \cx3 ->
+          cast x4 $ \cx4 ->
+            cast x5 $ \cx5 ->
+              cast x6 $ \cx6 ->
+                retryWithGC (f ca cx1 cx2 cx3 cx4 cx5 cx6) >>= \cy -> uncast cy return
+
+_cast8 :: (Castable a ca, Castable x1 cx1, Castable x2 cx2, Castable x3 cx3, Castable x4 cx4,
+           Castable x5 cx5, Castable x6 cx6, Castable x7 cx7, Castable y cy)
+       => (ca -> cx1 -> cx2 -> cx3 -> cx4 -> cx5 -> cx6 -> cx7 -> IO cy)
+          -> a -> x1 -> x2 -> x3 -> x4 -> x5 -> x6 -> x7 -> IO y
+_cast8 f a x1 x2 x3 x4 x5 x6 x7 =
+  cast a $ \ca ->
+    cast x1 $ \cx1 ->
+      cast x2 $ \cx2 ->
+        cast x3 $ \cx3 ->
+          cast x4 $ \cx4 ->
+            cast x5 $ \cx5 ->
+              cast x6 $ \cx6 ->
+                cast x7 $ \cx7 ->
+                  retryWithGC (f ca cx1 cx2 cx3 cx4 cx5 cx6 cx7) >>= \cy -> uncast cy return
+
+
+_cast9 :: (Castable a ca, Castable x1 cx1, Castable x2 cx2, Castable x3 cx3, Castable x4 cx4,
+           Castable x5 cx5, Castable x6 cx6, Castable x7 cx7, Castable x8 cx8, Castable y cy)
+       => (ca -> cx1 -> cx2 -> cx3 -> cx4 -> cx5 -> cx6 -> cx7 -> cx8 -> IO cy)
+          -> a -> x1 -> x2 -> x3 -> x4 -> x5 -> x6 -> x7 -> x8 -> IO y
+_cast9 f a x1 x2 x3 x4 x5 x6 x7 x8 =
+  cast a $ \ca ->
+    cast x1 $ \cx1 ->
+      cast x2 $ \cx2 ->
+        cast x3 $ \cx3 ->
+          cast x4 $ \cx4 ->
+            cast x5 $ \cx5 ->
+              cast x6 $ \cx6 ->
+                cast x7 $ \cx7 ->
+                  cast x8 $ \cx8 ->
+                    retryWithGC (f ca cx1 cx2 cx3 cx4 cx5 cx6 cx7 cx8) >>= \cy -> uncast cy return
+
+_cast10 :: (Castable a ca, Castable x1 cx1, Castable x2 cx2, Castable x3 cx3, Castable x4 cx4,
+           Castable x5 cx5, Castable x6 cx6, Castable x7 cx7, Castable x8 cx8, Castable x9 cx9,
+           Castable y cy)
+       => (ca -> cx1 -> cx2 -> cx3 -> cx4 -> cx5 -> cx6 -> cx7 -> cx8 -> cx9 -> IO cy)
+          -> a -> x1 -> x2 -> x3 -> x4 -> x5 -> x6 -> x7 -> x8 -> x9 -> IO y
+_cast10 f a x1 x2 x3 x4 x5 x6 x7 x8 x9 =
+  cast a $ \ca ->
+    cast x1 $ \cx1 ->
+      cast x2 $ \cx2 ->
+        cast x3 $ \cx3 ->
+          cast x4 $ \cx4 ->
+            cast x5 $ \cx5 ->
+              cast x6 $ \cx6 ->
+                cast x7 $ \cx7 ->
+                  cast x8 $ \cx8 ->
+                    cast x9 $ \cx9 ->
+                      retryWithGC (f ca cx1 cx2 cx3 cx4 cx5 cx6 cx7 cx8 cx9) >>= \cy -> uncast cy return
+
+_cast11 :: (Castable a ca, Castable x1 cx1, Castable x2 cx2, Castable x3 cx3, Castable x4 cx4,
+            Castable x5 cx5, Castable x6 cx6, Castable x7 cx7, Castable x8 cx8, Castable x9 cx9,
+            Castable x10 cx10, Castable y cy)
+       => (ca -> cx1 -> cx2 -> cx3 -> cx4 -> cx5 -> cx6 -> cx7 -> cx8 -> cx9 -> cx10 -> IO cy)
+          -> a -> x1 -> x2 -> x3 -> x4 -> x5 -> x6 -> x7 -> x8 -> x9 -> x10 -> IO y
+_cast11 f a x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 =
+  cast a $ \ca ->
+    cast x1 $ \cx1 ->
+      cast x2 $ \cx2 ->
+        cast x3 $ \cx3 ->
+          cast x4 $ \cx4 ->
+            cast x5 $ \cx5 ->
+              cast x6 $ \cx6 ->
+                cast x7 $ \cx7 ->
+                  cast x8 $ \cx8 ->
+                    cast x9 $ \cx9 ->
+                      cast x10 $ \cx10 ->
+                        retryWithGC (f ca cx1 cx2 cx3 cx4 cx5 cx6 cx7 cx8 cx9 cx10) >>= \cy -> uncast cy return
+
+_cast12 :: (Castable a ca, Castable x1 cx1, Castable x2 cx2, Castable x3 cx3, Castable x4 cx4,
+            Castable x5 cx5, Castable x6 cx6, Castable x7 cx7, Castable x8 cx8, Castable x9 cx9,
+            Castable x10 cx10, Castable x11 cx11, Castable y cy)
+       => (ca -> cx1 -> cx2 -> cx3 -> cx4 -> cx5 -> cx6 -> cx7 -> cx8 -> cx9 -> cx10 -> cx11 -> IO cy)
+          -> a -> x1 -> x2 -> x3 -> x4 -> x5 -> x6 -> x7 -> x8 -> x9 -> x10 -> x11 -> IO y
+_cast12 f a x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 =
+  cast a $ \ca ->
+    cast x1 $ \cx1 ->
+      cast x2 $ \cx2 ->
+        cast x3 $ \cx3 ->
+          cast x4 $ \cx4 ->
+            cast x5 $ \cx5 ->
+              cast x6 $ \cx6 ->
+                cast x7 $ \cx7 ->
+                  cast x8 $ \cx8 ->
+                    cast x9 $ \cx9 ->
+                      cast x10 $ \cx10 ->
+                        cast x11 $ \cx11 ->
+                         retryWithGC (f ca cx1 cx2 cx3 cx4 cx5 cx6 cx7 cx8 cx9 cx10 cx11) >>= \cy -> uncast cy return
+
+
+_cast13 :: (Castable a ca, Castable x1 cx1, Castable x2 cx2, Castable x3 cx3, Castable x4 cx4,
+            Castable x5 cx5, Castable x6 cx6, Castable x7 cx7, Castable x8 cx8, Castable x9 cx9,
+            Castable x10 cx10, Castable x11 cx11, Castable x12 cx12, Castable y cy)
+       => (ca -> cx1 -> cx2 -> cx3 -> cx4 -> cx5 -> cx6 -> cx7 -> cx8 -> cx9 -> cx10 -> cx11 -> cx12 -> IO cy)
+          -> a -> x1 -> x2 -> x3 -> x4 -> x5 -> x6 -> x7 -> x8 -> x9 -> x10 -> x11 -> x12 -> IO y
+_cast13 f a x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 =
+  cast a $ \ca ->
+    cast x1 $ \cx1 ->
+      cast x2 $ \cx2 ->
+        cast x3 $ \cx3 ->
+          cast x4 $ \cx4 ->
+            cast x5 $ \cx5 ->
+              cast x6 $ \cx6 ->
+                cast x7 $ \cx7 ->
+                  cast x8 $ \cx8 ->
+                    cast x9 $ \cx9 ->
+                      cast x10 $ \cx10 ->
+                        cast x11 $ \cx11 ->
+                          cast x12 $ \cx12 ->
+                            retryWithGC (f ca cx1 cx2 cx3 cx4 cx5 cx6 cx7 cx8 cx9 cx10 cx11 cx12) >>= \cy -> uncast cy return
+
+_cast14 :: (Castable a ca, Castable x1 cx1, Castable x2 cx2, Castable x3 cx3, Castable x4 cx4,
+            Castable x5 cx5, Castable x6 cx6, Castable x7 cx7, Castable x8 cx8, Castable x9 cx9,
+            Castable x10 cx10, Castable x11 cx11, Castable x12 cx12, Castable x13 cx13, Castable y cy)
+       => (ca -> cx1 -> cx2 -> cx3 -> cx4 -> cx5 -> cx6 -> cx7 -> cx8 -> cx9 -> cx10 -> cx11 -> cx12 -> cx13 -> IO cy)
+          -> a -> x1 -> x2 -> x3 -> x4 -> x5 -> x6 -> x7 -> x8 -> x9 -> x10 -> x11 -> x12 -> x13 -> IO y
+_cast14 f a x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 =
+  cast a $ \ca ->
+    cast x1 $ \cx1 ->
+      cast x2 $ \cx2 ->
+        cast x3 $ \cx3 ->
+          cast x4 $ \cx4 ->
+            cast x5 $ \cx5 ->
+              cast x6 $ \cx6 ->
+                cast x7 $ \cx7 ->
+                  cast x8 $ \cx8 ->
+                    cast x9 $ \cx9 ->
+                      cast x10 $ \cx10 ->
+                        cast x11 $ \cx11 ->
+                          cast x12 $ \cx12 ->
+                          cast x13 $ \cx13 ->
+                            retryWithGC (f ca cx1 cx2 cx3 cx4 cx5 cx6 cx7 cx8 cx9 cx10 cx11 cx12 cx13) >>= \cy -> uncast cy return
+
+
+_cast15 :: (Castable a ca, Castable x1 cx1, Castable x2 cx2, Castable x3 cx3, Castable x4 cx4,
+            Castable x5 cx5, Castable x6 cx6, Castable x7 cx7, Castable x8 cx8, Castable x9 cx9,
+            Castable x10 cx10, Castable x11 cx11, Castable x12 cx12, Castable x13 cx13, Castable x14 cx14, Castable y cy)
+       => (ca -> cx1 -> cx2 -> cx3 -> cx4 -> cx5 -> cx6 -> cx7 -> cx8 -> cx9 -> cx10 -> cx11 -> cx12 -> cx13 -> cx14 -> IO cy)
+          -> a -> x1 -> x2 -> x3 -> x4 -> x5 -> x6 -> x7 -> x8 -> x9 -> x10 -> x11 -> x12 -> x13 -> x14 -> IO y
+_cast15 f a x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 =
+  cast a $ \ca ->
+    cast x1 $ \cx1 ->
+      cast x2 $ \cx2 ->
+        cast x3 $ \cx3 ->
+          cast x4 $ \cx4 ->
+            cast x5 $ \cx5 ->
+              cast x6 $ \cx6 ->
+                cast x7 $ \cx7 ->
+                  cast x8 $ \cx8 ->
+                    cast x9 $ \cx9 ->
+                      cast x10 $ \cx10 ->
+                        cast x11 $ \cx11 ->
+                          cast x12 $ \cx12 ->
+                          cast x13 $ \cx13 ->
+                          cast x14 $ \cx14 ->
+                            retryWithGC (f ca cx1 cx2 cx3 cx4 cx5 cx6 cx7 cx8 cx9 cx10 cx11 cx12 cx13 cx14) >>= \cy -> uncast cy return
+
+
+_cast16 :: (Castable a ca, Castable x1 cx1, Castable x2 cx2, Castable x3 cx3, Castable x4 cx4,
+            Castable x5 cx5, Castable x6 cx6, Castable x7 cx7, Castable x8 cx8, Castable x9 cx9,
+            Castable x10 cx10, Castable x11 cx11, Castable x12 cx12, Castable x13 cx13, Castable x14 cx14, Castable x15 cx15, Castable y cy)
+       => (ca -> cx1 -> cx2 -> cx3 -> cx4 -> cx5 -> cx6 -> cx7 -> cx8 -> cx9 -> cx10 -> cx11 -> cx12 -> cx13 -> cx14 -> cx15 -> IO cy)
+          -> a -> x1 -> x2 -> x3 -> x4 -> x5 -> x6 -> x7 -> x8 -> x9 -> x10 -> x11 -> x12 -> x13 -> x14 -> x15 -> IO y
+_cast16 f a x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 =
+  cast a $ \ca ->
+    cast x1 $ \cx1 ->
+      cast x2 $ \cx2 ->
+        cast x3 $ \cx3 ->
+          cast x4 $ \cx4 ->
+            cast x5 $ \cx5 ->
+              cast x6 $ \cx6 ->
+                cast x7 $ \cx7 ->
+                  cast x8 $ \cx8 ->
+                    cast x9 $ \cx9 ->
+                      cast x10 $ \cx10 ->
+                        cast x11 $ \cx11 ->
+                          cast x12 $ \cx12 ->
+                          cast x13 $ \cx13 ->
+                          cast x14 $ \cx14 ->
+                          cast x15 $ \cx15 ->
+                            retryWithGC (f ca cx1 cx2 cx3 cx4 cx5 cx6 cx7 cx8 cx9 cx10 cx11 cx12 cx13 cx14 cx15) >>= \cy -> uncast cy return
+
+_cast17 :: (Castable a ca, Castable x1 cx1, Castable x2 cx2, Castable x3 cx3, Castable x4 cx4,
+            Castable x5 cx5, Castable x6 cx6, Castable x7 cx7, Castable x8 cx8, Castable x9 cx9,
+            Castable x10 cx10, Castable x11 cx11, Castable x12 cx12, Castable x13 cx13, Castable x14 cx14,
+            Castable x15 cx15, Castable x16 cx16,
+            Castable y cy)
+       => (ca -> cx1 -> cx2 -> cx3 -> cx4 -> cx5 -> cx6 -> cx7 -> cx8 -> cx9 -> cx10 -> cx11 -> cx12 -> cx13 -> cx14 -> cx15 -> cx16 -> IO cy)
+          -> a -> x1 -> x2 -> x3 -> x4 -> x5 -> x6 -> x7 -> x8 -> x9 -> x10 -> x11 -> x12 -> x13 -> x14 -> x15 -> x16 -> IO y
+_cast17 f a x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 =
+  cast a $ \ca ->
+    cast x1 $ \cx1 ->
+      cast x2 $ \cx2 ->
+        cast x3 $ \cx3 ->
+          cast x4 $ \cx4 ->
+            cast x5 $ \cx5 ->
+              cast x6 $ \cx6 ->
+                cast x7 $ \cx7 ->
+                  cast x8 $ \cx8 ->
+                    cast x9 $ \cx9 ->
+                      cast x10 $ \cx10 ->
+                        cast x11 $ \cx11 ->
+                          cast x12 $ \cx12 ->
+                          cast x13 $ \cx13 ->
+                          cast x14 $ \cx14 ->
+                          cast x15 $ \cx15 ->
+                          cast x16 $ \cx16 ->
+                            retryWithGC (f ca cx1 cx2 cx3 cx4 cx5 cx6 cx7 cx8 cx9 cx10 cx11 cx12 cx13 cx14 cx15 cx16) >>= \cy -> uncast cy return
+
+_cast21 :: (Castable a ca, Castable x1 cx1, Castable x2 cx2, Castable x3 cx3, Castable x4 cx4,
+            Castable x5 cx5, Castable x6 cx6, Castable x7 cx7, Castable x8 cx8, Castable x9 cx9,
+            Castable x10 cx10, Castable x11 cx11, Castable x12 cx12, Castable x13 cx13, Castable x14 cx14, Castable x15 cx15,
+            Castable x16 cx16, Castable x17 cx17, Castable x18 cx18, Castable x19 cx19, Castable x20 cx20,
+            Castable y cy)
+       => (ca -> cx1 -> cx2 -> cx3 -> cx4 -> cx5 -> cx6 -> cx7 -> cx8 -> cx9 ->
+           cx10 -> cx11 -> cx12 -> cx13 -> cx14 -> cx15 -> cx16 -> cx17 -> cx18 -> cx19 ->
+           cx20 -> IO cy) ->
+          a -> x1 -> x2 -> x3 -> x4 -> x5 -> x6 -> x7 -> x8 -> x9 ->
+          x10 -> x11 -> x12 -> x13 -> x14 -> x15 -> x16 -> x17 -> x18 -> x19 -> x20 -> IO y
+_cast21 f a x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 x19 x20 =
+  cast a $ \ca ->
+    cast x1 $ \cx1 ->
+      cast x2 $ \cx2 ->
+        cast x3 $ \cx3 ->
+          cast x4 $ \cx4 ->
+            cast x5 $ \cx5 ->
+              cast x6 $ \cx6 ->
+                cast x7 $ \cx7 ->
+                  cast x8 $ \cx8 ->
+                    cast x9 $ \cx9 ->
+                      cast x10 $ \cx10 ->
+                        cast x11 $ \cx11 ->
+                          cast x12 $ \cx12 ->
+                          cast x13 $ \cx13 ->
+                          cast x14 $ \cx14 ->
+                          cast x15 $ \cx15 ->
+                          cast x16 $ \cx16 ->
+                          cast x17 $ \cx17 ->
+                          cast x18 $ \cx18 ->
+                          cast x19 $ \cx19 ->
+                          cast x20 $ \cx20 ->
+                            retryWithGC (f ca cx1 cx2 cx3 cx4 cx5 cx6 cx7 cx8 cx9
+                              cx10 cx11 cx12 cx13 cx14 cx15 cx16 cx17 cx18 cx19
+                              cx20) >>= \cy -> uncast cy return
+
+
+_cast22 :: (Castable a ca, Castable x1 cx1, Castable x2 cx2, Castable x3 cx3, Castable x4 cx4,
+            Castable x5 cx5, Castable x6 cx6, Castable x7 cx7, Castable x8 cx8, Castable x9 cx9,
+            Castable x10 cx10, Castable x11 cx11, Castable x12 cx12, Castable x13 cx13, Castable x14 cx14,
+            Castable x15 cx15, Castable x16 cx16, Castable x17 cx17, Castable x18 cx18, Castable x19 cx19,
+            Castable x20 cx20, Castable x21 cx21,
+            Castable y cy)
+       => (ca -> cx1 -> cx2 -> cx3 -> cx4 -> cx5 -> cx6 -> cx7 -> cx8 -> cx9 ->
+           cx10 -> cx11 -> cx12 -> cx13 -> cx14 -> cx15 -> cx16 -> cx17 -> cx18 -> cx19 ->
+           cx20 -> cx21 -> IO cy) ->
+          a -> x1 -> x2 -> x3 -> x4 -> x5 -> x6 -> x7 -> x8 -> x9 ->
+          x10 -> x11 -> x12 -> x13 -> x14 -> x15 -> x16 -> x17 -> x18 -> x19 -> x20 -> x21 -> IO y
+_cast22 f a x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 x19 x20 x21 =
+  cast a $ \ca ->
+    cast x1 $ \cx1 ->
+      cast x2 $ \cx2 ->
+        cast x3 $ \cx3 ->
+          cast x4 $ \cx4 ->
+            cast x5 $ \cx5 ->
+              cast x6 $ \cx6 ->
+                cast x7 $ \cx7 ->
+                  cast x8 $ \cx8 ->
+                    cast x9 $ \cx9 ->
+                      cast x10 $ \cx10 ->
+                        cast x11 $ \cx11 ->
+                          cast x12 $ \cx12 ->
+                          cast x13 $ \cx13 ->
+                          cast x14 $ \cx14 ->
+                          cast x15 $ \cx15 ->
+                          cast x16 $ \cx16 ->
+                          cast x17 $ \cx17 ->
+                          cast x18 $ \cx18 ->
+                          cast x19 $ \cx19 ->
+                          cast x20 $ \cx20 ->
+                          cast x21 $ \cx21 ->
                             retryWithGC (f ca cx1 cx2 cx3 cx4 cx5 cx6 cx7 cx8 cx9
                               cx10 cx11 cx12 cx13 cx14 cx15 cx16 cx17 cx18 cx19
                               cx20 cx21) >>= \cy -> uncast cy return
 
+
+{-# INLINE _cast0 #-}
+{-# INLINE _cast1 #-}
+{-# INLINE _cast2 #-}
+{-# INLINE _cast3 #-}
+{-# INLINE _cast4 #-}
+{-# INLINE _cast5 #-}
+{-# INLINE _cast6 #-}
+{-# INLINE _cast7 #-}
+{-# INLINE _cast8 #-}
+{-# INLINE _cast9 #-}
+{-# INLINE _cast10 #-}
+{-# INLINE _cast11 #-}
+{-# INLINE _cast12 #-}
+{-# INLINE _cast13 #-}
+{-# INLINE _cast14 #-}
+{-# INLINE _cast15 #-}
+{-# INLINE _cast16 #-}
+{-# INLINE _cast17 #-}
+{-# INLINE _cast21 #-}
+{-# INLINE _cast22 #-}

--- a/libtorch-ffi/src/Torch/Internal/Class.hs
+++ b/libtorch-ffi/src/Torch/Internal/Class.hs
@@ -13,6 +13,7 @@ class Castable a b where
 
 class CppObject a where
   fromPtr :: Ptr a -> IO (ForeignPtr a)
+  deletePtr :: Ptr a -> IO ()
 
 class CppTuple2 m where
   type A m

--- a/libtorch-ffi/src/Torch/Internal/Const.hs
+++ b/libtorch-ffi/src/Torch/Internal/Const.hs
@@ -11,7 +11,7 @@
 module Torch.Internal.Const where
 
 import qualified Language.C.Inline.Cpp as C
-import qualified Language.C.Inline.Cpp.Exceptions as C
+import qualified Language.C.Inline.Cpp.Unsafe as C
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Types as C
 import qualified Data.Map as Map

--- a/libtorch-ffi/src/Torch/Internal/Managed/Autograd.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Autograd.hs
@@ -12,11 +12,11 @@ import Foreign.C.Types (CBool)
 
 
 grad :: ForeignPtr Tensor -> ForeignPtr TensorList -> IO (ForeignPtr TensorList)
-grad = cast2 Unmanaged.grad
+grad = _cast2 Unmanaged.grad
 
 
 makeIndependent :: ForeignPtr Tensor -> CBool -> IO (ForeignPtr Tensor)
-makeIndependent = cast2 Unmanaged.makeIndependent
+makeIndependent = _cast2 Unmanaged.makeIndependent
 
 dropVariable :: ForeignPtr Tensor -> IO (ForeignPtr Tensor)
-dropVariable = cast1 Unmanaged.dropVariable
+dropVariable = _cast1 Unmanaged.dropVariable

--- a/libtorch-ffi/src/Torch/Internal/Managed/Cast.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Cast.hs
@@ -33,15 +33,11 @@ instance Castable Int (ForeignPtr IntArray) where
 instance Castable [Int] (ForeignPtr IntArray) where
   cast xs f = do
     arr <- newIntArray
-    forM_ xs $ (intArray_push_back_l arr) . fromIntegral
+    intArray_fromList arr (map fromIntegral xs)
     f arr
   uncast xs f = do
-    len <- intArray_size xs
-    -- NB: This check is necessary, because len is unsigned and it will wrap around if
-    --     we subtract 1 when it's 0.
-    if len == 0
-      then f []
-      else f =<< mapM (\i -> intArray_at_s xs i >>= return . fromIntegral) [0..(len - 1)]
+    xs <- intArray_toList xs
+    f (map fromIntegral xs)
 
 instance Castable [Double] (ForeignPtr (StdVector CDouble)) where
   cast xs f = do

--- a/libtorch-ffi/src/Torch/Internal/Managed/Native/Extra.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Native/Extra.hs
@@ -27,12 +27,12 @@ max_values_tlb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-max_values_tlb = cast3 Unmanaged.max_values_tlb
+max_values_tlb = _cast3 Unmanaged.max_values_tlb
 
 min_values_tlb
   :: ForeignPtr Tensor
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-min_values_tlb = cast3 Unmanaged.min_values_tlb
+min_values_tlb = _cast3 Unmanaged.min_values_tlb
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Native/Native0.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Native/Native0.hs
@@ -25,131 +25,131 @@ _cast_Byte_tb
   :: ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-_cast_Byte_tb = cast2 Unmanaged._cast_Byte_tb
+_cast_Byte_tb = _cast2 Unmanaged._cast_Byte_tb
 
 _cast_Byte_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_cast_Byte_t = cast1 Unmanaged._cast_Byte_t
+_cast_Byte_t = _cast1 Unmanaged._cast_Byte_t
 
 _cast_Char_tb
   :: ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-_cast_Char_tb = cast2 Unmanaged._cast_Char_tb
+_cast_Char_tb = _cast2 Unmanaged._cast_Char_tb
 
 _cast_Char_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_cast_Char_t = cast1 Unmanaged._cast_Char_t
+_cast_Char_t = _cast1 Unmanaged._cast_Char_t
 
 _cast_Double_tb
   :: ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-_cast_Double_tb = cast2 Unmanaged._cast_Double_tb
+_cast_Double_tb = _cast2 Unmanaged._cast_Double_tb
 
 _cast_Double_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_cast_Double_t = cast1 Unmanaged._cast_Double_t
+_cast_Double_t = _cast1 Unmanaged._cast_Double_t
 
 _cast_Float_tb
   :: ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-_cast_Float_tb = cast2 Unmanaged._cast_Float_tb
+_cast_Float_tb = _cast2 Unmanaged._cast_Float_tb
 
 _cast_Float_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_cast_Float_t = cast1 Unmanaged._cast_Float_t
+_cast_Float_t = _cast1 Unmanaged._cast_Float_t
 
 _cast_Int_tb
   :: ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-_cast_Int_tb = cast2 Unmanaged._cast_Int_tb
+_cast_Int_tb = _cast2 Unmanaged._cast_Int_tb
 
 _cast_Int_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_cast_Int_t = cast1 Unmanaged._cast_Int_t
+_cast_Int_t = _cast1 Unmanaged._cast_Int_t
 
 _cast_Long_tb
   :: ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-_cast_Long_tb = cast2 Unmanaged._cast_Long_tb
+_cast_Long_tb = _cast2 Unmanaged._cast_Long_tb
 
 _cast_Long_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_cast_Long_t = cast1 Unmanaged._cast_Long_t
+_cast_Long_t = _cast1 Unmanaged._cast_Long_t
 
 _cast_Short_tb
   :: ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-_cast_Short_tb = cast2 Unmanaged._cast_Short_tb
+_cast_Short_tb = _cast2 Unmanaged._cast_Short_tb
 
 _cast_Short_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_cast_Short_t = cast1 Unmanaged._cast_Short_t
+_cast_Short_t = _cast1 Unmanaged._cast_Short_t
 
 _cast_Half_tb
   :: ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-_cast_Half_tb = cast2 Unmanaged._cast_Half_tb
+_cast_Half_tb = _cast2 Unmanaged._cast_Half_tb
 
 _cast_Half_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_cast_Half_t = cast1 Unmanaged._cast_Half_t
+_cast_Half_t = _cast1 Unmanaged._cast_Half_t
 
 _make_dual_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-_make_dual_ttl = cast3 Unmanaged._make_dual_ttl
+_make_dual_ttl = _cast3 Unmanaged._make_dual_ttl
 
 _unpack_dual_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-_unpack_dual_tl = cast2 Unmanaged._unpack_dual_tl
+_unpack_dual_tl = _cast2 Unmanaged._unpack_dual_tl
 
 _new_zeros_with_same_feature_meta_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-_new_zeros_with_same_feature_meta_ttl = cast3 Unmanaged._new_zeros_with_same_feature_meta_ttl
+_new_zeros_with_same_feature_meta_ttl = _cast3 Unmanaged._new_zeros_with_same_feature_meta_ttl
 
 _new_zeros_with_same_feature_meta_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_new_zeros_with_same_feature_meta_tt = cast2 Unmanaged._new_zeros_with_same_feature_meta_tt
+_new_zeros_with_same_feature_meta_tt = _cast2 Unmanaged._new_zeros_with_same_feature_meta_tt
 
 _has_same_storage_numel_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (CBool)
-_has_same_storage_numel_tt = cast2 Unmanaged._has_same_storage_numel_tt
+_has_same_storage_numel_tt = _cast2 Unmanaged._has_same_storage_numel_tt
 
 align_tensors_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr TensorList)
-align_tensors_l = cast1 Unmanaged.align_tensors_l
+align_tensors_l = _cast1 Unmanaged.align_tensors_l
 
 _assert_async_t
   :: ForeignPtr Tensor
   -> IO (())
-_assert_async_t = cast1 Unmanaged._assert_async_t
+_assert_async_t = _cast1 Unmanaged._assert_async_t
 
 _use_cudnn_ctc_loss_ttlll
   :: ForeignPtr Tensor
@@ -158,7 +158,7 @@ _use_cudnn_ctc_loss_ttlll
   -> ForeignPtr IntArray
   -> Int64
   -> IO (CBool)
-_use_cudnn_ctc_loss_ttlll = cast5 Unmanaged._use_cudnn_ctc_loss_ttlll
+_use_cudnn_ctc_loss_ttlll = _cast5 Unmanaged._use_cudnn_ctc_loss_ttlll
 
 _cudnn_ctc_loss_ttlllbb
   :: ForeignPtr Tensor
@@ -169,11 +169,11 @@ _cudnn_ctc_loss_ttlllbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-_cudnn_ctc_loss_ttlllbb = cast7 Unmanaged._cudnn_ctc_loss_ttlllbb
+_cudnn_ctc_loss_ttlllbb = _cast7 Unmanaged._cudnn_ctc_loss_ttlllbb
 
 _use_cudnn_rnn_flatten_weight
   :: IO (CBool)
-_use_cudnn_rnn_flatten_weight = cast0 Unmanaged._use_cudnn_rnn_flatten_weight
+_use_cudnn_rnn_flatten_weight = _cast0 Unmanaged._use_cudnn_rnn_flatten_weight
 
 _cudnn_rnn_flatten_weight_lllllllbb
   :: ForeignPtr TensorList
@@ -186,7 +186,7 @@ _cudnn_rnn_flatten_weight_lllllllbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-_cudnn_rnn_flatten_weight_lllllllbb = cast9 Unmanaged._cudnn_rnn_flatten_weight_lllllllbb
+_cudnn_rnn_flatten_weight_lllllllbb = _cast9 Unmanaged._cudnn_rnn_flatten_weight_lllllllbb
 
 _cudnn_rnn_tlltttllllbdbblt
   :: ForeignPtr Tensor
@@ -206,7 +206,7 @@ _cudnn_rnn_tlltttllllbdbblt
   -> ForeignPtr IntArray
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Tensor)))
-_cudnn_rnn_tlltttllllbdbblt = cast16 Unmanaged._cudnn_rnn_tlltttllllbdbblt
+_cudnn_rnn_tlltttllllbdbblt = _cast16 Unmanaged._cudnn_rnn_tlltttllllbdbblt
 
 _cudnn_rnn_backward_tlltttttttllllbdbbltta
   :: ForeignPtr Tensor
@@ -232,7 +232,7 @@ _cudnn_rnn_backward_tlltttttttllllbdbbltta
   -> ForeignPtr Tensor
   -> ForeignPtr (StdArray '(CBool,4))
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,TensorList)))
-_cudnn_rnn_backward_tlltttttttllllbdbbltta = cast22 Unmanaged._cudnn_rnn_backward_tlltttttttllllbdbbltta
+_cudnn_rnn_backward_tlltttttttllllbdbbltta = _cast22 Unmanaged._cudnn_rnn_backward_tlltttttttllllbdbbltta
 
 _cudnn_init_dropout_state_dblo
   :: CDouble
@@ -240,46 +240,46 @@ _cudnn_init_dropout_state_dblo
   -> Int64
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-_cudnn_init_dropout_state_dblo = cast4 Unmanaged._cudnn_init_dropout_state_dblo
+_cudnn_init_dropout_state_dblo = _cast4 Unmanaged._cudnn_init_dropout_state_dblo
 
 _debug_has_internal_overlap_t
   :: ForeignPtr Tensor
   -> IO (Int64)
-_debug_has_internal_overlap_t = cast1 Unmanaged._debug_has_internal_overlap_t
+_debug_has_internal_overlap_t = _cast1 Unmanaged._debug_has_internal_overlap_t
 
 _fused_dropout_tdG
   :: ForeignPtr Tensor
   -> CDouble
   -> ForeignPtr Generator
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-_fused_dropout_tdG = cast3 Unmanaged._fused_dropout_tdG
+_fused_dropout_tdG = _cast3 Unmanaged._fused_dropout_tdG
 
 _fused_dropout_td
   :: ForeignPtr Tensor
   -> CDouble
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-_fused_dropout_td = cast2 Unmanaged._fused_dropout_td
+_fused_dropout_td = _cast2 Unmanaged._fused_dropout_td
 
 _masked_scale_ttd
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> CDouble
   -> IO (ForeignPtr Tensor)
-_masked_scale_ttd = cast3 Unmanaged._masked_scale_ttd
+_masked_scale_ttd = _cast3 Unmanaged._masked_scale_ttd
 
 native_dropout_tdb
   :: ForeignPtr Tensor
   -> CDouble
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-native_dropout_tdb = cast3 Unmanaged.native_dropout_tdb
+native_dropout_tdb = _cast3 Unmanaged.native_dropout_tdb
 
 native_dropout_backward_ttd
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> CDouble
   -> IO (ForeignPtr Tensor)
-native_dropout_backward_ttd = cast3 Unmanaged.native_dropout_backward_ttd
+native_dropout_backward_ttd = _cast3 Unmanaged.native_dropout_backward_ttd
 
 _sobol_engine_draw_tltlls
   :: ForeignPtr Tensor
@@ -289,7 +289,7 @@ _sobol_engine_draw_tltlls
   -> Int64
   -> ScalarType
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-_sobol_engine_draw_tltlls = cast6 Unmanaged._sobol_engine_draw_tltlls
+_sobol_engine_draw_tltlls = _cast6 Unmanaged._sobol_engine_draw_tltlls
 
 _sobol_engine_ff__tltll
   :: ForeignPtr Tensor
@@ -298,234 +298,234 @@ _sobol_engine_ff__tltll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-_sobol_engine_ff__tltll = cast5 Unmanaged._sobol_engine_ff__tltll
+_sobol_engine_ff__tltll = _cast5 Unmanaged._sobol_engine_ff__tltll
 
 _sobol_engine_scramble__ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-_sobol_engine_scramble__ttl = cast3 Unmanaged._sobol_engine_scramble__ttl
+_sobol_engine_scramble__ttl = _cast3 Unmanaged._sobol_engine_scramble__ttl
 
 _sobol_engine_initialize_state__tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-_sobol_engine_initialize_state__tl = cast2 Unmanaged._sobol_engine_initialize_state__tl
+_sobol_engine_initialize_state__tl = _cast2 Unmanaged._sobol_engine_initialize_state__tl
 
 _reshape_from_tensor_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_reshape_from_tensor_tt = cast2 Unmanaged._reshape_from_tensor_tt
+_reshape_from_tensor_tt = _cast2 Unmanaged._reshape_from_tensor_tt
 
 _shape_as_tensor_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_shape_as_tensor_t = cast1 Unmanaged._shape_as_tensor_t
+_shape_as_tensor_t = _cast1 Unmanaged._shape_as_tensor_t
 
 dropout_tdb
   :: ForeignPtr Tensor
   -> CDouble
   -> CBool
   -> IO (ForeignPtr Tensor)
-dropout_tdb = cast3 Unmanaged.dropout_tdb
+dropout_tdb = _cast3 Unmanaged.dropout_tdb
 
 dropout__tdb
   :: ForeignPtr Tensor
   -> CDouble
   -> CBool
   -> IO (ForeignPtr Tensor)
-dropout__tdb = cast3 Unmanaged.dropout__tdb
+dropout__tdb = _cast3 Unmanaged.dropout__tdb
 
 feature_dropout_tdb
   :: ForeignPtr Tensor
   -> CDouble
   -> CBool
   -> IO (ForeignPtr Tensor)
-feature_dropout_tdb = cast3 Unmanaged.feature_dropout_tdb
+feature_dropout_tdb = _cast3 Unmanaged.feature_dropout_tdb
 
 feature_dropout__tdb
   :: ForeignPtr Tensor
   -> CDouble
   -> CBool
   -> IO (ForeignPtr Tensor)
-feature_dropout__tdb = cast3 Unmanaged.feature_dropout__tdb
+feature_dropout__tdb = _cast3 Unmanaged.feature_dropout__tdb
 
 alpha_dropout_tdb
   :: ForeignPtr Tensor
   -> CDouble
   -> CBool
   -> IO (ForeignPtr Tensor)
-alpha_dropout_tdb = cast3 Unmanaged.alpha_dropout_tdb
+alpha_dropout_tdb = _cast3 Unmanaged.alpha_dropout_tdb
 
 alpha_dropout__tdb
   :: ForeignPtr Tensor
   -> CDouble
   -> CBool
   -> IO (ForeignPtr Tensor)
-alpha_dropout__tdb = cast3 Unmanaged.alpha_dropout__tdb
+alpha_dropout__tdb = _cast3 Unmanaged.alpha_dropout__tdb
 
 feature_alpha_dropout_tdb
   :: ForeignPtr Tensor
   -> CDouble
   -> CBool
   -> IO (ForeignPtr Tensor)
-feature_alpha_dropout_tdb = cast3 Unmanaged.feature_alpha_dropout_tdb
+feature_alpha_dropout_tdb = _cast3 Unmanaged.feature_alpha_dropout_tdb
 
 feature_alpha_dropout__tdb
   :: ForeignPtr Tensor
   -> CDouble
   -> CBool
   -> IO (ForeignPtr Tensor)
-feature_alpha_dropout__tdb = cast3 Unmanaged.feature_alpha_dropout__tdb
+feature_alpha_dropout__tdb = _cast3 Unmanaged.feature_alpha_dropout__tdb
 
 abs_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-abs_t = cast1 Unmanaged.abs_t
+abs_t = _cast1 Unmanaged.abs_t
 
 abs__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-abs__t = cast1 Unmanaged.abs__t
+abs__t = _cast1 Unmanaged.abs__t
 
 abs_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-abs_out_tt = cast2 Unmanaged.abs_out_tt
+abs_out_tt = _cast2 Unmanaged.abs_out_tt
 
 absolute_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-absolute_t = cast1 Unmanaged.absolute_t
+absolute_t = _cast1 Unmanaged.absolute_t
 
 absolute_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-absolute_out_tt = cast2 Unmanaged.absolute_out_tt
+absolute_out_tt = _cast2 Unmanaged.absolute_out_tt
 
 angle_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-angle_t = cast1 Unmanaged.angle_t
+angle_t = _cast1 Unmanaged.angle_t
 
 angle_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-angle_out_tt = cast2 Unmanaged.angle_out_tt
+angle_out_tt = _cast2 Unmanaged.angle_out_tt
 
 view_as_real_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-view_as_real_t = cast1 Unmanaged.view_as_real_t
+view_as_real_t = _cast1 Unmanaged.view_as_real_t
 
 view_as_complex_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-view_as_complex_t = cast1 Unmanaged.view_as_complex_t
+view_as_complex_t = _cast1 Unmanaged.view_as_complex_t
 
 sgn_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-sgn_t = cast1 Unmanaged.sgn_t
+sgn_t = _cast1 Unmanaged.sgn_t
 
 sgn_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-sgn_out_tt = cast2 Unmanaged.sgn_out_tt
+sgn_out_tt = _cast2 Unmanaged.sgn_out_tt
 
 real_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-real_t = cast1 Unmanaged.real_t
+real_t = _cast1 Unmanaged.real_t
 
 imag_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-imag_t = cast1 Unmanaged.imag_t
+imag_t = _cast1 Unmanaged.imag_t
 
 _conj_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_conj_t = cast1 Unmanaged._conj_t
+_conj_t = _cast1 Unmanaged._conj_t
 
 conj_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-conj_t = cast1 Unmanaged.conj_t
+conj_t = _cast1 Unmanaged.conj_t
 
 _conj_physical_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_conj_physical_t = cast1 Unmanaged._conj_physical_t
+_conj_physical_t = _cast1 Unmanaged._conj_physical_t
 
 conj_physical_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-conj_physical_t = cast1 Unmanaged.conj_physical_t
+conj_physical_t = _cast1 Unmanaged.conj_physical_t
 
 conj_physical_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-conj_physical_out_tt = cast2 Unmanaged.conj_physical_out_tt
+conj_physical_out_tt = _cast2 Unmanaged.conj_physical_out_tt
 
 conj_physical__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-conj_physical__t = cast1 Unmanaged.conj_physical__t
+conj_physical__t = _cast1 Unmanaged.conj_physical__t
 
 resolve_conj_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-resolve_conj_t = cast1 Unmanaged.resolve_conj_t
+resolve_conj_t = _cast1 Unmanaged.resolve_conj_t
 
 resolve_neg_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-resolve_neg_t = cast1 Unmanaged.resolve_neg_t
+resolve_neg_t = _cast1 Unmanaged.resolve_neg_t
 
 _neg_view_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_neg_view_t = cast1 Unmanaged._neg_view_t
+_neg_view_t = _cast1 Unmanaged._neg_view_t
 
 acos_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-acos_t = cast1 Unmanaged.acos_t
+acos_t = _cast1 Unmanaged.acos_t
 
 acos__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-acos__t = cast1 Unmanaged.acos__t
+acos__t = _cast1 Unmanaged.acos__t
 
 acos_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-acos_out_tt = cast2 Unmanaged.acos_out_tt
+acos_out_tt = _cast2 Unmanaged.acos_out_tt
 
 arccos_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-arccos_t = cast1 Unmanaged.arccos_t
+arccos_t = _cast1 Unmanaged.arccos_t
 
 arccos__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-arccos__t = cast1 Unmanaged.arccos__t
+arccos__t = _cast1 Unmanaged.arccos__t
 
 arccos_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-arccos_out_tt = cast2 Unmanaged.arccos_out_tt
+arccos_out_tt = _cast2 Unmanaged.arccos_out_tt
 
 avg_pool1d_tlllbb
   :: ForeignPtr Tensor
@@ -535,7 +535,7 @@ avg_pool1d_tlllbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-avg_pool1d_tlllbb = cast6 Unmanaged.avg_pool1d_tlllbb
+avg_pool1d_tlllbb = _cast6 Unmanaged.avg_pool1d_tlllbb
 
 avg_pool1d_tlllb
   :: ForeignPtr Tensor
@@ -544,7 +544,7 @@ avg_pool1d_tlllb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-avg_pool1d_tlllb = cast5 Unmanaged.avg_pool1d_tlllb
+avg_pool1d_tlllb = _cast5 Unmanaged.avg_pool1d_tlllb
 
 avg_pool1d_tlll
   :: ForeignPtr Tensor
@@ -552,45 +552,45 @@ avg_pool1d_tlll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-avg_pool1d_tlll = cast4 Unmanaged.avg_pool1d_tlll
+avg_pool1d_tlll = _cast4 Unmanaged.avg_pool1d_tlll
 
 avg_pool1d_tll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-avg_pool1d_tll = cast3 Unmanaged.avg_pool1d_tll
+avg_pool1d_tll = _cast3 Unmanaged.avg_pool1d_tll
 
 avg_pool1d_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-avg_pool1d_tl = cast2 Unmanaged.avg_pool1d_tl
+avg_pool1d_tl = _cast2 Unmanaged.avg_pool1d_tl
 
 adaptive_avg_pool1d_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-adaptive_avg_pool1d_tl = cast2 Unmanaged.adaptive_avg_pool1d_tl
+adaptive_avg_pool1d_tl = _cast2 Unmanaged.adaptive_avg_pool1d_tl
 
 adaptive_max_pool1d_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-adaptive_max_pool1d_tl = cast2 Unmanaged.adaptive_max_pool1d_tl
+adaptive_max_pool1d_tl = _cast2 Unmanaged.adaptive_max_pool1d_tl
 
 add_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-add_tts = cast3 Unmanaged.add_tts
+add_tts = _cast3 Unmanaged.add_tts
 
 add_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-add_tt = cast2 Unmanaged.add_tt
+add_tt = _cast2 Unmanaged.add_tt
 
 add_out_ttts
   :: ForeignPtr Tensor
@@ -598,40 +598,40 @@ add_out_ttts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-add_out_ttts = cast4 Unmanaged.add_out_ttts
+add_out_ttts = _cast4 Unmanaged.add_out_ttts
 
 add_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-add_out_ttt = cast3 Unmanaged.add_out_ttt
+add_out_ttt = _cast3 Unmanaged.add_out_ttt
 
 _add_relu_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-_add_relu_tts = cast3 Unmanaged._add_relu_tts
+_add_relu_tts = _cast3 Unmanaged._add_relu_tts
 
 _add_relu_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_add_relu_tt = cast2 Unmanaged._add_relu_tt
+_add_relu_tt = _cast2 Unmanaged._add_relu_tt
 
 _add_relu__tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-_add_relu__tts = cast3 Unmanaged._add_relu__tts
+_add_relu__tts = _cast3 Unmanaged._add_relu__tts
 
 _add_relu__tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_add_relu__tt = cast2 Unmanaged._add_relu__tt
+_add_relu__tt = _cast2 Unmanaged._add_relu__tt
 
 _add_relu_out_ttts
   :: ForeignPtr Tensor
@@ -639,53 +639,53 @@ _add_relu_out_ttts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-_add_relu_out_ttts = cast4 Unmanaged._add_relu_out_ttts
+_add_relu_out_ttts = _cast4 Unmanaged._add_relu_out_ttts
 
 _add_relu_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_add_relu_out_ttt = cast3 Unmanaged._add_relu_out_ttt
+_add_relu_out_ttt = _cast3 Unmanaged._add_relu_out_ttt
 
 _add_relu_tss
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-_add_relu_tss = cast3 Unmanaged._add_relu_tss
+_add_relu_tss = _cast3 Unmanaged._add_relu_tss
 
 _add_relu_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-_add_relu_ts = cast2 Unmanaged._add_relu_ts
+_add_relu_ts = _cast2 Unmanaged._add_relu_ts
 
 _add_relu__tss
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-_add_relu__tss = cast3 Unmanaged._add_relu__tss
+_add_relu__tss = _cast3 Unmanaged._add_relu__tss
 
 _add_relu__ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-_add_relu__ts = cast2 Unmanaged._add_relu__ts
+_add_relu__ts = _cast2 Unmanaged._add_relu__ts
 
 add_tss
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-add_tss = cast3 Unmanaged.add_tss
+add_tss = _cast3 Unmanaged.add_tss
 
 add_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-add_ts = cast2 Unmanaged.add_ts
+add_ts = _cast2 Unmanaged.add_ts
 
 addmv_tttss
   :: ForeignPtr Tensor
@@ -694,7 +694,7 @@ addmv_tttss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-addmv_tttss = cast5 Unmanaged.addmv_tttss
+addmv_tttss = _cast5 Unmanaged.addmv_tttss
 
 addmv_ttts
   :: ForeignPtr Tensor
@@ -702,14 +702,14 @@ addmv_ttts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-addmv_ttts = cast4 Unmanaged.addmv_ttts
+addmv_ttts = _cast4 Unmanaged.addmv_ttts
 
 addmv_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-addmv_ttt = cast3 Unmanaged.addmv_ttt
+addmv_ttt = _cast3 Unmanaged.addmv_ttt
 
 addmv__tttss
   :: ForeignPtr Tensor
@@ -718,7 +718,7 @@ addmv__tttss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-addmv__tttss = cast5 Unmanaged.addmv__tttss
+addmv__tttss = _cast5 Unmanaged.addmv__tttss
 
 addmv__ttts
   :: ForeignPtr Tensor
@@ -726,14 +726,14 @@ addmv__ttts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-addmv__ttts = cast4 Unmanaged.addmv__ttts
+addmv__ttts = _cast4 Unmanaged.addmv__ttts
 
 addmv__ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-addmv__ttt = cast3 Unmanaged.addmv__ttt
+addmv__ttt = _cast3 Unmanaged.addmv__ttt
 
 addmv_out_ttttss
   :: ForeignPtr Tensor
@@ -743,7 +743,7 @@ addmv_out_ttttss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-addmv_out_ttttss = cast6 Unmanaged.addmv_out_ttttss
+addmv_out_ttttss = _cast6 Unmanaged.addmv_out_ttttss
 
 addmv_out_tttts
   :: ForeignPtr Tensor
@@ -752,7 +752,7 @@ addmv_out_tttts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-addmv_out_tttts = cast5 Unmanaged.addmv_out_tttts
+addmv_out_tttts = _cast5 Unmanaged.addmv_out_tttts
 
 addmv_out_tttt
   :: ForeignPtr Tensor
@@ -760,7 +760,7 @@ addmv_out_tttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-addmv_out_tttt = cast4 Unmanaged.addmv_out_tttt
+addmv_out_tttt = _cast4 Unmanaged.addmv_out_tttt
 
 addr_tttss
   :: ForeignPtr Tensor
@@ -769,7 +769,7 @@ addr_tttss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-addr_tttss = cast5 Unmanaged.addr_tttss
+addr_tttss = _cast5 Unmanaged.addr_tttss
 
 addr_ttts
   :: ForeignPtr Tensor
@@ -777,14 +777,14 @@ addr_ttts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-addr_ttts = cast4 Unmanaged.addr_ttts
+addr_ttts = _cast4 Unmanaged.addr_ttts
 
 addr_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-addr_ttt = cast3 Unmanaged.addr_ttt
+addr_ttt = _cast3 Unmanaged.addr_ttt
 
 addr_out_ttttss
   :: ForeignPtr Tensor
@@ -794,7 +794,7 @@ addr_out_ttttss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-addr_out_ttttss = cast6 Unmanaged.addr_out_ttttss
+addr_out_ttttss = _cast6 Unmanaged.addr_out_ttttss
 
 addr_out_tttts
   :: ForeignPtr Tensor
@@ -803,7 +803,7 @@ addr_out_tttts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-addr_out_tttts = cast5 Unmanaged.addr_out_tttts
+addr_out_tttts = _cast5 Unmanaged.addr_out_tttts
 
 addr_out_tttt
   :: ForeignPtr Tensor
@@ -811,34 +811,34 @@ addr_out_tttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-addr_out_tttt = cast4 Unmanaged.addr_out_tttt
+addr_out_tttt = _cast4 Unmanaged.addr_out_tttt
 
 affine_grid_generator_tlb
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-affine_grid_generator_tlb = cast3 Unmanaged.affine_grid_generator_tlb
+affine_grid_generator_tlb = _cast3 Unmanaged.affine_grid_generator_tlb
 
 affine_grid_generator_backward_tlb
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-affine_grid_generator_backward_tlb = cast3 Unmanaged.affine_grid_generator_backward_tlb
+affine_grid_generator_backward_tlb = _cast3 Unmanaged.affine_grid_generator_backward_tlb
 
 all_tlb
   :: ForeignPtr Tensor
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-all_tlb = cast3 Unmanaged.all_tlb
+all_tlb = _cast3 Unmanaged.all_tlb
 
 all_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-all_tl = cast2 Unmanaged.all_tl
+all_tl = _cast2 Unmanaged.all_tl
 
 all_out_ttlb
   :: ForeignPtr Tensor
@@ -846,27 +846,27 @@ all_out_ttlb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-all_out_ttlb = cast4 Unmanaged.all_out_ttlb
+all_out_ttlb = _cast4 Unmanaged.all_out_ttlb
 
 all_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-all_out_ttl = cast3 Unmanaged.all_out_ttl
+all_out_ttl = _cast3 Unmanaged.all_out_ttl
 
 all_tnb
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> CBool
   -> IO (ForeignPtr Tensor)
-all_tnb = cast3 Unmanaged.all_tnb
+all_tnb = _cast3 Unmanaged.all_tnb
 
 all_tn
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> IO (ForeignPtr Tensor)
-all_tn = cast2 Unmanaged.all_tn
+all_tn = _cast2 Unmanaged.all_tn
 
 all_out_ttnb
   :: ForeignPtr Tensor
@@ -874,14 +874,14 @@ all_out_ttnb
   -> ForeignPtr Dimname
   -> CBool
   -> IO (ForeignPtr Tensor)
-all_out_ttnb = cast4 Unmanaged.all_out_ttnb
+all_out_ttnb = _cast4 Unmanaged.all_out_ttnb
 
 all_out_ttn
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> IO (ForeignPtr Tensor)
-all_out_ttn = cast3 Unmanaged.all_out_ttn
+all_out_ttn = _cast3 Unmanaged.all_out_ttn
 
 allclose_ttddb
   :: ForeignPtr Tensor
@@ -890,7 +890,7 @@ allclose_ttddb
   -> CDouble
   -> CBool
   -> IO (CBool)
-allclose_ttddb = cast5 Unmanaged.allclose_ttddb
+allclose_ttddb = _cast5 Unmanaged.allclose_ttddb
 
 allclose_ttdd
   :: ForeignPtr Tensor
@@ -898,33 +898,33 @@ allclose_ttdd
   -> CDouble
   -> CDouble
   -> IO (CBool)
-allclose_ttdd = cast4 Unmanaged.allclose_ttdd
+allclose_ttdd = _cast4 Unmanaged.allclose_ttdd
 
 allclose_ttd
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> CDouble
   -> IO (CBool)
-allclose_ttd = cast3 Unmanaged.allclose_ttd
+allclose_ttd = _cast3 Unmanaged.allclose_ttd
 
 allclose_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (CBool)
-allclose_tt = cast2 Unmanaged.allclose_tt
+allclose_tt = _cast2 Unmanaged.allclose_tt
 
 any_tlb
   :: ForeignPtr Tensor
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-any_tlb = cast3 Unmanaged.any_tlb
+any_tlb = _cast3 Unmanaged.any_tlb
 
 any_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-any_tl = cast2 Unmanaged.any_tl
+any_tl = _cast2 Unmanaged.any_tl
 
 any_out_ttlb
   :: ForeignPtr Tensor
@@ -932,27 +932,27 @@ any_out_ttlb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-any_out_ttlb = cast4 Unmanaged.any_out_ttlb
+any_out_ttlb = _cast4 Unmanaged.any_out_ttlb
 
 any_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-any_out_ttl = cast3 Unmanaged.any_out_ttl
+any_out_ttl = _cast3 Unmanaged.any_out_ttl
 
 any_tnb
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> CBool
   -> IO (ForeignPtr Tensor)
-any_tnb = cast3 Unmanaged.any_tnb
+any_tnb = _cast3 Unmanaged.any_tnb
 
 any_tn
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> IO (ForeignPtr Tensor)
-any_tn = cast2 Unmanaged.any_tn
+any_tn = _cast2 Unmanaged.any_tn
 
 any_out_ttnb
   :: ForeignPtr Tensor
@@ -960,38 +960,38 @@ any_out_ttnb
   -> ForeignPtr Dimname
   -> CBool
   -> IO (ForeignPtr Tensor)
-any_out_ttnb = cast4 Unmanaged.any_out_ttnb
+any_out_ttnb = _cast4 Unmanaged.any_out_ttnb
 
 any_out_ttn
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> IO (ForeignPtr Tensor)
-any_out_ttn = cast3 Unmanaged.any_out_ttn
+any_out_ttn = _cast3 Unmanaged.any_out_ttn
 
 arange_so
   :: ForeignPtr Scalar
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-arange_so = cast2 Unmanaged.arange_so
+arange_so = _cast2 Unmanaged.arange_so
 
 arange_s
   :: ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-arange_s = cast1 Unmanaged.arange_s
+arange_s = _cast1 Unmanaged.arange_s
 
 arange_sso
   :: ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-arange_sso = cast3 Unmanaged.arange_sso
+arange_sso = _cast3 Unmanaged.arange_sso
 
 arange_ss
   :: ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-arange_ss = cast2 Unmanaged.arange_ss
+arange_ss = _cast2 Unmanaged.arange_ss
 
 arange_ssso
   :: ForeignPtr Scalar
@@ -999,20 +999,20 @@ arange_ssso
   -> ForeignPtr Scalar
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-arange_ssso = cast4 Unmanaged.arange_ssso
+arange_ssso = _cast4 Unmanaged.arange_ssso
 
 arange_sss
   :: ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-arange_sss = cast3 Unmanaged.arange_sss
+arange_sss = _cast3 Unmanaged.arange_sss
 
 arange_out_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-arange_out_ts = cast2 Unmanaged.arange_out_ts
+arange_out_ts = _cast2 Unmanaged.arange_out_ts
 
 arange_out_tsss
   :: ForeignPtr Tensor
@@ -1020,38 +1020,38 @@ arange_out_tsss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-arange_out_tsss = cast4 Unmanaged.arange_out_tsss
+arange_out_tsss = _cast4 Unmanaged.arange_out_tsss
 
 arange_out_tss
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-arange_out_tss = cast3 Unmanaged.arange_out_tss
+arange_out_tss = _cast3 Unmanaged.arange_out_tss
 
 _dim_arange_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-_dim_arange_tl = cast2 Unmanaged._dim_arange_tl
+_dim_arange_tl = _cast2 Unmanaged._dim_arange_tl
 
 argmax_tlb
   :: ForeignPtr Tensor
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-argmax_tlb = cast3 Unmanaged.argmax_tlb
+argmax_tlb = _cast3 Unmanaged.argmax_tlb
 
 argmax_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-argmax_tl = cast2 Unmanaged.argmax_tl
+argmax_tl = _cast2 Unmanaged.argmax_tl
 
 argmax_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-argmax_t = cast1 Unmanaged.argmax_t
+argmax_t = _cast1 Unmanaged.argmax_t
 
 argmax_out_ttlb
   :: ForeignPtr Tensor
@@ -1059,38 +1059,38 @@ argmax_out_ttlb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-argmax_out_ttlb = cast4 Unmanaged.argmax_out_ttlb
+argmax_out_ttlb = _cast4 Unmanaged.argmax_out_ttlb
 
 argmax_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-argmax_out_ttl = cast3 Unmanaged.argmax_out_ttl
+argmax_out_ttl = _cast3 Unmanaged.argmax_out_ttl
 
 argmax_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-argmax_out_tt = cast2 Unmanaged.argmax_out_tt
+argmax_out_tt = _cast2 Unmanaged.argmax_out_tt
 
 argmin_tlb
   :: ForeignPtr Tensor
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-argmin_tlb = cast3 Unmanaged.argmin_tlb
+argmin_tlb = _cast3 Unmanaged.argmin_tlb
 
 argmin_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-argmin_tl = cast2 Unmanaged.argmin_tl
+argmin_tl = _cast2 Unmanaged.argmin_tl
 
 argmin_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-argmin_t = cast1 Unmanaged.argmin_t
+argmin_t = _cast1 Unmanaged.argmin_t
 
 argmin_out_ttlb
   :: ForeignPtr Tensor
@@ -1098,116 +1098,116 @@ argmin_out_ttlb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-argmin_out_ttlb = cast4 Unmanaged.argmin_out_ttlb
+argmin_out_ttlb = _cast4 Unmanaged.argmin_out_ttlb
 
 argmin_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-argmin_out_ttl = cast3 Unmanaged.argmin_out_ttl
+argmin_out_ttl = _cast3 Unmanaged.argmin_out_ttl
 
 argmin_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-argmin_out_tt = cast2 Unmanaged.argmin_out_tt
+argmin_out_tt = _cast2 Unmanaged.argmin_out_tt
 
 acosh_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-acosh_t = cast1 Unmanaged.acosh_t
+acosh_t = _cast1 Unmanaged.acosh_t
 
 acosh__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-acosh__t = cast1 Unmanaged.acosh__t
+acosh__t = _cast1 Unmanaged.acosh__t
 
 acosh_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-acosh_out_tt = cast2 Unmanaged.acosh_out_tt
+acosh_out_tt = _cast2 Unmanaged.acosh_out_tt
 
 arccosh_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-arccosh_t = cast1 Unmanaged.arccosh_t
+arccosh_t = _cast1 Unmanaged.arccosh_t
 
 arccosh__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-arccosh__t = cast1 Unmanaged.arccosh__t
+arccosh__t = _cast1 Unmanaged.arccosh__t
 
 arccosh_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-arccosh_out_tt = cast2 Unmanaged.arccosh_out_tt
+arccosh_out_tt = _cast2 Unmanaged.arccosh_out_tt
 
 asinh_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-asinh_t = cast1 Unmanaged.asinh_t
+asinh_t = _cast1 Unmanaged.asinh_t
 
 asinh__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-asinh__t = cast1 Unmanaged.asinh__t
+asinh__t = _cast1 Unmanaged.asinh__t
 
 asinh_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-asinh_out_tt = cast2 Unmanaged.asinh_out_tt
+asinh_out_tt = _cast2 Unmanaged.asinh_out_tt
 
 arcsinh_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-arcsinh_t = cast1 Unmanaged.arcsinh_t
+arcsinh_t = _cast1 Unmanaged.arcsinh_t
 
 arcsinh__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-arcsinh__t = cast1 Unmanaged.arcsinh__t
+arcsinh__t = _cast1 Unmanaged.arcsinh__t
 
 arcsinh_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-arcsinh_out_tt = cast2 Unmanaged.arcsinh_out_tt
+arcsinh_out_tt = _cast2 Unmanaged.arcsinh_out_tt
 
 atanh_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-atanh_t = cast1 Unmanaged.atanh_t
+atanh_t = _cast1 Unmanaged.atanh_t
 
 atanh__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-atanh__t = cast1 Unmanaged.atanh__t
+atanh__t = _cast1 Unmanaged.atanh__t
 
 atanh_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-atanh_out_tt = cast2 Unmanaged.atanh_out_tt
+atanh_out_tt = _cast2 Unmanaged.atanh_out_tt
 
 arctanh_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-arctanh_t = cast1 Unmanaged.arctanh_t
+arctanh_t = _cast1 Unmanaged.arctanh_t
 
 arctanh__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-arctanh__t = cast1 Unmanaged.arctanh__t
+arctanh__t = _cast1 Unmanaged.arctanh__t
 
 arctanh_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-arctanh_out_tt = cast2 Unmanaged.arctanh_out_tt
+arctanh_out_tt = _cast2 Unmanaged.arctanh_out_tt
 
 as_strided_tlll
   :: ForeignPtr Tensor
@@ -1215,14 +1215,14 @@ as_strided_tlll
   -> ForeignPtr IntArray
   -> Int64
   -> IO (ForeignPtr Tensor)
-as_strided_tlll = cast4 Unmanaged.as_strided_tlll
+as_strided_tlll = _cast4 Unmanaged.as_strided_tlll
 
 as_strided_tll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-as_strided_tll = cast3 Unmanaged.as_strided_tll
+as_strided_tll = _cast3 Unmanaged.as_strided_tll
 
 as_strided__tlll
   :: ForeignPtr Tensor
@@ -1230,108 +1230,108 @@ as_strided__tlll
   -> ForeignPtr IntArray
   -> Int64
   -> IO (ForeignPtr Tensor)
-as_strided__tlll = cast4 Unmanaged.as_strided__tlll
+as_strided__tlll = _cast4 Unmanaged.as_strided__tlll
 
 as_strided__tll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-as_strided__tll = cast3 Unmanaged.as_strided__tll
+as_strided__tll = _cast3 Unmanaged.as_strided__tll
 
 asin_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-asin_t = cast1 Unmanaged.asin_t
+asin_t = _cast1 Unmanaged.asin_t
 
 asin__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-asin__t = cast1 Unmanaged.asin__t
+asin__t = _cast1 Unmanaged.asin__t
 
 asin_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-asin_out_tt = cast2 Unmanaged.asin_out_tt
+asin_out_tt = _cast2 Unmanaged.asin_out_tt
 
 arcsin_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-arcsin_t = cast1 Unmanaged.arcsin_t
+arcsin_t = _cast1 Unmanaged.arcsin_t
 
 arcsin__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-arcsin__t = cast1 Unmanaged.arcsin__t
+arcsin__t = _cast1 Unmanaged.arcsin__t
 
 arcsin_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-arcsin_out_tt = cast2 Unmanaged.arcsin_out_tt
+arcsin_out_tt = _cast2 Unmanaged.arcsin_out_tt
 
 atan_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-atan_t = cast1 Unmanaged.atan_t
+atan_t = _cast1 Unmanaged.atan_t
 
 atan__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-atan__t = cast1 Unmanaged.atan__t
+atan__t = _cast1 Unmanaged.atan__t
 
 atan_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-atan_out_tt = cast2 Unmanaged.atan_out_tt
+atan_out_tt = _cast2 Unmanaged.atan_out_tt
 
 arctan_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-arctan_t = cast1 Unmanaged.arctan_t
+arctan_t = _cast1 Unmanaged.arctan_t
 
 arctan__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-arctan__t = cast1 Unmanaged.arctan__t
+arctan__t = _cast1 Unmanaged.arctan__t
 
 arctan_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-arctan_out_tt = cast2 Unmanaged.arctan_out_tt
+arctan_out_tt = _cast2 Unmanaged.arctan_out_tt
 
 atleast_1d_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-atleast_1d_t = cast1 Unmanaged.atleast_1d_t
+atleast_1d_t = _cast1 Unmanaged.atleast_1d_t
 
 atleast_1d_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr TensorList)
-atleast_1d_l = cast1 Unmanaged.atleast_1d_l
+atleast_1d_l = _cast1 Unmanaged.atleast_1d_l
 
 atleast_2d_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-atleast_2d_t = cast1 Unmanaged.atleast_2d_t
+atleast_2d_t = _cast1 Unmanaged.atleast_2d_t
 
 atleast_2d_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr TensorList)
-atleast_2d_l = cast1 Unmanaged.atleast_2d_l
+atleast_2d_l = _cast1 Unmanaged.atleast_2d_l
 
 atleast_3d_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-atleast_3d_t = cast1 Unmanaged.atleast_3d_t
+atleast_3d_t = _cast1 Unmanaged.atleast_3d_t
 
 atleast_3d_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr TensorList)
-atleast_3d_l = cast1 Unmanaged.atleast_3d_l
+atleast_3d_l = _cast1 Unmanaged.atleast_3d_l
 
 baddbmm_tttss
   :: ForeignPtr Tensor
@@ -1340,7 +1340,7 @@ baddbmm_tttss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-baddbmm_tttss = cast5 Unmanaged.baddbmm_tttss
+baddbmm_tttss = _cast5 Unmanaged.baddbmm_tttss
 
 baddbmm_ttts
   :: ForeignPtr Tensor
@@ -1348,14 +1348,14 @@ baddbmm_ttts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-baddbmm_ttts = cast4 Unmanaged.baddbmm_ttts
+baddbmm_ttts = _cast4 Unmanaged.baddbmm_ttts
 
 baddbmm_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-baddbmm_ttt = cast3 Unmanaged.baddbmm_ttt
+baddbmm_ttt = _cast3 Unmanaged.baddbmm_ttt
 
 baddbmm_out_ttttss
   :: ForeignPtr Tensor
@@ -1365,7 +1365,7 @@ baddbmm_out_ttttss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-baddbmm_out_ttttss = cast6 Unmanaged.baddbmm_out_ttttss
+baddbmm_out_ttttss = _cast6 Unmanaged.baddbmm_out_ttttss
 
 baddbmm_out_tttts
   :: ForeignPtr Tensor
@@ -1374,7 +1374,7 @@ baddbmm_out_tttts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-baddbmm_out_tttts = cast5 Unmanaged.baddbmm_out_tttts
+baddbmm_out_tttts = _cast5 Unmanaged.baddbmm_out_tttts
 
 baddbmm_out_tttt
   :: ForeignPtr Tensor
@@ -1382,31 +1382,31 @@ baddbmm_out_tttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-baddbmm_out_tttt = cast4 Unmanaged.baddbmm_out_tttt
+baddbmm_out_tttt = _cast4 Unmanaged.baddbmm_out_tttt
 
 bartlett_window_lo
   :: Int64
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-bartlett_window_lo = cast2 Unmanaged.bartlett_window_lo
+bartlett_window_lo = _cast2 Unmanaged.bartlett_window_lo
 
 bartlett_window_l
   :: Int64
   -> IO (ForeignPtr Tensor)
-bartlett_window_l = cast1 Unmanaged.bartlett_window_l
+bartlett_window_l = _cast1 Unmanaged.bartlett_window_l
 
 bartlett_window_lbo
   :: Int64
   -> CBool
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-bartlett_window_lbo = cast3 Unmanaged.bartlett_window_lbo
+bartlett_window_lbo = _cast3 Unmanaged.bartlett_window_lbo
 
 bartlett_window_lb
   :: Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-bartlett_window_lb = cast2 Unmanaged.bartlett_window_lb
+bartlett_window_lb = _cast2 Unmanaged.bartlett_window_lb
 
 batch_norm_tttttbddb
   :: ForeignPtr Tensor
@@ -1419,7 +1419,7 @@ batch_norm_tttttbddb
   -> CDouble
   -> CBool
   -> IO (ForeignPtr Tensor)
-batch_norm_tttttbddb = cast9 Unmanaged.batch_norm_tttttbddb
+batch_norm_tttttbddb = _cast9 Unmanaged.batch_norm_tttttbddb
 
 quantized_batch_norm_tttttddl
   :: ForeignPtr Tensor
@@ -1431,7 +1431,7 @@ quantized_batch_norm_tttttddl
   -> CDouble
   -> Int64
   -> IO (ForeignPtr Tensor)
-quantized_batch_norm_tttttddl = cast8 Unmanaged.quantized_batch_norm_tttttddl
+quantized_batch_norm_tttttddl = _cast8 Unmanaged.quantized_batch_norm_tttttddl
 
 _batch_norm_impl_index_tttttbddb
   :: ForeignPtr Tensor
@@ -1444,7 +1444,7 @@ _batch_norm_impl_index_tttttbddb
   -> CDouble
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Int64)))
-_batch_norm_impl_index_tttttbddb = cast9 Unmanaged._batch_norm_impl_index_tttttbddb
+_batch_norm_impl_index_tttttbddb = _cast9 Unmanaged._batch_norm_impl_index_tttttbddb
 
 _batch_norm_impl_index_backward_ltttttttbdat
   :: Int64
@@ -1460,5 +1460,5 @@ _batch_norm_impl_index_backward_ltttttttbdat
   -> ForeignPtr (StdArray '(CBool,3))
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-_batch_norm_impl_index_backward_ltttttttbdat = cast12 Unmanaged._batch_norm_impl_index_backward_ltttttttbdat
+_batch_norm_impl_index_backward_ltttttttbdat = _cast12 Unmanaged._batch_norm_impl_index_backward_ltttttttbdat
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Native/Native1.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Native/Native1.hs
@@ -25,38 +25,38 @@ bernoulli_tG
   :: ForeignPtr Tensor
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-bernoulli_tG = cast2 Unmanaged.bernoulli_tG
+bernoulli_tG = _cast2 Unmanaged.bernoulli_tG
 
 bernoulli_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-bernoulli_t = cast1 Unmanaged.bernoulli_t
+bernoulli_t = _cast1 Unmanaged.bernoulli_t
 
 bernoulli_out_ttG
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-bernoulli_out_ttG = cast3 Unmanaged.bernoulli_out_ttG
+bernoulli_out_ttG = _cast3 Unmanaged.bernoulli_out_ttG
 
 bernoulli_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-bernoulli_out_tt = cast2 Unmanaged.bernoulli_out_tt
+bernoulli_out_tt = _cast2 Unmanaged.bernoulli_out_tt
 
 bernoulli_tdG
   :: ForeignPtr Tensor
   -> CDouble
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-bernoulli_tdG = cast3 Unmanaged.bernoulli_tdG
+bernoulli_tdG = _cast3 Unmanaged.bernoulli_tdG
 
 bernoulli_td
   :: ForeignPtr Tensor
   -> CDouble
   -> IO (ForeignPtr Tensor)
-bernoulli_td = cast2 Unmanaged.bernoulli_td
+bernoulli_td = _cast2 Unmanaged.bernoulli_td
 
 bilinear_tttt
   :: ForeignPtr Tensor
@@ -64,14 +64,14 @@ bilinear_tttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-bilinear_tttt = cast4 Unmanaged.bilinear_tttt
+bilinear_tttt = _cast4 Unmanaged.bilinear_tttt
 
 bilinear_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-bilinear_ttt = cast3 Unmanaged.bilinear_ttt
+bilinear_ttt = _cast3 Unmanaged.bilinear_ttt
 
 binary_cross_entropy_tttl
   :: ForeignPtr Tensor
@@ -79,20 +79,20 @@ binary_cross_entropy_tttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-binary_cross_entropy_tttl = cast4 Unmanaged.binary_cross_entropy_tttl
+binary_cross_entropy_tttl = _cast4 Unmanaged.binary_cross_entropy_tttl
 
 binary_cross_entropy_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-binary_cross_entropy_ttt = cast3 Unmanaged.binary_cross_entropy_ttt
+binary_cross_entropy_ttt = _cast3 Unmanaged.binary_cross_entropy_ttt
 
 binary_cross_entropy_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-binary_cross_entropy_tt = cast2 Unmanaged.binary_cross_entropy_tt
+binary_cross_entropy_tt = _cast2 Unmanaged.binary_cross_entropy_tt
 
 binary_cross_entropy_out_ttttl
   :: ForeignPtr Tensor
@@ -101,7 +101,7 @@ binary_cross_entropy_out_ttttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-binary_cross_entropy_out_ttttl = cast5 Unmanaged.binary_cross_entropy_out_ttttl
+binary_cross_entropy_out_ttttl = _cast5 Unmanaged.binary_cross_entropy_out_ttttl
 
 binary_cross_entropy_out_tttt
   :: ForeignPtr Tensor
@@ -109,14 +109,14 @@ binary_cross_entropy_out_tttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-binary_cross_entropy_out_tttt = cast4 Unmanaged.binary_cross_entropy_out_tttt
+binary_cross_entropy_out_tttt = _cast4 Unmanaged.binary_cross_entropy_out_tttt
 
 binary_cross_entropy_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-binary_cross_entropy_out_ttt = cast3 Unmanaged.binary_cross_entropy_out_ttt
+binary_cross_entropy_out_ttt = _cast3 Unmanaged.binary_cross_entropy_out_ttt
 
 binary_cross_entropy_backward_ttttl
   :: ForeignPtr Tensor
@@ -125,7 +125,7 @@ binary_cross_entropy_backward_ttttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-binary_cross_entropy_backward_ttttl = cast5 Unmanaged.binary_cross_entropy_backward_ttttl
+binary_cross_entropy_backward_ttttl = _cast5 Unmanaged.binary_cross_entropy_backward_ttttl
 
 binary_cross_entropy_backward_tttt
   :: ForeignPtr Tensor
@@ -133,14 +133,14 @@ binary_cross_entropy_backward_tttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-binary_cross_entropy_backward_tttt = cast4 Unmanaged.binary_cross_entropy_backward_tttt
+binary_cross_entropy_backward_tttt = _cast4 Unmanaged.binary_cross_entropy_backward_tttt
 
 binary_cross_entropy_backward_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-binary_cross_entropy_backward_ttt = cast3 Unmanaged.binary_cross_entropy_backward_ttt
+binary_cross_entropy_backward_ttt = _cast3 Unmanaged.binary_cross_entropy_backward_ttt
 
 binary_cross_entropy_backward_out_tttttl
   :: ForeignPtr Tensor
@@ -150,7 +150,7 @@ binary_cross_entropy_backward_out_tttttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-binary_cross_entropy_backward_out_tttttl = cast6 Unmanaged.binary_cross_entropy_backward_out_tttttl
+binary_cross_entropy_backward_out_tttttl = _cast6 Unmanaged.binary_cross_entropy_backward_out_tttttl
 
 binary_cross_entropy_backward_out_ttttt
   :: ForeignPtr Tensor
@@ -159,7 +159,7 @@ binary_cross_entropy_backward_out_ttttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-binary_cross_entropy_backward_out_ttttt = cast5 Unmanaged.binary_cross_entropy_backward_out_ttttt
+binary_cross_entropy_backward_out_ttttt = _cast5 Unmanaged.binary_cross_entropy_backward_out_ttttt
 
 binary_cross_entropy_backward_out_tttt
   :: ForeignPtr Tensor
@@ -167,7 +167,7 @@ binary_cross_entropy_backward_out_tttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-binary_cross_entropy_backward_out_tttt = cast4 Unmanaged.binary_cross_entropy_backward_out_tttt
+binary_cross_entropy_backward_out_tttt = _cast4 Unmanaged.binary_cross_entropy_backward_out_tttt
 
 binary_cross_entropy_with_logits_ttttl
   :: ForeignPtr Tensor
@@ -176,7 +176,7 @@ binary_cross_entropy_with_logits_ttttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-binary_cross_entropy_with_logits_ttttl = cast5 Unmanaged.binary_cross_entropy_with_logits_ttttl
+binary_cross_entropy_with_logits_ttttl = _cast5 Unmanaged.binary_cross_entropy_with_logits_ttttl
 
 binary_cross_entropy_with_logits_tttt
   :: ForeignPtr Tensor
@@ -184,20 +184,20 @@ binary_cross_entropy_with_logits_tttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-binary_cross_entropy_with_logits_tttt = cast4 Unmanaged.binary_cross_entropy_with_logits_tttt
+binary_cross_entropy_with_logits_tttt = _cast4 Unmanaged.binary_cross_entropy_with_logits_tttt
 
 binary_cross_entropy_with_logits_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-binary_cross_entropy_with_logits_ttt = cast3 Unmanaged.binary_cross_entropy_with_logits_ttt
+binary_cross_entropy_with_logits_ttt = _cast3 Unmanaged.binary_cross_entropy_with_logits_ttt
 
 binary_cross_entropy_with_logits_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-binary_cross_entropy_with_logits_tt = cast2 Unmanaged.binary_cross_entropy_with_logits_tt
+binary_cross_entropy_with_logits_tt = _cast2 Unmanaged.binary_cross_entropy_with_logits_tt
 
 binary_cross_entropy_with_logits_backward_tttttl
   :: ForeignPtr Tensor
@@ -207,7 +207,7 @@ binary_cross_entropy_with_logits_backward_tttttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-binary_cross_entropy_with_logits_backward_tttttl = cast6 Unmanaged.binary_cross_entropy_with_logits_backward_tttttl
+binary_cross_entropy_with_logits_backward_tttttl = _cast6 Unmanaged.binary_cross_entropy_with_logits_backward_tttttl
 
 binary_cross_entropy_with_logits_backward_ttttt
   :: ForeignPtr Tensor
@@ -216,7 +216,7 @@ binary_cross_entropy_with_logits_backward_ttttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-binary_cross_entropy_with_logits_backward_ttttt = cast5 Unmanaged.binary_cross_entropy_with_logits_backward_ttttt
+binary_cross_entropy_with_logits_backward_ttttt = _cast5 Unmanaged.binary_cross_entropy_with_logits_backward_ttttt
 
 binary_cross_entropy_with_logits_backward_tttt
   :: ForeignPtr Tensor
@@ -224,393 +224,393 @@ binary_cross_entropy_with_logits_backward_tttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-binary_cross_entropy_with_logits_backward_tttt = cast4 Unmanaged.binary_cross_entropy_with_logits_backward_tttt
+binary_cross_entropy_with_logits_backward_tttt = _cast4 Unmanaged.binary_cross_entropy_with_logits_backward_tttt
 
 binary_cross_entropy_with_logits_backward_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-binary_cross_entropy_with_logits_backward_ttt = cast3 Unmanaged.binary_cross_entropy_with_logits_backward_ttt
+binary_cross_entropy_with_logits_backward_ttt = _cast3 Unmanaged.binary_cross_entropy_with_logits_backward_ttt
 
 bincount_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-bincount_ttl = cast3 Unmanaged.bincount_ttl
+bincount_ttl = _cast3 Unmanaged.bincount_ttl
 
 bincount_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-bincount_tt = cast2 Unmanaged.bincount_tt
+bincount_tt = _cast2 Unmanaged.bincount_tt
 
 bincount_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-bincount_t = cast1 Unmanaged.bincount_t
+bincount_t = _cast1 Unmanaged.bincount_t
 
 bitwise_not_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-bitwise_not_t = cast1 Unmanaged.bitwise_not_t
+bitwise_not_t = _cast1 Unmanaged.bitwise_not_t
 
 bitwise_not_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-bitwise_not_out_tt = cast2 Unmanaged.bitwise_not_out_tt
+bitwise_not_out_tt = _cast2 Unmanaged.bitwise_not_out_tt
 
 copysign_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-copysign_out_ttt = cast3 Unmanaged.copysign_out_ttt
+copysign_out_ttt = _cast3 Unmanaged.copysign_out_ttt
 
 copysign_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-copysign_tt = cast2 Unmanaged.copysign_tt
+copysign_tt = _cast2 Unmanaged.copysign_tt
 
 copysign_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-copysign_ts = cast2 Unmanaged.copysign_ts
+copysign_ts = _cast2 Unmanaged.copysign_ts
 
 copysign_out_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-copysign_out_tts = cast3 Unmanaged.copysign_out_tts
+copysign_out_tts = _cast3 Unmanaged.copysign_out_tts
 
 logical_not_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-logical_not_t = cast1 Unmanaged.logical_not_t
+logical_not_t = _cast1 Unmanaged.logical_not_t
 
 logical_not_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-logical_not_out_tt = cast2 Unmanaged.logical_not_out_tt
+logical_not_out_tt = _cast2 Unmanaged.logical_not_out_tt
 
 logical_xor_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-logical_xor_tt = cast2 Unmanaged.logical_xor_tt
+logical_xor_tt = _cast2 Unmanaged.logical_xor_tt
 
 logical_xor_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-logical_xor_out_ttt = cast3 Unmanaged.logical_xor_out_ttt
+logical_xor_out_ttt = _cast3 Unmanaged.logical_xor_out_ttt
 
 logical_and_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-logical_and_tt = cast2 Unmanaged.logical_and_tt
+logical_and_tt = _cast2 Unmanaged.logical_and_tt
 
 logical_and_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-logical_and_out_ttt = cast3 Unmanaged.logical_and_out_ttt
+logical_and_out_ttt = _cast3 Unmanaged.logical_and_out_ttt
 
 logical_or_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-logical_or_tt = cast2 Unmanaged.logical_or_tt
+logical_or_tt = _cast2 Unmanaged.logical_or_tt
 
 logical_or_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-logical_or_out_ttt = cast3 Unmanaged.logical_or_out_ttt
+logical_or_out_ttt = _cast3 Unmanaged.logical_or_out_ttt
 
 blackman_window_lo
   :: Int64
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-blackman_window_lo = cast2 Unmanaged.blackman_window_lo
+blackman_window_lo = _cast2 Unmanaged.blackman_window_lo
 
 blackman_window_l
   :: Int64
   -> IO (ForeignPtr Tensor)
-blackman_window_l = cast1 Unmanaged.blackman_window_l
+blackman_window_l = _cast1 Unmanaged.blackman_window_l
 
 blackman_window_lbo
   :: Int64
   -> CBool
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-blackman_window_lbo = cast3 Unmanaged.blackman_window_lbo
+blackman_window_lbo = _cast3 Unmanaged.blackman_window_lbo
 
 blackman_window_lb
   :: Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-blackman_window_lb = cast2 Unmanaged.blackman_window_lb
+blackman_window_lb = _cast2 Unmanaged.blackman_window_lb
 
 bmm_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-bmm_tt = cast2 Unmanaged.bmm_tt
+bmm_tt = _cast2 Unmanaged.bmm_tt
 
 bmm_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-bmm_out_ttt = cast3 Unmanaged.bmm_out_ttt
+bmm_out_ttt = _cast3 Unmanaged.bmm_out_ttt
 
 broadcast_tensors_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr TensorList)
-broadcast_tensors_l = cast1 Unmanaged.broadcast_tensors_l
+broadcast_tensors_l = _cast1 Unmanaged.broadcast_tensors_l
 
 broadcast_to_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-broadcast_to_tl = cast2 Unmanaged.broadcast_to_tl
+broadcast_to_tl = _cast2 Unmanaged.broadcast_to_tl
 
 _sparse_broadcast_to_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-_sparse_broadcast_to_tl = cast2 Unmanaged._sparse_broadcast_to_tl
+_sparse_broadcast_to_tl = _cast2 Unmanaged._sparse_broadcast_to_tl
 
 cat_ll
   :: ForeignPtr TensorList
   -> Int64
   -> IO (ForeignPtr Tensor)
-cat_ll = cast2 Unmanaged.cat_ll
+cat_ll = _cast2 Unmanaged.cat_ll
 
 cat_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr Tensor)
-cat_l = cast1 Unmanaged.cat_l
+cat_l = _cast1 Unmanaged.cat_l
 
 cat_out_tll
   :: ForeignPtr Tensor
   -> ForeignPtr TensorList
   -> Int64
   -> IO (ForeignPtr Tensor)
-cat_out_tll = cast3 Unmanaged.cat_out_tll
+cat_out_tll = _cast3 Unmanaged.cat_out_tll
 
 cat_out_tl
   :: ForeignPtr Tensor
   -> ForeignPtr TensorList
   -> IO (ForeignPtr Tensor)
-cat_out_tl = cast2 Unmanaged.cat_out_tl
+cat_out_tl = _cast2 Unmanaged.cat_out_tl
 
 cat_ln
   :: ForeignPtr TensorList
   -> ForeignPtr Dimname
   -> IO (ForeignPtr Tensor)
-cat_ln = cast2 Unmanaged.cat_ln
+cat_ln = _cast2 Unmanaged.cat_ln
 
 cat_out_tln
   :: ForeignPtr Tensor
   -> ForeignPtr TensorList
   -> ForeignPtr Dimname
   -> IO (ForeignPtr Tensor)
-cat_out_tln = cast3 Unmanaged.cat_out_tln
+cat_out_tln = _cast3 Unmanaged.cat_out_tln
 
 concat_ll
   :: ForeignPtr TensorList
   -> Int64
   -> IO (ForeignPtr Tensor)
-concat_ll = cast2 Unmanaged.concat_ll
+concat_ll = _cast2 Unmanaged.concat_ll
 
 concat_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr Tensor)
-concat_l = cast1 Unmanaged.concat_l
+concat_l = _cast1 Unmanaged.concat_l
 
 concat_out_tll
   :: ForeignPtr Tensor
   -> ForeignPtr TensorList
   -> Int64
   -> IO (ForeignPtr Tensor)
-concat_out_tll = cast3 Unmanaged.concat_out_tll
+concat_out_tll = _cast3 Unmanaged.concat_out_tll
 
 concat_out_tl
   :: ForeignPtr Tensor
   -> ForeignPtr TensorList
   -> IO (ForeignPtr Tensor)
-concat_out_tl = cast2 Unmanaged.concat_out_tl
+concat_out_tl = _cast2 Unmanaged.concat_out_tl
 
 concat_ln
   :: ForeignPtr TensorList
   -> ForeignPtr Dimname
   -> IO (ForeignPtr Tensor)
-concat_ln = cast2 Unmanaged.concat_ln
+concat_ln = _cast2 Unmanaged.concat_ln
 
 concat_out_tln
   :: ForeignPtr Tensor
   -> ForeignPtr TensorList
   -> ForeignPtr Dimname
   -> IO (ForeignPtr Tensor)
-concat_out_tln = cast3 Unmanaged.concat_out_tln
+concat_out_tln = _cast3 Unmanaged.concat_out_tln
 
 block_diag_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr Tensor)
-block_diag_l = cast1 Unmanaged.block_diag_l
+block_diag_l = _cast1 Unmanaged.block_diag_l
 
 ceil_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-ceil_t = cast1 Unmanaged.ceil_t
+ceil_t = _cast1 Unmanaged.ceil_t
 
 ceil__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-ceil__t = cast1 Unmanaged.ceil__t
+ceil__t = _cast1 Unmanaged.ceil__t
 
 ceil_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-ceil_out_tt = cast2 Unmanaged.ceil_out_tt
+ceil_out_tt = _cast2 Unmanaged.ceil_out_tt
 
 chain_matmul_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr Tensor)
-chain_matmul_l = cast1 Unmanaged.chain_matmul_l
+chain_matmul_l = _cast1 Unmanaged.chain_matmul_l
 
 chain_matmul_out_tl
   :: ForeignPtr Tensor
   -> ForeignPtr TensorList
   -> IO (ForeignPtr Tensor)
-chain_matmul_out_tl = cast2 Unmanaged.chain_matmul_out_tl
+chain_matmul_out_tl = _cast2 Unmanaged.chain_matmul_out_tl
 
 unsafe_chunk_tll
   :: ForeignPtr Tensor
   -> Int64
   -> Int64
   -> IO (ForeignPtr TensorList)
-unsafe_chunk_tll = cast3 Unmanaged.unsafe_chunk_tll
+unsafe_chunk_tll = _cast3 Unmanaged.unsafe_chunk_tll
 
 unsafe_chunk_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr TensorList)
-unsafe_chunk_tl = cast2 Unmanaged.unsafe_chunk_tl
+unsafe_chunk_tl = _cast2 Unmanaged.unsafe_chunk_tl
 
 chunk_tll
   :: ForeignPtr Tensor
   -> Int64
   -> Int64
   -> IO (ForeignPtr TensorList)
-chunk_tll = cast3 Unmanaged.chunk_tll
+chunk_tll = _cast3 Unmanaged.chunk_tll
 
 chunk_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr TensorList)
-chunk_tl = cast2 Unmanaged.chunk_tl
+chunk_tl = _cast2 Unmanaged.chunk_tl
 
 tensor_split_tll
   :: ForeignPtr Tensor
   -> Int64
   -> Int64
   -> IO (ForeignPtr TensorList)
-tensor_split_tll = cast3 Unmanaged.tensor_split_tll
+tensor_split_tll = _cast3 Unmanaged.tensor_split_tll
 
 tensor_split_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr TensorList)
-tensor_split_tl = cast2 Unmanaged.tensor_split_tl
+tensor_split_tl = _cast2 Unmanaged.tensor_split_tl
 
 tensor_split_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr TensorList)
-tensor_split_ttl = cast3 Unmanaged.tensor_split_ttl
+tensor_split_ttl = _cast3 Unmanaged.tensor_split_ttl
 
 tensor_split_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr TensorList)
-tensor_split_tt = cast2 Unmanaged.tensor_split_tt
+tensor_split_tt = _cast2 Unmanaged.tensor_split_tt
 
 clamp_tss
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-clamp_tss = cast3 Unmanaged.clamp_tss
+clamp_tss = _cast3 Unmanaged.clamp_tss
 
 clamp_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-clamp_ts = cast2 Unmanaged.clamp_ts
+clamp_ts = _cast2 Unmanaged.clamp_ts
 
 clamp_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-clamp_t = cast1 Unmanaged.clamp_t
+clamp_t = _cast1 Unmanaged.clamp_t
 
 clamp_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-clamp_ttt = cast3 Unmanaged.clamp_ttt
+clamp_ttt = _cast3 Unmanaged.clamp_ttt
 
 clamp_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-clamp_tt = cast2 Unmanaged.clamp_tt
+clamp_tt = _cast2 Unmanaged.clamp_tt
 
 clamp__tss
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-clamp__tss = cast3 Unmanaged.clamp__tss
+clamp__tss = _cast3 Unmanaged.clamp__tss
 
 clamp__ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-clamp__ts = cast2 Unmanaged.clamp__ts
+clamp__ts = _cast2 Unmanaged.clamp__ts
 
 clamp__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-clamp__t = cast1 Unmanaged.clamp__t
+clamp__t = _cast1 Unmanaged.clamp__t
 
 clamp__ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-clamp__ttt = cast3 Unmanaged.clamp__ttt
+clamp__ttt = _cast3 Unmanaged.clamp__ttt
 
 clamp__tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-clamp__tt = cast2 Unmanaged.clamp__tt
+clamp__tt = _cast2 Unmanaged.clamp__tt
 
 clamp_out_ttss
   :: ForeignPtr Tensor
@@ -618,20 +618,20 @@ clamp_out_ttss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-clamp_out_ttss = cast4 Unmanaged.clamp_out_ttss
+clamp_out_ttss = _cast4 Unmanaged.clamp_out_ttss
 
 clamp_out_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-clamp_out_tts = cast3 Unmanaged.clamp_out_tts
+clamp_out_tts = _cast3 Unmanaged.clamp_out_tts
 
 clamp_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-clamp_out_tt = cast2 Unmanaged.clamp_out_tt
+clamp_out_tt = _cast2 Unmanaged.clamp_out_tt
 
 clamp_out_tttt
   :: ForeignPtr Tensor
@@ -639,152 +639,152 @@ clamp_out_tttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-clamp_out_tttt = cast4 Unmanaged.clamp_out_tttt
+clamp_out_tttt = _cast4 Unmanaged.clamp_out_tttt
 
 clamp_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-clamp_out_ttt = cast3 Unmanaged.clamp_out_ttt
+clamp_out_ttt = _cast3 Unmanaged.clamp_out_ttt
 
 clamp_max_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-clamp_max_ts = cast2 Unmanaged.clamp_max_ts
+clamp_max_ts = _cast2 Unmanaged.clamp_max_ts
 
 clamp_max_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-clamp_max_tt = cast2 Unmanaged.clamp_max_tt
+clamp_max_tt = _cast2 Unmanaged.clamp_max_tt
 
 clamp_max__ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-clamp_max__ts = cast2 Unmanaged.clamp_max__ts
+clamp_max__ts = _cast2 Unmanaged.clamp_max__ts
 
 clamp_max__tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-clamp_max__tt = cast2 Unmanaged.clamp_max__tt
+clamp_max__tt = _cast2 Unmanaged.clamp_max__tt
 
 clamp_max_out_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-clamp_max_out_tts = cast3 Unmanaged.clamp_max_out_tts
+clamp_max_out_tts = _cast3 Unmanaged.clamp_max_out_tts
 
 clamp_max_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-clamp_max_out_ttt = cast3 Unmanaged.clamp_max_out_ttt
+clamp_max_out_ttt = _cast3 Unmanaged.clamp_max_out_ttt
 
 clamp_min_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-clamp_min_ts = cast2 Unmanaged.clamp_min_ts
+clamp_min_ts = _cast2 Unmanaged.clamp_min_ts
 
 clamp_min_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-clamp_min_tt = cast2 Unmanaged.clamp_min_tt
+clamp_min_tt = _cast2 Unmanaged.clamp_min_tt
 
 clamp_min__ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-clamp_min__ts = cast2 Unmanaged.clamp_min__ts
+clamp_min__ts = _cast2 Unmanaged.clamp_min__ts
 
 clamp_min__tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-clamp_min__tt = cast2 Unmanaged.clamp_min__tt
+clamp_min__tt = _cast2 Unmanaged.clamp_min__tt
 
 clamp_min_out_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-clamp_min_out_tts = cast3 Unmanaged.clamp_min_out_tts
+clamp_min_out_tts = _cast3 Unmanaged.clamp_min_out_tts
 
 clamp_min_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-clamp_min_out_ttt = cast3 Unmanaged.clamp_min_out_ttt
+clamp_min_out_ttt = _cast3 Unmanaged.clamp_min_out_ttt
 
 clip_tss
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-clip_tss = cast3 Unmanaged.clip_tss
+clip_tss = _cast3 Unmanaged.clip_tss
 
 clip_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-clip_ts = cast2 Unmanaged.clip_ts
+clip_ts = _cast2 Unmanaged.clip_ts
 
 clip_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-clip_t = cast1 Unmanaged.clip_t
+clip_t = _cast1 Unmanaged.clip_t
 
 clip_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-clip_ttt = cast3 Unmanaged.clip_ttt
+clip_ttt = _cast3 Unmanaged.clip_ttt
 
 clip_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-clip_tt = cast2 Unmanaged.clip_tt
+clip_tt = _cast2 Unmanaged.clip_tt
 
 clip__tss
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-clip__tss = cast3 Unmanaged.clip__tss
+clip__tss = _cast3 Unmanaged.clip__tss
 
 clip__ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-clip__ts = cast2 Unmanaged.clip__ts
+clip__ts = _cast2 Unmanaged.clip__ts
 
 clip__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-clip__t = cast1 Unmanaged.clip__t
+clip__t = _cast1 Unmanaged.clip__t
 
 clip__ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-clip__ttt = cast3 Unmanaged.clip__ttt
+clip__ttt = _cast3 Unmanaged.clip__ttt
 
 clip__tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-clip__tt = cast2 Unmanaged.clip__tt
+clip__tt = _cast2 Unmanaged.clip__tt
 
 clip_out_ttss
   :: ForeignPtr Tensor
@@ -792,20 +792,20 @@ clip_out_ttss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-clip_out_ttss = cast4 Unmanaged.clip_out_ttss
+clip_out_ttss = _cast4 Unmanaged.clip_out_ttss
 
 clip_out_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-clip_out_tts = cast3 Unmanaged.clip_out_tts
+clip_out_tts = _cast3 Unmanaged.clip_out_tts
 
 clip_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-clip_out_tt = cast2 Unmanaged.clip_out_tt
+clip_out_tt = _cast2 Unmanaged.clip_out_tt
 
 clip_out_tttt
   :: ForeignPtr Tensor
@@ -813,58 +813,58 @@ clip_out_tttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-clip_out_tttt = cast4 Unmanaged.clip_out_tttt
+clip_out_tttt = _cast4 Unmanaged.clip_out_tttt
 
 clip_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-clip_out_ttt = cast3 Unmanaged.clip_out_ttt
+clip_out_ttt = _cast3 Unmanaged.clip_out_ttt
 
 cudnn_is_acceptable_t
   :: ForeignPtr Tensor
   -> IO (CBool)
-cudnn_is_acceptable_t = cast1 Unmanaged.cudnn_is_acceptable_t
+cudnn_is_acceptable_t = _cast1 Unmanaged.cudnn_is_acceptable_t
 
 complex_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-complex_tt = cast2 Unmanaged.complex_tt
+complex_tt = _cast2 Unmanaged.complex_tt
 
 complex_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-complex_out_ttt = cast3 Unmanaged.complex_out_ttt
+complex_out_ttt = _cast3 Unmanaged.complex_out_ttt
 
 polar_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-polar_tt = cast2 Unmanaged.polar_tt
+polar_tt = _cast2 Unmanaged.polar_tt
 
 polar_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-polar_out_ttt = cast3 Unmanaged.polar_out_ttt
+polar_out_ttt = _cast3 Unmanaged.polar_out_ttt
 
 constant_pad_nd_tls
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-constant_pad_nd_tls = cast3 Unmanaged.constant_pad_nd_tls
+constant_pad_nd_tls = _cast3 Unmanaged.constant_pad_nd_tls
 
 constant_pad_nd_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-constant_pad_nd_tl = cast2 Unmanaged.constant_pad_nd_tl
+constant_pad_nd_tl = _cast2 Unmanaged.constant_pad_nd_tl
 
 convolution_tttlllbll
   :: ForeignPtr Tensor
@@ -877,7 +877,7 @@ convolution_tttlllbll
   -> ForeignPtr IntArray
   -> Int64
   -> IO (ForeignPtr Tensor)
-convolution_tttlllbll = cast9 Unmanaged.convolution_tttlllbll
+convolution_tttlllbll = _cast9 Unmanaged.convolution_tttlllbll
 
 convolution_backward_tttllllblla
   :: ForeignPtr Tensor
@@ -892,7 +892,7 @@ convolution_backward_tttllllblla
   -> Int64
   -> ForeignPtr (StdArray '(CBool,3))
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-convolution_backward_tttllllblla = cast11 Unmanaged.convolution_backward_tttllllblla
+convolution_backward_tttllllblla = _cast11 Unmanaged.convolution_backward_tttllllblla
 
 convolution_overrideable_tttlllbll
   :: ForeignPtr Tensor
@@ -905,7 +905,7 @@ convolution_overrideable_tttlllbll
   -> ForeignPtr IntArray
   -> Int64
   -> IO (ForeignPtr Tensor)
-convolution_overrideable_tttlllbll = cast9 Unmanaged.convolution_overrideable_tttlllbll
+convolution_overrideable_tttlllbll = _cast9 Unmanaged.convolution_overrideable_tttlllbll
 
 convolution_backward_overrideable_tttlllblla
   :: ForeignPtr Tensor
@@ -919,7 +919,7 @@ convolution_backward_overrideable_tttlllblla
   -> Int64
   -> ForeignPtr (StdArray '(CBool,3))
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-convolution_backward_overrideable_tttlllblla = cast10 Unmanaged.convolution_backward_overrideable_tttlllblla
+convolution_backward_overrideable_tttlllblla = _cast10 Unmanaged.convolution_backward_overrideable_tttlllblla
 
 _convolution_tttlllbllbbbb
   :: ForeignPtr Tensor
@@ -936,7 +936,7 @@ _convolution_tttlllbllbbbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-_convolution_tttlllbllbbbb = cast13 Unmanaged._convolution_tttlllbllbbbb
+_convolution_tttlllbllbbbb = _cast13 Unmanaged._convolution_tttlllbllbbbb
 
 _convolution_tttlllbllbbb
   :: ForeignPtr Tensor
@@ -952,7 +952,7 @@ _convolution_tttlllbllbbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-_convolution_tttlllbllbbb = cast12 Unmanaged._convolution_tttlllbllbbb
+_convolution_tttlllbllbbb = _cast12 Unmanaged._convolution_tttlllbllbbb
 
 _convolution_mode_tttlsll
   :: ForeignPtr Tensor
@@ -963,7 +963,7 @@ _convolution_mode_tttlsll
   -> ForeignPtr IntArray
   -> Int64
   -> IO (ForeignPtr Tensor)
-_convolution_mode_tttlsll = cast7 Unmanaged._convolution_mode_tttlsll
+_convolution_mode_tttlsll = _cast7 Unmanaged._convolution_mode_tttlsll
 
 _convolution_double_backward_ttttttlllblla
   :: ForeignPtr Tensor
@@ -980,7 +980,7 @@ _convolution_double_backward_ttttttlllblla
   -> Int64
   -> ForeignPtr (StdArray '(CBool,3))
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-_convolution_double_backward_ttttttlllblla = cast13 Unmanaged._convolution_double_backward_ttttttlllblla
+_convolution_double_backward_ttttttlllblla = _cast13 Unmanaged._convolution_double_backward_ttttttlllblla
 
 conv1d_tttllll
   :: ForeignPtr Tensor
@@ -991,7 +991,7 @@ conv1d_tttllll
   -> ForeignPtr IntArray
   -> Int64
   -> IO (ForeignPtr Tensor)
-conv1d_tttllll = cast7 Unmanaged.conv1d_tttllll
+conv1d_tttllll = _cast7 Unmanaged.conv1d_tttllll
 
 conv1d_tttlll
   :: ForeignPtr Tensor
@@ -1001,7 +1001,7 @@ conv1d_tttlll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-conv1d_tttlll = cast6 Unmanaged.conv1d_tttlll
+conv1d_tttlll = _cast6 Unmanaged.conv1d_tttlll
 
 conv1d_tttll
   :: ForeignPtr Tensor
@@ -1010,7 +1010,7 @@ conv1d_tttll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-conv1d_tttll = cast5 Unmanaged.conv1d_tttll
+conv1d_tttll = _cast5 Unmanaged.conv1d_tttll
 
 conv1d_tttl
   :: ForeignPtr Tensor
@@ -1018,20 +1018,20 @@ conv1d_tttl
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-conv1d_tttl = cast4 Unmanaged.conv1d_tttl
+conv1d_tttl = _cast4 Unmanaged.conv1d_tttl
 
 conv1d_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-conv1d_ttt = cast3 Unmanaged.conv1d_ttt
+conv1d_ttt = _cast3 Unmanaged.conv1d_ttt
 
 conv1d_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-conv1d_tt = cast2 Unmanaged.conv1d_tt
+conv1d_tt = _cast2 Unmanaged.conv1d_tt
 
 conv2d_tttllll
   :: ForeignPtr Tensor
@@ -1042,7 +1042,7 @@ conv2d_tttllll
   -> ForeignPtr IntArray
   -> Int64
   -> IO (ForeignPtr Tensor)
-conv2d_tttllll = cast7 Unmanaged.conv2d_tttllll
+conv2d_tttllll = _cast7 Unmanaged.conv2d_tttllll
 
 conv2d_tttlll
   :: ForeignPtr Tensor
@@ -1052,7 +1052,7 @@ conv2d_tttlll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-conv2d_tttlll = cast6 Unmanaged.conv2d_tttlll
+conv2d_tttlll = _cast6 Unmanaged.conv2d_tttlll
 
 conv2d_tttll
   :: ForeignPtr Tensor
@@ -1061,7 +1061,7 @@ conv2d_tttll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-conv2d_tttll = cast5 Unmanaged.conv2d_tttll
+conv2d_tttll = _cast5 Unmanaged.conv2d_tttll
 
 conv2d_tttl
   :: ForeignPtr Tensor
@@ -1069,20 +1069,20 @@ conv2d_tttl
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-conv2d_tttl = cast4 Unmanaged.conv2d_tttl
+conv2d_tttl = _cast4 Unmanaged.conv2d_tttl
 
 conv2d_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-conv2d_ttt = cast3 Unmanaged.conv2d_ttt
+conv2d_ttt = _cast3 Unmanaged.conv2d_ttt
 
 conv2d_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-conv2d_tt = cast2 Unmanaged.conv2d_tt
+conv2d_tt = _cast2 Unmanaged.conv2d_tt
 
 conv3d_tttllll
   :: ForeignPtr Tensor
@@ -1093,7 +1093,7 @@ conv3d_tttllll
   -> ForeignPtr IntArray
   -> Int64
   -> IO (ForeignPtr Tensor)
-conv3d_tttllll = cast7 Unmanaged.conv3d_tttllll
+conv3d_tttllll = _cast7 Unmanaged.conv3d_tttllll
 
 conv3d_tttlll
   :: ForeignPtr Tensor
@@ -1103,7 +1103,7 @@ conv3d_tttlll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-conv3d_tttlll = cast6 Unmanaged.conv3d_tttlll
+conv3d_tttlll = _cast6 Unmanaged.conv3d_tttlll
 
 conv3d_tttll
   :: ForeignPtr Tensor
@@ -1112,7 +1112,7 @@ conv3d_tttll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-conv3d_tttll = cast5 Unmanaged.conv3d_tttll
+conv3d_tttll = _cast5 Unmanaged.conv3d_tttll
 
 conv3d_tttl
   :: ForeignPtr Tensor
@@ -1120,20 +1120,20 @@ conv3d_tttl
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-conv3d_tttl = cast4 Unmanaged.conv3d_tttl
+conv3d_tttl = _cast4 Unmanaged.conv3d_tttl
 
 conv3d_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-conv3d_ttt = cast3 Unmanaged.conv3d_ttt
+conv3d_ttt = _cast3 Unmanaged.conv3d_ttt
 
 conv3d_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-conv3d_tt = cast2 Unmanaged.conv3d_tt
+conv3d_tt = _cast2 Unmanaged.conv3d_tt
 
 conv1d_tttlsll
   :: ForeignPtr Tensor
@@ -1144,7 +1144,7 @@ conv1d_tttlsll
   -> ForeignPtr IntArray
   -> Int64
   -> IO (ForeignPtr Tensor)
-conv1d_tttlsll = cast7 Unmanaged.conv1d_tttlsll
+conv1d_tttlsll = _cast7 Unmanaged.conv1d_tttlsll
 
 conv1d_tttlsl
   :: ForeignPtr Tensor
@@ -1154,7 +1154,7 @@ conv1d_tttlsl
   -> ForeignPtr StdString
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-conv1d_tttlsl = cast6 Unmanaged.conv1d_tttlsl
+conv1d_tttlsl = _cast6 Unmanaged.conv1d_tttlsl
 
 conv1d_tttls
   :: ForeignPtr Tensor
@@ -1163,7 +1163,7 @@ conv1d_tttls
   -> ForeignPtr IntArray
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-conv1d_tttls = cast5 Unmanaged.conv1d_tttls
+conv1d_tttls = _cast5 Unmanaged.conv1d_tttls
 
 conv2d_tttlsll
   :: ForeignPtr Tensor
@@ -1174,7 +1174,7 @@ conv2d_tttlsll
   -> ForeignPtr IntArray
   -> Int64
   -> IO (ForeignPtr Tensor)
-conv2d_tttlsll = cast7 Unmanaged.conv2d_tttlsll
+conv2d_tttlsll = _cast7 Unmanaged.conv2d_tttlsll
 
 conv2d_tttlsl
   :: ForeignPtr Tensor
@@ -1184,7 +1184,7 @@ conv2d_tttlsl
   -> ForeignPtr StdString
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-conv2d_tttlsl = cast6 Unmanaged.conv2d_tttlsl
+conv2d_tttlsl = _cast6 Unmanaged.conv2d_tttlsl
 
 conv2d_tttls
   :: ForeignPtr Tensor
@@ -1193,7 +1193,7 @@ conv2d_tttls
   -> ForeignPtr IntArray
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-conv2d_tttls = cast5 Unmanaged.conv2d_tttls
+conv2d_tttls = _cast5 Unmanaged.conv2d_tttls
 
 conv3d_tttlsll
   :: ForeignPtr Tensor
@@ -1204,7 +1204,7 @@ conv3d_tttlsll
   -> ForeignPtr IntArray
   -> Int64
   -> IO (ForeignPtr Tensor)
-conv3d_tttlsll = cast7 Unmanaged.conv3d_tttlsll
+conv3d_tttlsll = _cast7 Unmanaged.conv3d_tttlsll
 
 conv3d_tttlsl
   :: ForeignPtr Tensor
@@ -1214,7 +1214,7 @@ conv3d_tttlsl
   -> ForeignPtr StdString
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-conv3d_tttlsl = cast6 Unmanaged.conv3d_tttlsl
+conv3d_tttlsl = _cast6 Unmanaged.conv3d_tttlsl
 
 conv3d_tttls
   :: ForeignPtr Tensor
@@ -1223,7 +1223,7 @@ conv3d_tttls
   -> ForeignPtr IntArray
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-conv3d_tttls = cast5 Unmanaged.conv3d_tttls
+conv3d_tttls = _cast5 Unmanaged.conv3d_tttls
 
 conv_tbc_tttl
   :: ForeignPtr Tensor
@@ -1231,14 +1231,14 @@ conv_tbc_tttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-conv_tbc_tttl = cast4 Unmanaged.conv_tbc_tttl
+conv_tbc_tttl = _cast4 Unmanaged.conv_tbc_tttl
 
 conv_tbc_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-conv_tbc_ttt = cast3 Unmanaged.conv_tbc_ttt
+conv_tbc_ttt = _cast3 Unmanaged.conv_tbc_ttt
 
 conv_tbc_backward_ttttl
   :: ForeignPtr Tensor
@@ -1247,7 +1247,7 @@ conv_tbc_backward_ttttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-conv_tbc_backward_ttttl = cast5 Unmanaged.conv_tbc_backward_ttttl
+conv_tbc_backward_ttttl = _cast5 Unmanaged.conv_tbc_backward_ttttl
 
 conv_transpose1d_tttlllll
   :: ForeignPtr Tensor
@@ -1259,7 +1259,7 @@ conv_transpose1d_tttlllll
   -> Int64
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-conv_transpose1d_tttlllll = cast8 Unmanaged.conv_transpose1d_tttlllll
+conv_transpose1d_tttlllll = _cast8 Unmanaged.conv_transpose1d_tttlllll
 
 conv_transpose1d_tttllll
   :: ForeignPtr Tensor
@@ -1270,7 +1270,7 @@ conv_transpose1d_tttllll
   -> ForeignPtr IntArray
   -> Int64
   -> IO (ForeignPtr Tensor)
-conv_transpose1d_tttllll = cast7 Unmanaged.conv_transpose1d_tttllll
+conv_transpose1d_tttllll = _cast7 Unmanaged.conv_transpose1d_tttllll
 
 conv_transpose1d_tttlll
   :: ForeignPtr Tensor
@@ -1280,7 +1280,7 @@ conv_transpose1d_tttlll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-conv_transpose1d_tttlll = cast6 Unmanaged.conv_transpose1d_tttlll
+conv_transpose1d_tttlll = _cast6 Unmanaged.conv_transpose1d_tttlll
 
 conv_transpose1d_tttll
   :: ForeignPtr Tensor
@@ -1289,7 +1289,7 @@ conv_transpose1d_tttll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-conv_transpose1d_tttll = cast5 Unmanaged.conv_transpose1d_tttll
+conv_transpose1d_tttll = _cast5 Unmanaged.conv_transpose1d_tttll
 
 conv_transpose1d_tttl
   :: ForeignPtr Tensor
@@ -1297,20 +1297,20 @@ conv_transpose1d_tttl
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-conv_transpose1d_tttl = cast4 Unmanaged.conv_transpose1d_tttl
+conv_transpose1d_tttl = _cast4 Unmanaged.conv_transpose1d_tttl
 
 conv_transpose1d_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-conv_transpose1d_ttt = cast3 Unmanaged.conv_transpose1d_ttt
+conv_transpose1d_ttt = _cast3 Unmanaged.conv_transpose1d_ttt
 
 conv_transpose1d_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-conv_transpose1d_tt = cast2 Unmanaged.conv_transpose1d_tt
+conv_transpose1d_tt = _cast2 Unmanaged.conv_transpose1d_tt
 
 conv_transpose2d_tttlllll
   :: ForeignPtr Tensor
@@ -1322,7 +1322,7 @@ conv_transpose2d_tttlllll
   -> Int64
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-conv_transpose2d_tttlllll = cast8 Unmanaged.conv_transpose2d_tttlllll
+conv_transpose2d_tttlllll = _cast8 Unmanaged.conv_transpose2d_tttlllll
 
 conv_transpose2d_tttllll
   :: ForeignPtr Tensor
@@ -1333,7 +1333,7 @@ conv_transpose2d_tttllll
   -> ForeignPtr IntArray
   -> Int64
   -> IO (ForeignPtr Tensor)
-conv_transpose2d_tttllll = cast7 Unmanaged.conv_transpose2d_tttllll
+conv_transpose2d_tttllll = _cast7 Unmanaged.conv_transpose2d_tttllll
 
 conv_transpose2d_tttlll
   :: ForeignPtr Tensor
@@ -1343,7 +1343,7 @@ conv_transpose2d_tttlll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-conv_transpose2d_tttlll = cast6 Unmanaged.conv_transpose2d_tttlll
+conv_transpose2d_tttlll = _cast6 Unmanaged.conv_transpose2d_tttlll
 
 conv_transpose2d_tttll
   :: ForeignPtr Tensor
@@ -1352,7 +1352,7 @@ conv_transpose2d_tttll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-conv_transpose2d_tttll = cast5 Unmanaged.conv_transpose2d_tttll
+conv_transpose2d_tttll = _cast5 Unmanaged.conv_transpose2d_tttll
 
 conv_transpose2d_tttl
   :: ForeignPtr Tensor
@@ -1360,20 +1360,20 @@ conv_transpose2d_tttl
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-conv_transpose2d_tttl = cast4 Unmanaged.conv_transpose2d_tttl
+conv_transpose2d_tttl = _cast4 Unmanaged.conv_transpose2d_tttl
 
 conv_transpose2d_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-conv_transpose2d_ttt = cast3 Unmanaged.conv_transpose2d_ttt
+conv_transpose2d_ttt = _cast3 Unmanaged.conv_transpose2d_ttt
 
 conv_transpose2d_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-conv_transpose2d_tt = cast2 Unmanaged.conv_transpose2d_tt
+conv_transpose2d_tt = _cast2 Unmanaged.conv_transpose2d_tt
 
 conv_transpose3d_tttlllll
   :: ForeignPtr Tensor
@@ -1385,7 +1385,7 @@ conv_transpose3d_tttlllll
   -> Int64
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-conv_transpose3d_tttlllll = cast8 Unmanaged.conv_transpose3d_tttlllll
+conv_transpose3d_tttlllll = _cast8 Unmanaged.conv_transpose3d_tttlllll
 
 conv_transpose3d_tttllll
   :: ForeignPtr Tensor
@@ -1396,7 +1396,7 @@ conv_transpose3d_tttllll
   -> ForeignPtr IntArray
   -> Int64
   -> IO (ForeignPtr Tensor)
-conv_transpose3d_tttllll = cast7 Unmanaged.conv_transpose3d_tttllll
+conv_transpose3d_tttllll = _cast7 Unmanaged.conv_transpose3d_tttllll
 
 conv_transpose3d_tttlll
   :: ForeignPtr Tensor
@@ -1406,7 +1406,7 @@ conv_transpose3d_tttlll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-conv_transpose3d_tttlll = cast6 Unmanaged.conv_transpose3d_tttlll
+conv_transpose3d_tttlll = _cast6 Unmanaged.conv_transpose3d_tttlll
 
 conv_transpose3d_tttll
   :: ForeignPtr Tensor
@@ -1415,7 +1415,7 @@ conv_transpose3d_tttll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-conv_transpose3d_tttll = cast5 Unmanaged.conv_transpose3d_tttll
+conv_transpose3d_tttll = _cast5 Unmanaged.conv_transpose3d_tttll
 
 conv_transpose3d_tttl
   :: ForeignPtr Tensor
@@ -1423,69 +1423,69 @@ conv_transpose3d_tttl
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-conv_transpose3d_tttl = cast4 Unmanaged.conv_transpose3d_tttl
+conv_transpose3d_tttl = _cast4 Unmanaged.conv_transpose3d_tttl
 
 conv_transpose3d_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-conv_transpose3d_ttt = cast3 Unmanaged.conv_transpose3d_ttt
+conv_transpose3d_ttt = _cast3 Unmanaged.conv_transpose3d_ttt
 
 conv_transpose3d_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-conv_transpose3d_tt = cast2 Unmanaged.conv_transpose3d_tt
+conv_transpose3d_tt = _cast2 Unmanaged.conv_transpose3d_tt
 
 _copy_from_ttb
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-_copy_from_ttb = cast3 Unmanaged._copy_from_ttb
+_copy_from_ttb = _cast3 Unmanaged._copy_from_ttb
 
 _copy_from_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_copy_from_tt = cast2 Unmanaged._copy_from_tt
+_copy_from_tt = _cast2 Unmanaged._copy_from_tt
 
 _copy_from_and_resize_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_copy_from_and_resize_tt = cast2 Unmanaged._copy_from_and_resize_tt
+_copy_from_and_resize_tt = _cast2 Unmanaged._copy_from_and_resize_tt
 
 cos_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-cos_t = cast1 Unmanaged.cos_t
+cos_t = _cast1 Unmanaged.cos_t
 
 cos__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-cos__t = cast1 Unmanaged.cos__t
+cos__t = _cast1 Unmanaged.cos__t
 
 cos_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-cos_out_tt = cast2 Unmanaged.cos_out_tt
+cos_out_tt = _cast2 Unmanaged.cos_out_tt
 
 cosh_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-cosh_t = cast1 Unmanaged.cosh_t
+cosh_t = _cast1 Unmanaged.cosh_t
 
 cosh__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-cosh__t = cast1 Unmanaged.cosh__t
+cosh__t = _cast1 Unmanaged.cosh__t
 
 cosh_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-cosh_out_tt = cast2 Unmanaged.cosh_out_tt
+cosh_out_tt = _cast2 Unmanaged.cosh_out_tt
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Native/Native10.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Native/Native10.hs
@@ -26,133 +26,133 @@ nextafter_out_ttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-nextafter_out_ttt = cast3 Unmanaged.nextafter_out_ttt
+nextafter_out_ttt = _cast3 Unmanaged.nextafter_out_ttt
 
 nextafter_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-nextafter_tt = cast2 Unmanaged.nextafter_tt
+nextafter_tt = _cast2 Unmanaged.nextafter_tt
 
 remainder_out_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-remainder_out_tts = cast3 Unmanaged.remainder_out_tts
+remainder_out_tts = _cast3 Unmanaged.remainder_out_tts
 
 remainder_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-remainder_ts = cast2 Unmanaged.remainder_ts
+remainder_ts = _cast2 Unmanaged.remainder_ts
 
 remainder_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-remainder_out_ttt = cast3 Unmanaged.remainder_out_ttt
+remainder_out_ttt = _cast3 Unmanaged.remainder_out_ttt
 
 remainder_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-remainder_tt = cast2 Unmanaged.remainder_tt
+remainder_tt = _cast2 Unmanaged.remainder_tt
 
 remainder_st
   :: ForeignPtr Scalar
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-remainder_st = cast2 Unmanaged.remainder_st
+remainder_st = _cast2 Unmanaged.remainder_st
 
 min_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-min_t = cast1 Unmanaged.min_t
+min_t = _cast1 Unmanaged.min_t
 
 fmin_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fmin_tt = cast2 Unmanaged.fmin_tt
+fmin_tt = _cast2 Unmanaged.fmin_tt
 
 fmin_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fmin_out_ttt = cast3 Unmanaged.fmin_out_ttt
+fmin_out_ttt = _cast3 Unmanaged.fmin_out_ttt
 
 max_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-max_t = cast1 Unmanaged.max_t
+max_t = _cast1 Unmanaged.max_t
 
 fmax_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fmax_tt = cast2 Unmanaged.fmax_tt
+fmax_tt = _cast2 Unmanaged.fmax_tt
 
 fmax_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fmax_out_ttt = cast3 Unmanaged.fmax_out_ttt
+fmax_out_ttt = _cast3 Unmanaged.fmax_out_ttt
 
 maximum_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-maximum_tt = cast2 Unmanaged.maximum_tt
+maximum_tt = _cast2 Unmanaged.maximum_tt
 
 maximum_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-maximum_out_ttt = cast3 Unmanaged.maximum_out_ttt
+maximum_out_ttt = _cast3 Unmanaged.maximum_out_ttt
 
 max_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-max_tt = cast2 Unmanaged.max_tt
+max_tt = _cast2 Unmanaged.max_tt
 
 max_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-max_out_ttt = cast3 Unmanaged.max_out_ttt
+max_out_ttt = _cast3 Unmanaged.max_out_ttt
 
 minimum_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-minimum_tt = cast2 Unmanaged.minimum_tt
+minimum_tt = _cast2 Unmanaged.minimum_tt
 
 minimum_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-minimum_out_ttt = cast3 Unmanaged.minimum_out_ttt
+minimum_out_ttt = _cast3 Unmanaged.minimum_out_ttt
 
 min_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-min_out_ttt = cast3 Unmanaged.min_out_ttt
+min_out_ttt = _cast3 Unmanaged.min_out_ttt
 
 min_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-min_tt = cast2 Unmanaged.min_tt
+min_tt = _cast2 Unmanaged.min_tt
 
 quantile_ttlbs
   :: ForeignPtr Tensor
@@ -161,7 +161,7 @@ quantile_ttlbs
   -> CBool
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-quantile_ttlbs = cast5 Unmanaged.quantile_ttlbs
+quantile_ttlbs = _cast5 Unmanaged.quantile_ttlbs
 
 quantile_ttlb
   :: ForeignPtr Tensor
@@ -169,20 +169,20 @@ quantile_ttlb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-quantile_ttlb = cast4 Unmanaged.quantile_ttlb
+quantile_ttlb = _cast4 Unmanaged.quantile_ttlb
 
 quantile_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-quantile_ttl = cast3 Unmanaged.quantile_ttl
+quantile_ttl = _cast3 Unmanaged.quantile_ttl
 
 quantile_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-quantile_tt = cast2 Unmanaged.quantile_tt
+quantile_tt = _cast2 Unmanaged.quantile_tt
 
 quantile_out_tttlbs
   :: ForeignPtr Tensor
@@ -192,7 +192,7 @@ quantile_out_tttlbs
   -> CBool
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-quantile_out_tttlbs = cast6 Unmanaged.quantile_out_tttlbs
+quantile_out_tttlbs = _cast6 Unmanaged.quantile_out_tttlbs
 
 quantile_out_tttlb
   :: ForeignPtr Tensor
@@ -201,7 +201,7 @@ quantile_out_tttlb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-quantile_out_tttlb = cast5 Unmanaged.quantile_out_tttlb
+quantile_out_tttlb = _cast5 Unmanaged.quantile_out_tttlb
 
 quantile_out_tttl
   :: ForeignPtr Tensor
@@ -209,14 +209,14 @@ quantile_out_tttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-quantile_out_tttl = cast4 Unmanaged.quantile_out_tttl
+quantile_out_tttl = _cast4 Unmanaged.quantile_out_tttl
 
 quantile_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-quantile_out_ttt = cast3 Unmanaged.quantile_out_ttt
+quantile_out_ttt = _cast3 Unmanaged.quantile_out_ttt
 
 quantile_tdlbs
   :: ForeignPtr Tensor
@@ -225,7 +225,7 @@ quantile_tdlbs
   -> CBool
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-quantile_tdlbs = cast5 Unmanaged.quantile_tdlbs
+quantile_tdlbs = _cast5 Unmanaged.quantile_tdlbs
 
 quantile_tdlb
   :: ForeignPtr Tensor
@@ -233,20 +233,20 @@ quantile_tdlb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-quantile_tdlb = cast4 Unmanaged.quantile_tdlb
+quantile_tdlb = _cast4 Unmanaged.quantile_tdlb
 
 quantile_tdl
   :: ForeignPtr Tensor
   -> CDouble
   -> Int64
   -> IO (ForeignPtr Tensor)
-quantile_tdl = cast3 Unmanaged.quantile_tdl
+quantile_tdl = _cast3 Unmanaged.quantile_tdl
 
 quantile_td
   :: ForeignPtr Tensor
   -> CDouble
   -> IO (ForeignPtr Tensor)
-quantile_td = cast2 Unmanaged.quantile_td
+quantile_td = _cast2 Unmanaged.quantile_td
 
 quantile_out_ttdlbs
   :: ForeignPtr Tensor
@@ -256,7 +256,7 @@ quantile_out_ttdlbs
   -> CBool
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-quantile_out_ttdlbs = cast6 Unmanaged.quantile_out_ttdlbs
+quantile_out_ttdlbs = _cast6 Unmanaged.quantile_out_ttdlbs
 
 quantile_out_ttdlb
   :: ForeignPtr Tensor
@@ -265,7 +265,7 @@ quantile_out_ttdlb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-quantile_out_ttdlb = cast5 Unmanaged.quantile_out_ttdlb
+quantile_out_ttdlb = _cast5 Unmanaged.quantile_out_ttdlb
 
 quantile_out_ttdl
   :: ForeignPtr Tensor
@@ -273,14 +273,14 @@ quantile_out_ttdl
   -> CDouble
   -> Int64
   -> IO (ForeignPtr Tensor)
-quantile_out_ttdl = cast4 Unmanaged.quantile_out_ttdl
+quantile_out_ttdl = _cast4 Unmanaged.quantile_out_ttdl
 
 quantile_out_ttd
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> CDouble
   -> IO (ForeignPtr Tensor)
-quantile_out_ttd = cast3 Unmanaged.quantile_out_ttd
+quantile_out_ttd = _cast3 Unmanaged.quantile_out_ttd
 
 nanquantile_ttlbs
   :: ForeignPtr Tensor
@@ -289,7 +289,7 @@ nanquantile_ttlbs
   -> CBool
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-nanquantile_ttlbs = cast5 Unmanaged.nanquantile_ttlbs
+nanquantile_ttlbs = _cast5 Unmanaged.nanquantile_ttlbs
 
 nanquantile_ttlb
   :: ForeignPtr Tensor
@@ -297,20 +297,20 @@ nanquantile_ttlb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-nanquantile_ttlb = cast4 Unmanaged.nanquantile_ttlb
+nanquantile_ttlb = _cast4 Unmanaged.nanquantile_ttlb
 
 nanquantile_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-nanquantile_ttl = cast3 Unmanaged.nanquantile_ttl
+nanquantile_ttl = _cast3 Unmanaged.nanquantile_ttl
 
 nanquantile_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-nanquantile_tt = cast2 Unmanaged.nanquantile_tt
+nanquantile_tt = _cast2 Unmanaged.nanquantile_tt
 
 nanquantile_out_tttlbs
   :: ForeignPtr Tensor
@@ -320,7 +320,7 @@ nanquantile_out_tttlbs
   -> CBool
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-nanquantile_out_tttlbs = cast6 Unmanaged.nanquantile_out_tttlbs
+nanquantile_out_tttlbs = _cast6 Unmanaged.nanquantile_out_tttlbs
 
 nanquantile_out_tttlb
   :: ForeignPtr Tensor
@@ -329,7 +329,7 @@ nanquantile_out_tttlb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-nanquantile_out_tttlb = cast5 Unmanaged.nanquantile_out_tttlb
+nanquantile_out_tttlb = _cast5 Unmanaged.nanquantile_out_tttlb
 
 nanquantile_out_tttl
   :: ForeignPtr Tensor
@@ -337,14 +337,14 @@ nanquantile_out_tttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-nanquantile_out_tttl = cast4 Unmanaged.nanquantile_out_tttl
+nanquantile_out_tttl = _cast4 Unmanaged.nanquantile_out_tttl
 
 nanquantile_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-nanquantile_out_ttt = cast3 Unmanaged.nanquantile_out_ttt
+nanquantile_out_ttt = _cast3 Unmanaged.nanquantile_out_ttt
 
 nanquantile_tdlbs
   :: ForeignPtr Tensor
@@ -353,7 +353,7 @@ nanquantile_tdlbs
   -> CBool
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-nanquantile_tdlbs = cast5 Unmanaged.nanquantile_tdlbs
+nanquantile_tdlbs = _cast5 Unmanaged.nanquantile_tdlbs
 
 nanquantile_tdlb
   :: ForeignPtr Tensor
@@ -361,20 +361,20 @@ nanquantile_tdlb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-nanquantile_tdlb = cast4 Unmanaged.nanquantile_tdlb
+nanquantile_tdlb = _cast4 Unmanaged.nanquantile_tdlb
 
 nanquantile_tdl
   :: ForeignPtr Tensor
   -> CDouble
   -> Int64
   -> IO (ForeignPtr Tensor)
-nanquantile_tdl = cast3 Unmanaged.nanquantile_tdl
+nanquantile_tdl = _cast3 Unmanaged.nanquantile_tdl
 
 nanquantile_td
   :: ForeignPtr Tensor
   -> CDouble
   -> IO (ForeignPtr Tensor)
-nanquantile_td = cast2 Unmanaged.nanquantile_td
+nanquantile_td = _cast2 Unmanaged.nanquantile_td
 
 nanquantile_out_ttdlbs
   :: ForeignPtr Tensor
@@ -384,7 +384,7 @@ nanquantile_out_ttdlbs
   -> CBool
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-nanquantile_out_ttdlbs = cast6 Unmanaged.nanquantile_out_ttdlbs
+nanquantile_out_ttdlbs = _cast6 Unmanaged.nanquantile_out_ttdlbs
 
 nanquantile_out_ttdlb
   :: ForeignPtr Tensor
@@ -393,7 +393,7 @@ nanquantile_out_ttdlb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-nanquantile_out_ttdlb = cast5 Unmanaged.nanquantile_out_ttdlb
+nanquantile_out_ttdlb = _cast5 Unmanaged.nanquantile_out_ttdlb
 
 nanquantile_out_ttdl
   :: ForeignPtr Tensor
@@ -401,14 +401,14 @@ nanquantile_out_ttdl
   -> CDouble
   -> Int64
   -> IO (ForeignPtr Tensor)
-nanquantile_out_ttdl = cast4 Unmanaged.nanquantile_out_ttdl
+nanquantile_out_ttdl = _cast4 Unmanaged.nanquantile_out_ttdl
 
 nanquantile_out_ttd
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> CDouble
   -> IO (ForeignPtr Tensor)
-nanquantile_out_ttd = cast3 Unmanaged.nanquantile_out_ttd
+nanquantile_out_ttd = _cast3 Unmanaged.nanquantile_out_ttd
 
 sort_out_tttlb
   :: ForeignPtr Tensor
@@ -417,7 +417,7 @@ sort_out_tttlb
   -> Int64
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-sort_out_tttlb = cast5 Unmanaged.sort_out_tttlb
+sort_out_tttlb = _cast5 Unmanaged.sort_out_tttlb
 
 sort_out_tttl
   :: ForeignPtr Tensor
@@ -425,14 +425,14 @@ sort_out_tttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-sort_out_tttl = cast4 Unmanaged.sort_out_tttl
+sort_out_tttl = _cast4 Unmanaged.sort_out_tttl
 
 sort_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-sort_out_ttt = cast3 Unmanaged.sort_out_ttt
+sort_out_ttt = _cast3 Unmanaged.sort_out_ttt
 
 sort_out_tttblb
   :: ForeignPtr Tensor
@@ -442,7 +442,7 @@ sort_out_tttblb
   -> Int64
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-sort_out_tttblb = cast6 Unmanaged.sort_out_tttblb
+sort_out_tttblb = _cast6 Unmanaged.sort_out_tttblb
 
 sort_out_tttb
   :: ForeignPtr Tensor
@@ -450,25 +450,25 @@ sort_out_tttb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-sort_out_tttb = cast4 Unmanaged.sort_out_tttb
+sort_out_tttb = _cast4 Unmanaged.sort_out_tttb
 
 sort_tlb
   :: ForeignPtr Tensor
   -> Int64
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-sort_tlb = cast3 Unmanaged.sort_tlb
+sort_tlb = _cast3 Unmanaged.sort_tlb
 
 sort_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-sort_tl = cast2 Unmanaged.sort_tl
+sort_tl = _cast2 Unmanaged.sort_tl
 
 sort_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-sort_t = cast1 Unmanaged.sort_t
+sort_t = _cast1 Unmanaged.sort_t
 
 sort_tblb
   :: ForeignPtr Tensor
@@ -476,20 +476,20 @@ sort_tblb
   -> Int64
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-sort_tblb = cast4 Unmanaged.sort_tblb
+sort_tblb = _cast4 Unmanaged.sort_tblb
 
 -- sort_tbl
 --   :: ForeignPtr Tensor
 --   -> CBool
 --   -> Int64
 --   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
--- sort_tbl = cast3 Unmanaged.sort_tbl
+-- sort_tbl = _cast3 Unmanaged.sort_tbl
 
 sort_tb
   :: ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-sort_tb = cast2 Unmanaged.sort_tb
+sort_tb = _cast2 Unmanaged.sort_tb
 
 sort_out_tttnb
   :: ForeignPtr Tensor
@@ -498,7 +498,7 @@ sort_out_tttnb
   -> ForeignPtr Dimname
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-sort_out_tttnb = cast5 Unmanaged.sort_out_tttnb
+sort_out_tttnb = _cast5 Unmanaged.sort_out_tttnb
 
 sort_out_tttn
   :: ForeignPtr Tensor
@@ -506,7 +506,7 @@ sort_out_tttn
   -> ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-sort_out_tttn = cast4 Unmanaged.sort_out_tttn
+sort_out_tttn = _cast4 Unmanaged.sort_out_tttn
 
 sort_out_tttbnb
   :: ForeignPtr Tensor
@@ -516,7 +516,7 @@ sort_out_tttbnb
   -> ForeignPtr Dimname
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-sort_out_tttbnb = cast6 Unmanaged.sort_out_tttbnb
+sort_out_tttbnb = _cast6 Unmanaged.sort_out_tttbnb
 
 sort_out_tttbn
   :: ForeignPtr Tensor
@@ -525,20 +525,20 @@ sort_out_tttbn
   -> CBool
   -> ForeignPtr Dimname
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-sort_out_tttbn = cast5 Unmanaged.sort_out_tttbn
+sort_out_tttbn = _cast5 Unmanaged.sort_out_tttbn
 
 sort_tnb
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-sort_tnb = cast3 Unmanaged.sort_tnb
+sort_tnb = _cast3 Unmanaged.sort_tnb
 
 sort_tn
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-sort_tn = cast2 Unmanaged.sort_tn
+sort_tn = _cast2 Unmanaged.sort_tn
 
 sort_tbnb
   :: ForeignPtr Tensor
@@ -546,56 +546,56 @@ sort_tbnb
   -> ForeignPtr Dimname
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-sort_tbnb = cast4 Unmanaged.sort_tbnb
+sort_tbnb = _cast4 Unmanaged.sort_tbnb
 
 sort_tbn
   :: ForeignPtr Tensor
   -> CBool
   -> ForeignPtr Dimname
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-sort_tbn = cast3 Unmanaged.sort_tbn
+sort_tbn = _cast3 Unmanaged.sort_tbn
 
 msort_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-msort_out_tt = cast2 Unmanaged.msort_out_tt
+msort_out_tt = _cast2 Unmanaged.msort_out_tt
 
 msort_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-msort_t = cast1 Unmanaged.msort_t
+msort_t = _cast1 Unmanaged.msort_t
 
 argsort_tlb
   :: ForeignPtr Tensor
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-argsort_tlb = cast3 Unmanaged.argsort_tlb
+argsort_tlb = _cast3 Unmanaged.argsort_tlb
 
 argsort_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-argsort_tl = cast2 Unmanaged.argsort_tl
+argsort_tl = _cast2 Unmanaged.argsort_tl
 
 argsort_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-argsort_t = cast1 Unmanaged.argsort_t
+argsort_t = _cast1 Unmanaged.argsort_t
 
 argsort_tnb
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> CBool
   -> IO (ForeignPtr Tensor)
-argsort_tnb = cast3 Unmanaged.argsort_tnb
+argsort_tnb = _cast3 Unmanaged.argsort_tnb
 
 argsort_tn
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> IO (ForeignPtr Tensor)
-argsort_tn = cast2 Unmanaged.argsort_tn
+argsort_tn = _cast2 Unmanaged.argsort_tn
 
 topk_out_tttllbb
   :: ForeignPtr Tensor
@@ -606,7 +606,7 @@ topk_out_tttllbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-topk_out_tttllbb = cast7 Unmanaged.topk_out_tttllbb
+topk_out_tttllbb = _cast7 Unmanaged.topk_out_tttllbb
 
 topk_out_tttllb
   :: ForeignPtr Tensor
@@ -616,7 +616,7 @@ topk_out_tttllb
   -> Int64
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-topk_out_tttllb = cast6 Unmanaged.topk_out_tttllb
+topk_out_tttllb = _cast6 Unmanaged.topk_out_tttllb
 
 topk_out_tttll
   :: ForeignPtr Tensor
@@ -625,7 +625,7 @@ topk_out_tttll
   -> Int64
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-topk_out_tttll = cast5 Unmanaged.topk_out_tttll
+topk_out_tttll = _cast5 Unmanaged.topk_out_tttll
 
 topk_out_tttl
   :: ForeignPtr Tensor
@@ -633,7 +633,7 @@ topk_out_tttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-topk_out_tttl = cast4 Unmanaged.topk_out_tttl
+topk_out_tttl = _cast4 Unmanaged.topk_out_tttl
 
 topk_tllbb
   :: ForeignPtr Tensor
@@ -642,7 +642,7 @@ topk_tllbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-topk_tllbb = cast5 Unmanaged.topk_tllbb
+topk_tllbb = _cast5 Unmanaged.topk_tllbb
 
 topk_tllb
   :: ForeignPtr Tensor
@@ -650,42 +650,42 @@ topk_tllb
   -> Int64
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-topk_tllb = cast4 Unmanaged.topk_tllb
+topk_tllb = _cast4 Unmanaged.topk_tllb
 
 topk_tll
   :: ForeignPtr Tensor
   -> Int64
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-topk_tll = cast3 Unmanaged.topk_tll
+topk_tll = _cast3 Unmanaged.topk_tll
 
 topk_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-topk_tl = cast2 Unmanaged.topk_tl
+topk_tl = _cast2 Unmanaged.topk_tl
 
 all_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-all_t = cast1 Unmanaged.all_t
+all_t = _cast1 Unmanaged.all_t
 
 all_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-all_out_tt = cast2 Unmanaged.all_out_tt
+all_out_tt = _cast2 Unmanaged.all_out_tt
 
 any_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-any_t = cast1 Unmanaged.any_t
+any_t = _cast1 Unmanaged.any_t
 
 any_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-any_out_tt = cast2 Unmanaged.any_out_tt
+any_out_tt = _cast2 Unmanaged.any_out_tt
 
 renorm_out_ttsls
   :: ForeignPtr Tensor
@@ -694,7 +694,7 @@ renorm_out_ttsls
   -> Int64
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-renorm_out_ttsls = cast5 Unmanaged.renorm_out_ttsls
+renorm_out_ttsls = _cast5 Unmanaged.renorm_out_ttsls
 
 renorm_tsls
   :: ForeignPtr Tensor
@@ -702,7 +702,7 @@ renorm_tsls
   -> Int64
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-renorm_tsls = cast4 Unmanaged.renorm_tsls
+renorm_tsls = _cast4 Unmanaged.renorm_tsls
 
 unfold_backward_tllll
   :: ForeignPtr Tensor
@@ -711,91 +711,91 @@ unfold_backward_tllll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-unfold_backward_tllll = cast5 Unmanaged.unfold_backward_tllll
+unfold_backward_tllll = _cast5 Unmanaged.unfold_backward_tllll
 
 equal_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (CBool)
-equal_tt = cast2 Unmanaged.equal_tt
+equal_tt = _cast2 Unmanaged.equal_tt
 
 pow_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-pow_out_ttt = cast3 Unmanaged.pow_out_ttt
+pow_out_ttt = _cast3 Unmanaged.pow_out_ttt
 
 pow_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-pow_tt = cast2 Unmanaged.pow_tt
+pow_tt = _cast2 Unmanaged.pow_tt
 
 pow_out_tst
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-pow_out_tst = cast3 Unmanaged.pow_out_tst
+pow_out_tst = _cast3 Unmanaged.pow_out_tst
 
 pow_st
   :: ForeignPtr Scalar
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-pow_st = cast2 Unmanaged.pow_st
+pow_st = _cast2 Unmanaged.pow_st
 
 pow_out_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-pow_out_tts = cast3 Unmanaged.pow_out_tts
+pow_out_tts = _cast3 Unmanaged.pow_out_tts
 
 pow_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-pow_ts = cast2 Unmanaged.pow_ts
+pow_ts = _cast2 Unmanaged.pow_ts
 
 float_power_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-float_power_out_ttt = cast3 Unmanaged.float_power_out_ttt
+float_power_out_ttt = _cast3 Unmanaged.float_power_out_ttt
 
 float_power_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-float_power_tt = cast2 Unmanaged.float_power_tt
+float_power_tt = _cast2 Unmanaged.float_power_tt
 
 float_power_out_tst
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-float_power_out_tst = cast3 Unmanaged.float_power_out_tst
+float_power_out_tst = _cast3 Unmanaged.float_power_out_tst
 
 float_power_st
   :: ForeignPtr Scalar
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-float_power_st = cast2 Unmanaged.float_power_st
+float_power_st = _cast2 Unmanaged.float_power_st
 
 float_power_out_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-float_power_out_tts = cast3 Unmanaged.float_power_out_tts
+float_power_out_tts = _cast3 Unmanaged.float_power_out_tts
 
 float_power_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-float_power_ts = cast2 Unmanaged.float_power_ts
+float_power_ts = _cast2 Unmanaged.float_power_ts
 
 normal_out_ttdG
   :: ForeignPtr Tensor
@@ -803,38 +803,38 @@ normal_out_ttdG
   -> CDouble
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-normal_out_ttdG = cast4 Unmanaged.normal_out_ttdG
+normal_out_ttdG = _cast4 Unmanaged.normal_out_ttdG
 
 normal_out_ttd
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> CDouble
   -> IO (ForeignPtr Tensor)
-normal_out_ttd = cast3 Unmanaged.normal_out_ttd
+normal_out_ttd = _cast3 Unmanaged.normal_out_ttd
 
 normal_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-normal_out_tt = cast2 Unmanaged.normal_out_tt
+normal_out_tt = _cast2 Unmanaged.normal_out_tt
 
 normal_tdG
   :: ForeignPtr Tensor
   -> CDouble
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-normal_tdG = cast3 Unmanaged.normal_tdG
+normal_tdG = _cast3 Unmanaged.normal_tdG
 
 normal_td
   :: ForeignPtr Tensor
   -> CDouble
   -> IO (ForeignPtr Tensor)
-normal_td = cast2 Unmanaged.normal_td
+normal_td = _cast2 Unmanaged.normal_td
 
 normal_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-normal_t = cast1 Unmanaged.normal_t
+normal_t = _cast1 Unmanaged.normal_t
 
 normal_out_tdtG
   :: ForeignPtr Tensor
@@ -842,27 +842,27 @@ normal_out_tdtG
   -> ForeignPtr Tensor
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-normal_out_tdtG = cast4 Unmanaged.normal_out_tdtG
+normal_out_tdtG = _cast4 Unmanaged.normal_out_tdtG
 
 normal_out_tdt
   :: ForeignPtr Tensor
   -> CDouble
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-normal_out_tdt = cast3 Unmanaged.normal_out_tdt
+normal_out_tdt = _cast3 Unmanaged.normal_out_tdt
 
 normal_dtG
   :: CDouble
   -> ForeignPtr Tensor
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-normal_dtG = cast3 Unmanaged.normal_dtG
+normal_dtG = _cast3 Unmanaged.normal_dtG
 
 normal_dt
   :: CDouble
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-normal_dt = cast2 Unmanaged.normal_dt
+normal_dt = _cast2 Unmanaged.normal_dt
 
 normal_out_tttG
   :: ForeignPtr Tensor
@@ -870,27 +870,27 @@ normal_out_tttG
   -> ForeignPtr Tensor
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-normal_out_tttG = cast4 Unmanaged.normal_out_tttG
+normal_out_tttG = _cast4 Unmanaged.normal_out_tttG
 
 normal_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-normal_out_ttt = cast3 Unmanaged.normal_out_ttt
+normal_out_ttt = _cast3 Unmanaged.normal_out_ttt
 
 normal_ttG
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-normal_ttG = cast3 Unmanaged.normal_ttG
+normal_ttG = _cast3 Unmanaged.normal_ttG
 
 normal_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-normal_tt = cast2 Unmanaged.normal_tt
+normal_tt = _cast2 Unmanaged.normal_tt
 
 normal_ddlGo
   :: CDouble
@@ -899,7 +899,7 @@ normal_ddlGo
   -> ForeignPtr Generator
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-normal_ddlGo = cast5 Unmanaged.normal_ddlGo
+normal_ddlGo = _cast5 Unmanaged.normal_ddlGo
 
 normal_ddlG
   :: CDouble
@@ -907,14 +907,14 @@ normal_ddlG
   -> ForeignPtr IntArray
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-normal_ddlG = cast4 Unmanaged.normal_ddlG
+normal_ddlG = _cast4 Unmanaged.normal_ddlG
 
 normal_ddl
   :: CDouble
   -> CDouble
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-normal_ddl = cast3 Unmanaged.normal_ddl
+normal_ddl = _cast3 Unmanaged.normal_ddl
 
 normal_out_tddlG
   :: ForeignPtr Tensor
@@ -923,7 +923,7 @@ normal_out_tddlG
   -> ForeignPtr IntArray
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-normal_out_tddlG = cast5 Unmanaged.normal_out_tddlG
+normal_out_tddlG = _cast5 Unmanaged.normal_out_tddlG
 
 normal_out_tddl
   :: ForeignPtr Tensor
@@ -931,12 +931,12 @@ normal_out_tddl
   -> CDouble
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-normal_out_tddl = cast4 Unmanaged.normal_out_tddl
+normal_out_tddl = _cast4 Unmanaged.normal_out_tddl
 
 alias_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-alias_t = cast1 Unmanaged.alias_t
+alias_t = _cast1 Unmanaged.alias_t
 
 _index_copy__tltt
   :: ForeignPtr Tensor
@@ -944,14 +944,14 @@ _index_copy__tltt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_index_copy__tltt = cast4 Unmanaged._index_copy__tltt
+_index_copy__tltt = _cast4 Unmanaged._index_copy__tltt
 
 _amp_foreach_non_finite_check_and_unscale__ltt
   :: ForeignPtr TensorList
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (())
-_amp_foreach_non_finite_check_and_unscale__ltt = cast3 Unmanaged._amp_foreach_non_finite_check_and_unscale__ltt
+_amp_foreach_non_finite_check_and_unscale__ltt = _cast3 Unmanaged._amp_foreach_non_finite_check_and_unscale__ltt
 
 _amp_update_scale__tttddl
   :: ForeignPtr Tensor
@@ -961,456 +961,456 @@ _amp_update_scale__tttddl
   -> CDouble
   -> Int64
   -> IO (ForeignPtr Tensor)
-_amp_update_scale__tttddl = cast6 Unmanaged._amp_update_scale__tttddl
+_amp_update_scale__tttddl = _cast6 Unmanaged._amp_update_scale__tttddl
 
 _cat_ll
   :: ForeignPtr TensorList
   -> Int64
   -> IO (ForeignPtr Tensor)
-_cat_ll = cast2 Unmanaged._cat_ll
+_cat_ll = _cast2 Unmanaged._cat_ll
 
 _cat_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr Tensor)
-_cat_l = cast1 Unmanaged._cat_l
+_cat_l = _cast1 Unmanaged._cat_l
 
 _cat_out_tll
   :: ForeignPtr Tensor
   -> ForeignPtr TensorList
   -> Int64
   -> IO (ForeignPtr Tensor)
-_cat_out_tll = cast3 Unmanaged._cat_out_tll
+_cat_out_tll = _cast3 Unmanaged._cat_out_tll
 
 _cat_out_tl
   :: ForeignPtr Tensor
   -> ForeignPtr TensorList
   -> IO (ForeignPtr Tensor)
-_cat_out_tl = cast2 Unmanaged._cat_out_tl
+_cat_out_tl = _cast2 Unmanaged._cat_out_tl
 
 _foreach_add_ls
   :: ForeignPtr TensorList
   -> ForeignPtr Scalar
   -> IO (ForeignPtr TensorList)
-_foreach_add_ls = cast2 Unmanaged._foreach_add_ls
+_foreach_add_ls = _cast2 Unmanaged._foreach_add_ls
 
 _foreach_add__ls
   :: ForeignPtr TensorList
   -> ForeignPtr Scalar
   -> IO (())
-_foreach_add__ls = cast2 Unmanaged._foreach_add__ls
+_foreach_add__ls = _cast2 Unmanaged._foreach_add__ls
 
 _foreach_sub_ls
   :: ForeignPtr TensorList
   -> ForeignPtr Scalar
   -> IO (ForeignPtr TensorList)
-_foreach_sub_ls = cast2 Unmanaged._foreach_sub_ls
+_foreach_sub_ls = _cast2 Unmanaged._foreach_sub_ls
 
 _foreach_sub__ls
   :: ForeignPtr TensorList
   -> ForeignPtr Scalar
   -> IO (())
-_foreach_sub__ls = cast2 Unmanaged._foreach_sub__ls
+_foreach_sub__ls = _cast2 Unmanaged._foreach_sub__ls
 
 _foreach_mul_ls
   :: ForeignPtr TensorList
   -> ForeignPtr Scalar
   -> IO (ForeignPtr TensorList)
-_foreach_mul_ls = cast2 Unmanaged._foreach_mul_ls
+_foreach_mul_ls = _cast2 Unmanaged._foreach_mul_ls
 
 _foreach_mul__ls
   :: ForeignPtr TensorList
   -> ForeignPtr Scalar
   -> IO (())
-_foreach_mul__ls = cast2 Unmanaged._foreach_mul__ls
+_foreach_mul__ls = _cast2 Unmanaged._foreach_mul__ls
 
 _foreach_div_ls
   :: ForeignPtr TensorList
   -> ForeignPtr Scalar
   -> IO (ForeignPtr TensorList)
-_foreach_div_ls = cast2 Unmanaged._foreach_div_ls
+_foreach_div_ls = _cast2 Unmanaged._foreach_div_ls
 
 _foreach_div__ls
   :: ForeignPtr TensorList
   -> ForeignPtr Scalar
   -> IO (())
-_foreach_div__ls = cast2 Unmanaged._foreach_div__ls
+_foreach_div__ls = _cast2 Unmanaged._foreach_div__ls
 
 _foreach_add_lls
   :: ForeignPtr TensorList
   -> ForeignPtr TensorList
   -> ForeignPtr Scalar
   -> IO (ForeignPtr TensorList)
-_foreach_add_lls = cast3 Unmanaged._foreach_add_lls
+_foreach_add_lls = _cast3 Unmanaged._foreach_add_lls
 
 _foreach_add_ll
   :: ForeignPtr TensorList
   -> ForeignPtr TensorList
   -> IO (ForeignPtr TensorList)
-_foreach_add_ll = cast2 Unmanaged._foreach_add_ll
+_foreach_add_ll = _cast2 Unmanaged._foreach_add_ll
 
 _foreach_add__lls
   :: ForeignPtr TensorList
   -> ForeignPtr TensorList
   -> ForeignPtr Scalar
   -> IO (())
-_foreach_add__lls = cast3 Unmanaged._foreach_add__lls
+_foreach_add__lls = _cast3 Unmanaged._foreach_add__lls
 
 _foreach_add__ll
   :: ForeignPtr TensorList
   -> ForeignPtr TensorList
   -> IO (())
-_foreach_add__ll = cast2 Unmanaged._foreach_add__ll
+_foreach_add__ll = _cast2 Unmanaged._foreach_add__ll
 
 _foreach_sub_lls
   :: ForeignPtr TensorList
   -> ForeignPtr TensorList
   -> ForeignPtr Scalar
   -> IO (ForeignPtr TensorList)
-_foreach_sub_lls = cast3 Unmanaged._foreach_sub_lls
+_foreach_sub_lls = _cast3 Unmanaged._foreach_sub_lls
 
 _foreach_sub_ll
   :: ForeignPtr TensorList
   -> ForeignPtr TensorList
   -> IO (ForeignPtr TensorList)
-_foreach_sub_ll = cast2 Unmanaged._foreach_sub_ll
+_foreach_sub_ll = _cast2 Unmanaged._foreach_sub_ll
 
 _foreach_sub__lls
   :: ForeignPtr TensorList
   -> ForeignPtr TensorList
   -> ForeignPtr Scalar
   -> IO (())
-_foreach_sub__lls = cast3 Unmanaged._foreach_sub__lls
+_foreach_sub__lls = _cast3 Unmanaged._foreach_sub__lls
 
 _foreach_sub__ll
   :: ForeignPtr TensorList
   -> ForeignPtr TensorList
   -> IO (())
-_foreach_sub__ll = cast2 Unmanaged._foreach_sub__ll
+_foreach_sub__ll = _cast2 Unmanaged._foreach_sub__ll
 
 _foreach_mul_ll
   :: ForeignPtr TensorList
   -> ForeignPtr TensorList
   -> IO (ForeignPtr TensorList)
-_foreach_mul_ll = cast2 Unmanaged._foreach_mul_ll
+_foreach_mul_ll = _cast2 Unmanaged._foreach_mul_ll
 
 _foreach_mul__ll
   :: ForeignPtr TensorList
   -> ForeignPtr TensorList
   -> IO (())
-_foreach_mul__ll = cast2 Unmanaged._foreach_mul__ll
+_foreach_mul__ll = _cast2 Unmanaged._foreach_mul__ll
 
 _foreach_div_ll
   :: ForeignPtr TensorList
   -> ForeignPtr TensorList
   -> IO (ForeignPtr TensorList)
-_foreach_div_ll = cast2 Unmanaged._foreach_div_ll
+_foreach_div_ll = _cast2 Unmanaged._foreach_div_ll
 
 _foreach_div__ll
   :: ForeignPtr TensorList
   -> ForeignPtr TensorList
   -> IO (())
-_foreach_div__ll = cast2 Unmanaged._foreach_div__ll
+_foreach_div__ll = _cast2 Unmanaged._foreach_div__ll
 
 _foreach_add_lA
   :: ForeignPtr TensorList
   -> ForeignPtr (StdVector Scalar)
   -> IO (ForeignPtr TensorList)
-_foreach_add_lA = cast2 Unmanaged._foreach_add_lA
+_foreach_add_lA = _cast2 Unmanaged._foreach_add_lA
 
 _foreach_add__lA
   :: ForeignPtr TensorList
   -> ForeignPtr (StdVector Scalar)
   -> IO (())
-_foreach_add__lA = cast2 Unmanaged._foreach_add__lA
+_foreach_add__lA = _cast2 Unmanaged._foreach_add__lA
 
 _foreach_sub_lA
   :: ForeignPtr TensorList
   -> ForeignPtr (StdVector Scalar)
   -> IO (ForeignPtr TensorList)
-_foreach_sub_lA = cast2 Unmanaged._foreach_sub_lA
+_foreach_sub_lA = _cast2 Unmanaged._foreach_sub_lA
 
 _foreach_sub__lA
   :: ForeignPtr TensorList
   -> ForeignPtr (StdVector Scalar)
   -> IO (())
-_foreach_sub__lA = cast2 Unmanaged._foreach_sub__lA
+_foreach_sub__lA = _cast2 Unmanaged._foreach_sub__lA
 
 _foreach_div_lA
   :: ForeignPtr TensorList
   -> ForeignPtr (StdVector Scalar)
   -> IO (ForeignPtr TensorList)
-_foreach_div_lA = cast2 Unmanaged._foreach_div_lA
+_foreach_div_lA = _cast2 Unmanaged._foreach_div_lA
 
 _foreach_div__lA
   :: ForeignPtr TensorList
   -> ForeignPtr (StdVector Scalar)
   -> IO (())
-_foreach_div__lA = cast2 Unmanaged._foreach_div__lA
+_foreach_div__lA = _cast2 Unmanaged._foreach_div__lA
 
 _foreach_mul_lA
   :: ForeignPtr TensorList
   -> ForeignPtr (StdVector Scalar)
   -> IO (ForeignPtr TensorList)
-_foreach_mul_lA = cast2 Unmanaged._foreach_mul_lA
+_foreach_mul_lA = _cast2 Unmanaged._foreach_mul_lA
 
 _foreach_mul__lA
   :: ForeignPtr TensorList
   -> ForeignPtr (StdVector Scalar)
   -> IO (())
-_foreach_mul__lA = cast2 Unmanaged._foreach_mul__lA
+_foreach_mul__lA = _cast2 Unmanaged._foreach_mul__lA
 
 _foreach_exp_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr TensorList)
-_foreach_exp_l = cast1 Unmanaged._foreach_exp_l
+_foreach_exp_l = _cast1 Unmanaged._foreach_exp_l
 
 _foreach_zero__l
   :: ForeignPtr TensorList
   -> IO (())
-_foreach_zero__l = cast1 Unmanaged._foreach_zero__l
+_foreach_zero__l = _cast1 Unmanaged._foreach_zero__l
 
 _foreach_exp__l
   :: ForeignPtr TensorList
   -> IO (())
-_foreach_exp__l = cast1 Unmanaged._foreach_exp__l
+_foreach_exp__l = _cast1 Unmanaged._foreach_exp__l
 
 _foreach_sqrt_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr TensorList)
-_foreach_sqrt_l = cast1 Unmanaged._foreach_sqrt_l
+_foreach_sqrt_l = _cast1 Unmanaged._foreach_sqrt_l
 
 _foreach_sqrt__l
   :: ForeignPtr TensorList
   -> IO (())
-_foreach_sqrt__l = cast1 Unmanaged._foreach_sqrt__l
+_foreach_sqrt__l = _cast1 Unmanaged._foreach_sqrt__l
 
 _foreach_abs_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr TensorList)
-_foreach_abs_l = cast1 Unmanaged._foreach_abs_l
+_foreach_abs_l = _cast1 Unmanaged._foreach_abs_l
 
 _foreach_abs__l
   :: ForeignPtr TensorList
   -> IO (())
-_foreach_abs__l = cast1 Unmanaged._foreach_abs__l
+_foreach_abs__l = _cast1 Unmanaged._foreach_abs__l
 
 _foreach_acos_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr TensorList)
-_foreach_acos_l = cast1 Unmanaged._foreach_acos_l
+_foreach_acos_l = _cast1 Unmanaged._foreach_acos_l
 
 _foreach_acos__l
   :: ForeignPtr TensorList
   -> IO (())
-_foreach_acos__l = cast1 Unmanaged._foreach_acos__l
+_foreach_acos__l = _cast1 Unmanaged._foreach_acos__l
 
 _foreach_asin_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr TensorList)
-_foreach_asin_l = cast1 Unmanaged._foreach_asin_l
+_foreach_asin_l = _cast1 Unmanaged._foreach_asin_l
 
 _foreach_asin__l
   :: ForeignPtr TensorList
   -> IO (())
-_foreach_asin__l = cast1 Unmanaged._foreach_asin__l
+_foreach_asin__l = _cast1 Unmanaged._foreach_asin__l
 
 _foreach_atan_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr TensorList)
-_foreach_atan_l = cast1 Unmanaged._foreach_atan_l
+_foreach_atan_l = _cast1 Unmanaged._foreach_atan_l
 
 _foreach_atan__l
   :: ForeignPtr TensorList
   -> IO (())
-_foreach_atan__l = cast1 Unmanaged._foreach_atan__l
+_foreach_atan__l = _cast1 Unmanaged._foreach_atan__l
 
 _foreach_ceil_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr TensorList)
-_foreach_ceil_l = cast1 Unmanaged._foreach_ceil_l
+_foreach_ceil_l = _cast1 Unmanaged._foreach_ceil_l
 
 _foreach_ceil__l
   :: ForeignPtr TensorList
   -> IO (())
-_foreach_ceil__l = cast1 Unmanaged._foreach_ceil__l
+_foreach_ceil__l = _cast1 Unmanaged._foreach_ceil__l
 
 _foreach_cos_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr TensorList)
-_foreach_cos_l = cast1 Unmanaged._foreach_cos_l
+_foreach_cos_l = _cast1 Unmanaged._foreach_cos_l
 
 _foreach_cos__l
   :: ForeignPtr TensorList
   -> IO (())
-_foreach_cos__l = cast1 Unmanaged._foreach_cos__l
+_foreach_cos__l = _cast1 Unmanaged._foreach_cos__l
 
 _foreach_cosh_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr TensorList)
-_foreach_cosh_l = cast1 Unmanaged._foreach_cosh_l
+_foreach_cosh_l = _cast1 Unmanaged._foreach_cosh_l
 
 _foreach_cosh__l
   :: ForeignPtr TensorList
   -> IO (())
-_foreach_cosh__l = cast1 Unmanaged._foreach_cosh__l
+_foreach_cosh__l = _cast1 Unmanaged._foreach_cosh__l
 
 _foreach_erf_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr TensorList)
-_foreach_erf_l = cast1 Unmanaged._foreach_erf_l
+_foreach_erf_l = _cast1 Unmanaged._foreach_erf_l
 
 _foreach_erf__l
   :: ForeignPtr TensorList
   -> IO (())
-_foreach_erf__l = cast1 Unmanaged._foreach_erf__l
+_foreach_erf__l = _cast1 Unmanaged._foreach_erf__l
 
 _foreach_erfc_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr TensorList)
-_foreach_erfc_l = cast1 Unmanaged._foreach_erfc_l
+_foreach_erfc_l = _cast1 Unmanaged._foreach_erfc_l
 
 _foreach_erfc__l
   :: ForeignPtr TensorList
   -> IO (())
-_foreach_erfc__l = cast1 Unmanaged._foreach_erfc__l
+_foreach_erfc__l = _cast1 Unmanaged._foreach_erfc__l
 
 _foreach_expm1_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr TensorList)
-_foreach_expm1_l = cast1 Unmanaged._foreach_expm1_l
+_foreach_expm1_l = _cast1 Unmanaged._foreach_expm1_l
 
 _foreach_expm1__l
   :: ForeignPtr TensorList
   -> IO (())
-_foreach_expm1__l = cast1 Unmanaged._foreach_expm1__l
+_foreach_expm1__l = _cast1 Unmanaged._foreach_expm1__l
 
 _foreach_floor_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr TensorList)
-_foreach_floor_l = cast1 Unmanaged._foreach_floor_l
+_foreach_floor_l = _cast1 Unmanaged._foreach_floor_l
 
 _foreach_floor__l
   :: ForeignPtr TensorList
   -> IO (())
-_foreach_floor__l = cast1 Unmanaged._foreach_floor__l
+_foreach_floor__l = _cast1 Unmanaged._foreach_floor__l
 
 _foreach_log_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr TensorList)
-_foreach_log_l = cast1 Unmanaged._foreach_log_l
+_foreach_log_l = _cast1 Unmanaged._foreach_log_l
 
 _foreach_log__l
   :: ForeignPtr TensorList
   -> IO (())
-_foreach_log__l = cast1 Unmanaged._foreach_log__l
+_foreach_log__l = _cast1 Unmanaged._foreach_log__l
 
 _foreach_log10_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr TensorList)
-_foreach_log10_l = cast1 Unmanaged._foreach_log10_l
+_foreach_log10_l = _cast1 Unmanaged._foreach_log10_l
 
 _foreach_log10__l
   :: ForeignPtr TensorList
   -> IO (())
-_foreach_log10__l = cast1 Unmanaged._foreach_log10__l
+_foreach_log10__l = _cast1 Unmanaged._foreach_log10__l
 
 _foreach_log1p_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr TensorList)
-_foreach_log1p_l = cast1 Unmanaged._foreach_log1p_l
+_foreach_log1p_l = _cast1 Unmanaged._foreach_log1p_l
 
 _foreach_log1p__l
   :: ForeignPtr TensorList
   -> IO (())
-_foreach_log1p__l = cast1 Unmanaged._foreach_log1p__l
+_foreach_log1p__l = _cast1 Unmanaged._foreach_log1p__l
 
 _foreach_log2_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr TensorList)
-_foreach_log2_l = cast1 Unmanaged._foreach_log2_l
+_foreach_log2_l = _cast1 Unmanaged._foreach_log2_l
 
 _foreach_log2__l
   :: ForeignPtr TensorList
   -> IO (())
-_foreach_log2__l = cast1 Unmanaged._foreach_log2__l
+_foreach_log2__l = _cast1 Unmanaged._foreach_log2__l
 
 _foreach_neg_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr TensorList)
-_foreach_neg_l = cast1 Unmanaged._foreach_neg_l
+_foreach_neg_l = _cast1 Unmanaged._foreach_neg_l
 
 _foreach_neg__l
   :: ForeignPtr TensorList
   -> IO (())
-_foreach_neg__l = cast1 Unmanaged._foreach_neg__l
+_foreach_neg__l = _cast1 Unmanaged._foreach_neg__l
 
 _foreach_tan_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr TensorList)
-_foreach_tan_l = cast1 Unmanaged._foreach_tan_l
+_foreach_tan_l = _cast1 Unmanaged._foreach_tan_l
 
 _foreach_tan__l
   :: ForeignPtr TensorList
   -> IO (())
-_foreach_tan__l = cast1 Unmanaged._foreach_tan__l
+_foreach_tan__l = _cast1 Unmanaged._foreach_tan__l
 
 _foreach_tanh_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr TensorList)
-_foreach_tanh_l = cast1 Unmanaged._foreach_tanh_l
+_foreach_tanh_l = _cast1 Unmanaged._foreach_tanh_l
 
 _foreach_tanh__l
   :: ForeignPtr TensorList
   -> IO (())
-_foreach_tanh__l = cast1 Unmanaged._foreach_tanh__l
+_foreach_tanh__l = _cast1 Unmanaged._foreach_tanh__l
 
 _foreach_sin_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr TensorList)
-_foreach_sin_l = cast1 Unmanaged._foreach_sin_l
+_foreach_sin_l = _cast1 Unmanaged._foreach_sin_l
 
 _foreach_sin__l
   :: ForeignPtr TensorList
   -> IO (())
-_foreach_sin__l = cast1 Unmanaged._foreach_sin__l
+_foreach_sin__l = _cast1 Unmanaged._foreach_sin__l
 
 _foreach_sinh_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr TensorList)
-_foreach_sinh_l = cast1 Unmanaged._foreach_sinh_l
+_foreach_sinh_l = _cast1 Unmanaged._foreach_sinh_l
 
 _foreach_sinh__l
   :: ForeignPtr TensorList
   -> IO (())
-_foreach_sinh__l = cast1 Unmanaged._foreach_sinh__l
+_foreach_sinh__l = _cast1 Unmanaged._foreach_sinh__l
 
 _foreach_round_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr TensorList)
-_foreach_round_l = cast1 Unmanaged._foreach_round_l
+_foreach_round_l = _cast1 Unmanaged._foreach_round_l
 
 _foreach_round__l
   :: ForeignPtr TensorList
   -> IO (())
-_foreach_round__l = cast1 Unmanaged._foreach_round__l
+_foreach_round__l = _cast1 Unmanaged._foreach_round__l
 
 _foreach_lgamma_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr TensorList)
-_foreach_lgamma_l = cast1 Unmanaged._foreach_lgamma_l
+_foreach_lgamma_l = _cast1 Unmanaged._foreach_lgamma_l
 
 _foreach_lgamma__l
   :: ForeignPtr TensorList
   -> IO (())
-_foreach_lgamma__l = cast1 Unmanaged._foreach_lgamma__l
+_foreach_lgamma__l = _cast1 Unmanaged._foreach_lgamma__l
 
 _foreach_frac_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr TensorList)
-_foreach_frac_l = cast1 Unmanaged._foreach_frac_l
+_foreach_frac_l = _cast1 Unmanaged._foreach_frac_l
 
 _foreach_frac__l
   :: ForeignPtr TensorList
   -> IO (())
-_foreach_frac__l = cast1 Unmanaged._foreach_frac__l
+_foreach_frac__l = _cast1 Unmanaged._foreach_frac__l
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Native/Native11.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Native/Native11.hs
@@ -24,32 +24,32 @@ import qualified Torch.Internal.Unmanaged.Native.Native11 as Unmanaged
 _foreach_reciprocal_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr TensorList)
-_foreach_reciprocal_l = cast1 Unmanaged._foreach_reciprocal_l
+_foreach_reciprocal_l = _cast1 Unmanaged._foreach_reciprocal_l
 
 _foreach_reciprocal__l
   :: ForeignPtr TensorList
   -> IO (())
-_foreach_reciprocal__l = cast1 Unmanaged._foreach_reciprocal__l
+_foreach_reciprocal__l = _cast1 Unmanaged._foreach_reciprocal__l
 
 _foreach_sigmoid_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr TensorList)
-_foreach_sigmoid_l = cast1 Unmanaged._foreach_sigmoid_l
+_foreach_sigmoid_l = _cast1 Unmanaged._foreach_sigmoid_l
 
 _foreach_sigmoid__l
   :: ForeignPtr TensorList
   -> IO (())
-_foreach_sigmoid__l = cast1 Unmanaged._foreach_sigmoid__l
+_foreach_sigmoid__l = _cast1 Unmanaged._foreach_sigmoid__l
 
 _foreach_trunc_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr TensorList)
-_foreach_trunc_l = cast1 Unmanaged._foreach_trunc_l
+_foreach_trunc_l = _cast1 Unmanaged._foreach_trunc_l
 
 _foreach_trunc__l
   :: ForeignPtr TensorList
   -> IO (())
-_foreach_trunc__l = cast1 Unmanaged._foreach_trunc__l
+_foreach_trunc__l = _cast1 Unmanaged._foreach_trunc__l
 
 _foreach_addcdiv__llls
   :: ForeignPtr TensorList
@@ -57,14 +57,14 @@ _foreach_addcdiv__llls
   -> ForeignPtr TensorList
   -> ForeignPtr Scalar
   -> IO (())
-_foreach_addcdiv__llls = cast4 Unmanaged._foreach_addcdiv__llls
+_foreach_addcdiv__llls = _cast4 Unmanaged._foreach_addcdiv__llls
 
 _foreach_addcdiv__lll
   :: ForeignPtr TensorList
   -> ForeignPtr TensorList
   -> ForeignPtr TensorList
   -> IO (())
-_foreach_addcdiv__lll = cast3 Unmanaged._foreach_addcdiv__lll
+_foreach_addcdiv__lll = _cast3 Unmanaged._foreach_addcdiv__lll
 
 _foreach_addcmul__llls
   :: ForeignPtr TensorList
@@ -72,14 +72,14 @@ _foreach_addcmul__llls
   -> ForeignPtr TensorList
   -> ForeignPtr Scalar
   -> IO (())
-_foreach_addcmul__llls = cast4 Unmanaged._foreach_addcmul__llls
+_foreach_addcmul__llls = _cast4 Unmanaged._foreach_addcmul__llls
 
 _foreach_addcmul__lll
   :: ForeignPtr TensorList
   -> ForeignPtr TensorList
   -> ForeignPtr TensorList
   -> IO (())
-_foreach_addcmul__lll = cast3 Unmanaged._foreach_addcmul__lll
+_foreach_addcmul__lll = _cast3 Unmanaged._foreach_addcmul__lll
 
 _foreach_addcdiv__lllA
   :: ForeignPtr TensorList
@@ -87,7 +87,7 @@ _foreach_addcdiv__lllA
   -> ForeignPtr TensorList
   -> ForeignPtr (StdVector Scalar)
   -> IO (())
-_foreach_addcdiv__lllA = cast4 Unmanaged._foreach_addcdiv__lllA
+_foreach_addcdiv__lllA = _cast4 Unmanaged._foreach_addcdiv__lllA
 
 _foreach_addcmul__lllA
   :: ForeignPtr TensorList
@@ -95,7 +95,7 @@ _foreach_addcmul__lllA
   -> ForeignPtr TensorList
   -> ForeignPtr (StdVector Scalar)
   -> IO (())
-_foreach_addcmul__lllA = cast4 Unmanaged._foreach_addcmul__lllA
+_foreach_addcmul__lllA = _cast4 Unmanaged._foreach_addcmul__lllA
 
 _foreach_addcdiv_llls
   :: ForeignPtr TensorList
@@ -103,14 +103,14 @@ _foreach_addcdiv_llls
   -> ForeignPtr TensorList
   -> ForeignPtr Scalar
   -> IO (ForeignPtr TensorList)
-_foreach_addcdiv_llls = cast4 Unmanaged._foreach_addcdiv_llls
+_foreach_addcdiv_llls = _cast4 Unmanaged._foreach_addcdiv_llls
 
 _foreach_addcdiv_lll
   :: ForeignPtr TensorList
   -> ForeignPtr TensorList
   -> ForeignPtr TensorList
   -> IO (ForeignPtr TensorList)
-_foreach_addcdiv_lll = cast3 Unmanaged._foreach_addcdiv_lll
+_foreach_addcdiv_lll = _cast3 Unmanaged._foreach_addcdiv_lll
 
 _foreach_addcmul_llls
   :: ForeignPtr TensorList
@@ -118,14 +118,14 @@ _foreach_addcmul_llls
   -> ForeignPtr TensorList
   -> ForeignPtr Scalar
   -> IO (ForeignPtr TensorList)
-_foreach_addcmul_llls = cast4 Unmanaged._foreach_addcmul_llls
+_foreach_addcmul_llls = _cast4 Unmanaged._foreach_addcmul_llls
 
 _foreach_addcmul_lll
   :: ForeignPtr TensorList
   -> ForeignPtr TensorList
   -> ForeignPtr TensorList
   -> IO (ForeignPtr TensorList)
-_foreach_addcmul_lll = cast3 Unmanaged._foreach_addcmul_lll
+_foreach_addcmul_lll = _cast3 Unmanaged._foreach_addcmul_lll
 
 _foreach_addcdiv_lllA
   :: ForeignPtr TensorList
@@ -133,7 +133,7 @@ _foreach_addcdiv_lllA
   -> ForeignPtr TensorList
   -> ForeignPtr (StdVector Scalar)
   -> IO (ForeignPtr TensorList)
-_foreach_addcdiv_lllA = cast4 Unmanaged._foreach_addcdiv_lllA
+_foreach_addcdiv_lllA = _cast4 Unmanaged._foreach_addcdiv_lllA
 
 _foreach_addcmul_lllA
   :: ForeignPtr TensorList
@@ -141,30 +141,30 @@ _foreach_addcmul_lllA
   -> ForeignPtr TensorList
   -> ForeignPtr (StdVector Scalar)
   -> IO (ForeignPtr TensorList)
-_foreach_addcmul_lllA = cast4 Unmanaged._foreach_addcmul_lllA
+_foreach_addcmul_lllA = _cast4 Unmanaged._foreach_addcmul_lllA
 
 _foreach_maximum_ll
   :: ForeignPtr TensorList
   -> ForeignPtr TensorList
   -> IO (ForeignPtr TensorList)
-_foreach_maximum_ll = cast2 Unmanaged._foreach_maximum_ll
+_foreach_maximum_ll = _cast2 Unmanaged._foreach_maximum_ll
 
 _foreach_minimum_ll
   :: ForeignPtr TensorList
   -> ForeignPtr TensorList
   -> IO (ForeignPtr TensorList)
-_foreach_minimum_ll = cast2 Unmanaged._foreach_minimum_ll
+_foreach_minimum_ll = _cast2 Unmanaged._foreach_minimum_ll
 
 _foreach_norm_ls
   :: ForeignPtr TensorList
   -> ForeignPtr Scalar
   -> IO (ForeignPtr TensorList)
-_foreach_norm_ls = cast2 Unmanaged._foreach_norm_ls
+_foreach_norm_ls = _cast2 Unmanaged._foreach_norm_ls
 
 _foreach_norm_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr TensorList)
-_foreach_norm_l = cast1 Unmanaged._foreach_norm_l
+_foreach_norm_l = _cast1 Unmanaged._foreach_norm_l
 
 bucketize_ttbb
   :: ForeignPtr Tensor
@@ -172,20 +172,20 @@ bucketize_ttbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-bucketize_ttbb = cast4 Unmanaged.bucketize_ttbb
+bucketize_ttbb = _cast4 Unmanaged.bucketize_ttbb
 
 bucketize_ttb
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-bucketize_ttb = cast3 Unmanaged.bucketize_ttb
+bucketize_ttb = _cast3 Unmanaged.bucketize_ttb
 
 bucketize_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-bucketize_tt = cast2 Unmanaged.bucketize_tt
+bucketize_tt = _cast2 Unmanaged.bucketize_tt
 
 bucketize_out_tttbb
   :: ForeignPtr Tensor
@@ -194,7 +194,7 @@ bucketize_out_tttbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-bucketize_out_tttbb = cast5 Unmanaged.bucketize_out_tttbb
+bucketize_out_tttbb = _cast5 Unmanaged.bucketize_out_tttbb
 
 bucketize_out_tttb
   :: ForeignPtr Tensor
@@ -202,14 +202,14 @@ bucketize_out_tttb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-bucketize_out_tttb = cast4 Unmanaged.bucketize_out_tttb
+bucketize_out_tttb = _cast4 Unmanaged.bucketize_out_tttb
 
 bucketize_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-bucketize_out_ttt = cast3 Unmanaged.bucketize_out_ttt
+bucketize_out_ttt = _cast3 Unmanaged.bucketize_out_ttt
 
 bucketize_stbb
   :: ForeignPtr Scalar
@@ -217,20 +217,20 @@ bucketize_stbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-bucketize_stbb = cast4 Unmanaged.bucketize_stbb
+bucketize_stbb = _cast4 Unmanaged.bucketize_stbb
 
 bucketize_stb
   :: ForeignPtr Scalar
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-bucketize_stb = cast3 Unmanaged.bucketize_stb
+bucketize_stb = _cast3 Unmanaged.bucketize_stb
 
 bucketize_st
   :: ForeignPtr Scalar
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-bucketize_st = cast2 Unmanaged.bucketize_st
+bucketize_st = _cast2 Unmanaged.bucketize_st
 
 searchsorted_ttbbst
   :: ForeignPtr Tensor
@@ -240,7 +240,7 @@ searchsorted_ttbbst
   -> ForeignPtr StdString
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-searchsorted_ttbbst = cast6 Unmanaged.searchsorted_ttbbst
+searchsorted_ttbbst = _cast6 Unmanaged.searchsorted_ttbbst
 
 searchsorted_ttbbs
   :: ForeignPtr Tensor
@@ -249,7 +249,7 @@ searchsorted_ttbbs
   -> CBool
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-searchsorted_ttbbs = cast5 Unmanaged.searchsorted_ttbbs
+searchsorted_ttbbs = _cast5 Unmanaged.searchsorted_ttbbs
 
 searchsorted_ttbb
   :: ForeignPtr Tensor
@@ -257,25 +257,25 @@ searchsorted_ttbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-searchsorted_ttbb = cast4 Unmanaged.searchsorted_ttbb
+searchsorted_ttbb = _cast4 Unmanaged.searchsorted_ttbb
 
 searchsorted_ttb
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-searchsorted_ttb = cast3 Unmanaged.searchsorted_ttb
+searchsorted_ttb = _cast3 Unmanaged.searchsorted_ttb
 
 searchsorted_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-searchsorted_tt = cast2 Unmanaged.searchsorted_tt
+searchsorted_tt = _cast2 Unmanaged.searchsorted_tt
 
 _torch_cuda_cu_linker_symbol_op_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_torch_cuda_cu_linker_symbol_op_t = cast1 Unmanaged._torch_cuda_cu_linker_symbol_op_t
+_torch_cuda_cu_linker_symbol_op_t = _cast1 Unmanaged._torch_cuda_cu_linker_symbol_op_t
 
 searchsorted_out_tttbbst
   :: ForeignPtr Tensor
@@ -286,7 +286,7 @@ searchsorted_out_tttbbst
   -> ForeignPtr StdString
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-searchsorted_out_tttbbst = cast7 Unmanaged.searchsorted_out_tttbbst
+searchsorted_out_tttbbst = _cast7 Unmanaged.searchsorted_out_tttbbst
 
 searchsorted_out_tttbbs
   :: ForeignPtr Tensor
@@ -296,7 +296,7 @@ searchsorted_out_tttbbs
   -> CBool
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-searchsorted_out_tttbbs = cast6 Unmanaged.searchsorted_out_tttbbs
+searchsorted_out_tttbbs = _cast6 Unmanaged.searchsorted_out_tttbbs
 
 searchsorted_out_tttbb
   :: ForeignPtr Tensor
@@ -305,7 +305,7 @@ searchsorted_out_tttbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-searchsorted_out_tttbb = cast5 Unmanaged.searchsorted_out_tttbb
+searchsorted_out_tttbb = _cast5 Unmanaged.searchsorted_out_tttbb
 
 searchsorted_out_tttb
   :: ForeignPtr Tensor
@@ -313,14 +313,14 @@ searchsorted_out_tttb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-searchsorted_out_tttb = cast4 Unmanaged.searchsorted_out_tttb
+searchsorted_out_tttb = _cast4 Unmanaged.searchsorted_out_tttb
 
 searchsorted_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-searchsorted_out_ttt = cast3 Unmanaged.searchsorted_out_ttt
+searchsorted_out_ttt = _cast3 Unmanaged.searchsorted_out_ttt
 
 searchsorted_tsbbst
   :: ForeignPtr Tensor
@@ -330,7 +330,7 @@ searchsorted_tsbbst
   -> ForeignPtr StdString
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-searchsorted_tsbbst = cast6 Unmanaged.searchsorted_tsbbst
+searchsorted_tsbbst = _cast6 Unmanaged.searchsorted_tsbbst
 
 searchsorted_tsbbs
   :: ForeignPtr Tensor
@@ -339,7 +339,7 @@ searchsorted_tsbbs
   -> CBool
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-searchsorted_tsbbs = cast5 Unmanaged.searchsorted_tsbbs
+searchsorted_tsbbs = _cast5 Unmanaged.searchsorted_tsbbs
 
 searchsorted_tsbb
   :: ForeignPtr Tensor
@@ -347,33 +347,33 @@ searchsorted_tsbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-searchsorted_tsbb = cast4 Unmanaged.searchsorted_tsbb
+searchsorted_tsbb = _cast4 Unmanaged.searchsorted_tsbb
 
 searchsorted_tsb
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> CBool
   -> IO (ForeignPtr Tensor)
-searchsorted_tsb = cast3 Unmanaged.searchsorted_tsb
+searchsorted_tsb = _cast3 Unmanaged.searchsorted_tsb
 
 searchsorted_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-searchsorted_ts = cast2 Unmanaged.searchsorted_ts
+searchsorted_ts = _cast2 Unmanaged.searchsorted_ts
 
 _convert_indices_from_coo_to_csr_tlb
   :: ForeignPtr Tensor
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-_convert_indices_from_coo_to_csr_tlb = cast3 Unmanaged._convert_indices_from_coo_to_csr_tlb
+_convert_indices_from_coo_to_csr_tlb = _cast3 Unmanaged._convert_indices_from_coo_to_csr_tlb
 
 _convert_indices_from_coo_to_csr_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-_convert_indices_from_coo_to_csr_tl = cast2 Unmanaged._convert_indices_from_coo_to_csr_tl
+_convert_indices_from_coo_to_csr_tl = _cast2 Unmanaged._convert_indices_from_coo_to_csr_tl
 
 _convert_indices_from_coo_to_csr_out_ttlb
   :: ForeignPtr Tensor
@@ -381,14 +381,14 @@ _convert_indices_from_coo_to_csr_out_ttlb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-_convert_indices_from_coo_to_csr_out_ttlb = cast4 Unmanaged._convert_indices_from_coo_to_csr_out_ttlb
+_convert_indices_from_coo_to_csr_out_ttlb = _cast4 Unmanaged._convert_indices_from_coo_to_csr_out_ttlb
 
 _convert_indices_from_coo_to_csr_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-_convert_indices_from_coo_to_csr_out_ttl = cast3 Unmanaged._convert_indices_from_coo_to_csr_out_ttl
+_convert_indices_from_coo_to_csr_out_ttl = _cast3 Unmanaged._convert_indices_from_coo_to_csr_out_ttl
 
 _convert_indices_from_csr_to_coo_ttbb
   :: ForeignPtr Tensor
@@ -396,20 +396,20 @@ _convert_indices_from_csr_to_coo_ttbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-_convert_indices_from_csr_to_coo_ttbb = cast4 Unmanaged._convert_indices_from_csr_to_coo_ttbb
+_convert_indices_from_csr_to_coo_ttbb = _cast4 Unmanaged._convert_indices_from_csr_to_coo_ttbb
 
 _convert_indices_from_csr_to_coo_ttb
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-_convert_indices_from_csr_to_coo_ttb = cast3 Unmanaged._convert_indices_from_csr_to_coo_ttb
+_convert_indices_from_csr_to_coo_ttb = _cast3 Unmanaged._convert_indices_from_csr_to_coo_ttb
 
 _convert_indices_from_csr_to_coo_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_convert_indices_from_csr_to_coo_tt = cast2 Unmanaged._convert_indices_from_csr_to_coo_tt
+_convert_indices_from_csr_to_coo_tt = _cast2 Unmanaged._convert_indices_from_csr_to_coo_tt
 
 _convert_indices_from_csr_to_coo_out_tttbb
   :: ForeignPtr Tensor
@@ -418,7 +418,7 @@ _convert_indices_from_csr_to_coo_out_tttbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-_convert_indices_from_csr_to_coo_out_tttbb = cast5 Unmanaged._convert_indices_from_csr_to_coo_out_tttbb
+_convert_indices_from_csr_to_coo_out_tttbb = _cast5 Unmanaged._convert_indices_from_csr_to_coo_out_tttbb
 
 _convert_indices_from_csr_to_coo_out_tttb
   :: ForeignPtr Tensor
@@ -426,14 +426,14 @@ _convert_indices_from_csr_to_coo_out_tttb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-_convert_indices_from_csr_to_coo_out_tttb = cast4 Unmanaged._convert_indices_from_csr_to_coo_out_tttb
+_convert_indices_from_csr_to_coo_out_tttb = _cast4 Unmanaged._convert_indices_from_csr_to_coo_out_tttb
 
 _convert_indices_from_csr_to_coo_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_convert_indices_from_csr_to_coo_out_ttt = cast3 Unmanaged._convert_indices_from_csr_to_coo_out_ttt
+_convert_indices_from_csr_to_coo_out_ttt = _cast3 Unmanaged._convert_indices_from_csr_to_coo_out_ttt
 
 mse_loss_out_tttl
   :: ForeignPtr Tensor
@@ -441,27 +441,27 @@ mse_loss_out_tttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-mse_loss_out_tttl = cast4 Unmanaged.mse_loss_out_tttl
+mse_loss_out_tttl = _cast4 Unmanaged.mse_loss_out_tttl
 
 mse_loss_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-mse_loss_out_ttt = cast3 Unmanaged.mse_loss_out_ttt
+mse_loss_out_ttt = _cast3 Unmanaged.mse_loss_out_ttt
 
 mse_loss_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-mse_loss_ttl = cast3 Unmanaged.mse_loss_ttl
+mse_loss_ttl = _cast3 Unmanaged.mse_loss_ttl
 
 mse_loss_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-mse_loss_tt = cast2 Unmanaged.mse_loss_tt
+mse_loss_tt = _cast2 Unmanaged.mse_loss_tt
 
 mse_loss_backward_out_ttttl
   :: ForeignPtr Tensor
@@ -470,7 +470,7 @@ mse_loss_backward_out_ttttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-mse_loss_backward_out_ttttl = cast5 Unmanaged.mse_loss_backward_out_ttttl
+mse_loss_backward_out_ttttl = _cast5 Unmanaged.mse_loss_backward_out_ttttl
 
 mse_loss_backward_tttl
   :: ForeignPtr Tensor
@@ -478,7 +478,7 @@ mse_loss_backward_tttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-mse_loss_backward_tttl = cast4 Unmanaged.mse_loss_backward_tttl
+mse_loss_backward_tttl = _cast4 Unmanaged.mse_loss_backward_tttl
 
 l1_loss_out_tttl
   :: ForeignPtr Tensor
@@ -486,27 +486,27 @@ l1_loss_out_tttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-l1_loss_out_tttl = cast4 Unmanaged.l1_loss_out_tttl
+l1_loss_out_tttl = _cast4 Unmanaged.l1_loss_out_tttl
 
 l1_loss_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-l1_loss_out_ttt = cast3 Unmanaged.l1_loss_out_ttt
+l1_loss_out_ttt = _cast3 Unmanaged.l1_loss_out_ttt
 
 l1_loss_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-l1_loss_ttl = cast3 Unmanaged.l1_loss_ttl
+l1_loss_ttl = _cast3 Unmanaged.l1_loss_ttl
 
 l1_loss_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-l1_loss_tt = cast2 Unmanaged.l1_loss_tt
+l1_loss_tt = _cast2 Unmanaged.l1_loss_tt
 
 l1_loss_backward_out_ttttl
   :: ForeignPtr Tensor
@@ -515,7 +515,7 @@ l1_loss_backward_out_ttttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-l1_loss_backward_out_ttttl = cast5 Unmanaged.l1_loss_backward_out_ttttl
+l1_loss_backward_out_ttttl = _cast5 Unmanaged.l1_loss_backward_out_ttttl
 
 l1_loss_backward_tttl
   :: ForeignPtr Tensor
@@ -523,7 +523,7 @@ l1_loss_backward_tttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-l1_loss_backward_tttl = cast4 Unmanaged.l1_loss_backward_tttl
+l1_loss_backward_tttl = _cast4 Unmanaged.l1_loss_backward_tttl
 
 multi_margin_loss_out_tttsstl
   :: ForeignPtr Tensor
@@ -534,7 +534,7 @@ multi_margin_loss_out_tttsstl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-multi_margin_loss_out_tttsstl = cast7 Unmanaged.multi_margin_loss_out_tttsstl
+multi_margin_loss_out_tttsstl = _cast7 Unmanaged.multi_margin_loss_out_tttsstl
 
 multi_margin_loss_out_tttsst
   :: ForeignPtr Tensor
@@ -544,7 +544,7 @@ multi_margin_loss_out_tttsst
   -> ForeignPtr Scalar
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-multi_margin_loss_out_tttsst = cast6 Unmanaged.multi_margin_loss_out_tttsst
+multi_margin_loss_out_tttsst = _cast6 Unmanaged.multi_margin_loss_out_tttsst
 
 multi_margin_loss_out_tttss
   :: ForeignPtr Tensor
@@ -553,7 +553,7 @@ multi_margin_loss_out_tttss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-multi_margin_loss_out_tttss = cast5 Unmanaged.multi_margin_loss_out_tttss
+multi_margin_loss_out_tttss = _cast5 Unmanaged.multi_margin_loss_out_tttss
 
 multi_margin_loss_out_ttts
   :: ForeignPtr Tensor
@@ -561,14 +561,14 @@ multi_margin_loss_out_ttts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-multi_margin_loss_out_ttts = cast4 Unmanaged.multi_margin_loss_out_ttts
+multi_margin_loss_out_ttts = _cast4 Unmanaged.multi_margin_loss_out_ttts
 
 multi_margin_loss_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-multi_margin_loss_out_ttt = cast3 Unmanaged.multi_margin_loss_out_ttt
+multi_margin_loss_out_ttt = _cast3 Unmanaged.multi_margin_loss_out_ttt
 
 multi_margin_loss_ttsstl
   :: ForeignPtr Tensor
@@ -578,7 +578,7 @@ multi_margin_loss_ttsstl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-multi_margin_loss_ttsstl = cast6 Unmanaged.multi_margin_loss_ttsstl
+multi_margin_loss_ttsstl = _cast6 Unmanaged.multi_margin_loss_ttsstl
 
 multi_margin_loss_ttsst
   :: ForeignPtr Tensor
@@ -587,7 +587,7 @@ multi_margin_loss_ttsst
   -> ForeignPtr Scalar
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-multi_margin_loss_ttsst = cast5 Unmanaged.multi_margin_loss_ttsst
+multi_margin_loss_ttsst = _cast5 Unmanaged.multi_margin_loss_ttsst
 
 multi_margin_loss_ttss
   :: ForeignPtr Tensor
@@ -595,20 +595,20 @@ multi_margin_loss_ttss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-multi_margin_loss_ttss = cast4 Unmanaged.multi_margin_loss_ttss
+multi_margin_loss_ttss = _cast4 Unmanaged.multi_margin_loss_ttss
 
 multi_margin_loss_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-multi_margin_loss_tts = cast3 Unmanaged.multi_margin_loss_tts
+multi_margin_loss_tts = _cast3 Unmanaged.multi_margin_loss_tts
 
 multi_margin_loss_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-multi_margin_loss_tt = cast2 Unmanaged.multi_margin_loss_tt
+multi_margin_loss_tt = _cast2 Unmanaged.multi_margin_loss_tt
 
 multi_margin_loss_backward_out_ttttsstl
   :: ForeignPtr Tensor
@@ -620,7 +620,7 @@ multi_margin_loss_backward_out_ttttsstl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-multi_margin_loss_backward_out_ttttsstl = cast8 Unmanaged.multi_margin_loss_backward_out_ttttsstl
+multi_margin_loss_backward_out_ttttsstl = _cast8 Unmanaged.multi_margin_loss_backward_out_ttttsstl
 
 multi_margin_loss_backward_out_ttttsst
   :: ForeignPtr Tensor
@@ -631,7 +631,7 @@ multi_margin_loss_backward_out_ttttsst
   -> ForeignPtr Scalar
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-multi_margin_loss_backward_out_ttttsst = cast7 Unmanaged.multi_margin_loss_backward_out_ttttsst
+multi_margin_loss_backward_out_ttttsst = _cast7 Unmanaged.multi_margin_loss_backward_out_ttttsst
 
 multi_margin_loss_backward_out_ttttss
   :: ForeignPtr Tensor
@@ -641,7 +641,7 @@ multi_margin_loss_backward_out_ttttss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-multi_margin_loss_backward_out_ttttss = cast6 Unmanaged.multi_margin_loss_backward_out_ttttss
+multi_margin_loss_backward_out_ttttss = _cast6 Unmanaged.multi_margin_loss_backward_out_ttttss
 
 multi_margin_loss_backward_tttsstl
   :: ForeignPtr Tensor
@@ -652,7 +652,7 @@ multi_margin_loss_backward_tttsstl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-multi_margin_loss_backward_tttsstl = cast7 Unmanaged.multi_margin_loss_backward_tttsstl
+multi_margin_loss_backward_tttsstl = _cast7 Unmanaged.multi_margin_loss_backward_tttsstl
 
 multi_margin_loss_backward_tttsst
   :: ForeignPtr Tensor
@@ -662,7 +662,7 @@ multi_margin_loss_backward_tttsst
   -> ForeignPtr Scalar
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-multi_margin_loss_backward_tttsst = cast6 Unmanaged.multi_margin_loss_backward_tttsst
+multi_margin_loss_backward_tttsst = _cast6 Unmanaged.multi_margin_loss_backward_tttsst
 
 multi_margin_loss_backward_tttss
   :: ForeignPtr Tensor
@@ -671,7 +671,7 @@ multi_margin_loss_backward_tttss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-multi_margin_loss_backward_tttss = cast5 Unmanaged.multi_margin_loss_backward_tttss
+multi_margin_loss_backward_tttss = _cast5 Unmanaged.multi_margin_loss_backward_tttss
 
 multilabel_margin_loss_out_tttl
   :: ForeignPtr Tensor
@@ -679,27 +679,27 @@ multilabel_margin_loss_out_tttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-multilabel_margin_loss_out_tttl = cast4 Unmanaged.multilabel_margin_loss_out_tttl
+multilabel_margin_loss_out_tttl = _cast4 Unmanaged.multilabel_margin_loss_out_tttl
 
 multilabel_margin_loss_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-multilabel_margin_loss_out_ttt = cast3 Unmanaged.multilabel_margin_loss_out_ttt
+multilabel_margin_loss_out_ttt = _cast3 Unmanaged.multilabel_margin_loss_out_ttt
 
 multilabel_margin_loss_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-multilabel_margin_loss_ttl = cast3 Unmanaged.multilabel_margin_loss_ttl
+multilabel_margin_loss_ttl = _cast3 Unmanaged.multilabel_margin_loss_ttl
 
 multilabel_margin_loss_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-multilabel_margin_loss_tt = cast2 Unmanaged.multilabel_margin_loss_tt
+multilabel_margin_loss_tt = _cast2 Unmanaged.multilabel_margin_loss_tt
 
 multilabel_margin_loss_forward_out_ttttl
   :: ForeignPtr Tensor
@@ -708,14 +708,14 @@ multilabel_margin_loss_forward_out_ttttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-multilabel_margin_loss_forward_out_ttttl = cast5 Unmanaged.multilabel_margin_loss_forward_out_ttttl
+multilabel_margin_loss_forward_out_ttttl = _cast5 Unmanaged.multilabel_margin_loss_forward_out_ttttl
 
 multilabel_margin_loss_forward_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-multilabel_margin_loss_forward_ttl = cast3 Unmanaged.multilabel_margin_loss_forward_ttl
+multilabel_margin_loss_forward_ttl = _cast3 Unmanaged.multilabel_margin_loss_forward_ttl
 
 multilabel_margin_loss_backward_out_ttttlt
   :: ForeignPtr Tensor
@@ -725,7 +725,7 @@ multilabel_margin_loss_backward_out_ttttlt
   -> Int64
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-multilabel_margin_loss_backward_out_ttttlt = cast6 Unmanaged.multilabel_margin_loss_backward_out_ttttlt
+multilabel_margin_loss_backward_out_ttttlt = _cast6 Unmanaged.multilabel_margin_loss_backward_out_ttttlt
 
 multilabel_margin_loss_backward_tttlt
   :: ForeignPtr Tensor
@@ -734,7 +734,7 @@ multilabel_margin_loss_backward_tttlt
   -> Int64
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-multilabel_margin_loss_backward_tttlt = cast5 Unmanaged.multilabel_margin_loss_backward_tttlt
+multilabel_margin_loss_backward_tttlt = _cast5 Unmanaged.multilabel_margin_loss_backward_tttlt
 
 nll_loss_out_ttttll
   :: ForeignPtr Tensor
@@ -744,7 +744,7 @@ nll_loss_out_ttttll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-nll_loss_out_ttttll = cast6 Unmanaged.nll_loss_out_ttttll
+nll_loss_out_ttttll = _cast6 Unmanaged.nll_loss_out_ttttll
 
 nll_loss_out_ttttl
   :: ForeignPtr Tensor
@@ -753,7 +753,7 @@ nll_loss_out_ttttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-nll_loss_out_ttttl = cast5 Unmanaged.nll_loss_out_ttttl
+nll_loss_out_ttttl = _cast5 Unmanaged.nll_loss_out_ttttl
 
 nll_loss_out_tttt
   :: ForeignPtr Tensor
@@ -761,14 +761,14 @@ nll_loss_out_tttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-nll_loss_out_tttt = cast4 Unmanaged.nll_loss_out_tttt
+nll_loss_out_tttt = _cast4 Unmanaged.nll_loss_out_tttt
 
 nll_loss_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-nll_loss_out_ttt = cast3 Unmanaged.nll_loss_out_ttt
+nll_loss_out_ttt = _cast3 Unmanaged.nll_loss_out_ttt
 
 nll_loss_nd_tttll
   :: ForeignPtr Tensor
@@ -777,7 +777,7 @@ nll_loss_nd_tttll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-nll_loss_nd_tttll = cast5 Unmanaged.nll_loss_nd_tttll
+nll_loss_nd_tttll = _cast5 Unmanaged.nll_loss_nd_tttll
 
 nll_loss_nd_tttl
   :: ForeignPtr Tensor
@@ -785,20 +785,20 @@ nll_loss_nd_tttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-nll_loss_nd_tttl = cast4 Unmanaged.nll_loss_nd_tttl
+nll_loss_nd_tttl = _cast4 Unmanaged.nll_loss_nd_tttl
 
 nll_loss_nd_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-nll_loss_nd_ttt = cast3 Unmanaged.nll_loss_nd_ttt
+nll_loss_nd_ttt = _cast3 Unmanaged.nll_loss_nd_ttt
 
 nll_loss_nd_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-nll_loss_nd_tt = cast2 Unmanaged.nll_loss_nd_tt
+nll_loss_nd_tt = _cast2 Unmanaged.nll_loss_nd_tt
 
 nll_loss_tttll
   :: ForeignPtr Tensor
@@ -807,7 +807,7 @@ nll_loss_tttll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-nll_loss_tttll = cast5 Unmanaged.nll_loss_tttll
+nll_loss_tttll = _cast5 Unmanaged.nll_loss_tttll
 
 nll_loss_tttl
   :: ForeignPtr Tensor
@@ -815,20 +815,20 @@ nll_loss_tttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-nll_loss_tttl = cast4 Unmanaged.nll_loss_tttl
+nll_loss_tttl = _cast4 Unmanaged.nll_loss_tttl
 
 nll_loss_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-nll_loss_ttt = cast3 Unmanaged.nll_loss_ttt
+nll_loss_ttt = _cast3 Unmanaged.nll_loss_ttt
 
 nll_loss_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-nll_loss_tt = cast2 Unmanaged.nll_loss_tt
+nll_loss_tt = _cast2 Unmanaged.nll_loss_tt
 
 nll_loss_forward_out_tttttll
   :: ForeignPtr Tensor
@@ -839,7 +839,7 @@ nll_loss_forward_out_tttttll
   -> Int64
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-nll_loss_forward_out_tttttll = cast7 Unmanaged.nll_loss_forward_out_tttttll
+nll_loss_forward_out_tttttll = _cast7 Unmanaged.nll_loss_forward_out_tttttll
 
 nll_loss_forward_tttll
   :: ForeignPtr Tensor
@@ -848,7 +848,7 @@ nll_loss_forward_tttll
   -> Int64
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-nll_loss_forward_tttll = cast5 Unmanaged.nll_loss_forward_tttll
+nll_loss_forward_tttll = _cast5 Unmanaged.nll_loss_forward_tttll
 
 nll_loss_backward_out_tttttllt
   :: ForeignPtr Tensor
@@ -860,7 +860,7 @@ nll_loss_backward_out_tttttllt
   -> Int64
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-nll_loss_backward_out_tttttllt = cast8 Unmanaged.nll_loss_backward_out_tttttllt
+nll_loss_backward_out_tttttllt = _cast8 Unmanaged.nll_loss_backward_out_tttttllt
 
 nll_loss_backward_ttttllt
   :: ForeignPtr Tensor
@@ -871,7 +871,7 @@ nll_loss_backward_ttttllt
   -> Int64
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-nll_loss_backward_ttttllt = cast7 Unmanaged.nll_loss_backward_ttttllt
+nll_loss_backward_ttttllt = _cast7 Unmanaged.nll_loss_backward_ttttllt
 
 nll_loss2d_out_ttttll
   :: ForeignPtr Tensor
@@ -881,7 +881,7 @@ nll_loss2d_out_ttttll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-nll_loss2d_out_ttttll = cast6 Unmanaged.nll_loss2d_out_ttttll
+nll_loss2d_out_ttttll = _cast6 Unmanaged.nll_loss2d_out_ttttll
 
 nll_loss2d_out_ttttl
   :: ForeignPtr Tensor
@@ -890,7 +890,7 @@ nll_loss2d_out_ttttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-nll_loss2d_out_ttttl = cast5 Unmanaged.nll_loss2d_out_ttttl
+nll_loss2d_out_ttttl = _cast5 Unmanaged.nll_loss2d_out_ttttl
 
 nll_loss2d_out_tttt
   :: ForeignPtr Tensor
@@ -898,14 +898,14 @@ nll_loss2d_out_tttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-nll_loss2d_out_tttt = cast4 Unmanaged.nll_loss2d_out_tttt
+nll_loss2d_out_tttt = _cast4 Unmanaged.nll_loss2d_out_tttt
 
 nll_loss2d_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-nll_loss2d_out_ttt = cast3 Unmanaged.nll_loss2d_out_ttt
+nll_loss2d_out_ttt = _cast3 Unmanaged.nll_loss2d_out_ttt
 
 nll_loss2d_tttll
   :: ForeignPtr Tensor
@@ -914,7 +914,7 @@ nll_loss2d_tttll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-nll_loss2d_tttll = cast5 Unmanaged.nll_loss2d_tttll
+nll_loss2d_tttll = _cast5 Unmanaged.nll_loss2d_tttll
 
 nll_loss2d_tttl
   :: ForeignPtr Tensor
@@ -922,20 +922,20 @@ nll_loss2d_tttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-nll_loss2d_tttl = cast4 Unmanaged.nll_loss2d_tttl
+nll_loss2d_tttl = _cast4 Unmanaged.nll_loss2d_tttl
 
 nll_loss2d_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-nll_loss2d_ttt = cast3 Unmanaged.nll_loss2d_ttt
+nll_loss2d_ttt = _cast3 Unmanaged.nll_loss2d_ttt
 
 nll_loss2d_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-nll_loss2d_tt = cast2 Unmanaged.nll_loss2d_tt
+nll_loss2d_tt = _cast2 Unmanaged.nll_loss2d_tt
 
 nll_loss2d_forward_out_tttttll
   :: ForeignPtr Tensor
@@ -946,7 +946,7 @@ nll_loss2d_forward_out_tttttll
   -> Int64
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-nll_loss2d_forward_out_tttttll = cast7 Unmanaged.nll_loss2d_forward_out_tttttll
+nll_loss2d_forward_out_tttttll = _cast7 Unmanaged.nll_loss2d_forward_out_tttttll
 
 nll_loss2d_forward_tttll
   :: ForeignPtr Tensor
@@ -955,7 +955,7 @@ nll_loss2d_forward_tttll
   -> Int64
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-nll_loss2d_forward_tttll = cast5 Unmanaged.nll_loss2d_forward_tttll
+nll_loss2d_forward_tttll = _cast5 Unmanaged.nll_loss2d_forward_tttll
 
 nll_loss2d_backward_out_tttttllt
   :: ForeignPtr Tensor
@@ -967,7 +967,7 @@ nll_loss2d_backward_out_tttttllt
   -> Int64
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-nll_loss2d_backward_out_tttttllt = cast8 Unmanaged.nll_loss2d_backward_out_tttttllt
+nll_loss2d_backward_out_tttttllt = _cast8 Unmanaged.nll_loss2d_backward_out_tttttllt
 
 nll_loss2d_backward_ttttllt
   :: ForeignPtr Tensor
@@ -978,7 +978,7 @@ nll_loss2d_backward_ttttllt
   -> Int64
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-nll_loss2d_backward_ttttllt = cast7 Unmanaged.nll_loss2d_backward_ttttllt
+nll_loss2d_backward_ttttllt = _cast7 Unmanaged.nll_loss2d_backward_ttttllt
 
 smooth_l1_loss_out_tttld
   :: ForeignPtr Tensor
@@ -987,7 +987,7 @@ smooth_l1_loss_out_tttld
   -> Int64
   -> CDouble
   -> IO (ForeignPtr Tensor)
-smooth_l1_loss_out_tttld = cast5 Unmanaged.smooth_l1_loss_out_tttld
+smooth_l1_loss_out_tttld = _cast5 Unmanaged.smooth_l1_loss_out_tttld
 
 smooth_l1_loss_out_tttl
   :: ForeignPtr Tensor
@@ -995,14 +995,14 @@ smooth_l1_loss_out_tttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-smooth_l1_loss_out_tttl = cast4 Unmanaged.smooth_l1_loss_out_tttl
+smooth_l1_loss_out_tttl = _cast4 Unmanaged.smooth_l1_loss_out_tttl
 
 smooth_l1_loss_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-smooth_l1_loss_out_ttt = cast3 Unmanaged.smooth_l1_loss_out_ttt
+smooth_l1_loss_out_ttt = _cast3 Unmanaged.smooth_l1_loss_out_ttt
 
 smooth_l1_loss_ttld
   :: ForeignPtr Tensor
@@ -1010,20 +1010,20 @@ smooth_l1_loss_ttld
   -> Int64
   -> CDouble
   -> IO (ForeignPtr Tensor)
-smooth_l1_loss_ttld = cast4 Unmanaged.smooth_l1_loss_ttld
+smooth_l1_loss_ttld = _cast4 Unmanaged.smooth_l1_loss_ttld
 
 smooth_l1_loss_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-smooth_l1_loss_ttl = cast3 Unmanaged.smooth_l1_loss_ttl
+smooth_l1_loss_ttl = _cast3 Unmanaged.smooth_l1_loss_ttl
 
 smooth_l1_loss_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-smooth_l1_loss_tt = cast2 Unmanaged.smooth_l1_loss_tt
+smooth_l1_loss_tt = _cast2 Unmanaged.smooth_l1_loss_tt
 
 smooth_l1_loss_backward_out_ttttld
   :: ForeignPtr Tensor
@@ -1033,7 +1033,7 @@ smooth_l1_loss_backward_out_ttttld
   -> Int64
   -> CDouble
   -> IO (ForeignPtr Tensor)
-smooth_l1_loss_backward_out_ttttld = cast6 Unmanaged.smooth_l1_loss_backward_out_ttttld
+smooth_l1_loss_backward_out_ttttld = _cast6 Unmanaged.smooth_l1_loss_backward_out_ttttld
 
 smooth_l1_loss_backward_tttld
   :: ForeignPtr Tensor
@@ -1042,7 +1042,7 @@ smooth_l1_loss_backward_tttld
   -> Int64
   -> CDouble
   -> IO (ForeignPtr Tensor)
-smooth_l1_loss_backward_tttld = cast5 Unmanaged.smooth_l1_loss_backward_tttld
+smooth_l1_loss_backward_tttld = _cast5 Unmanaged.smooth_l1_loss_backward_tttld
 
 huber_loss_out_tttld
   :: ForeignPtr Tensor
@@ -1051,7 +1051,7 @@ huber_loss_out_tttld
   -> Int64
   -> CDouble
   -> IO (ForeignPtr Tensor)
-huber_loss_out_tttld = cast5 Unmanaged.huber_loss_out_tttld
+huber_loss_out_tttld = _cast5 Unmanaged.huber_loss_out_tttld
 
 huber_loss_out_tttl
   :: ForeignPtr Tensor
@@ -1059,14 +1059,14 @@ huber_loss_out_tttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-huber_loss_out_tttl = cast4 Unmanaged.huber_loss_out_tttl
+huber_loss_out_tttl = _cast4 Unmanaged.huber_loss_out_tttl
 
 huber_loss_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-huber_loss_out_ttt = cast3 Unmanaged.huber_loss_out_ttt
+huber_loss_out_ttt = _cast3 Unmanaged.huber_loss_out_ttt
 
 huber_loss_ttld
   :: ForeignPtr Tensor
@@ -1074,20 +1074,20 @@ huber_loss_ttld
   -> Int64
   -> CDouble
   -> IO (ForeignPtr Tensor)
-huber_loss_ttld = cast4 Unmanaged.huber_loss_ttld
+huber_loss_ttld = _cast4 Unmanaged.huber_loss_ttld
 
 huber_loss_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-huber_loss_ttl = cast3 Unmanaged.huber_loss_ttl
+huber_loss_ttl = _cast3 Unmanaged.huber_loss_ttl
 
 huber_loss_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-huber_loss_tt = cast2 Unmanaged.huber_loss_tt
+huber_loss_tt = _cast2 Unmanaged.huber_loss_tt
 
 huber_loss_backward_out_ttttld
   :: ForeignPtr Tensor
@@ -1097,7 +1097,7 @@ huber_loss_backward_out_ttttld
   -> Int64
   -> CDouble
   -> IO (ForeignPtr Tensor)
-huber_loss_backward_out_ttttld = cast6 Unmanaged.huber_loss_backward_out_ttttld
+huber_loss_backward_out_ttttld = _cast6 Unmanaged.huber_loss_backward_out_ttttld
 
 huber_loss_backward_tttld
   :: ForeignPtr Tensor
@@ -1106,7 +1106,7 @@ huber_loss_backward_tttld
   -> Int64
   -> CDouble
   -> IO (ForeignPtr Tensor)
-huber_loss_backward_tttld = cast5 Unmanaged.huber_loss_backward_tttld
+huber_loss_backward_tttld = _cast5 Unmanaged.huber_loss_backward_tttld
 
 soft_margin_loss_out_tttl
   :: ForeignPtr Tensor
@@ -1114,27 +1114,27 @@ soft_margin_loss_out_tttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-soft_margin_loss_out_tttl = cast4 Unmanaged.soft_margin_loss_out_tttl
+soft_margin_loss_out_tttl = _cast4 Unmanaged.soft_margin_loss_out_tttl
 
 soft_margin_loss_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-soft_margin_loss_out_ttt = cast3 Unmanaged.soft_margin_loss_out_ttt
+soft_margin_loss_out_ttt = _cast3 Unmanaged.soft_margin_loss_out_ttt
 
 soft_margin_loss_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-soft_margin_loss_ttl = cast3 Unmanaged.soft_margin_loss_ttl
+soft_margin_loss_ttl = _cast3 Unmanaged.soft_margin_loss_ttl
 
 soft_margin_loss_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-soft_margin_loss_tt = cast2 Unmanaged.soft_margin_loss_tt
+soft_margin_loss_tt = _cast2 Unmanaged.soft_margin_loss_tt
 
 soft_margin_loss_backward_out_ttttl
   :: ForeignPtr Tensor
@@ -1143,7 +1143,7 @@ soft_margin_loss_backward_out_ttttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-soft_margin_loss_backward_out_ttttl = cast5 Unmanaged.soft_margin_loss_backward_out_ttttl
+soft_margin_loss_backward_out_ttttl = _cast5 Unmanaged.soft_margin_loss_backward_out_ttttl
 
 soft_margin_loss_backward_tttl
   :: ForeignPtr Tensor
@@ -1151,7 +1151,7 @@ soft_margin_loss_backward_tttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-soft_margin_loss_backward_tttl = cast4 Unmanaged.soft_margin_loss_backward_tttl
+soft_margin_loss_backward_tttl = _cast4 Unmanaged.soft_margin_loss_backward_tttl
 
 elu_out_ttsss
   :: ForeignPtr Tensor
@@ -1160,7 +1160,7 @@ elu_out_ttsss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-elu_out_ttsss = cast5 Unmanaged.elu_out_ttsss
+elu_out_ttsss = _cast5 Unmanaged.elu_out_ttsss
 
 elu_out_ttss
   :: ForeignPtr Tensor
@@ -1168,20 +1168,20 @@ elu_out_ttss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-elu_out_ttss = cast4 Unmanaged.elu_out_ttss
+elu_out_ttss = _cast4 Unmanaged.elu_out_ttss
 
 elu_out_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-elu_out_tts = cast3 Unmanaged.elu_out_tts
+elu_out_tts = _cast3 Unmanaged.elu_out_tts
 
 elu_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-elu_out_tt = cast2 Unmanaged.elu_out_tt
+elu_out_tt = _cast2 Unmanaged.elu_out_tt
 
 elu_tsss
   :: ForeignPtr Tensor
@@ -1189,25 +1189,25 @@ elu_tsss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-elu_tsss = cast4 Unmanaged.elu_tsss
+elu_tsss = _cast4 Unmanaged.elu_tsss
 
 elu_tss
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-elu_tss = cast3 Unmanaged.elu_tss
+elu_tss = _cast3 Unmanaged.elu_tss
 
 elu_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-elu_ts = cast2 Unmanaged.elu_ts
+elu_ts = _cast2 Unmanaged.elu_ts
 
 elu_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-elu_t = cast1 Unmanaged.elu_t
+elu_t = _cast1 Unmanaged.elu_t
 
 elu_backward_out_ttsssbt
   :: ForeignPtr Tensor
@@ -1218,7 +1218,7 @@ elu_backward_out_ttsssbt
   -> CBool
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-elu_backward_out_ttsssbt = cast7 Unmanaged.elu_backward_out_ttsssbt
+elu_backward_out_ttsssbt = _cast7 Unmanaged.elu_backward_out_ttsssbt
 
 elu_backward_tsssbt
   :: ForeignPtr Tensor
@@ -1228,7 +1228,7 @@ elu_backward_tsssbt
   -> CBool
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-elu_backward_tsssbt = cast6 Unmanaged.elu_backward_tsssbt
+elu_backward_tsssbt = _cast6 Unmanaged.elu_backward_tsssbt
 
 elu__tsss
   :: ForeignPtr Tensor
@@ -1236,49 +1236,49 @@ elu__tsss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-elu__tsss = cast4 Unmanaged.elu__tsss
+elu__tsss = _cast4 Unmanaged.elu__tsss
 
 elu__tss
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-elu__tss = cast3 Unmanaged.elu__tss
+elu__tss = _cast3 Unmanaged.elu__tss
 
 elu__ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-elu__ts = cast2 Unmanaged.elu__ts
+elu__ts = _cast2 Unmanaged.elu__ts
 
 elu__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-elu__t = cast1 Unmanaged.elu__t
+elu__t = _cast1 Unmanaged.elu__t
 
 glu_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-glu_out_ttl = cast3 Unmanaged.glu_out_ttl
+glu_out_ttl = _cast3 Unmanaged.glu_out_ttl
 
 glu_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-glu_out_tt = cast2 Unmanaged.glu_out_tt
+glu_out_tt = _cast2 Unmanaged.glu_out_tt
 
 glu_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-glu_tl = cast2 Unmanaged.glu_tl
+glu_tl = _cast2 Unmanaged.glu_tl
 
 glu_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-glu_t = cast1 Unmanaged.glu_t
+glu_t = _cast1 Unmanaged.glu_t
 
 glu_backward_out_tttl
   :: ForeignPtr Tensor
@@ -1286,43 +1286,43 @@ glu_backward_out_tttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-glu_backward_out_tttl = cast4 Unmanaged.glu_backward_out_tttl
+glu_backward_out_tttl = _cast4 Unmanaged.glu_backward_out_tttl
 
 glu_backward_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-glu_backward_ttl = cast3 Unmanaged.glu_backward_ttl
+glu_backward_ttl = _cast3 Unmanaged.glu_backward_ttl
 
 hardsigmoid_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-hardsigmoid_out_tt = cast2 Unmanaged.hardsigmoid_out_tt
+hardsigmoid_out_tt = _cast2 Unmanaged.hardsigmoid_out_tt
 
 hardsigmoid_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-hardsigmoid_t = cast1 Unmanaged.hardsigmoid_t
+hardsigmoid_t = _cast1 Unmanaged.hardsigmoid_t
 
 hardsigmoid__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-hardsigmoid__t = cast1 Unmanaged.hardsigmoid__t
+hardsigmoid__t = _cast1 Unmanaged.hardsigmoid__t
 
 hardsigmoid_backward_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-hardsigmoid_backward_out_ttt = cast3 Unmanaged.hardsigmoid_backward_out_ttt
+hardsigmoid_backward_out_ttt = _cast3 Unmanaged.hardsigmoid_backward_out_ttt
 
 hardsigmoid_backward_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-hardsigmoid_backward_tt = cast2 Unmanaged.hardsigmoid_backward_tt
+hardsigmoid_backward_tt = _cast2 Unmanaged.hardsigmoid_backward_tt
 
 hardtanh_out_ttss
   :: ForeignPtr Tensor
@@ -1330,38 +1330,38 @@ hardtanh_out_ttss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-hardtanh_out_ttss = cast4 Unmanaged.hardtanh_out_ttss
+hardtanh_out_ttss = _cast4 Unmanaged.hardtanh_out_ttss
 
 hardtanh_out_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-hardtanh_out_tts = cast3 Unmanaged.hardtanh_out_tts
+hardtanh_out_tts = _cast3 Unmanaged.hardtanh_out_tts
 
 hardtanh_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-hardtanh_out_tt = cast2 Unmanaged.hardtanh_out_tt
+hardtanh_out_tt = _cast2 Unmanaged.hardtanh_out_tt
 
 hardtanh_tss
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-hardtanh_tss = cast3 Unmanaged.hardtanh_tss
+hardtanh_tss = _cast3 Unmanaged.hardtanh_tss
 
 hardtanh_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-hardtanh_ts = cast2 Unmanaged.hardtanh_ts
+hardtanh_ts = _cast2 Unmanaged.hardtanh_ts
 
 hardtanh_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-hardtanh_t = cast1 Unmanaged.hardtanh_t
+hardtanh_t = _cast1 Unmanaged.hardtanh_t
 
 hardtanh_backward_out_tttss
   :: ForeignPtr Tensor
@@ -1370,7 +1370,7 @@ hardtanh_backward_out_tttss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-hardtanh_backward_out_tttss = cast5 Unmanaged.hardtanh_backward_out_tttss
+hardtanh_backward_out_tttss = _cast5 Unmanaged.hardtanh_backward_out_tttss
 
 hardtanh_backward_ttss
   :: ForeignPtr Tensor
@@ -1378,71 +1378,71 @@ hardtanh_backward_ttss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-hardtanh_backward_ttss = cast4 Unmanaged.hardtanh_backward_ttss
+hardtanh_backward_ttss = _cast4 Unmanaged.hardtanh_backward_ttss
 
 hardtanh__tss
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-hardtanh__tss = cast3 Unmanaged.hardtanh__tss
+hardtanh__tss = _cast3 Unmanaged.hardtanh__tss
 
 hardtanh__ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-hardtanh__ts = cast2 Unmanaged.hardtanh__ts
+hardtanh__ts = _cast2 Unmanaged.hardtanh__ts
 
 hardtanh__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-hardtanh__t = cast1 Unmanaged.hardtanh__t
+hardtanh__t = _cast1 Unmanaged.hardtanh__t
 
 hardswish_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-hardswish_out_tt = cast2 Unmanaged.hardswish_out_tt
+hardswish_out_tt = _cast2 Unmanaged.hardswish_out_tt
 
 hardswish_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-hardswish_t = cast1 Unmanaged.hardswish_t
+hardswish_t = _cast1 Unmanaged.hardswish_t
 
 hardswish__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-hardswish__t = cast1 Unmanaged.hardswish__t
+hardswish__t = _cast1 Unmanaged.hardswish__t
 
 hardswish_backward_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-hardswish_backward_tt = cast2 Unmanaged.hardswish_backward_tt
+hardswish_backward_tt = _cast2 Unmanaged.hardswish_backward_tt
 
 leaky_relu_out_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-leaky_relu_out_tts = cast3 Unmanaged.leaky_relu_out_tts
+leaky_relu_out_tts = _cast3 Unmanaged.leaky_relu_out_tts
 
 leaky_relu_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-leaky_relu_out_tt = cast2 Unmanaged.leaky_relu_out_tt
+leaky_relu_out_tt = _cast2 Unmanaged.leaky_relu_out_tt
 
 leaky_relu_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-leaky_relu_ts = cast2 Unmanaged.leaky_relu_ts
+leaky_relu_ts = _cast2 Unmanaged.leaky_relu_ts
 
 leaky_relu_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-leaky_relu_t = cast1 Unmanaged.leaky_relu_t
+leaky_relu_t = _cast1 Unmanaged.leaky_relu_t
 
 leaky_relu_backward_out_tttsb
   :: ForeignPtr Tensor
@@ -1451,7 +1451,7 @@ leaky_relu_backward_out_tttsb
   -> ForeignPtr Scalar
   -> CBool
   -> IO (ForeignPtr Tensor)
-leaky_relu_backward_out_tttsb = cast5 Unmanaged.leaky_relu_backward_out_tttsb
+leaky_relu_backward_out_tttsb = _cast5 Unmanaged.leaky_relu_backward_out_tttsb
 
 leaky_relu_backward_ttsb
   :: ForeignPtr Tensor
@@ -1459,41 +1459,41 @@ leaky_relu_backward_ttsb
   -> ForeignPtr Scalar
   -> CBool
   -> IO (ForeignPtr Tensor)
-leaky_relu_backward_ttsb = cast4 Unmanaged.leaky_relu_backward_ttsb
+leaky_relu_backward_ttsb = _cast4 Unmanaged.leaky_relu_backward_ttsb
 
 leaky_relu__ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-leaky_relu__ts = cast2 Unmanaged.leaky_relu__ts
+leaky_relu__ts = _cast2 Unmanaged.leaky_relu__ts
 
 leaky_relu__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-leaky_relu__t = cast1 Unmanaged.leaky_relu__t
+leaky_relu__t = _cast1 Unmanaged.leaky_relu__t
 
 log_sigmoid_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-log_sigmoid_out_tt = cast2 Unmanaged.log_sigmoid_out_tt
+log_sigmoid_out_tt = _cast2 Unmanaged.log_sigmoid_out_tt
 
 log_sigmoid_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-log_sigmoid_t = cast1 Unmanaged.log_sigmoid_t
+log_sigmoid_t = _cast1 Unmanaged.log_sigmoid_t
 
 log_sigmoid_forward_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-log_sigmoid_forward_out_ttt = cast3 Unmanaged.log_sigmoid_forward_out_ttt
+log_sigmoid_forward_out_ttt = _cast3 Unmanaged.log_sigmoid_forward_out_ttt
 
 log_sigmoid_forward_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-log_sigmoid_forward_t = cast1 Unmanaged.log_sigmoid_forward_t
+log_sigmoid_forward_t = _cast1 Unmanaged.log_sigmoid_forward_t
 
 log_sigmoid_backward_out_tttt
   :: ForeignPtr Tensor
@@ -1501,14 +1501,14 @@ log_sigmoid_backward_out_tttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-log_sigmoid_backward_out_tttt = cast4 Unmanaged.log_sigmoid_backward_out_tttt
+log_sigmoid_backward_out_tttt = _cast4 Unmanaged.log_sigmoid_backward_out_tttt
 
 log_sigmoid_backward_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-log_sigmoid_backward_ttt = cast3 Unmanaged.log_sigmoid_backward_ttt
+log_sigmoid_backward_ttt = _cast3 Unmanaged.log_sigmoid_backward_ttt
 
 rrelu_with_noise_out_tttssbG
   :: ForeignPtr Tensor
@@ -1519,7 +1519,7 @@ rrelu_with_noise_out_tttssbG
   -> CBool
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-rrelu_with_noise_out_tttssbG = cast7 Unmanaged.rrelu_with_noise_out_tttssbG
+rrelu_with_noise_out_tttssbG = _cast7 Unmanaged.rrelu_with_noise_out_tttssbG
 
 rrelu_with_noise_out_tttssb
   :: ForeignPtr Tensor
@@ -1529,7 +1529,7 @@ rrelu_with_noise_out_tttssb
   -> ForeignPtr Scalar
   -> CBool
   -> IO (ForeignPtr Tensor)
-rrelu_with_noise_out_tttssb = cast6 Unmanaged.rrelu_with_noise_out_tttssb
+rrelu_with_noise_out_tttssb = _cast6 Unmanaged.rrelu_with_noise_out_tttssb
 
 rrelu_with_noise_out_tttss
   :: ForeignPtr Tensor
@@ -1538,7 +1538,7 @@ rrelu_with_noise_out_tttss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-rrelu_with_noise_out_tttss = cast5 Unmanaged.rrelu_with_noise_out_tttss
+rrelu_with_noise_out_tttss = _cast5 Unmanaged.rrelu_with_noise_out_tttss
 
 rrelu_with_noise_out_ttts
   :: ForeignPtr Tensor
@@ -1546,14 +1546,14 @@ rrelu_with_noise_out_ttts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-rrelu_with_noise_out_ttts = cast4 Unmanaged.rrelu_with_noise_out_ttts
+rrelu_with_noise_out_ttts = _cast4 Unmanaged.rrelu_with_noise_out_ttts
 
 rrelu_with_noise_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-rrelu_with_noise_out_ttt = cast3 Unmanaged.rrelu_with_noise_out_ttt
+rrelu_with_noise_out_ttt = _cast3 Unmanaged.rrelu_with_noise_out_ttt
 
 rrelu_with_noise_ttssbG
   :: ForeignPtr Tensor
@@ -1563,7 +1563,7 @@ rrelu_with_noise_ttssbG
   -> CBool
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-rrelu_with_noise_ttssbG = cast6 Unmanaged.rrelu_with_noise_ttssbG
+rrelu_with_noise_ttssbG = _cast6 Unmanaged.rrelu_with_noise_ttssbG
 
 rrelu_with_noise_ttssb
   :: ForeignPtr Tensor
@@ -1572,7 +1572,7 @@ rrelu_with_noise_ttssb
   -> ForeignPtr Scalar
   -> CBool
   -> IO (ForeignPtr Tensor)
-rrelu_with_noise_ttssb = cast5 Unmanaged.rrelu_with_noise_ttssb
+rrelu_with_noise_ttssb = _cast5 Unmanaged.rrelu_with_noise_ttssb
 
 rrelu_with_noise_ttss
   :: ForeignPtr Tensor
@@ -1580,20 +1580,20 @@ rrelu_with_noise_ttss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-rrelu_with_noise_ttss = cast4 Unmanaged.rrelu_with_noise_ttss
+rrelu_with_noise_ttss = _cast4 Unmanaged.rrelu_with_noise_ttss
 
 rrelu_with_noise_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-rrelu_with_noise_tts = cast3 Unmanaged.rrelu_with_noise_tts
+rrelu_with_noise_tts = _cast3 Unmanaged.rrelu_with_noise_tts
 
 rrelu_with_noise_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-rrelu_with_noise_tt = cast2 Unmanaged.rrelu_with_noise_tt
+rrelu_with_noise_tt = _cast2 Unmanaged.rrelu_with_noise_tt
 
 rrelu_with_noise_backward_tttssbb
   :: ForeignPtr Tensor
@@ -1604,7 +1604,7 @@ rrelu_with_noise_backward_tttssbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-rrelu_with_noise_backward_tttssbb = cast7 Unmanaged.rrelu_with_noise_backward_tttssbb
+rrelu_with_noise_backward_tttssbb = _cast7 Unmanaged.rrelu_with_noise_backward_tttssbb
 
 rrelu_with_noise__ttssbG
   :: ForeignPtr Tensor
@@ -1614,7 +1614,7 @@ rrelu_with_noise__ttssbG
   -> CBool
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-rrelu_with_noise__ttssbG = cast6 Unmanaged.rrelu_with_noise__ttssbG
+rrelu_with_noise__ttssbG = _cast6 Unmanaged.rrelu_with_noise__ttssbG
 
 rrelu_with_noise__ttssb
   :: ForeignPtr Tensor
@@ -1623,7 +1623,7 @@ rrelu_with_noise__ttssb
   -> ForeignPtr Scalar
   -> CBool
   -> IO (ForeignPtr Tensor)
-rrelu_with_noise__ttssb = cast5 Unmanaged.rrelu_with_noise__ttssb
+rrelu_with_noise__ttssb = _cast5 Unmanaged.rrelu_with_noise__ttssb
 
 rrelu_with_noise__ttss
   :: ForeignPtr Tensor
@@ -1631,20 +1631,20 @@ rrelu_with_noise__ttss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-rrelu_with_noise__ttss = cast4 Unmanaged.rrelu_with_noise__ttss
+rrelu_with_noise__ttss = _cast4 Unmanaged.rrelu_with_noise__ttss
 
 rrelu_with_noise__tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-rrelu_with_noise__tts = cast3 Unmanaged.rrelu_with_noise__tts
+rrelu_with_noise__tts = _cast3 Unmanaged.rrelu_with_noise__tts
 
 rrelu_with_noise__tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-rrelu_with_noise__tt = cast2 Unmanaged.rrelu_with_noise__tt
+rrelu_with_noise__tt = _cast2 Unmanaged.rrelu_with_noise__tt
 
 softplus_out_ttss
   :: ForeignPtr Tensor
@@ -1652,5 +1652,5 @@ softplus_out_ttss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-softplus_out_ttss = cast4 Unmanaged.softplus_out_ttss
+softplus_out_ttss = _cast4 Unmanaged.softplus_out_ttss
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Native/Native12.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Native/Native12.hs
@@ -26,31 +26,31 @@ softplus_out_tts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-softplus_out_tts = cast3 Unmanaged.softplus_out_tts
+softplus_out_tts = _cast3 Unmanaged.softplus_out_tts
 
 softplus_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-softplus_out_tt = cast2 Unmanaged.softplus_out_tt
+softplus_out_tt = _cast2 Unmanaged.softplus_out_tt
 
 softplus_tss
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-softplus_tss = cast3 Unmanaged.softplus_tss
+softplus_tss = _cast3 Unmanaged.softplus_tss
 
 softplus_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-softplus_ts = cast2 Unmanaged.softplus_ts
+softplus_ts = _cast2 Unmanaged.softplus_ts
 
 softplus_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-softplus_t = cast1 Unmanaged.softplus_t
+softplus_t = _cast1 Unmanaged.softplus_t
 
 softplus_backward_out_tttss
   :: ForeignPtr Tensor
@@ -59,7 +59,7 @@ softplus_backward_out_tttss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-softplus_backward_out_tttss = cast5 Unmanaged.softplus_backward_out_tttss
+softplus_backward_out_tttss = _cast5 Unmanaged.softplus_backward_out_tttss
 
 softplus_backward_ttss
   :: ForeignPtr Tensor
@@ -67,31 +67,31 @@ softplus_backward_ttss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-softplus_backward_ttss = cast4 Unmanaged.softplus_backward_ttss
+softplus_backward_ttss = _cast4 Unmanaged.softplus_backward_ttss
 
 softshrink_out_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-softshrink_out_tts = cast3 Unmanaged.softshrink_out_tts
+softshrink_out_tts = _cast3 Unmanaged.softshrink_out_tts
 
 softshrink_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-softshrink_out_tt = cast2 Unmanaged.softshrink_out_tt
+softshrink_out_tt = _cast2 Unmanaged.softshrink_out_tt
 
 softshrink_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-softshrink_ts = cast2 Unmanaged.softshrink_ts
+softshrink_ts = _cast2 Unmanaged.softshrink_ts
 
 softshrink_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-softshrink_t = cast1 Unmanaged.softshrink_t
+softshrink_t = _cast1 Unmanaged.softshrink_t
 
 softshrink_backward_out_ttts
   :: ForeignPtr Tensor
@@ -99,83 +99,83 @@ softshrink_backward_out_ttts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-softshrink_backward_out_ttts = cast4 Unmanaged.softshrink_backward_out_ttts
+softshrink_backward_out_ttts = _cast4 Unmanaged.softshrink_backward_out_ttts
 
 softshrink_backward_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-softshrink_backward_tts = cast3 Unmanaged.softshrink_backward_tts
+softshrink_backward_tts = _cast3 Unmanaged.softshrink_backward_tts
 
 adaptive_avg_pool2d_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-adaptive_avg_pool2d_out_ttl = cast3 Unmanaged.adaptive_avg_pool2d_out_ttl
+adaptive_avg_pool2d_out_ttl = _cast3 Unmanaged.adaptive_avg_pool2d_out_ttl
 
 adaptive_avg_pool2d_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-adaptive_avg_pool2d_tl = cast2 Unmanaged.adaptive_avg_pool2d_tl
+adaptive_avg_pool2d_tl = _cast2 Unmanaged.adaptive_avg_pool2d_tl
 
 mkldnn_adaptive_avg_pool2d_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-mkldnn_adaptive_avg_pool2d_tl = cast2 Unmanaged.mkldnn_adaptive_avg_pool2d_tl
+mkldnn_adaptive_avg_pool2d_tl = _cast2 Unmanaged.mkldnn_adaptive_avg_pool2d_tl
 
 mkldnn_adaptive_avg_pool2d_backward_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-mkldnn_adaptive_avg_pool2d_backward_tt = cast2 Unmanaged.mkldnn_adaptive_avg_pool2d_backward_tt
+mkldnn_adaptive_avg_pool2d_backward_tt = _cast2 Unmanaged.mkldnn_adaptive_avg_pool2d_backward_tt
 
 _adaptive_avg_pool2d_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-_adaptive_avg_pool2d_tl = cast2 Unmanaged._adaptive_avg_pool2d_tl
+_adaptive_avg_pool2d_tl = _cast2 Unmanaged._adaptive_avg_pool2d_tl
 
 _adaptive_avg_pool2d_backward_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_adaptive_avg_pool2d_backward_tt = cast2 Unmanaged._adaptive_avg_pool2d_backward_tt
+_adaptive_avg_pool2d_backward_tt = _cast2 Unmanaged._adaptive_avg_pool2d_backward_tt
 
 adaptive_avg_pool3d_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-adaptive_avg_pool3d_out_ttl = cast3 Unmanaged.adaptive_avg_pool3d_out_ttl
+adaptive_avg_pool3d_out_ttl = _cast3 Unmanaged.adaptive_avg_pool3d_out_ttl
 
 adaptive_avg_pool3d_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-adaptive_avg_pool3d_tl = cast2 Unmanaged.adaptive_avg_pool3d_tl
+adaptive_avg_pool3d_tl = _cast2 Unmanaged.adaptive_avg_pool3d_tl
 
 _adaptive_avg_pool3d_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-_adaptive_avg_pool3d_tl = cast2 Unmanaged._adaptive_avg_pool3d_tl
+_adaptive_avg_pool3d_tl = _cast2 Unmanaged._adaptive_avg_pool3d_tl
 
 adaptive_avg_pool3d_backward_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-adaptive_avg_pool3d_backward_out_ttt = cast3 Unmanaged.adaptive_avg_pool3d_backward_out_ttt
+adaptive_avg_pool3d_backward_out_ttt = _cast3 Unmanaged.adaptive_avg_pool3d_backward_out_ttt
 
 _adaptive_avg_pool3d_backward_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_adaptive_avg_pool3d_backward_tt = cast2 Unmanaged._adaptive_avg_pool3d_backward_tt
+_adaptive_avg_pool3d_backward_tt = _cast2 Unmanaged._adaptive_avg_pool3d_backward_tt
 
 adaptive_max_pool2d_out_tttl
   :: ForeignPtr Tensor
@@ -183,13 +183,13 @@ adaptive_max_pool2d_out_tttl
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-adaptive_max_pool2d_out_tttl = cast4 Unmanaged.adaptive_max_pool2d_out_tttl
+adaptive_max_pool2d_out_tttl = _cast4 Unmanaged.adaptive_max_pool2d_out_tttl
 
 adaptive_max_pool2d_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-adaptive_max_pool2d_tl = cast2 Unmanaged.adaptive_max_pool2d_tl
+adaptive_max_pool2d_tl = _cast2 Unmanaged.adaptive_max_pool2d_tl
 
 adaptive_max_pool2d_backward_out_tttt
   :: ForeignPtr Tensor
@@ -197,14 +197,14 @@ adaptive_max_pool2d_backward_out_tttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-adaptive_max_pool2d_backward_out_tttt = cast4 Unmanaged.adaptive_max_pool2d_backward_out_tttt
+adaptive_max_pool2d_backward_out_tttt = _cast4 Unmanaged.adaptive_max_pool2d_backward_out_tttt
 
 adaptive_max_pool2d_backward_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-adaptive_max_pool2d_backward_ttt = cast3 Unmanaged.adaptive_max_pool2d_backward_ttt
+adaptive_max_pool2d_backward_ttt = _cast3 Unmanaged.adaptive_max_pool2d_backward_ttt
 
 adaptive_max_pool3d_out_tttl
   :: ForeignPtr Tensor
@@ -212,13 +212,13 @@ adaptive_max_pool3d_out_tttl
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-adaptive_max_pool3d_out_tttl = cast4 Unmanaged.adaptive_max_pool3d_out_tttl
+adaptive_max_pool3d_out_tttl = _cast4 Unmanaged.adaptive_max_pool3d_out_tttl
 
 adaptive_max_pool3d_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-adaptive_max_pool3d_tl = cast2 Unmanaged.adaptive_max_pool3d_tl
+adaptive_max_pool3d_tl = _cast2 Unmanaged.adaptive_max_pool3d_tl
 
 adaptive_max_pool3d_backward_out_tttt
   :: ForeignPtr Tensor
@@ -226,14 +226,14 @@ adaptive_max_pool3d_backward_out_tttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-adaptive_max_pool3d_backward_out_tttt = cast4 Unmanaged.adaptive_max_pool3d_backward_out_tttt
+adaptive_max_pool3d_backward_out_tttt = _cast4 Unmanaged.adaptive_max_pool3d_backward_out_tttt
 
 adaptive_max_pool3d_backward_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-adaptive_max_pool3d_backward_ttt = cast3 Unmanaged.adaptive_max_pool3d_backward_ttt
+adaptive_max_pool3d_backward_ttt = _cast3 Unmanaged.adaptive_max_pool3d_backward_ttt
 
 avg_pool2d_out_ttlllbbl
   :: ForeignPtr Tensor
@@ -245,7 +245,7 @@ avg_pool2d_out_ttlllbbl
   -> CBool
   -> Int64
   -> IO (ForeignPtr Tensor)
-avg_pool2d_out_ttlllbbl = cast8 Unmanaged.avg_pool2d_out_ttlllbbl
+avg_pool2d_out_ttlllbbl = _cast8 Unmanaged.avg_pool2d_out_ttlllbbl
 
 avg_pool2d_out_ttlllbb
   :: ForeignPtr Tensor
@@ -256,7 +256,7 @@ avg_pool2d_out_ttlllbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-avg_pool2d_out_ttlllbb = cast7 Unmanaged.avg_pool2d_out_ttlllbb
+avg_pool2d_out_ttlllbb = _cast7 Unmanaged.avg_pool2d_out_ttlllbb
 
 avg_pool2d_out_ttlllb
   :: ForeignPtr Tensor
@@ -266,7 +266,7 @@ avg_pool2d_out_ttlllb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-avg_pool2d_out_ttlllb = cast6 Unmanaged.avg_pool2d_out_ttlllb
+avg_pool2d_out_ttlllb = _cast6 Unmanaged.avg_pool2d_out_ttlllb
 
 avg_pool2d_out_ttlll
   :: ForeignPtr Tensor
@@ -275,7 +275,7 @@ avg_pool2d_out_ttlll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-avg_pool2d_out_ttlll = cast5 Unmanaged.avg_pool2d_out_ttlll
+avg_pool2d_out_ttlll = _cast5 Unmanaged.avg_pool2d_out_ttlll
 
 avg_pool2d_out_ttll
   :: ForeignPtr Tensor
@@ -283,14 +283,14 @@ avg_pool2d_out_ttll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-avg_pool2d_out_ttll = cast4 Unmanaged.avg_pool2d_out_ttll
+avg_pool2d_out_ttll = _cast4 Unmanaged.avg_pool2d_out_ttll
 
 avg_pool2d_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-avg_pool2d_out_ttl = cast3 Unmanaged.avg_pool2d_out_ttl
+avg_pool2d_out_ttl = _cast3 Unmanaged.avg_pool2d_out_ttl
 
 avg_pool2d_tlllbbl
   :: ForeignPtr Tensor
@@ -301,7 +301,7 @@ avg_pool2d_tlllbbl
   -> CBool
   -> Int64
   -> IO (ForeignPtr Tensor)
-avg_pool2d_tlllbbl = cast7 Unmanaged.avg_pool2d_tlllbbl
+avg_pool2d_tlllbbl = _cast7 Unmanaged.avg_pool2d_tlllbbl
 
 avg_pool2d_tlllbb
   :: ForeignPtr Tensor
@@ -311,7 +311,7 @@ avg_pool2d_tlllbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-avg_pool2d_tlllbb = cast6 Unmanaged.avg_pool2d_tlllbb
+avg_pool2d_tlllbb = _cast6 Unmanaged.avg_pool2d_tlllbb
 
 avg_pool2d_tlllb
   :: ForeignPtr Tensor
@@ -320,7 +320,7 @@ avg_pool2d_tlllb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-avg_pool2d_tlllb = cast5 Unmanaged.avg_pool2d_tlllb
+avg_pool2d_tlllb = _cast5 Unmanaged.avg_pool2d_tlllb
 
 avg_pool2d_tlll
   :: ForeignPtr Tensor
@@ -328,20 +328,20 @@ avg_pool2d_tlll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-avg_pool2d_tlll = cast4 Unmanaged.avg_pool2d_tlll
+avg_pool2d_tlll = _cast4 Unmanaged.avg_pool2d_tlll
 
 avg_pool2d_tll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-avg_pool2d_tll = cast3 Unmanaged.avg_pool2d_tll
+avg_pool2d_tll = _cast3 Unmanaged.avg_pool2d_tll
 
 avg_pool2d_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-avg_pool2d_tl = cast2 Unmanaged.avg_pool2d_tl
+avg_pool2d_tl = _cast2 Unmanaged.avg_pool2d_tl
 
 avg_pool2d_backward_out_tttlllbbl
   :: ForeignPtr Tensor
@@ -354,7 +354,7 @@ avg_pool2d_backward_out_tttlllbbl
   -> CBool
   -> Int64
   -> IO (ForeignPtr Tensor)
-avg_pool2d_backward_out_tttlllbbl = cast9 Unmanaged.avg_pool2d_backward_out_tttlllbbl
+avg_pool2d_backward_out_tttlllbbl = _cast9 Unmanaged.avg_pool2d_backward_out_tttlllbbl
 
 avg_pool2d_backward_ttlllbbl
   :: ForeignPtr Tensor
@@ -366,7 +366,7 @@ avg_pool2d_backward_ttlllbbl
   -> CBool
   -> Int64
   -> IO (ForeignPtr Tensor)
-avg_pool2d_backward_ttlllbbl = cast8 Unmanaged.avg_pool2d_backward_ttlllbbl
+avg_pool2d_backward_ttlllbbl = _cast8 Unmanaged.avg_pool2d_backward_ttlllbbl
 
 avg_pool3d_out_ttlllbbl
   :: ForeignPtr Tensor
@@ -378,7 +378,7 @@ avg_pool3d_out_ttlllbbl
   -> CBool
   -> Int64
   -> IO (ForeignPtr Tensor)
-avg_pool3d_out_ttlllbbl = cast8 Unmanaged.avg_pool3d_out_ttlllbbl
+avg_pool3d_out_ttlllbbl = _cast8 Unmanaged.avg_pool3d_out_ttlllbbl
 
 avg_pool3d_out_ttlllbb
   :: ForeignPtr Tensor
@@ -389,7 +389,7 @@ avg_pool3d_out_ttlllbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-avg_pool3d_out_ttlllbb = cast7 Unmanaged.avg_pool3d_out_ttlllbb
+avg_pool3d_out_ttlllbb = _cast7 Unmanaged.avg_pool3d_out_ttlllbb
 
 avg_pool3d_out_ttlllb
   :: ForeignPtr Tensor
@@ -399,7 +399,7 @@ avg_pool3d_out_ttlllb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-avg_pool3d_out_ttlllb = cast6 Unmanaged.avg_pool3d_out_ttlllb
+avg_pool3d_out_ttlllb = _cast6 Unmanaged.avg_pool3d_out_ttlllb
 
 avg_pool3d_out_ttlll
   :: ForeignPtr Tensor
@@ -408,7 +408,7 @@ avg_pool3d_out_ttlll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-avg_pool3d_out_ttlll = cast5 Unmanaged.avg_pool3d_out_ttlll
+avg_pool3d_out_ttlll = _cast5 Unmanaged.avg_pool3d_out_ttlll
 
 avg_pool3d_out_ttll
   :: ForeignPtr Tensor
@@ -416,14 +416,14 @@ avg_pool3d_out_ttll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-avg_pool3d_out_ttll = cast4 Unmanaged.avg_pool3d_out_ttll
+avg_pool3d_out_ttll = _cast4 Unmanaged.avg_pool3d_out_ttll
 
 avg_pool3d_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-avg_pool3d_out_ttl = cast3 Unmanaged.avg_pool3d_out_ttl
+avg_pool3d_out_ttl = _cast3 Unmanaged.avg_pool3d_out_ttl
 
 avg_pool3d_tlllbbl
   :: ForeignPtr Tensor
@@ -434,7 +434,7 @@ avg_pool3d_tlllbbl
   -> CBool
   -> Int64
   -> IO (ForeignPtr Tensor)
-avg_pool3d_tlllbbl = cast7 Unmanaged.avg_pool3d_tlllbbl
+avg_pool3d_tlllbbl = _cast7 Unmanaged.avg_pool3d_tlllbbl
 
 avg_pool3d_tlllbb
   :: ForeignPtr Tensor
@@ -444,7 +444,7 @@ avg_pool3d_tlllbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-avg_pool3d_tlllbb = cast6 Unmanaged.avg_pool3d_tlllbb
+avg_pool3d_tlllbb = _cast6 Unmanaged.avg_pool3d_tlllbb
 
 avg_pool3d_tlllb
   :: ForeignPtr Tensor
@@ -453,7 +453,7 @@ avg_pool3d_tlllb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-avg_pool3d_tlllb = cast5 Unmanaged.avg_pool3d_tlllb
+avg_pool3d_tlllb = _cast5 Unmanaged.avg_pool3d_tlllb
 
 avg_pool3d_tlll
   :: ForeignPtr Tensor
@@ -461,20 +461,20 @@ avg_pool3d_tlll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-avg_pool3d_tlll = cast4 Unmanaged.avg_pool3d_tlll
+avg_pool3d_tlll = _cast4 Unmanaged.avg_pool3d_tlll
 
 avg_pool3d_tll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-avg_pool3d_tll = cast3 Unmanaged.avg_pool3d_tll
+avg_pool3d_tll = _cast3 Unmanaged.avg_pool3d_tll
 
 avg_pool3d_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-avg_pool3d_tl = cast2 Unmanaged.avg_pool3d_tl
+avg_pool3d_tl = _cast2 Unmanaged.avg_pool3d_tl
 
 avg_pool3d_backward_out_tttlllbbl
   :: ForeignPtr Tensor
@@ -487,7 +487,7 @@ avg_pool3d_backward_out_tttlllbbl
   -> CBool
   -> Int64
   -> IO (ForeignPtr Tensor)
-avg_pool3d_backward_out_tttlllbbl = cast9 Unmanaged.avg_pool3d_backward_out_tttlllbbl
+avg_pool3d_backward_out_tttlllbbl = _cast9 Unmanaged.avg_pool3d_backward_out_tttlllbbl
 
 avg_pool3d_backward_ttlllbbl
   :: ForeignPtr Tensor
@@ -499,7 +499,7 @@ avg_pool3d_backward_ttlllbbl
   -> CBool
   -> Int64
   -> IO (ForeignPtr Tensor)
-avg_pool3d_backward_ttlllbbl = cast8 Unmanaged.avg_pool3d_backward_ttlllbbl
+avg_pool3d_backward_ttlllbbl = _cast8 Unmanaged.avg_pool3d_backward_ttlllbbl
 
 fractional_max_pool2d_out_tttllt
   :: ForeignPtr Tensor
@@ -509,7 +509,7 @@ fractional_max_pool2d_out_tttllt
   -> ForeignPtr IntArray
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-fractional_max_pool2d_out_tttllt = cast6 Unmanaged.fractional_max_pool2d_out_tttllt
+fractional_max_pool2d_out_tttllt = _cast6 Unmanaged.fractional_max_pool2d_out_tttllt
 
 fractional_max_pool2d_tllt
   :: ForeignPtr Tensor
@@ -517,7 +517,7 @@ fractional_max_pool2d_tllt
   -> ForeignPtr IntArray
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-fractional_max_pool2d_tllt = cast4 Unmanaged.fractional_max_pool2d_tllt
+fractional_max_pool2d_tllt = _cast4 Unmanaged.fractional_max_pool2d_tllt
 
 fractional_max_pool2d_backward_out_tttllt
   :: ForeignPtr Tensor
@@ -527,7 +527,7 @@ fractional_max_pool2d_backward_out_tttllt
   -> ForeignPtr IntArray
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fractional_max_pool2d_backward_out_tttllt = cast6 Unmanaged.fractional_max_pool2d_backward_out_tttllt
+fractional_max_pool2d_backward_out_tttllt = _cast6 Unmanaged.fractional_max_pool2d_backward_out_tttllt
 
 fractional_max_pool2d_backward_ttllt
   :: ForeignPtr Tensor
@@ -536,7 +536,7 @@ fractional_max_pool2d_backward_ttllt
   -> ForeignPtr IntArray
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fractional_max_pool2d_backward_ttllt = cast5 Unmanaged.fractional_max_pool2d_backward_ttllt
+fractional_max_pool2d_backward_ttllt = _cast5 Unmanaged.fractional_max_pool2d_backward_ttllt
 
 fractional_max_pool3d_out_tttllt
   :: ForeignPtr Tensor
@@ -546,7 +546,7 @@ fractional_max_pool3d_out_tttllt
   -> ForeignPtr IntArray
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-fractional_max_pool3d_out_tttllt = cast6 Unmanaged.fractional_max_pool3d_out_tttllt
+fractional_max_pool3d_out_tttllt = _cast6 Unmanaged.fractional_max_pool3d_out_tttllt
 
 fractional_max_pool3d_tllt
   :: ForeignPtr Tensor
@@ -554,7 +554,7 @@ fractional_max_pool3d_tllt
   -> ForeignPtr IntArray
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-fractional_max_pool3d_tllt = cast4 Unmanaged.fractional_max_pool3d_tllt
+fractional_max_pool3d_tllt = _cast4 Unmanaged.fractional_max_pool3d_tllt
 
 fractional_max_pool3d_backward_out_tttllt
   :: ForeignPtr Tensor
@@ -564,7 +564,7 @@ fractional_max_pool3d_backward_out_tttllt
   -> ForeignPtr IntArray
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fractional_max_pool3d_backward_out_tttllt = cast6 Unmanaged.fractional_max_pool3d_backward_out_tttllt
+fractional_max_pool3d_backward_out_tttllt = _cast6 Unmanaged.fractional_max_pool3d_backward_out_tttllt
 
 fractional_max_pool3d_backward_ttllt
   :: ForeignPtr Tensor
@@ -573,7 +573,7 @@ fractional_max_pool3d_backward_ttllt
   -> ForeignPtr IntArray
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fractional_max_pool3d_backward_ttllt = cast5 Unmanaged.fractional_max_pool3d_backward_ttllt
+fractional_max_pool3d_backward_ttllt = _cast5 Unmanaged.fractional_max_pool3d_backward_ttllt
 
 max_pool2d_with_indices_out_tttllllb
   :: ForeignPtr Tensor
@@ -585,7 +585,7 @@ max_pool2d_with_indices_out_tttllllb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_pool2d_with_indices_out_tttllllb = cast8 Unmanaged.max_pool2d_with_indices_out_tttllllb
+max_pool2d_with_indices_out_tttllllb = _cast8 Unmanaged.max_pool2d_with_indices_out_tttllllb
 
 max_pool2d_with_indices_out_tttllll
   :: ForeignPtr Tensor
@@ -596,7 +596,7 @@ max_pool2d_with_indices_out_tttllll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_pool2d_with_indices_out_tttllll = cast7 Unmanaged.max_pool2d_with_indices_out_tttllll
+max_pool2d_with_indices_out_tttllll = _cast7 Unmanaged.max_pool2d_with_indices_out_tttllll
 
 max_pool2d_with_indices_out_tttlll
   :: ForeignPtr Tensor
@@ -606,7 +606,7 @@ max_pool2d_with_indices_out_tttlll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_pool2d_with_indices_out_tttlll = cast6 Unmanaged.max_pool2d_with_indices_out_tttlll
+max_pool2d_with_indices_out_tttlll = _cast6 Unmanaged.max_pool2d_with_indices_out_tttlll
 
 max_pool2d_with_indices_out_tttll
   :: ForeignPtr Tensor
@@ -615,7 +615,7 @@ max_pool2d_with_indices_out_tttll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_pool2d_with_indices_out_tttll = cast5 Unmanaged.max_pool2d_with_indices_out_tttll
+max_pool2d_with_indices_out_tttll = _cast5 Unmanaged.max_pool2d_with_indices_out_tttll
 
 max_pool2d_with_indices_out_tttl
   :: ForeignPtr Tensor
@@ -623,7 +623,7 @@ max_pool2d_with_indices_out_tttl
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_pool2d_with_indices_out_tttl = cast4 Unmanaged.max_pool2d_with_indices_out_tttl
+max_pool2d_with_indices_out_tttl = _cast4 Unmanaged.max_pool2d_with_indices_out_tttl
 
 max_pool2d_with_indices_tllllb
   :: ForeignPtr Tensor
@@ -633,7 +633,7 @@ max_pool2d_with_indices_tllllb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_pool2d_with_indices_tllllb = cast6 Unmanaged.max_pool2d_with_indices_tllllb
+max_pool2d_with_indices_tllllb = _cast6 Unmanaged.max_pool2d_with_indices_tllllb
 
 max_pool2d_with_indices_tllll
   :: ForeignPtr Tensor
@@ -642,7 +642,7 @@ max_pool2d_with_indices_tllll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_pool2d_with_indices_tllll = cast5 Unmanaged.max_pool2d_with_indices_tllll
+max_pool2d_with_indices_tllll = _cast5 Unmanaged.max_pool2d_with_indices_tllll
 
 max_pool2d_with_indices_tlll
   :: ForeignPtr Tensor
@@ -650,20 +650,20 @@ max_pool2d_with_indices_tlll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_pool2d_with_indices_tlll = cast4 Unmanaged.max_pool2d_with_indices_tlll
+max_pool2d_with_indices_tlll = _cast4 Unmanaged.max_pool2d_with_indices_tlll
 
 max_pool2d_with_indices_tll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_pool2d_with_indices_tll = cast3 Unmanaged.max_pool2d_with_indices_tll
+max_pool2d_with_indices_tll = _cast3 Unmanaged.max_pool2d_with_indices_tll
 
 max_pool2d_with_indices_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_pool2d_with_indices_tl = cast2 Unmanaged.max_pool2d_with_indices_tl
+max_pool2d_with_indices_tl = _cast2 Unmanaged.max_pool2d_with_indices_tl
 
 max_pool2d_with_indices_backward_out_tttllllbt
   :: ForeignPtr Tensor
@@ -676,7 +676,7 @@ max_pool2d_with_indices_backward_out_tttllllbt
   -> CBool
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-max_pool2d_with_indices_backward_out_tttllllbt = cast9 Unmanaged.max_pool2d_with_indices_backward_out_tttllllbt
+max_pool2d_with_indices_backward_out_tttllllbt = _cast9 Unmanaged.max_pool2d_with_indices_backward_out_tttllllbt
 
 max_pool2d_with_indices_backward_ttllllbt
   :: ForeignPtr Tensor
@@ -688,7 +688,7 @@ max_pool2d_with_indices_backward_ttllllbt
   -> CBool
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-max_pool2d_with_indices_backward_ttllllbt = cast8 Unmanaged.max_pool2d_with_indices_backward_ttllllbt
+max_pool2d_with_indices_backward_ttllllbt = _cast8 Unmanaged.max_pool2d_with_indices_backward_ttllllbt
 
 max_pool3d_with_indices_out_tttllllb
   :: ForeignPtr Tensor
@@ -700,7 +700,7 @@ max_pool3d_with_indices_out_tttllllb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_pool3d_with_indices_out_tttllllb = cast8 Unmanaged.max_pool3d_with_indices_out_tttllllb
+max_pool3d_with_indices_out_tttllllb = _cast8 Unmanaged.max_pool3d_with_indices_out_tttllllb
 
 max_pool3d_with_indices_out_tttllll
   :: ForeignPtr Tensor
@@ -711,7 +711,7 @@ max_pool3d_with_indices_out_tttllll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_pool3d_with_indices_out_tttllll = cast7 Unmanaged.max_pool3d_with_indices_out_tttllll
+max_pool3d_with_indices_out_tttllll = _cast7 Unmanaged.max_pool3d_with_indices_out_tttllll
 
 max_pool3d_with_indices_out_tttlll
   :: ForeignPtr Tensor
@@ -721,7 +721,7 @@ max_pool3d_with_indices_out_tttlll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_pool3d_with_indices_out_tttlll = cast6 Unmanaged.max_pool3d_with_indices_out_tttlll
+max_pool3d_with_indices_out_tttlll = _cast6 Unmanaged.max_pool3d_with_indices_out_tttlll
 
 max_pool3d_with_indices_out_tttll
   :: ForeignPtr Tensor
@@ -730,7 +730,7 @@ max_pool3d_with_indices_out_tttll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_pool3d_with_indices_out_tttll = cast5 Unmanaged.max_pool3d_with_indices_out_tttll
+max_pool3d_with_indices_out_tttll = _cast5 Unmanaged.max_pool3d_with_indices_out_tttll
 
 max_pool3d_with_indices_out_tttl
   :: ForeignPtr Tensor
@@ -738,7 +738,7 @@ max_pool3d_with_indices_out_tttl
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_pool3d_with_indices_out_tttl = cast4 Unmanaged.max_pool3d_with_indices_out_tttl
+max_pool3d_with_indices_out_tttl = _cast4 Unmanaged.max_pool3d_with_indices_out_tttl
 
 max_pool3d_with_indices_tllllb
   :: ForeignPtr Tensor
@@ -748,7 +748,7 @@ max_pool3d_with_indices_tllllb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_pool3d_with_indices_tllllb = cast6 Unmanaged.max_pool3d_with_indices_tllllb
+max_pool3d_with_indices_tllllb = _cast6 Unmanaged.max_pool3d_with_indices_tllllb
 
 max_pool3d_with_indices_tllll
   :: ForeignPtr Tensor
@@ -757,7 +757,7 @@ max_pool3d_with_indices_tllll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_pool3d_with_indices_tllll = cast5 Unmanaged.max_pool3d_with_indices_tllll
+max_pool3d_with_indices_tllll = _cast5 Unmanaged.max_pool3d_with_indices_tllll
 
 max_pool3d_with_indices_tlll
   :: ForeignPtr Tensor
@@ -765,20 +765,20 @@ max_pool3d_with_indices_tlll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_pool3d_with_indices_tlll = cast4 Unmanaged.max_pool3d_with_indices_tlll
+max_pool3d_with_indices_tlll = _cast4 Unmanaged.max_pool3d_with_indices_tlll
 
 max_pool3d_with_indices_tll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_pool3d_with_indices_tll = cast3 Unmanaged.max_pool3d_with_indices_tll
+max_pool3d_with_indices_tll = _cast3 Unmanaged.max_pool3d_with_indices_tll
 
 max_pool3d_with_indices_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_pool3d_with_indices_tl = cast2 Unmanaged.max_pool3d_with_indices_tl
+max_pool3d_with_indices_tl = _cast2 Unmanaged.max_pool3d_with_indices_tl
 
 max_pool3d_with_indices_backward_out_tttllllbt
   :: ForeignPtr Tensor
@@ -791,7 +791,7 @@ max_pool3d_with_indices_backward_out_tttllllbt
   -> CBool
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-max_pool3d_with_indices_backward_out_tttllllbt = cast9 Unmanaged.max_pool3d_with_indices_backward_out_tttllllbt
+max_pool3d_with_indices_backward_out_tttllllbt = _cast9 Unmanaged.max_pool3d_with_indices_backward_out_tttllllbt
 
 max_pool3d_with_indices_backward_ttllllbt
   :: ForeignPtr Tensor
@@ -803,7 +803,7 @@ max_pool3d_with_indices_backward_ttllllbt
   -> CBool
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-max_pool3d_with_indices_backward_ttllllbt = cast8 Unmanaged.max_pool3d_with_indices_backward_ttllllbt
+max_pool3d_with_indices_backward_ttllllbt = _cast8 Unmanaged.max_pool3d_with_indices_backward_ttllllbt
 
 max_unpool2d_out_tttl
   :: ForeignPtr Tensor
@@ -811,14 +811,14 @@ max_unpool2d_out_tttl
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-max_unpool2d_out_tttl = cast4 Unmanaged.max_unpool2d_out_tttl
+max_unpool2d_out_tttl = _cast4 Unmanaged.max_unpool2d_out_tttl
 
 max_unpool2d_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-max_unpool2d_ttl = cast3 Unmanaged.max_unpool2d_ttl
+max_unpool2d_ttl = _cast3 Unmanaged.max_unpool2d_ttl
 
 max_unpool2d_backward_out_ttttl
   :: ForeignPtr Tensor
@@ -827,7 +827,7 @@ max_unpool2d_backward_out_ttttl
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-max_unpool2d_backward_out_ttttl = cast5 Unmanaged.max_unpool2d_backward_out_ttttl
+max_unpool2d_backward_out_ttttl = _cast5 Unmanaged.max_unpool2d_backward_out_ttttl
 
 max_unpool2d_backward_tttl
   :: ForeignPtr Tensor
@@ -835,7 +835,7 @@ max_unpool2d_backward_tttl
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-max_unpool2d_backward_tttl = cast4 Unmanaged.max_unpool2d_backward_tttl
+max_unpool2d_backward_tttl = _cast4 Unmanaged.max_unpool2d_backward_tttl
 
 max_unpool3d_out_tttlll
   :: ForeignPtr Tensor
@@ -845,7 +845,7 @@ max_unpool3d_out_tttlll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-max_unpool3d_out_tttlll = cast6 Unmanaged.max_unpool3d_out_tttlll
+max_unpool3d_out_tttlll = _cast6 Unmanaged.max_unpool3d_out_tttlll
 
 max_unpool3d_ttlll
   :: ForeignPtr Tensor
@@ -854,7 +854,7 @@ max_unpool3d_ttlll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-max_unpool3d_ttlll = cast5 Unmanaged.max_unpool3d_ttlll
+max_unpool3d_ttlll = _cast5 Unmanaged.max_unpool3d_ttlll
 
 max_unpool3d_backward_out_ttttlll
   :: ForeignPtr Tensor
@@ -865,7 +865,7 @@ max_unpool3d_backward_out_ttttlll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-max_unpool3d_backward_out_ttttlll = cast7 Unmanaged.max_unpool3d_backward_out_ttttlll
+max_unpool3d_backward_out_ttttlll = _cast7 Unmanaged.max_unpool3d_backward_out_ttttlll
 
 max_unpool3d_backward_tttlll
   :: ForeignPtr Tensor
@@ -875,20 +875,20 @@ max_unpool3d_backward_tttlll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-max_unpool3d_backward_tttlll = cast6 Unmanaged.max_unpool3d_backward_tttlll
+max_unpool3d_backward_tttlll = _cast6 Unmanaged.max_unpool3d_backward_tttlll
 
 reflection_pad1d_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-reflection_pad1d_out_ttl = cast3 Unmanaged.reflection_pad1d_out_ttl
+reflection_pad1d_out_ttl = _cast3 Unmanaged.reflection_pad1d_out_ttl
 
 reflection_pad1d_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-reflection_pad1d_tl = cast2 Unmanaged.reflection_pad1d_tl
+reflection_pad1d_tl = _cast2 Unmanaged.reflection_pad1d_tl
 
 reflection_pad1d_backward_out_tttl
   :: ForeignPtr Tensor
@@ -896,27 +896,27 @@ reflection_pad1d_backward_out_tttl
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-reflection_pad1d_backward_out_tttl = cast4 Unmanaged.reflection_pad1d_backward_out_tttl
+reflection_pad1d_backward_out_tttl = _cast4 Unmanaged.reflection_pad1d_backward_out_tttl
 
 reflection_pad1d_backward_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-reflection_pad1d_backward_ttl = cast3 Unmanaged.reflection_pad1d_backward_ttl
+reflection_pad1d_backward_ttl = _cast3 Unmanaged.reflection_pad1d_backward_ttl
 
 reflection_pad2d_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-reflection_pad2d_out_ttl = cast3 Unmanaged.reflection_pad2d_out_ttl
+reflection_pad2d_out_ttl = _cast3 Unmanaged.reflection_pad2d_out_ttl
 
 reflection_pad2d_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-reflection_pad2d_tl = cast2 Unmanaged.reflection_pad2d_tl
+reflection_pad2d_tl = _cast2 Unmanaged.reflection_pad2d_tl
 
 reflection_pad2d_backward_out_tttl
   :: ForeignPtr Tensor
@@ -924,27 +924,27 @@ reflection_pad2d_backward_out_tttl
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-reflection_pad2d_backward_out_tttl = cast4 Unmanaged.reflection_pad2d_backward_out_tttl
+reflection_pad2d_backward_out_tttl = _cast4 Unmanaged.reflection_pad2d_backward_out_tttl
 
 reflection_pad2d_backward_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-reflection_pad2d_backward_ttl = cast3 Unmanaged.reflection_pad2d_backward_ttl
+reflection_pad2d_backward_ttl = _cast3 Unmanaged.reflection_pad2d_backward_ttl
 
 reflection_pad3d_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-reflection_pad3d_out_ttl = cast3 Unmanaged.reflection_pad3d_out_ttl
+reflection_pad3d_out_ttl = _cast3 Unmanaged.reflection_pad3d_out_ttl
 
 reflection_pad3d_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-reflection_pad3d_tl = cast2 Unmanaged.reflection_pad3d_tl
+reflection_pad3d_tl = _cast2 Unmanaged.reflection_pad3d_tl
 
 reflection_pad3d_backward_out_tttl
   :: ForeignPtr Tensor
@@ -952,27 +952,27 @@ reflection_pad3d_backward_out_tttl
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-reflection_pad3d_backward_out_tttl = cast4 Unmanaged.reflection_pad3d_backward_out_tttl
+reflection_pad3d_backward_out_tttl = _cast4 Unmanaged.reflection_pad3d_backward_out_tttl
 
 reflection_pad3d_backward_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-reflection_pad3d_backward_ttl = cast3 Unmanaged.reflection_pad3d_backward_ttl
+reflection_pad3d_backward_ttl = _cast3 Unmanaged.reflection_pad3d_backward_ttl
 
 replication_pad1d_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-replication_pad1d_out_ttl = cast3 Unmanaged.replication_pad1d_out_ttl
+replication_pad1d_out_ttl = _cast3 Unmanaged.replication_pad1d_out_ttl
 
 replication_pad1d_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-replication_pad1d_tl = cast2 Unmanaged.replication_pad1d_tl
+replication_pad1d_tl = _cast2 Unmanaged.replication_pad1d_tl
 
 replication_pad1d_backward_out_tttl
   :: ForeignPtr Tensor
@@ -980,27 +980,27 @@ replication_pad1d_backward_out_tttl
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-replication_pad1d_backward_out_tttl = cast4 Unmanaged.replication_pad1d_backward_out_tttl
+replication_pad1d_backward_out_tttl = _cast4 Unmanaged.replication_pad1d_backward_out_tttl
 
 replication_pad1d_backward_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-replication_pad1d_backward_ttl = cast3 Unmanaged.replication_pad1d_backward_ttl
+replication_pad1d_backward_ttl = _cast3 Unmanaged.replication_pad1d_backward_ttl
 
 replication_pad2d_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-replication_pad2d_out_ttl = cast3 Unmanaged.replication_pad2d_out_ttl
+replication_pad2d_out_ttl = _cast3 Unmanaged.replication_pad2d_out_ttl
 
 replication_pad2d_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-replication_pad2d_tl = cast2 Unmanaged.replication_pad2d_tl
+replication_pad2d_tl = _cast2 Unmanaged.replication_pad2d_tl
 
 replication_pad2d_backward_out_tttl
   :: ForeignPtr Tensor
@@ -1008,27 +1008,27 @@ replication_pad2d_backward_out_tttl
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-replication_pad2d_backward_out_tttl = cast4 Unmanaged.replication_pad2d_backward_out_tttl
+replication_pad2d_backward_out_tttl = _cast4 Unmanaged.replication_pad2d_backward_out_tttl
 
 replication_pad2d_backward_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-replication_pad2d_backward_ttl = cast3 Unmanaged.replication_pad2d_backward_ttl
+replication_pad2d_backward_ttl = _cast3 Unmanaged.replication_pad2d_backward_ttl
 
 replication_pad3d_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-replication_pad3d_out_ttl = cast3 Unmanaged.replication_pad3d_out_ttl
+replication_pad3d_out_ttl = _cast3 Unmanaged.replication_pad3d_out_ttl
 
 replication_pad3d_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-replication_pad3d_tl = cast2 Unmanaged.replication_pad3d_tl
+replication_pad3d_tl = _cast2 Unmanaged.replication_pad3d_tl
 
 replication_pad3d_backward_out_tttl
   :: ForeignPtr Tensor
@@ -1036,14 +1036,14 @@ replication_pad3d_backward_out_tttl
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-replication_pad3d_backward_out_tttl = cast4 Unmanaged.replication_pad3d_backward_out_tttl
+replication_pad3d_backward_out_tttl = _cast4 Unmanaged.replication_pad3d_backward_out_tttl
 
 replication_pad3d_backward_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-replication_pad3d_backward_ttl = cast3 Unmanaged.replication_pad3d_backward_ttl
+replication_pad3d_backward_ttl = _cast3 Unmanaged.replication_pad3d_backward_ttl
 
 upsample_linear1d_tlba
   :: ForeignPtr Tensor
@@ -1051,7 +1051,7 @@ upsample_linear1d_tlba
   -> CBool
   -> ForeignPtr (StdVector CDouble)
   -> IO (ForeignPtr Tensor)
-upsample_linear1d_tlba = cast4 Unmanaged.upsample_linear1d_tlba
+upsample_linear1d_tlba = _cast4 Unmanaged.upsample_linear1d_tlba
 
 upsample_linear1d_backward_tllba
   :: ForeignPtr Tensor
@@ -1060,7 +1060,7 @@ upsample_linear1d_backward_tllba
   -> CBool
   -> ForeignPtr (StdVector CDouble)
   -> IO (ForeignPtr Tensor)
-upsample_linear1d_backward_tllba = cast5 Unmanaged.upsample_linear1d_backward_tllba
+upsample_linear1d_backward_tllba = _cast5 Unmanaged.upsample_linear1d_backward_tllba
 
 upsample_bilinear2d_tlba
   :: ForeignPtr Tensor
@@ -1068,7 +1068,7 @@ upsample_bilinear2d_tlba
   -> CBool
   -> ForeignPtr (StdVector CDouble)
   -> IO (ForeignPtr Tensor)
-upsample_bilinear2d_tlba = cast4 Unmanaged.upsample_bilinear2d_tlba
+upsample_bilinear2d_tlba = _cast4 Unmanaged.upsample_bilinear2d_tlba
 
 upsample_bilinear2d_backward_tllba
   :: ForeignPtr Tensor
@@ -1077,7 +1077,7 @@ upsample_bilinear2d_backward_tllba
   -> CBool
   -> ForeignPtr (StdVector CDouble)
   -> IO (ForeignPtr Tensor)
-upsample_bilinear2d_backward_tllba = cast5 Unmanaged.upsample_bilinear2d_backward_tllba
+upsample_bilinear2d_backward_tllba = _cast5 Unmanaged.upsample_bilinear2d_backward_tllba
 
 _upsample_bilinear2d_aa_tlba
   :: ForeignPtr Tensor
@@ -1085,7 +1085,7 @@ _upsample_bilinear2d_aa_tlba
   -> CBool
   -> ForeignPtr (StdVector CDouble)
   -> IO (ForeignPtr Tensor)
-_upsample_bilinear2d_aa_tlba = cast4 Unmanaged._upsample_bilinear2d_aa_tlba
+_upsample_bilinear2d_aa_tlba = _cast4 Unmanaged._upsample_bilinear2d_aa_tlba
 
 _upsample_bilinear2d_aa_backward_tllba
   :: ForeignPtr Tensor
@@ -1094,7 +1094,7 @@ _upsample_bilinear2d_aa_backward_tllba
   -> CBool
   -> ForeignPtr (StdVector CDouble)
   -> IO (ForeignPtr Tensor)
-_upsample_bilinear2d_aa_backward_tllba = cast5 Unmanaged._upsample_bilinear2d_aa_backward_tllba
+_upsample_bilinear2d_aa_backward_tllba = _cast5 Unmanaged._upsample_bilinear2d_aa_backward_tllba
 
 upsample_trilinear3d_tlba
   :: ForeignPtr Tensor
@@ -1102,7 +1102,7 @@ upsample_trilinear3d_tlba
   -> CBool
   -> ForeignPtr (StdVector CDouble)
   -> IO (ForeignPtr Tensor)
-upsample_trilinear3d_tlba = cast4 Unmanaged.upsample_trilinear3d_tlba
+upsample_trilinear3d_tlba = _cast4 Unmanaged.upsample_trilinear3d_tlba
 
 upsample_trilinear3d_backward_tllba
   :: ForeignPtr Tensor
@@ -1111,7 +1111,7 @@ upsample_trilinear3d_backward_tllba
   -> CBool
   -> ForeignPtr (StdVector CDouble)
   -> IO (ForeignPtr Tensor)
-upsample_trilinear3d_backward_tllba = cast5 Unmanaged.upsample_trilinear3d_backward_tllba
+upsample_trilinear3d_backward_tllba = _cast5 Unmanaged.upsample_trilinear3d_backward_tllba
 
 upsample_bicubic2d_tlba
   :: ForeignPtr Tensor
@@ -1119,7 +1119,7 @@ upsample_bicubic2d_tlba
   -> CBool
   -> ForeignPtr (StdVector CDouble)
   -> IO (ForeignPtr Tensor)
-upsample_bicubic2d_tlba = cast4 Unmanaged.upsample_bicubic2d_tlba
+upsample_bicubic2d_tlba = _cast4 Unmanaged.upsample_bicubic2d_tlba
 
 upsample_bicubic2d_backward_tllba
   :: ForeignPtr Tensor
@@ -1128,7 +1128,7 @@ upsample_bicubic2d_backward_tllba
   -> CBool
   -> ForeignPtr (StdVector CDouble)
   -> IO (ForeignPtr Tensor)
-upsample_bicubic2d_backward_tllba = cast5 Unmanaged.upsample_bicubic2d_backward_tllba
+upsample_bicubic2d_backward_tllba = _cast5 Unmanaged.upsample_bicubic2d_backward_tllba
 
 _upsample_bicubic2d_aa_tlba
   :: ForeignPtr Tensor
@@ -1136,7 +1136,7 @@ _upsample_bicubic2d_aa_tlba
   -> CBool
   -> ForeignPtr (StdVector CDouble)
   -> IO (ForeignPtr Tensor)
-_upsample_bicubic2d_aa_tlba = cast4 Unmanaged._upsample_bicubic2d_aa_tlba
+_upsample_bicubic2d_aa_tlba = _cast4 Unmanaged._upsample_bicubic2d_aa_tlba
 
 _upsample_bicubic2d_aa_backward_tllba
   :: ForeignPtr Tensor
@@ -1145,21 +1145,21 @@ _upsample_bicubic2d_aa_backward_tllba
   -> CBool
   -> ForeignPtr (StdVector CDouble)
   -> IO (ForeignPtr Tensor)
-_upsample_bicubic2d_aa_backward_tllba = cast5 Unmanaged._upsample_bicubic2d_aa_backward_tllba
+_upsample_bicubic2d_aa_backward_tllba = _cast5 Unmanaged._upsample_bicubic2d_aa_backward_tllba
 
 upsample_nearest1d_tla
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr (StdVector CDouble)
   -> IO (ForeignPtr Tensor)
-upsample_nearest1d_tla = cast3 Unmanaged.upsample_nearest1d_tla
+upsample_nearest1d_tla = _cast3 Unmanaged.upsample_nearest1d_tla
 
 _upsample_nearest_exact1d_tla
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr (StdVector CDouble)
   -> IO (ForeignPtr Tensor)
-_upsample_nearest_exact1d_tla = cast3 Unmanaged._upsample_nearest_exact1d_tla
+_upsample_nearest_exact1d_tla = _cast3 Unmanaged._upsample_nearest_exact1d_tla
 
 upsample_nearest1d_backward_tlla
   :: ForeignPtr Tensor
@@ -1167,7 +1167,7 @@ upsample_nearest1d_backward_tlla
   -> ForeignPtr IntArray
   -> ForeignPtr (StdVector CDouble)
   -> IO (ForeignPtr Tensor)
-upsample_nearest1d_backward_tlla = cast4 Unmanaged.upsample_nearest1d_backward_tlla
+upsample_nearest1d_backward_tlla = _cast4 Unmanaged.upsample_nearest1d_backward_tlla
 
 _upsample_nearest_exact1d_backward_tlla
   :: ForeignPtr Tensor
@@ -1175,21 +1175,21 @@ _upsample_nearest_exact1d_backward_tlla
   -> ForeignPtr IntArray
   -> ForeignPtr (StdVector CDouble)
   -> IO (ForeignPtr Tensor)
-_upsample_nearest_exact1d_backward_tlla = cast4 Unmanaged._upsample_nearest_exact1d_backward_tlla
+_upsample_nearest_exact1d_backward_tlla = _cast4 Unmanaged._upsample_nearest_exact1d_backward_tlla
 
 upsample_nearest2d_tla
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr (StdVector CDouble)
   -> IO (ForeignPtr Tensor)
-upsample_nearest2d_tla = cast3 Unmanaged.upsample_nearest2d_tla
+upsample_nearest2d_tla = _cast3 Unmanaged.upsample_nearest2d_tla
 
 _upsample_nearest_exact2d_tla
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr (StdVector CDouble)
   -> IO (ForeignPtr Tensor)
-_upsample_nearest_exact2d_tla = cast3 Unmanaged._upsample_nearest_exact2d_tla
+_upsample_nearest_exact2d_tla = _cast3 Unmanaged._upsample_nearest_exact2d_tla
 
 upsample_nearest2d_backward_tlla
   :: ForeignPtr Tensor
@@ -1197,7 +1197,7 @@ upsample_nearest2d_backward_tlla
   -> ForeignPtr IntArray
   -> ForeignPtr (StdVector CDouble)
   -> IO (ForeignPtr Tensor)
-upsample_nearest2d_backward_tlla = cast4 Unmanaged.upsample_nearest2d_backward_tlla
+upsample_nearest2d_backward_tlla = _cast4 Unmanaged.upsample_nearest2d_backward_tlla
 
 _upsample_nearest_exact2d_backward_tlla
   :: ForeignPtr Tensor
@@ -1205,21 +1205,21 @@ _upsample_nearest_exact2d_backward_tlla
   -> ForeignPtr IntArray
   -> ForeignPtr (StdVector CDouble)
   -> IO (ForeignPtr Tensor)
-_upsample_nearest_exact2d_backward_tlla = cast4 Unmanaged._upsample_nearest_exact2d_backward_tlla
+_upsample_nearest_exact2d_backward_tlla = _cast4 Unmanaged._upsample_nearest_exact2d_backward_tlla
 
 upsample_nearest3d_tla
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr (StdVector CDouble)
   -> IO (ForeignPtr Tensor)
-upsample_nearest3d_tla = cast3 Unmanaged.upsample_nearest3d_tla
+upsample_nearest3d_tla = _cast3 Unmanaged.upsample_nearest3d_tla
 
 _upsample_nearest_exact3d_tla
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr (StdVector CDouble)
   -> IO (ForeignPtr Tensor)
-_upsample_nearest_exact3d_tla = cast3 Unmanaged._upsample_nearest_exact3d_tla
+_upsample_nearest_exact3d_tla = _cast3 Unmanaged._upsample_nearest_exact3d_tla
 
 upsample_nearest3d_backward_tlla
   :: ForeignPtr Tensor
@@ -1227,7 +1227,7 @@ upsample_nearest3d_backward_tlla
   -> ForeignPtr IntArray
   -> ForeignPtr (StdVector CDouble)
   -> IO (ForeignPtr Tensor)
-upsample_nearest3d_backward_tlla = cast4 Unmanaged.upsample_nearest3d_backward_tlla
+upsample_nearest3d_backward_tlla = _cast4 Unmanaged.upsample_nearest3d_backward_tlla
 
 _upsample_nearest_exact3d_backward_tlla
   :: ForeignPtr Tensor
@@ -1235,7 +1235,7 @@ _upsample_nearest_exact3d_backward_tlla
   -> ForeignPtr IntArray
   -> ForeignPtr (StdVector CDouble)
   -> IO (ForeignPtr Tensor)
-_upsample_nearest_exact3d_backward_tlla = cast4 Unmanaged._upsample_nearest_exact3d_backward_tlla
+_upsample_nearest_exact3d_backward_tlla = _cast4 Unmanaged._upsample_nearest_exact3d_backward_tlla
 
 upsample_linear1d_out_ttlbd
   :: ForeignPtr Tensor
@@ -1244,7 +1244,7 @@ upsample_linear1d_out_ttlbd
   -> CBool
   -> CDouble
   -> IO (ForeignPtr Tensor)
-upsample_linear1d_out_ttlbd = cast5 Unmanaged.upsample_linear1d_out_ttlbd
+upsample_linear1d_out_ttlbd = _cast5 Unmanaged.upsample_linear1d_out_ttlbd
 
 upsample_linear1d_out_ttlb
   :: ForeignPtr Tensor
@@ -1252,14 +1252,14 @@ upsample_linear1d_out_ttlb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-upsample_linear1d_out_ttlb = cast4 Unmanaged.upsample_linear1d_out_ttlb
+upsample_linear1d_out_ttlb = _cast4 Unmanaged.upsample_linear1d_out_ttlb
 
 upsample_linear1d_tlb
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-upsample_linear1d_tlb = cast3 Unmanaged.upsample_linear1d_tlb
+upsample_linear1d_tlb = _cast3 Unmanaged.upsample_linear1d_tlb
 
 upsample_linear1d_backward_out_ttllbd
   :: ForeignPtr Tensor
@@ -1269,7 +1269,7 @@ upsample_linear1d_backward_out_ttllbd
   -> CBool
   -> CDouble
   -> IO (ForeignPtr Tensor)
-upsample_linear1d_backward_out_ttllbd = cast6 Unmanaged.upsample_linear1d_backward_out_ttllbd
+upsample_linear1d_backward_out_ttllbd = _cast6 Unmanaged.upsample_linear1d_backward_out_ttllbd
 
 upsample_linear1d_backward_out_ttllb
   :: ForeignPtr Tensor
@@ -1278,7 +1278,7 @@ upsample_linear1d_backward_out_ttllb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-upsample_linear1d_backward_out_ttllb = cast5 Unmanaged.upsample_linear1d_backward_out_ttllb
+upsample_linear1d_backward_out_ttllb = _cast5 Unmanaged.upsample_linear1d_backward_out_ttllb
 
 upsample_linear1d_backward_tllb
   :: ForeignPtr Tensor
@@ -1286,7 +1286,7 @@ upsample_linear1d_backward_tllb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-upsample_linear1d_backward_tllb = cast4 Unmanaged.upsample_linear1d_backward_tllb
+upsample_linear1d_backward_tllb = _cast4 Unmanaged.upsample_linear1d_backward_tllb
 
 upsample_bilinear2d_out_ttlbdd
   :: ForeignPtr Tensor
@@ -1296,7 +1296,7 @@ upsample_bilinear2d_out_ttlbdd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-upsample_bilinear2d_out_ttlbdd = cast6 Unmanaged.upsample_bilinear2d_out_ttlbdd
+upsample_bilinear2d_out_ttlbdd = _cast6 Unmanaged.upsample_bilinear2d_out_ttlbdd
 
 upsample_bilinear2d_out_ttlbd
   :: ForeignPtr Tensor
@@ -1305,7 +1305,7 @@ upsample_bilinear2d_out_ttlbd
   -> CBool
   -> CDouble
   -> IO (ForeignPtr Tensor)
-upsample_bilinear2d_out_ttlbd = cast5 Unmanaged.upsample_bilinear2d_out_ttlbd
+upsample_bilinear2d_out_ttlbd = _cast5 Unmanaged.upsample_bilinear2d_out_ttlbd
 
 upsample_bilinear2d_out_ttlb
   :: ForeignPtr Tensor
@@ -1313,7 +1313,7 @@ upsample_bilinear2d_out_ttlb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-upsample_bilinear2d_out_ttlb = cast4 Unmanaged.upsample_bilinear2d_out_ttlb
+upsample_bilinear2d_out_ttlb = _cast4 Unmanaged.upsample_bilinear2d_out_ttlb
 
 upsample_bilinear2d_tlbdd
   :: ForeignPtr Tensor
@@ -1322,14 +1322,14 @@ upsample_bilinear2d_tlbdd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-upsample_bilinear2d_tlbdd = cast5 Unmanaged.upsample_bilinear2d_tlbdd
+upsample_bilinear2d_tlbdd = _cast5 Unmanaged.upsample_bilinear2d_tlbdd
 
 upsample_bilinear2d_tlb
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-upsample_bilinear2d_tlb = cast3 Unmanaged.upsample_bilinear2d_tlb
+upsample_bilinear2d_tlb = _cast3 Unmanaged.upsample_bilinear2d_tlb
 
 upsample_bilinear2d_backward_out_ttllbdd
   :: ForeignPtr Tensor
@@ -1340,7 +1340,7 @@ upsample_bilinear2d_backward_out_ttllbdd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-upsample_bilinear2d_backward_out_ttllbdd = cast7 Unmanaged.upsample_bilinear2d_backward_out_ttllbdd
+upsample_bilinear2d_backward_out_ttllbdd = _cast7 Unmanaged.upsample_bilinear2d_backward_out_ttllbdd
 
 upsample_bilinear2d_backward_out_ttllbd
   :: ForeignPtr Tensor
@@ -1350,7 +1350,7 @@ upsample_bilinear2d_backward_out_ttllbd
   -> CBool
   -> CDouble
   -> IO (ForeignPtr Tensor)
-upsample_bilinear2d_backward_out_ttllbd = cast6 Unmanaged.upsample_bilinear2d_backward_out_ttllbd
+upsample_bilinear2d_backward_out_ttllbd = _cast6 Unmanaged.upsample_bilinear2d_backward_out_ttllbd
 
 upsample_bilinear2d_backward_out_ttllb
   :: ForeignPtr Tensor
@@ -1359,7 +1359,7 @@ upsample_bilinear2d_backward_out_ttllb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-upsample_bilinear2d_backward_out_ttllb = cast5 Unmanaged.upsample_bilinear2d_backward_out_ttllb
+upsample_bilinear2d_backward_out_ttllb = _cast5 Unmanaged.upsample_bilinear2d_backward_out_ttllb
 
 upsample_bilinear2d_backward_tllbdd
   :: ForeignPtr Tensor
@@ -1369,7 +1369,7 @@ upsample_bilinear2d_backward_tllbdd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-upsample_bilinear2d_backward_tllbdd = cast6 Unmanaged.upsample_bilinear2d_backward_tllbdd
+upsample_bilinear2d_backward_tllbdd = _cast6 Unmanaged.upsample_bilinear2d_backward_tllbdd
 
 upsample_bilinear2d_backward_tllb
   :: ForeignPtr Tensor
@@ -1377,7 +1377,7 @@ upsample_bilinear2d_backward_tllb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-upsample_bilinear2d_backward_tllb = cast4 Unmanaged.upsample_bilinear2d_backward_tllb
+upsample_bilinear2d_backward_tllb = _cast4 Unmanaged.upsample_bilinear2d_backward_tllb
 
 _upsample_bilinear2d_aa_out_ttlbdd
   :: ForeignPtr Tensor
@@ -1387,7 +1387,7 @@ _upsample_bilinear2d_aa_out_ttlbdd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-_upsample_bilinear2d_aa_out_ttlbdd = cast6 Unmanaged._upsample_bilinear2d_aa_out_ttlbdd
+_upsample_bilinear2d_aa_out_ttlbdd = _cast6 Unmanaged._upsample_bilinear2d_aa_out_ttlbdd
 
 _upsample_bilinear2d_aa_out_ttlbd
   :: ForeignPtr Tensor
@@ -1396,7 +1396,7 @@ _upsample_bilinear2d_aa_out_ttlbd
   -> CBool
   -> CDouble
   -> IO (ForeignPtr Tensor)
-_upsample_bilinear2d_aa_out_ttlbd = cast5 Unmanaged._upsample_bilinear2d_aa_out_ttlbd
+_upsample_bilinear2d_aa_out_ttlbd = _cast5 Unmanaged._upsample_bilinear2d_aa_out_ttlbd
 
 _upsample_bilinear2d_aa_out_ttlb
   :: ForeignPtr Tensor
@@ -1404,7 +1404,7 @@ _upsample_bilinear2d_aa_out_ttlb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-_upsample_bilinear2d_aa_out_ttlb = cast4 Unmanaged._upsample_bilinear2d_aa_out_ttlb
+_upsample_bilinear2d_aa_out_ttlb = _cast4 Unmanaged._upsample_bilinear2d_aa_out_ttlb
 
 _upsample_bilinear2d_aa_tlbdd
   :: ForeignPtr Tensor
@@ -1413,7 +1413,7 @@ _upsample_bilinear2d_aa_tlbdd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-_upsample_bilinear2d_aa_tlbdd = cast5 Unmanaged._upsample_bilinear2d_aa_tlbdd
+_upsample_bilinear2d_aa_tlbdd = _cast5 Unmanaged._upsample_bilinear2d_aa_tlbdd
 
 -- _upsample_bilinear2d_aa_tlbd
 --   :: ForeignPtr Tensor
@@ -1421,14 +1421,14 @@ _upsample_bilinear2d_aa_tlbdd = cast5 Unmanaged._upsample_bilinear2d_aa_tlbdd
 --   -> CBool
 --   -> CDouble
 --   -> IO (ForeignPtr Tensor)
--- _upsample_bilinear2d_aa_tlbd = cast4 Unmanaged._upsample_bilinear2d_aa_tlbd
+-- _upsample_bilinear2d_aa_tlbd = _cast4 Unmanaged._upsample_bilinear2d_aa_tlbd
 
 _upsample_bilinear2d_aa_tlb
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-_upsample_bilinear2d_aa_tlb = cast3 Unmanaged._upsample_bilinear2d_aa_tlb
+_upsample_bilinear2d_aa_tlb = _cast3 Unmanaged._upsample_bilinear2d_aa_tlb
 
 _upsample_bilinear2d_aa_backward_out_ttllbdd
   :: ForeignPtr Tensor
@@ -1439,7 +1439,7 @@ _upsample_bilinear2d_aa_backward_out_ttllbdd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-_upsample_bilinear2d_aa_backward_out_ttllbdd = cast7 Unmanaged._upsample_bilinear2d_aa_backward_out_ttllbdd
+_upsample_bilinear2d_aa_backward_out_ttllbdd = _cast7 Unmanaged._upsample_bilinear2d_aa_backward_out_ttllbdd
 
 _upsample_bilinear2d_aa_backward_out_ttllbd
   :: ForeignPtr Tensor
@@ -1449,7 +1449,7 @@ _upsample_bilinear2d_aa_backward_out_ttllbd
   -> CBool
   -> CDouble
   -> IO (ForeignPtr Tensor)
-_upsample_bilinear2d_aa_backward_out_ttllbd = cast6 Unmanaged._upsample_bilinear2d_aa_backward_out_ttllbd
+_upsample_bilinear2d_aa_backward_out_ttllbd = _cast6 Unmanaged._upsample_bilinear2d_aa_backward_out_ttllbd
 
 _upsample_bilinear2d_aa_backward_out_ttllb
   :: ForeignPtr Tensor
@@ -1458,7 +1458,7 @@ _upsample_bilinear2d_aa_backward_out_ttllb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-_upsample_bilinear2d_aa_backward_out_ttllb = cast5 Unmanaged._upsample_bilinear2d_aa_backward_out_ttllb
+_upsample_bilinear2d_aa_backward_out_ttllb = _cast5 Unmanaged._upsample_bilinear2d_aa_backward_out_ttllb
 
 _upsample_bilinear2d_aa_backward_tllbdd
   :: ForeignPtr Tensor
@@ -1468,7 +1468,7 @@ _upsample_bilinear2d_aa_backward_tllbdd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-_upsample_bilinear2d_aa_backward_tllbdd = cast6 Unmanaged._upsample_bilinear2d_aa_backward_tllbdd
+_upsample_bilinear2d_aa_backward_tllbdd = _cast6 Unmanaged._upsample_bilinear2d_aa_backward_tllbdd
 
 -- _upsample_bilinear2d_aa_backward_tllbd
 --   :: ForeignPtr Tensor
@@ -1477,7 +1477,7 @@ _upsample_bilinear2d_aa_backward_tllbdd = cast6 Unmanaged._upsample_bilinear2d_a
 --   -> CBool
 --   -> CDouble
 --   -> IO (ForeignPtr Tensor)
--- _upsample_bilinear2d_aa_backward_tllbd = cast5 Unmanaged._upsample_bilinear2d_aa_backward_tllbd
+-- _upsample_bilinear2d_aa_backward_tllbd = _cast5 Unmanaged._upsample_bilinear2d_aa_backward_tllbd
 
 _upsample_bilinear2d_aa_backward_tllb
   :: ForeignPtr Tensor
@@ -1485,7 +1485,7 @@ _upsample_bilinear2d_aa_backward_tllb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-_upsample_bilinear2d_aa_backward_tllb = cast4 Unmanaged._upsample_bilinear2d_aa_backward_tllb
+_upsample_bilinear2d_aa_backward_tllb = _cast4 Unmanaged._upsample_bilinear2d_aa_backward_tllb
 
 upsample_bicubic2d_out_ttlbdd
   :: ForeignPtr Tensor
@@ -1495,7 +1495,7 @@ upsample_bicubic2d_out_ttlbdd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-upsample_bicubic2d_out_ttlbdd = cast6 Unmanaged.upsample_bicubic2d_out_ttlbdd
+upsample_bicubic2d_out_ttlbdd = _cast6 Unmanaged.upsample_bicubic2d_out_ttlbdd
 
 upsample_bicubic2d_out_ttlbd
   :: ForeignPtr Tensor
@@ -1504,7 +1504,7 @@ upsample_bicubic2d_out_ttlbd
   -> CBool
   -> CDouble
   -> IO (ForeignPtr Tensor)
-upsample_bicubic2d_out_ttlbd = cast5 Unmanaged.upsample_bicubic2d_out_ttlbd
+upsample_bicubic2d_out_ttlbd = _cast5 Unmanaged.upsample_bicubic2d_out_ttlbd
 
 upsample_bicubic2d_out_ttlb
   :: ForeignPtr Tensor
@@ -1512,7 +1512,7 @@ upsample_bicubic2d_out_ttlb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-upsample_bicubic2d_out_ttlb = cast4 Unmanaged.upsample_bicubic2d_out_ttlb
+upsample_bicubic2d_out_ttlb = _cast4 Unmanaged.upsample_bicubic2d_out_ttlb
 
 upsample_bicubic2d_tlbdd
   :: ForeignPtr Tensor
@@ -1521,14 +1521,14 @@ upsample_bicubic2d_tlbdd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-upsample_bicubic2d_tlbdd = cast5 Unmanaged.upsample_bicubic2d_tlbdd
+upsample_bicubic2d_tlbdd = _cast5 Unmanaged.upsample_bicubic2d_tlbdd
 
 upsample_bicubic2d_tlb
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-upsample_bicubic2d_tlb = cast3 Unmanaged.upsample_bicubic2d_tlb
+upsample_bicubic2d_tlb = _cast3 Unmanaged.upsample_bicubic2d_tlb
 
 upsample_bicubic2d_backward_out_ttllbdd
   :: ForeignPtr Tensor
@@ -1539,7 +1539,7 @@ upsample_bicubic2d_backward_out_ttllbdd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-upsample_bicubic2d_backward_out_ttllbdd = cast7 Unmanaged.upsample_bicubic2d_backward_out_ttllbdd
+upsample_bicubic2d_backward_out_ttllbdd = _cast7 Unmanaged.upsample_bicubic2d_backward_out_ttllbdd
 
 upsample_bicubic2d_backward_out_ttllbd
   :: ForeignPtr Tensor
@@ -1549,7 +1549,7 @@ upsample_bicubic2d_backward_out_ttllbd
   -> CBool
   -> CDouble
   -> IO (ForeignPtr Tensor)
-upsample_bicubic2d_backward_out_ttllbd = cast6 Unmanaged.upsample_bicubic2d_backward_out_ttllbd
+upsample_bicubic2d_backward_out_ttllbd = _cast6 Unmanaged.upsample_bicubic2d_backward_out_ttllbd
 
 upsample_bicubic2d_backward_out_ttllb
   :: ForeignPtr Tensor
@@ -1558,7 +1558,7 @@ upsample_bicubic2d_backward_out_ttllb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-upsample_bicubic2d_backward_out_ttllb = cast5 Unmanaged.upsample_bicubic2d_backward_out_ttllb
+upsample_bicubic2d_backward_out_ttllb = _cast5 Unmanaged.upsample_bicubic2d_backward_out_ttllb
 
 upsample_bicubic2d_backward_tllbdd
   :: ForeignPtr Tensor
@@ -1568,7 +1568,7 @@ upsample_bicubic2d_backward_tllbdd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-upsample_bicubic2d_backward_tllbdd = cast6 Unmanaged.upsample_bicubic2d_backward_tllbdd
+upsample_bicubic2d_backward_tllbdd = _cast6 Unmanaged.upsample_bicubic2d_backward_tllbdd
 
 upsample_bicubic2d_backward_tllb
   :: ForeignPtr Tensor
@@ -1576,7 +1576,7 @@ upsample_bicubic2d_backward_tllb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-upsample_bicubic2d_backward_tllb = cast4 Unmanaged.upsample_bicubic2d_backward_tllb
+upsample_bicubic2d_backward_tllb = _cast4 Unmanaged.upsample_bicubic2d_backward_tllb
 
 _upsample_bicubic2d_aa_out_ttlbdd
   :: ForeignPtr Tensor
@@ -1586,7 +1586,7 @@ _upsample_bicubic2d_aa_out_ttlbdd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-_upsample_bicubic2d_aa_out_ttlbdd = cast6 Unmanaged._upsample_bicubic2d_aa_out_ttlbdd
+_upsample_bicubic2d_aa_out_ttlbdd = _cast6 Unmanaged._upsample_bicubic2d_aa_out_ttlbdd
 
 _upsample_bicubic2d_aa_out_ttlbd
   :: ForeignPtr Tensor
@@ -1595,7 +1595,7 @@ _upsample_bicubic2d_aa_out_ttlbd
   -> CBool
   -> CDouble
   -> IO (ForeignPtr Tensor)
-_upsample_bicubic2d_aa_out_ttlbd = cast5 Unmanaged._upsample_bicubic2d_aa_out_ttlbd
+_upsample_bicubic2d_aa_out_ttlbd = _cast5 Unmanaged._upsample_bicubic2d_aa_out_ttlbd
 
 _upsample_bicubic2d_aa_out_ttlb
   :: ForeignPtr Tensor
@@ -1603,7 +1603,7 @@ _upsample_bicubic2d_aa_out_ttlb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-_upsample_bicubic2d_aa_out_ttlb = cast4 Unmanaged._upsample_bicubic2d_aa_out_ttlb
+_upsample_bicubic2d_aa_out_ttlb = _cast4 Unmanaged._upsample_bicubic2d_aa_out_ttlb
 
 _upsample_bicubic2d_aa_tlbdd
   :: ForeignPtr Tensor
@@ -1612,7 +1612,7 @@ _upsample_bicubic2d_aa_tlbdd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-_upsample_bicubic2d_aa_tlbdd = cast5 Unmanaged._upsample_bicubic2d_aa_tlbdd
+_upsample_bicubic2d_aa_tlbdd = _cast5 Unmanaged._upsample_bicubic2d_aa_tlbdd
 
 -- _upsample_bicubic2d_aa_tlbd
 --   :: ForeignPtr Tensor
@@ -1620,14 +1620,14 @@ _upsample_bicubic2d_aa_tlbdd = cast5 Unmanaged._upsample_bicubic2d_aa_tlbdd
 --   -> CBool
 --   -> CDouble
 --   -> IO (ForeignPtr Tensor)
--- _upsample_bicubic2d_aa_tlbd = cast4 Unmanaged._upsample_bicubic2d_aa_tlbd
+-- _upsample_bicubic2d_aa_tlbd = _cast4 Unmanaged._upsample_bicubic2d_aa_tlbd
 
 _upsample_bicubic2d_aa_tlb
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-_upsample_bicubic2d_aa_tlb = cast3 Unmanaged._upsample_bicubic2d_aa_tlb
+_upsample_bicubic2d_aa_tlb = _cast3 Unmanaged._upsample_bicubic2d_aa_tlb
 
 _upsample_bicubic2d_aa_backward_out_ttllbdd
   :: ForeignPtr Tensor
@@ -1638,7 +1638,7 @@ _upsample_bicubic2d_aa_backward_out_ttllbdd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-_upsample_bicubic2d_aa_backward_out_ttllbdd = cast7 Unmanaged._upsample_bicubic2d_aa_backward_out_ttllbdd
+_upsample_bicubic2d_aa_backward_out_ttllbdd = _cast7 Unmanaged._upsample_bicubic2d_aa_backward_out_ttllbdd
 
 _upsample_bicubic2d_aa_backward_out_ttllbd
   :: ForeignPtr Tensor
@@ -1648,7 +1648,7 @@ _upsample_bicubic2d_aa_backward_out_ttllbd
   -> CBool
   -> CDouble
   -> IO (ForeignPtr Tensor)
-_upsample_bicubic2d_aa_backward_out_ttllbd = cast6 Unmanaged._upsample_bicubic2d_aa_backward_out_ttllbd
+_upsample_bicubic2d_aa_backward_out_ttllbd = _cast6 Unmanaged._upsample_bicubic2d_aa_backward_out_ttllbd
 
 _upsample_bicubic2d_aa_backward_out_ttllb
   :: ForeignPtr Tensor
@@ -1657,7 +1657,7 @@ _upsample_bicubic2d_aa_backward_out_ttllb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-_upsample_bicubic2d_aa_backward_out_ttllb = cast5 Unmanaged._upsample_bicubic2d_aa_backward_out_ttllb
+_upsample_bicubic2d_aa_backward_out_ttllb = _cast5 Unmanaged._upsample_bicubic2d_aa_backward_out_ttllb
 
 _upsample_bicubic2d_aa_backward_tllbdd
   :: ForeignPtr Tensor
@@ -1667,7 +1667,7 @@ _upsample_bicubic2d_aa_backward_tllbdd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-_upsample_bicubic2d_aa_backward_tllbdd = cast6 Unmanaged._upsample_bicubic2d_aa_backward_tllbdd
+_upsample_bicubic2d_aa_backward_tllbdd = _cast6 Unmanaged._upsample_bicubic2d_aa_backward_tllbdd
 
 -- _upsample_bicubic2d_aa_backward_tllbd
 --   :: ForeignPtr Tensor
@@ -1676,7 +1676,7 @@ _upsample_bicubic2d_aa_backward_tllbdd = cast6 Unmanaged._upsample_bicubic2d_aa_
 --   -> CBool
 --   -> CDouble
 --   -> IO (ForeignPtr Tensor)
--- _upsample_bicubic2d_aa_backward_tllbd = cast5 Unmanaged._upsample_bicubic2d_aa_backward_tllbd
+-- _upsample_bicubic2d_aa_backward_tllbd = _cast5 Unmanaged._upsample_bicubic2d_aa_backward_tllbd
 
 _upsample_bicubic2d_aa_backward_tllb
   :: ForeignPtr Tensor
@@ -1684,7 +1684,7 @@ _upsample_bicubic2d_aa_backward_tllb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-_upsample_bicubic2d_aa_backward_tllb = cast4 Unmanaged._upsample_bicubic2d_aa_backward_tllb
+_upsample_bicubic2d_aa_backward_tllb = _cast4 Unmanaged._upsample_bicubic2d_aa_backward_tllb
 
 upsample_trilinear3d_out_ttlbddd
   :: ForeignPtr Tensor
@@ -1695,7 +1695,7 @@ upsample_trilinear3d_out_ttlbddd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-upsample_trilinear3d_out_ttlbddd = cast7 Unmanaged.upsample_trilinear3d_out_ttlbddd
+upsample_trilinear3d_out_ttlbddd = _cast7 Unmanaged.upsample_trilinear3d_out_ttlbddd
 
 upsample_trilinear3d_out_ttlbdd
   :: ForeignPtr Tensor
@@ -1705,7 +1705,7 @@ upsample_trilinear3d_out_ttlbdd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-upsample_trilinear3d_out_ttlbdd = cast6 Unmanaged.upsample_trilinear3d_out_ttlbdd
+upsample_trilinear3d_out_ttlbdd = _cast6 Unmanaged.upsample_trilinear3d_out_ttlbdd
 
 upsample_trilinear3d_out_ttlbd
   :: ForeignPtr Tensor
@@ -1714,7 +1714,7 @@ upsample_trilinear3d_out_ttlbd
   -> CBool
   -> CDouble
   -> IO (ForeignPtr Tensor)
-upsample_trilinear3d_out_ttlbd = cast5 Unmanaged.upsample_trilinear3d_out_ttlbd
+upsample_trilinear3d_out_ttlbd = _cast5 Unmanaged.upsample_trilinear3d_out_ttlbd
 
 upsample_trilinear3d_out_ttlb
   :: ForeignPtr Tensor
@@ -1722,7 +1722,7 @@ upsample_trilinear3d_out_ttlb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-upsample_trilinear3d_out_ttlb = cast4 Unmanaged.upsample_trilinear3d_out_ttlb
+upsample_trilinear3d_out_ttlb = _cast4 Unmanaged.upsample_trilinear3d_out_ttlb
 
 upsample_trilinear3d_tlbddd
   :: ForeignPtr Tensor
@@ -1732,7 +1732,7 @@ upsample_trilinear3d_tlbddd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-upsample_trilinear3d_tlbddd = cast6 Unmanaged.upsample_trilinear3d_tlbddd
+upsample_trilinear3d_tlbddd = _cast6 Unmanaged.upsample_trilinear3d_tlbddd
 
 upsample_trilinear3d_tlbdd
   :: ForeignPtr Tensor
@@ -1741,14 +1741,14 @@ upsample_trilinear3d_tlbdd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-upsample_trilinear3d_tlbdd = cast5 Unmanaged.upsample_trilinear3d_tlbdd
+upsample_trilinear3d_tlbdd = _cast5 Unmanaged.upsample_trilinear3d_tlbdd
 
 upsample_trilinear3d_tlb
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-upsample_trilinear3d_tlb = cast3 Unmanaged.upsample_trilinear3d_tlb
+upsample_trilinear3d_tlb = _cast3 Unmanaged.upsample_trilinear3d_tlb
 
 upsample_trilinear3d_backward_out_ttllbddd
   :: ForeignPtr Tensor
@@ -1760,7 +1760,7 @@ upsample_trilinear3d_backward_out_ttllbddd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-upsample_trilinear3d_backward_out_ttllbddd = cast8 Unmanaged.upsample_trilinear3d_backward_out_ttllbddd
+upsample_trilinear3d_backward_out_ttllbddd = _cast8 Unmanaged.upsample_trilinear3d_backward_out_ttllbddd
 
 upsample_trilinear3d_backward_out_ttllbdd
   :: ForeignPtr Tensor
@@ -1771,5 +1771,5 @@ upsample_trilinear3d_backward_out_ttllbdd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-upsample_trilinear3d_backward_out_ttllbdd = cast7 Unmanaged.upsample_trilinear3d_backward_out_ttllbdd
+upsample_trilinear3d_backward_out_ttllbdd = _cast7 Unmanaged.upsample_trilinear3d_backward_out_ttllbdd
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Native/Native13.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Native/Native13.hs
@@ -29,7 +29,7 @@ upsample_trilinear3d_backward_out_ttllbd
   -> CBool
   -> CDouble
   -> IO (ForeignPtr Tensor)
-upsample_trilinear3d_backward_out_ttllbd = cast6 Unmanaged.upsample_trilinear3d_backward_out_ttllbd
+upsample_trilinear3d_backward_out_ttllbd = _cast6 Unmanaged.upsample_trilinear3d_backward_out_ttllbd
 
 upsample_trilinear3d_backward_out_ttllb
   :: ForeignPtr Tensor
@@ -38,7 +38,7 @@ upsample_trilinear3d_backward_out_ttllb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-upsample_trilinear3d_backward_out_ttllb = cast5 Unmanaged.upsample_trilinear3d_backward_out_ttllb
+upsample_trilinear3d_backward_out_ttllb = _cast5 Unmanaged.upsample_trilinear3d_backward_out_ttllb
 
 upsample_trilinear3d_backward_tllbddd
   :: ForeignPtr Tensor
@@ -49,7 +49,7 @@ upsample_trilinear3d_backward_tllbddd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-upsample_trilinear3d_backward_tllbddd = cast7 Unmanaged.upsample_trilinear3d_backward_tllbddd
+upsample_trilinear3d_backward_tllbddd = _cast7 Unmanaged.upsample_trilinear3d_backward_tllbddd
 
 upsample_trilinear3d_backward_tllbdd
   :: ForeignPtr Tensor
@@ -59,7 +59,7 @@ upsample_trilinear3d_backward_tllbdd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-upsample_trilinear3d_backward_tllbdd = cast6 Unmanaged.upsample_trilinear3d_backward_tllbdd
+upsample_trilinear3d_backward_tllbdd = _cast6 Unmanaged.upsample_trilinear3d_backward_tllbdd
 
 upsample_trilinear3d_backward_tllb
   :: ForeignPtr Tensor
@@ -67,7 +67,7 @@ upsample_trilinear3d_backward_tllb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-upsample_trilinear3d_backward_tllb = cast4 Unmanaged.upsample_trilinear3d_backward_tllb
+upsample_trilinear3d_backward_tllb = _cast4 Unmanaged.upsample_trilinear3d_backward_tllb
 
 upsample_nearest1d_out_ttld
   :: ForeignPtr Tensor
@@ -75,14 +75,14 @@ upsample_nearest1d_out_ttld
   -> ForeignPtr IntArray
   -> CDouble
   -> IO (ForeignPtr Tensor)
-upsample_nearest1d_out_ttld = cast4 Unmanaged.upsample_nearest1d_out_ttld
+upsample_nearest1d_out_ttld = _cast4 Unmanaged.upsample_nearest1d_out_ttld
 
 upsample_nearest1d_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-upsample_nearest1d_out_ttl = cast3 Unmanaged.upsample_nearest1d_out_ttl
+upsample_nearest1d_out_ttl = _cast3 Unmanaged.upsample_nearest1d_out_ttl
 
 _upsample_nearest_exact1d_out_ttld
   :: ForeignPtr Tensor
@@ -90,33 +90,33 @@ _upsample_nearest_exact1d_out_ttld
   -> ForeignPtr IntArray
   -> CDouble
   -> IO (ForeignPtr Tensor)
-_upsample_nearest_exact1d_out_ttld = cast4 Unmanaged._upsample_nearest_exact1d_out_ttld
+_upsample_nearest_exact1d_out_ttld = _cast4 Unmanaged._upsample_nearest_exact1d_out_ttld
 
 _upsample_nearest_exact1d_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-_upsample_nearest_exact1d_out_ttl = cast3 Unmanaged._upsample_nearest_exact1d_out_ttl
+_upsample_nearest_exact1d_out_ttl = _cast3 Unmanaged._upsample_nearest_exact1d_out_ttl
 
 upsample_nearest1d_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-upsample_nearest1d_tl = cast2 Unmanaged.upsample_nearest1d_tl
+upsample_nearest1d_tl = _cast2 Unmanaged.upsample_nearest1d_tl
 
 -- _upsample_nearest_exact1d_tld
 --   :: ForeignPtr Tensor
 --   -> ForeignPtr IntArray
 --   -> CDouble
 --   -> IO (ForeignPtr Tensor)
--- _upsample_nearest_exact1d_tld = cast3 Unmanaged._upsample_nearest_exact1d_tld
+-- _upsample_nearest_exact1d_tld = _cast3 Unmanaged._upsample_nearest_exact1d_tld
 
 _upsample_nearest_exact1d_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-_upsample_nearest_exact1d_tl = cast2 Unmanaged._upsample_nearest_exact1d_tl
+_upsample_nearest_exact1d_tl = _cast2 Unmanaged._upsample_nearest_exact1d_tl
 
 upsample_nearest1d_backward_out_ttlld
   :: ForeignPtr Tensor
@@ -125,7 +125,7 @@ upsample_nearest1d_backward_out_ttlld
   -> ForeignPtr IntArray
   -> CDouble
   -> IO (ForeignPtr Tensor)
-upsample_nearest1d_backward_out_ttlld = cast5 Unmanaged.upsample_nearest1d_backward_out_ttlld
+upsample_nearest1d_backward_out_ttlld = _cast5 Unmanaged.upsample_nearest1d_backward_out_ttlld
 
 upsample_nearest1d_backward_out_ttll
   :: ForeignPtr Tensor
@@ -133,7 +133,7 @@ upsample_nearest1d_backward_out_ttll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-upsample_nearest1d_backward_out_ttll = cast4 Unmanaged.upsample_nearest1d_backward_out_ttll
+upsample_nearest1d_backward_out_ttll = _cast4 Unmanaged.upsample_nearest1d_backward_out_ttll
 
 _upsample_nearest_exact1d_backward_out_ttlld
   :: ForeignPtr Tensor
@@ -142,7 +142,7 @@ _upsample_nearest_exact1d_backward_out_ttlld
   -> ForeignPtr IntArray
   -> CDouble
   -> IO (ForeignPtr Tensor)
-_upsample_nearest_exact1d_backward_out_ttlld = cast5 Unmanaged._upsample_nearest_exact1d_backward_out_ttlld
+_upsample_nearest_exact1d_backward_out_ttlld = _cast5 Unmanaged._upsample_nearest_exact1d_backward_out_ttlld
 
 _upsample_nearest_exact1d_backward_out_ttll
   :: ForeignPtr Tensor
@@ -150,14 +150,14 @@ _upsample_nearest_exact1d_backward_out_ttll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-_upsample_nearest_exact1d_backward_out_ttll = cast4 Unmanaged._upsample_nearest_exact1d_backward_out_ttll
+_upsample_nearest_exact1d_backward_out_ttll = _cast4 Unmanaged._upsample_nearest_exact1d_backward_out_ttll
 
 upsample_nearest1d_backward_tll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-upsample_nearest1d_backward_tll = cast3 Unmanaged.upsample_nearest1d_backward_tll
+upsample_nearest1d_backward_tll = _cast3 Unmanaged.upsample_nearest1d_backward_tll
 
 -- _upsample_nearest_exact1d_backward_tlld
 --   :: ForeignPtr Tensor
@@ -165,14 +165,14 @@ upsample_nearest1d_backward_tll = cast3 Unmanaged.upsample_nearest1d_backward_tl
 --   -> ForeignPtr IntArray
 --   -> CDouble
 --   -> IO (ForeignPtr Tensor)
--- _upsample_nearest_exact1d_backward_tlld = cast4 Unmanaged._upsample_nearest_exact1d_backward_tlld
+-- _upsample_nearest_exact1d_backward_tlld = _cast4 Unmanaged._upsample_nearest_exact1d_backward_tlld
 
 _upsample_nearest_exact1d_backward_tll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-_upsample_nearest_exact1d_backward_tll = cast3 Unmanaged._upsample_nearest_exact1d_backward_tll
+_upsample_nearest_exact1d_backward_tll = _cast3 Unmanaged._upsample_nearest_exact1d_backward_tll
 
 upsample_nearest2d_out_ttldd
   :: ForeignPtr Tensor
@@ -181,7 +181,7 @@ upsample_nearest2d_out_ttldd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-upsample_nearest2d_out_ttldd = cast5 Unmanaged.upsample_nearest2d_out_ttldd
+upsample_nearest2d_out_ttldd = _cast5 Unmanaged.upsample_nearest2d_out_ttldd
 
 upsample_nearest2d_out_ttld
   :: ForeignPtr Tensor
@@ -189,14 +189,14 @@ upsample_nearest2d_out_ttld
   -> ForeignPtr IntArray
   -> CDouble
   -> IO (ForeignPtr Tensor)
-upsample_nearest2d_out_ttld = cast4 Unmanaged.upsample_nearest2d_out_ttld
+upsample_nearest2d_out_ttld = _cast4 Unmanaged.upsample_nearest2d_out_ttld
 
 upsample_nearest2d_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-upsample_nearest2d_out_ttl = cast3 Unmanaged.upsample_nearest2d_out_ttl
+upsample_nearest2d_out_ttl = _cast3 Unmanaged.upsample_nearest2d_out_ttl
 
 _upsample_nearest_exact2d_out_ttldd
   :: ForeignPtr Tensor
@@ -205,7 +205,7 @@ _upsample_nearest_exact2d_out_ttldd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-_upsample_nearest_exact2d_out_ttldd = cast5 Unmanaged._upsample_nearest_exact2d_out_ttldd
+_upsample_nearest_exact2d_out_ttldd = _cast5 Unmanaged._upsample_nearest_exact2d_out_ttldd
 
 _upsample_nearest_exact2d_out_ttld
   :: ForeignPtr Tensor
@@ -213,14 +213,14 @@ _upsample_nearest_exact2d_out_ttld
   -> ForeignPtr IntArray
   -> CDouble
   -> IO (ForeignPtr Tensor)
-_upsample_nearest_exact2d_out_ttld = cast4 Unmanaged._upsample_nearest_exact2d_out_ttld
+_upsample_nearest_exact2d_out_ttld = _cast4 Unmanaged._upsample_nearest_exact2d_out_ttld
 
 _upsample_nearest_exact2d_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-_upsample_nearest_exact2d_out_ttl = cast3 Unmanaged._upsample_nearest_exact2d_out_ttl
+_upsample_nearest_exact2d_out_ttl = _cast3 Unmanaged._upsample_nearest_exact2d_out_ttl
 
 upsample_nearest2d_tldd
   :: ForeignPtr Tensor
@@ -228,13 +228,13 @@ upsample_nearest2d_tldd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-upsample_nearest2d_tldd = cast4 Unmanaged.upsample_nearest2d_tldd
+upsample_nearest2d_tldd = _cast4 Unmanaged.upsample_nearest2d_tldd
 
 upsample_nearest2d_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-upsample_nearest2d_tl = cast2 Unmanaged.upsample_nearest2d_tl
+upsample_nearest2d_tl = _cast2 Unmanaged.upsample_nearest2d_tl
 
 _upsample_nearest_exact2d_tldd
   :: ForeignPtr Tensor
@@ -242,20 +242,20 @@ _upsample_nearest_exact2d_tldd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-_upsample_nearest_exact2d_tldd = cast4 Unmanaged._upsample_nearest_exact2d_tldd
+_upsample_nearest_exact2d_tldd = _cast4 Unmanaged._upsample_nearest_exact2d_tldd
 
 -- _upsample_nearest_exact2d_tld
 --   :: ForeignPtr Tensor
 --   -> ForeignPtr IntArray
 --   -> CDouble
 --   -> IO (ForeignPtr Tensor)
--- _upsample_nearest_exact2d_tld = cast3 Unmanaged._upsample_nearest_exact2d_tld
+-- _upsample_nearest_exact2d_tld = _cast3 Unmanaged._upsample_nearest_exact2d_tld
 
 _upsample_nearest_exact2d_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-_upsample_nearest_exact2d_tl = cast2 Unmanaged._upsample_nearest_exact2d_tl
+_upsample_nearest_exact2d_tl = _cast2 Unmanaged._upsample_nearest_exact2d_tl
 
 upsample_nearest2d_backward_out_ttlldd
   :: ForeignPtr Tensor
@@ -265,7 +265,7 @@ upsample_nearest2d_backward_out_ttlldd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-upsample_nearest2d_backward_out_ttlldd = cast6 Unmanaged.upsample_nearest2d_backward_out_ttlldd
+upsample_nearest2d_backward_out_ttlldd = _cast6 Unmanaged.upsample_nearest2d_backward_out_ttlldd
 
 upsample_nearest2d_backward_out_ttlld
   :: ForeignPtr Tensor
@@ -274,7 +274,7 @@ upsample_nearest2d_backward_out_ttlld
   -> ForeignPtr IntArray
   -> CDouble
   -> IO (ForeignPtr Tensor)
-upsample_nearest2d_backward_out_ttlld = cast5 Unmanaged.upsample_nearest2d_backward_out_ttlld
+upsample_nearest2d_backward_out_ttlld = _cast5 Unmanaged.upsample_nearest2d_backward_out_ttlld
 
 upsample_nearest2d_backward_out_ttll
   :: ForeignPtr Tensor
@@ -282,7 +282,7 @@ upsample_nearest2d_backward_out_ttll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-upsample_nearest2d_backward_out_ttll = cast4 Unmanaged.upsample_nearest2d_backward_out_ttll
+upsample_nearest2d_backward_out_ttll = _cast4 Unmanaged.upsample_nearest2d_backward_out_ttll
 
 _upsample_nearest_exact2d_backward_out_ttlldd
   :: ForeignPtr Tensor
@@ -292,7 +292,7 @@ _upsample_nearest_exact2d_backward_out_ttlldd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-_upsample_nearest_exact2d_backward_out_ttlldd = cast6 Unmanaged._upsample_nearest_exact2d_backward_out_ttlldd
+_upsample_nearest_exact2d_backward_out_ttlldd = _cast6 Unmanaged._upsample_nearest_exact2d_backward_out_ttlldd
 
 _upsample_nearest_exact2d_backward_out_ttlld
   :: ForeignPtr Tensor
@@ -301,7 +301,7 @@ _upsample_nearest_exact2d_backward_out_ttlld
   -> ForeignPtr IntArray
   -> CDouble
   -> IO (ForeignPtr Tensor)
-_upsample_nearest_exact2d_backward_out_ttlld = cast5 Unmanaged._upsample_nearest_exact2d_backward_out_ttlld
+_upsample_nearest_exact2d_backward_out_ttlld = _cast5 Unmanaged._upsample_nearest_exact2d_backward_out_ttlld
 
 _upsample_nearest_exact2d_backward_out_ttll
   :: ForeignPtr Tensor
@@ -309,7 +309,7 @@ _upsample_nearest_exact2d_backward_out_ttll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-_upsample_nearest_exact2d_backward_out_ttll = cast4 Unmanaged._upsample_nearest_exact2d_backward_out_ttll
+_upsample_nearest_exact2d_backward_out_ttll = _cast4 Unmanaged._upsample_nearest_exact2d_backward_out_ttll
 
 upsample_nearest2d_backward_tlldd
   :: ForeignPtr Tensor
@@ -318,14 +318,14 @@ upsample_nearest2d_backward_tlldd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-upsample_nearest2d_backward_tlldd = cast5 Unmanaged.upsample_nearest2d_backward_tlldd
+upsample_nearest2d_backward_tlldd = _cast5 Unmanaged.upsample_nearest2d_backward_tlldd
 
 upsample_nearest2d_backward_tll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-upsample_nearest2d_backward_tll = cast3 Unmanaged.upsample_nearest2d_backward_tll
+upsample_nearest2d_backward_tll = _cast3 Unmanaged.upsample_nearest2d_backward_tll
 
 _upsample_nearest_exact2d_backward_tlldd
   :: ForeignPtr Tensor
@@ -334,7 +334,7 @@ _upsample_nearest_exact2d_backward_tlldd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-_upsample_nearest_exact2d_backward_tlldd = cast5 Unmanaged._upsample_nearest_exact2d_backward_tlldd
+_upsample_nearest_exact2d_backward_tlldd = _cast5 Unmanaged._upsample_nearest_exact2d_backward_tlldd
 
 -- _upsample_nearest_exact2d_backward_tlld
 --   :: ForeignPtr Tensor
@@ -342,14 +342,14 @@ _upsample_nearest_exact2d_backward_tlldd = cast5 Unmanaged._upsample_nearest_exa
 --   -> ForeignPtr IntArray
 --   -> CDouble
 --   -> IO (ForeignPtr Tensor)
--- _upsample_nearest_exact2d_backward_tlld = cast4 Unmanaged._upsample_nearest_exact2d_backward_tlld
+-- _upsample_nearest_exact2d_backward_tlld = _cast4 Unmanaged._upsample_nearest_exact2d_backward_tlld
 
 _upsample_nearest_exact2d_backward_tll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-_upsample_nearest_exact2d_backward_tll = cast3 Unmanaged._upsample_nearest_exact2d_backward_tll
+_upsample_nearest_exact2d_backward_tll = _cast3 Unmanaged._upsample_nearest_exact2d_backward_tll
 
 upsample_nearest3d_out_ttlddd
   :: ForeignPtr Tensor
@@ -359,7 +359,7 @@ upsample_nearest3d_out_ttlddd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-upsample_nearest3d_out_ttlddd = cast6 Unmanaged.upsample_nearest3d_out_ttlddd
+upsample_nearest3d_out_ttlddd = _cast6 Unmanaged.upsample_nearest3d_out_ttlddd
 
 upsample_nearest3d_out_ttldd
   :: ForeignPtr Tensor
@@ -368,7 +368,7 @@ upsample_nearest3d_out_ttldd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-upsample_nearest3d_out_ttldd = cast5 Unmanaged.upsample_nearest3d_out_ttldd
+upsample_nearest3d_out_ttldd = _cast5 Unmanaged.upsample_nearest3d_out_ttldd
 
 upsample_nearest3d_out_ttld
   :: ForeignPtr Tensor
@@ -376,14 +376,14 @@ upsample_nearest3d_out_ttld
   -> ForeignPtr IntArray
   -> CDouble
   -> IO (ForeignPtr Tensor)
-upsample_nearest3d_out_ttld = cast4 Unmanaged.upsample_nearest3d_out_ttld
+upsample_nearest3d_out_ttld = _cast4 Unmanaged.upsample_nearest3d_out_ttld
 
 upsample_nearest3d_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-upsample_nearest3d_out_ttl = cast3 Unmanaged.upsample_nearest3d_out_ttl
+upsample_nearest3d_out_ttl = _cast3 Unmanaged.upsample_nearest3d_out_ttl
 
 _upsample_nearest_exact3d_out_ttlddd
   :: ForeignPtr Tensor
@@ -393,7 +393,7 @@ _upsample_nearest_exact3d_out_ttlddd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-_upsample_nearest_exact3d_out_ttlddd = cast6 Unmanaged._upsample_nearest_exact3d_out_ttlddd
+_upsample_nearest_exact3d_out_ttlddd = _cast6 Unmanaged._upsample_nearest_exact3d_out_ttlddd
 
 _upsample_nearest_exact3d_out_ttldd
   :: ForeignPtr Tensor
@@ -402,7 +402,7 @@ _upsample_nearest_exact3d_out_ttldd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-_upsample_nearest_exact3d_out_ttldd = cast5 Unmanaged._upsample_nearest_exact3d_out_ttldd
+_upsample_nearest_exact3d_out_ttldd = _cast5 Unmanaged._upsample_nearest_exact3d_out_ttldd
 
 _upsample_nearest_exact3d_out_ttld
   :: ForeignPtr Tensor
@@ -410,14 +410,14 @@ _upsample_nearest_exact3d_out_ttld
   -> ForeignPtr IntArray
   -> CDouble
   -> IO (ForeignPtr Tensor)
-_upsample_nearest_exact3d_out_ttld = cast4 Unmanaged._upsample_nearest_exact3d_out_ttld
+_upsample_nearest_exact3d_out_ttld = _cast4 Unmanaged._upsample_nearest_exact3d_out_ttld
 
 _upsample_nearest_exact3d_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-_upsample_nearest_exact3d_out_ttl = cast3 Unmanaged._upsample_nearest_exact3d_out_ttl
+_upsample_nearest_exact3d_out_ttl = _cast3 Unmanaged._upsample_nearest_exact3d_out_ttl
 
 upsample_nearest3d_tlddd
   :: ForeignPtr Tensor
@@ -426,7 +426,7 @@ upsample_nearest3d_tlddd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-upsample_nearest3d_tlddd = cast5 Unmanaged.upsample_nearest3d_tlddd
+upsample_nearest3d_tlddd = _cast5 Unmanaged.upsample_nearest3d_tlddd
 
 upsample_nearest3d_tldd
   :: ForeignPtr Tensor
@@ -434,13 +434,13 @@ upsample_nearest3d_tldd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-upsample_nearest3d_tldd = cast4 Unmanaged.upsample_nearest3d_tldd
+upsample_nearest3d_tldd = _cast4 Unmanaged.upsample_nearest3d_tldd
 
 upsample_nearest3d_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-upsample_nearest3d_tl = cast2 Unmanaged.upsample_nearest3d_tl
+upsample_nearest3d_tl = _cast2 Unmanaged.upsample_nearest3d_tl
 
 _upsample_nearest_exact3d_tlddd
   :: ForeignPtr Tensor
@@ -449,7 +449,7 @@ _upsample_nearest_exact3d_tlddd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-_upsample_nearest_exact3d_tlddd = cast5 Unmanaged._upsample_nearest_exact3d_tlddd
+_upsample_nearest_exact3d_tlddd = _cast5 Unmanaged._upsample_nearest_exact3d_tlddd
 
 _upsample_nearest_exact3d_tldd
   :: ForeignPtr Tensor
@@ -457,20 +457,20 @@ _upsample_nearest_exact3d_tldd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-_upsample_nearest_exact3d_tldd = cast4 Unmanaged._upsample_nearest_exact3d_tldd
+_upsample_nearest_exact3d_tldd = _cast4 Unmanaged._upsample_nearest_exact3d_tldd
 
 -- _upsample_nearest_exact3d_tld
 --   :: ForeignPtr Tensor
 --   -> ForeignPtr IntArray
 --   -> CDouble
 --   -> IO (ForeignPtr Tensor)
--- _upsample_nearest_exact3d_tld = cast3 Unmanaged._upsample_nearest_exact3d_tld
+-- _upsample_nearest_exact3d_tld = _cast3 Unmanaged._upsample_nearest_exact3d_tld
 
 _upsample_nearest_exact3d_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-_upsample_nearest_exact3d_tl = cast2 Unmanaged._upsample_nearest_exact3d_tl
+_upsample_nearest_exact3d_tl = _cast2 Unmanaged._upsample_nearest_exact3d_tl
 
 upsample_nearest3d_backward_out_ttllddd
   :: ForeignPtr Tensor
@@ -481,7 +481,7 @@ upsample_nearest3d_backward_out_ttllddd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-upsample_nearest3d_backward_out_ttllddd = cast7 Unmanaged.upsample_nearest3d_backward_out_ttllddd
+upsample_nearest3d_backward_out_ttllddd = _cast7 Unmanaged.upsample_nearest3d_backward_out_ttllddd
 
 upsample_nearest3d_backward_out_ttlldd
   :: ForeignPtr Tensor
@@ -491,7 +491,7 @@ upsample_nearest3d_backward_out_ttlldd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-upsample_nearest3d_backward_out_ttlldd = cast6 Unmanaged.upsample_nearest3d_backward_out_ttlldd
+upsample_nearest3d_backward_out_ttlldd = _cast6 Unmanaged.upsample_nearest3d_backward_out_ttlldd
 
 upsample_nearest3d_backward_out_ttlld
   :: ForeignPtr Tensor
@@ -500,7 +500,7 @@ upsample_nearest3d_backward_out_ttlld
   -> ForeignPtr IntArray
   -> CDouble
   -> IO (ForeignPtr Tensor)
-upsample_nearest3d_backward_out_ttlld = cast5 Unmanaged.upsample_nearest3d_backward_out_ttlld
+upsample_nearest3d_backward_out_ttlld = _cast5 Unmanaged.upsample_nearest3d_backward_out_ttlld
 
 upsample_nearest3d_backward_out_ttll
   :: ForeignPtr Tensor
@@ -508,7 +508,7 @@ upsample_nearest3d_backward_out_ttll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-upsample_nearest3d_backward_out_ttll = cast4 Unmanaged.upsample_nearest3d_backward_out_ttll
+upsample_nearest3d_backward_out_ttll = _cast4 Unmanaged.upsample_nearest3d_backward_out_ttll
 
 _upsample_nearest_exact3d_backward_out_ttllddd
   :: ForeignPtr Tensor
@@ -519,7 +519,7 @@ _upsample_nearest_exact3d_backward_out_ttllddd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-_upsample_nearest_exact3d_backward_out_ttllddd = cast7 Unmanaged._upsample_nearest_exact3d_backward_out_ttllddd
+_upsample_nearest_exact3d_backward_out_ttllddd = _cast7 Unmanaged._upsample_nearest_exact3d_backward_out_ttllddd
 
 _upsample_nearest_exact3d_backward_out_ttlldd
   :: ForeignPtr Tensor
@@ -529,7 +529,7 @@ _upsample_nearest_exact3d_backward_out_ttlldd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-_upsample_nearest_exact3d_backward_out_ttlldd = cast6 Unmanaged._upsample_nearest_exact3d_backward_out_ttlldd
+_upsample_nearest_exact3d_backward_out_ttlldd = _cast6 Unmanaged._upsample_nearest_exact3d_backward_out_ttlldd
 
 _upsample_nearest_exact3d_backward_out_ttlld
   :: ForeignPtr Tensor
@@ -538,7 +538,7 @@ _upsample_nearest_exact3d_backward_out_ttlld
   -> ForeignPtr IntArray
   -> CDouble
   -> IO (ForeignPtr Tensor)
-_upsample_nearest_exact3d_backward_out_ttlld = cast5 Unmanaged._upsample_nearest_exact3d_backward_out_ttlld
+_upsample_nearest_exact3d_backward_out_ttlld = _cast5 Unmanaged._upsample_nearest_exact3d_backward_out_ttlld
 
 _upsample_nearest_exact3d_backward_out_ttll
   :: ForeignPtr Tensor
@@ -546,7 +546,7 @@ _upsample_nearest_exact3d_backward_out_ttll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-_upsample_nearest_exact3d_backward_out_ttll = cast4 Unmanaged._upsample_nearest_exact3d_backward_out_ttll
+_upsample_nearest_exact3d_backward_out_ttll = _cast4 Unmanaged._upsample_nearest_exact3d_backward_out_ttll
 
 upsample_nearest3d_backward_tllddd
   :: ForeignPtr Tensor
@@ -556,7 +556,7 @@ upsample_nearest3d_backward_tllddd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-upsample_nearest3d_backward_tllddd = cast6 Unmanaged.upsample_nearest3d_backward_tllddd
+upsample_nearest3d_backward_tllddd = _cast6 Unmanaged.upsample_nearest3d_backward_tllddd
 
 upsample_nearest3d_backward_tlldd
   :: ForeignPtr Tensor
@@ -565,14 +565,14 @@ upsample_nearest3d_backward_tlldd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-upsample_nearest3d_backward_tlldd = cast5 Unmanaged.upsample_nearest3d_backward_tlldd
+upsample_nearest3d_backward_tlldd = _cast5 Unmanaged.upsample_nearest3d_backward_tlldd
 
 upsample_nearest3d_backward_tll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-upsample_nearest3d_backward_tll = cast3 Unmanaged.upsample_nearest3d_backward_tll
+upsample_nearest3d_backward_tll = _cast3 Unmanaged.upsample_nearest3d_backward_tll
 
 _upsample_nearest_exact3d_backward_tllddd
   :: ForeignPtr Tensor
@@ -582,7 +582,7 @@ _upsample_nearest_exact3d_backward_tllddd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-_upsample_nearest_exact3d_backward_tllddd = cast6 Unmanaged._upsample_nearest_exact3d_backward_tllddd
+_upsample_nearest_exact3d_backward_tllddd = _cast6 Unmanaged._upsample_nearest_exact3d_backward_tllddd
 
 _upsample_nearest_exact3d_backward_tlldd
   :: ForeignPtr Tensor
@@ -591,7 +591,7 @@ _upsample_nearest_exact3d_backward_tlldd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-_upsample_nearest_exact3d_backward_tlldd = cast5 Unmanaged._upsample_nearest_exact3d_backward_tlldd
+_upsample_nearest_exact3d_backward_tlldd = _cast5 Unmanaged._upsample_nearest_exact3d_backward_tlldd
 
 -- _upsample_nearest_exact3d_backward_tlld
 --   :: ForeignPtr Tensor
@@ -599,27 +599,27 @@ _upsample_nearest_exact3d_backward_tlldd = cast5 Unmanaged._upsample_nearest_exa
 --   -> ForeignPtr IntArray
 --   -> CDouble
 --   -> IO (ForeignPtr Tensor)
--- _upsample_nearest_exact3d_backward_tlld = cast4 Unmanaged._upsample_nearest_exact3d_backward_tlld
+-- _upsample_nearest_exact3d_backward_tlld = _cast4 Unmanaged._upsample_nearest_exact3d_backward_tlld
 
 _upsample_nearest_exact3d_backward_tll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-_upsample_nearest_exact3d_backward_tll = cast3 Unmanaged._upsample_nearest_exact3d_backward_tll
+_upsample_nearest_exact3d_backward_tll = _cast3 Unmanaged._upsample_nearest_exact3d_backward_tll
 
 sigmoid_backward_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-sigmoid_backward_out_ttt = cast3 Unmanaged.sigmoid_backward_out_ttt
+sigmoid_backward_out_ttt = _cast3 Unmanaged.sigmoid_backward_out_ttt
 
 sigmoid_backward_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-sigmoid_backward_tt = cast2 Unmanaged.sigmoid_backward_tt
+sigmoid_backward_tt = _cast2 Unmanaged.sigmoid_backward_tt
 
 logit_backward_out_tttd
   :: ForeignPtr Tensor
@@ -627,40 +627,40 @@ logit_backward_out_tttd
   -> ForeignPtr Tensor
   -> CDouble
   -> IO (ForeignPtr Tensor)
-logit_backward_out_tttd = cast4 Unmanaged.logit_backward_out_tttd
+logit_backward_out_tttd = _cast4 Unmanaged.logit_backward_out_tttd
 
 logit_backward_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-logit_backward_out_ttt = cast3 Unmanaged.logit_backward_out_ttt
+logit_backward_out_ttt = _cast3 Unmanaged.logit_backward_out_ttt
 
 logit_backward_ttd
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> CDouble
   -> IO (ForeignPtr Tensor)
-logit_backward_ttd = cast3 Unmanaged.logit_backward_ttd
+logit_backward_ttd = _cast3 Unmanaged.logit_backward_ttd
 
 logit_backward_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-logit_backward_tt = cast2 Unmanaged.logit_backward_tt
+logit_backward_tt = _cast2 Unmanaged.logit_backward_tt
 
 tanh_backward_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tanh_backward_out_ttt = cast3 Unmanaged.tanh_backward_out_ttt
+tanh_backward_out_ttt = _cast3 Unmanaged.tanh_backward_out_ttt
 
 tanh_backward_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tanh_backward_tt = cast2 Unmanaged.tanh_backward_tt
+tanh_backward_tt = _cast2 Unmanaged.tanh_backward_tt
 
 slow_conv_transpose2d_out_tttltllll
   :: ForeignPtr Tensor
@@ -673,7 +673,7 @@ slow_conv_transpose2d_out_tttltllll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-slow_conv_transpose2d_out_tttltllll = cast9 Unmanaged.slow_conv_transpose2d_out_tttltllll
+slow_conv_transpose2d_out_tttltllll = _cast9 Unmanaged.slow_conv_transpose2d_out_tttltllll
 
 slow_conv_transpose2d_out_tttltlll
   :: ForeignPtr Tensor
@@ -685,7 +685,7 @@ slow_conv_transpose2d_out_tttltlll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-slow_conv_transpose2d_out_tttltlll = cast8 Unmanaged.slow_conv_transpose2d_out_tttltlll
+slow_conv_transpose2d_out_tttltlll = _cast8 Unmanaged.slow_conv_transpose2d_out_tttltlll
 
 slow_conv_transpose2d_out_tttltll
   :: ForeignPtr Tensor
@@ -696,7 +696,7 @@ slow_conv_transpose2d_out_tttltll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-slow_conv_transpose2d_out_tttltll = cast7 Unmanaged.slow_conv_transpose2d_out_tttltll
+slow_conv_transpose2d_out_tttltll = _cast7 Unmanaged.slow_conv_transpose2d_out_tttltll
 
 slow_conv_transpose2d_out_tttltl
   :: ForeignPtr Tensor
@@ -706,7 +706,7 @@ slow_conv_transpose2d_out_tttltl
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-slow_conv_transpose2d_out_tttltl = cast6 Unmanaged.slow_conv_transpose2d_out_tttltl
+slow_conv_transpose2d_out_tttltl = _cast6 Unmanaged.slow_conv_transpose2d_out_tttltl
 
 slow_conv_transpose2d_out_tttlt
   :: ForeignPtr Tensor
@@ -715,7 +715,7 @@ slow_conv_transpose2d_out_tttlt
   -> ForeignPtr IntArray
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-slow_conv_transpose2d_out_tttlt = cast5 Unmanaged.slow_conv_transpose2d_out_tttlt
+slow_conv_transpose2d_out_tttlt = _cast5 Unmanaged.slow_conv_transpose2d_out_tttlt
 
 slow_conv_transpose2d_out_tttl
   :: ForeignPtr Tensor
@@ -723,7 +723,7 @@ slow_conv_transpose2d_out_tttl
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-slow_conv_transpose2d_out_tttl = cast4 Unmanaged.slow_conv_transpose2d_out_tttl
+slow_conv_transpose2d_out_tttl = _cast4 Unmanaged.slow_conv_transpose2d_out_tttl
 
 slow_conv_transpose2d_ttltllll
   :: ForeignPtr Tensor
@@ -735,7 +735,7 @@ slow_conv_transpose2d_ttltllll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-slow_conv_transpose2d_ttltllll = cast8 Unmanaged.slow_conv_transpose2d_ttltllll
+slow_conv_transpose2d_ttltllll = _cast8 Unmanaged.slow_conv_transpose2d_ttltllll
 
 slow_conv_transpose2d_ttltlll
   :: ForeignPtr Tensor
@@ -746,7 +746,7 @@ slow_conv_transpose2d_ttltlll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-slow_conv_transpose2d_ttltlll = cast7 Unmanaged.slow_conv_transpose2d_ttltlll
+slow_conv_transpose2d_ttltlll = _cast7 Unmanaged.slow_conv_transpose2d_ttltlll
 
 slow_conv_transpose2d_ttltll
   :: ForeignPtr Tensor
@@ -756,7 +756,7 @@ slow_conv_transpose2d_ttltll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-slow_conv_transpose2d_ttltll = cast6 Unmanaged.slow_conv_transpose2d_ttltll
+slow_conv_transpose2d_ttltll = _cast6 Unmanaged.slow_conv_transpose2d_ttltll
 
 slow_conv_transpose2d_ttltl
   :: ForeignPtr Tensor
@@ -765,7 +765,7 @@ slow_conv_transpose2d_ttltl
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-slow_conv_transpose2d_ttltl = cast5 Unmanaged.slow_conv_transpose2d_ttltl
+slow_conv_transpose2d_ttltl = _cast5 Unmanaged.slow_conv_transpose2d_ttltl
 
 slow_conv_transpose2d_ttlt
   :: ForeignPtr Tensor
@@ -773,14 +773,14 @@ slow_conv_transpose2d_ttlt
   -> ForeignPtr IntArray
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-slow_conv_transpose2d_ttlt = cast4 Unmanaged.slow_conv_transpose2d_ttlt
+slow_conv_transpose2d_ttlt = _cast4 Unmanaged.slow_conv_transpose2d_ttlt
 
 slow_conv_transpose2d_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-slow_conv_transpose2d_ttl = cast3 Unmanaged.slow_conv_transpose2d_ttl
+slow_conv_transpose2d_ttl = _cast3 Unmanaged.slow_conv_transpose2d_ttl
 
 slow_conv_transpose3d_out_tttltllll
   :: ForeignPtr Tensor
@@ -793,7 +793,7 @@ slow_conv_transpose3d_out_tttltllll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-slow_conv_transpose3d_out_tttltllll = cast9 Unmanaged.slow_conv_transpose3d_out_tttltllll
+slow_conv_transpose3d_out_tttltllll = _cast9 Unmanaged.slow_conv_transpose3d_out_tttltllll
 
 slow_conv_transpose3d_out_tttltlll
   :: ForeignPtr Tensor
@@ -805,7 +805,7 @@ slow_conv_transpose3d_out_tttltlll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-slow_conv_transpose3d_out_tttltlll = cast8 Unmanaged.slow_conv_transpose3d_out_tttltlll
+slow_conv_transpose3d_out_tttltlll = _cast8 Unmanaged.slow_conv_transpose3d_out_tttltlll
 
 slow_conv_transpose3d_out_tttltll
   :: ForeignPtr Tensor
@@ -816,7 +816,7 @@ slow_conv_transpose3d_out_tttltll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-slow_conv_transpose3d_out_tttltll = cast7 Unmanaged.slow_conv_transpose3d_out_tttltll
+slow_conv_transpose3d_out_tttltll = _cast7 Unmanaged.slow_conv_transpose3d_out_tttltll
 
 slow_conv_transpose3d_out_tttltl
   :: ForeignPtr Tensor
@@ -826,7 +826,7 @@ slow_conv_transpose3d_out_tttltl
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-slow_conv_transpose3d_out_tttltl = cast6 Unmanaged.slow_conv_transpose3d_out_tttltl
+slow_conv_transpose3d_out_tttltl = _cast6 Unmanaged.slow_conv_transpose3d_out_tttltl
 
 slow_conv_transpose3d_out_tttlt
   :: ForeignPtr Tensor
@@ -835,7 +835,7 @@ slow_conv_transpose3d_out_tttlt
   -> ForeignPtr IntArray
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-slow_conv_transpose3d_out_tttlt = cast5 Unmanaged.slow_conv_transpose3d_out_tttlt
+slow_conv_transpose3d_out_tttlt = _cast5 Unmanaged.slow_conv_transpose3d_out_tttlt
 
 slow_conv_transpose3d_out_tttl
   :: ForeignPtr Tensor
@@ -843,7 +843,7 @@ slow_conv_transpose3d_out_tttl
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-slow_conv_transpose3d_out_tttl = cast4 Unmanaged.slow_conv_transpose3d_out_tttl
+slow_conv_transpose3d_out_tttl = _cast4 Unmanaged.slow_conv_transpose3d_out_tttl
 
 slow_conv_transpose3d_ttltllll
   :: ForeignPtr Tensor
@@ -855,7 +855,7 @@ slow_conv_transpose3d_ttltllll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-slow_conv_transpose3d_ttltllll = cast8 Unmanaged.slow_conv_transpose3d_ttltllll
+slow_conv_transpose3d_ttltllll = _cast8 Unmanaged.slow_conv_transpose3d_ttltllll
 
 slow_conv_transpose3d_ttltlll
   :: ForeignPtr Tensor
@@ -866,7 +866,7 @@ slow_conv_transpose3d_ttltlll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-slow_conv_transpose3d_ttltlll = cast7 Unmanaged.slow_conv_transpose3d_ttltlll
+slow_conv_transpose3d_ttltlll = _cast7 Unmanaged.slow_conv_transpose3d_ttltlll
 
 slow_conv_transpose3d_ttltll
   :: ForeignPtr Tensor
@@ -876,7 +876,7 @@ slow_conv_transpose3d_ttltll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-slow_conv_transpose3d_ttltll = cast6 Unmanaged.slow_conv_transpose3d_ttltll
+slow_conv_transpose3d_ttltll = _cast6 Unmanaged.slow_conv_transpose3d_ttltll
 
 slow_conv_transpose3d_ttltl
   :: ForeignPtr Tensor
@@ -885,7 +885,7 @@ slow_conv_transpose3d_ttltl
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-slow_conv_transpose3d_ttltl = cast5 Unmanaged.slow_conv_transpose3d_ttltl
+slow_conv_transpose3d_ttltl = _cast5 Unmanaged.slow_conv_transpose3d_ttltl
 
 slow_conv_transpose3d_ttlt
   :: ForeignPtr Tensor
@@ -893,14 +893,14 @@ slow_conv_transpose3d_ttlt
   -> ForeignPtr IntArray
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-slow_conv_transpose3d_ttlt = cast4 Unmanaged.slow_conv_transpose3d_ttlt
+slow_conv_transpose3d_ttlt = _cast4 Unmanaged.slow_conv_transpose3d_ttlt
 
 slow_conv_transpose3d_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-slow_conv_transpose3d_ttl = cast3 Unmanaged.slow_conv_transpose3d_ttl
+slow_conv_transpose3d_ttl = _cast3 Unmanaged.slow_conv_transpose3d_ttl
 
 thnn_conv2d_out_tttltll
   :: ForeignPtr Tensor
@@ -911,7 +911,7 @@ thnn_conv2d_out_tttltll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-thnn_conv2d_out_tttltll = cast7 Unmanaged.thnn_conv2d_out_tttltll
+thnn_conv2d_out_tttltll = _cast7 Unmanaged.thnn_conv2d_out_tttltll
 
 thnn_conv2d_out_tttltl
   :: ForeignPtr Tensor
@@ -921,7 +921,7 @@ thnn_conv2d_out_tttltl
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-thnn_conv2d_out_tttltl = cast6 Unmanaged.thnn_conv2d_out_tttltl
+thnn_conv2d_out_tttltl = _cast6 Unmanaged.thnn_conv2d_out_tttltl
 
 thnn_conv2d_out_tttlt
   :: ForeignPtr Tensor
@@ -930,7 +930,7 @@ thnn_conv2d_out_tttlt
   -> ForeignPtr IntArray
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-thnn_conv2d_out_tttlt = cast5 Unmanaged.thnn_conv2d_out_tttlt
+thnn_conv2d_out_tttlt = _cast5 Unmanaged.thnn_conv2d_out_tttlt
 
 thnn_conv2d_out_tttl
   :: ForeignPtr Tensor
@@ -938,7 +938,7 @@ thnn_conv2d_out_tttl
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-thnn_conv2d_out_tttl = cast4 Unmanaged.thnn_conv2d_out_tttl
+thnn_conv2d_out_tttl = _cast4 Unmanaged.thnn_conv2d_out_tttl
 
 thnn_conv2d_ttltll
   :: ForeignPtr Tensor
@@ -948,7 +948,7 @@ thnn_conv2d_ttltll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-thnn_conv2d_ttltll = cast6 Unmanaged.thnn_conv2d_ttltll
+thnn_conv2d_ttltll = _cast6 Unmanaged.thnn_conv2d_ttltll
 
 thnn_conv2d_ttltl
   :: ForeignPtr Tensor
@@ -957,7 +957,7 @@ thnn_conv2d_ttltl
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-thnn_conv2d_ttltl = cast5 Unmanaged.thnn_conv2d_ttltl
+thnn_conv2d_ttltl = _cast5 Unmanaged.thnn_conv2d_ttltl
 
 thnn_conv2d_ttlt
   :: ForeignPtr Tensor
@@ -965,14 +965,14 @@ thnn_conv2d_ttlt
   -> ForeignPtr IntArray
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-thnn_conv2d_ttlt = cast4 Unmanaged.thnn_conv2d_ttlt
+thnn_conv2d_ttlt = _cast4 Unmanaged.thnn_conv2d_ttlt
 
 thnn_conv2d_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-thnn_conv2d_ttl = cast3 Unmanaged.thnn_conv2d_ttl
+thnn_conv2d_ttl = _cast3 Unmanaged.thnn_conv2d_ttl
 
 _slow_conv2d_forward_out_tttltll
   :: ForeignPtr Tensor
@@ -983,7 +983,7 @@ _slow_conv2d_forward_out_tttltll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-_slow_conv2d_forward_out_tttltll = cast7 Unmanaged._slow_conv2d_forward_out_tttltll
+_slow_conv2d_forward_out_tttltll = _cast7 Unmanaged._slow_conv2d_forward_out_tttltll
 
 _slow_conv2d_forward_ttltll
   :: ForeignPtr Tensor
@@ -993,7 +993,7 @@ _slow_conv2d_forward_ttltll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-_slow_conv2d_forward_ttltll = cast6 Unmanaged._slow_conv2d_forward_ttltll
+_slow_conv2d_forward_ttltll = _cast6 Unmanaged._slow_conv2d_forward_ttltll
 
 _slow_conv2d_backward_out_ttttttlll
   :: ForeignPtr Tensor
@@ -1006,7 +1006,7 @@ _slow_conv2d_backward_out_ttttttlll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-_slow_conv2d_backward_out_ttttttlll = cast9 Unmanaged._slow_conv2d_backward_out_ttttttlll
+_slow_conv2d_backward_out_ttttttlll = _cast9 Unmanaged._slow_conv2d_backward_out_ttttttlll
 
 _slow_conv2d_backward_tttllla
   :: ForeignPtr Tensor
@@ -1017,7 +1017,7 @@ _slow_conv2d_backward_tttllla
   -> ForeignPtr IntArray
   -> ForeignPtr (StdArray '(CBool,3))
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-_slow_conv2d_backward_tttllla = cast7 Unmanaged._slow_conv2d_backward_tttllla
+_slow_conv2d_backward_tttllla = _cast7 Unmanaged._slow_conv2d_backward_tttllla
 
 _conv_depthwise2d_out_tttltlll
   :: ForeignPtr Tensor
@@ -1029,7 +1029,7 @@ _conv_depthwise2d_out_tttltlll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-_conv_depthwise2d_out_tttltlll = cast8 Unmanaged._conv_depthwise2d_out_tttltlll
+_conv_depthwise2d_out_tttltlll = _cast8 Unmanaged._conv_depthwise2d_out_tttltlll
 
 _conv_depthwise2d_ttltlll
   :: ForeignPtr Tensor
@@ -1040,7 +1040,7 @@ _conv_depthwise2d_ttltlll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-_conv_depthwise2d_ttltlll = cast7 Unmanaged._conv_depthwise2d_ttltlll
+_conv_depthwise2d_ttltlll = _cast7 Unmanaged._conv_depthwise2d_ttltlll
 
 conv_depthwise3d_ttltlll
   :: ForeignPtr Tensor
@@ -1051,7 +1051,7 @@ conv_depthwise3d_ttltlll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-conv_depthwise3d_ttltlll = cast7 Unmanaged.conv_depthwise3d_ttltlll
+conv_depthwise3d_ttltlll = _cast7 Unmanaged.conv_depthwise3d_ttltlll
 
 slow_conv3d_out_tttltll
   :: ForeignPtr Tensor
@@ -1062,7 +1062,7 @@ slow_conv3d_out_tttltll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-slow_conv3d_out_tttltll = cast7 Unmanaged.slow_conv3d_out_tttltll
+slow_conv3d_out_tttltll = _cast7 Unmanaged.slow_conv3d_out_tttltll
 
 slow_conv3d_out_tttltl
   :: ForeignPtr Tensor
@@ -1072,7 +1072,7 @@ slow_conv3d_out_tttltl
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-slow_conv3d_out_tttltl = cast6 Unmanaged.slow_conv3d_out_tttltl
+slow_conv3d_out_tttltl = _cast6 Unmanaged.slow_conv3d_out_tttltl
 
 slow_conv3d_out_tttlt
   :: ForeignPtr Tensor
@@ -1081,7 +1081,7 @@ slow_conv3d_out_tttlt
   -> ForeignPtr IntArray
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-slow_conv3d_out_tttlt = cast5 Unmanaged.slow_conv3d_out_tttlt
+slow_conv3d_out_tttlt = _cast5 Unmanaged.slow_conv3d_out_tttlt
 
 slow_conv3d_out_tttl
   :: ForeignPtr Tensor
@@ -1089,7 +1089,7 @@ slow_conv3d_out_tttl
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-slow_conv3d_out_tttl = cast4 Unmanaged.slow_conv3d_out_tttl
+slow_conv3d_out_tttl = _cast4 Unmanaged.slow_conv3d_out_tttl
 
 slow_conv3d_ttltll
   :: ForeignPtr Tensor
@@ -1099,7 +1099,7 @@ slow_conv3d_ttltll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-slow_conv3d_ttltll = cast6 Unmanaged.slow_conv3d_ttltll
+slow_conv3d_ttltll = _cast6 Unmanaged.slow_conv3d_ttltll
 
 slow_conv3d_ttltl
   :: ForeignPtr Tensor
@@ -1108,7 +1108,7 @@ slow_conv3d_ttltl
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-slow_conv3d_ttltl = cast5 Unmanaged.slow_conv3d_ttltl
+slow_conv3d_ttltl = _cast5 Unmanaged.slow_conv3d_ttltl
 
 slow_conv3d_ttlt
   :: ForeignPtr Tensor
@@ -1116,14 +1116,14 @@ slow_conv3d_ttlt
   -> ForeignPtr IntArray
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-slow_conv3d_ttlt = cast4 Unmanaged.slow_conv3d_ttlt
+slow_conv3d_ttlt = _cast4 Unmanaged.slow_conv3d_ttlt
 
 slow_conv3d_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-slow_conv3d_ttl = cast3 Unmanaged.slow_conv3d_ttl
+slow_conv3d_ttl = _cast3 Unmanaged.slow_conv3d_ttl
 
 slow_conv3d_forward_out_tttltll
   :: ForeignPtr Tensor
@@ -1134,7 +1134,7 @@ slow_conv3d_forward_out_tttltll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-slow_conv3d_forward_out_tttltll = cast7 Unmanaged.slow_conv3d_forward_out_tttltll
+slow_conv3d_forward_out_tttltll = _cast7 Unmanaged.slow_conv3d_forward_out_tttltll
 
 slow_conv3d_forward_ttltll
   :: ForeignPtr Tensor
@@ -1144,7 +1144,7 @@ slow_conv3d_forward_ttltll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-slow_conv3d_forward_ttltll = cast6 Unmanaged.slow_conv3d_forward_ttltll
+slow_conv3d_forward_ttltll = _cast6 Unmanaged.slow_conv3d_forward_ttltll
 
 slow_conv_dilated2d_ttltlll
   :: ForeignPtr Tensor
@@ -1155,7 +1155,7 @@ slow_conv_dilated2d_ttltlll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-slow_conv_dilated2d_ttltlll = cast7 Unmanaged.slow_conv_dilated2d_ttltlll
+slow_conv_dilated2d_ttltlll = _cast7 Unmanaged.slow_conv_dilated2d_ttltlll
 
 slow_conv_dilated2d_ttltll
   :: ForeignPtr Tensor
@@ -1165,7 +1165,7 @@ slow_conv_dilated2d_ttltll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-slow_conv_dilated2d_ttltll = cast6 Unmanaged.slow_conv_dilated2d_ttltll
+slow_conv_dilated2d_ttltll = _cast6 Unmanaged.slow_conv_dilated2d_ttltll
 
 slow_conv_dilated2d_ttltl
   :: ForeignPtr Tensor
@@ -1174,7 +1174,7 @@ slow_conv_dilated2d_ttltl
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-slow_conv_dilated2d_ttltl = cast5 Unmanaged.slow_conv_dilated2d_ttltl
+slow_conv_dilated2d_ttltl = _cast5 Unmanaged.slow_conv_dilated2d_ttltl
 
 slow_conv_dilated2d_ttlt
   :: ForeignPtr Tensor
@@ -1182,14 +1182,14 @@ slow_conv_dilated2d_ttlt
   -> ForeignPtr IntArray
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-slow_conv_dilated2d_ttlt = cast4 Unmanaged.slow_conv_dilated2d_ttlt
+slow_conv_dilated2d_ttlt = _cast4 Unmanaged.slow_conv_dilated2d_ttlt
 
 slow_conv_dilated2d_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-slow_conv_dilated2d_ttl = cast3 Unmanaged.slow_conv_dilated2d_ttl
+slow_conv_dilated2d_ttl = _cast3 Unmanaged.slow_conv_dilated2d_ttl
 
 slow_conv_dilated3d_ttltlll
   :: ForeignPtr Tensor
@@ -1200,7 +1200,7 @@ slow_conv_dilated3d_ttltlll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-slow_conv_dilated3d_ttltlll = cast7 Unmanaged.slow_conv_dilated3d_ttltlll
+slow_conv_dilated3d_ttltlll = _cast7 Unmanaged.slow_conv_dilated3d_ttltlll
 
 slow_conv_dilated3d_ttltll
   :: ForeignPtr Tensor
@@ -1210,7 +1210,7 @@ slow_conv_dilated3d_ttltll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-slow_conv_dilated3d_ttltll = cast6 Unmanaged.slow_conv_dilated3d_ttltll
+slow_conv_dilated3d_ttltll = _cast6 Unmanaged.slow_conv_dilated3d_ttltll
 
 slow_conv_dilated3d_ttltl
   :: ForeignPtr Tensor
@@ -1219,7 +1219,7 @@ slow_conv_dilated3d_ttltl
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-slow_conv_dilated3d_ttltl = cast5 Unmanaged.slow_conv_dilated3d_ttltl
+slow_conv_dilated3d_ttltl = _cast5 Unmanaged.slow_conv_dilated3d_ttltl
 
 slow_conv_dilated3d_ttlt
   :: ForeignPtr Tensor
@@ -1227,14 +1227,14 @@ slow_conv_dilated3d_ttlt
   -> ForeignPtr IntArray
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-slow_conv_dilated3d_ttlt = cast4 Unmanaged.slow_conv_dilated3d_ttlt
+slow_conv_dilated3d_ttlt = _cast4 Unmanaged.slow_conv_dilated3d_ttlt
 
 slow_conv_dilated3d_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-slow_conv_dilated3d_ttl = cast3 Unmanaged.slow_conv_dilated3d_ttl
+slow_conv_dilated3d_ttl = _cast3 Unmanaged.slow_conv_dilated3d_ttl
 
 col2im_out_ttlllll
   :: ForeignPtr Tensor
@@ -1245,7 +1245,7 @@ col2im_out_ttlllll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-col2im_out_ttlllll = cast7 Unmanaged.col2im_out_ttlllll
+col2im_out_ttlllll = _cast7 Unmanaged.col2im_out_ttlllll
 
 col2im_tlllll
   :: ForeignPtr Tensor
@@ -1255,7 +1255,7 @@ col2im_tlllll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-col2im_tlllll = cast6 Unmanaged.col2im_tlllll
+col2im_tlllll = _cast6 Unmanaged.col2im_tlllll
 
 col2im_backward_out_ttllll
   :: ForeignPtr Tensor
@@ -1265,7 +1265,7 @@ col2im_backward_out_ttllll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-col2im_backward_out_ttllll = cast6 Unmanaged.col2im_backward_out_ttllll
+col2im_backward_out_ttllll = _cast6 Unmanaged.col2im_backward_out_ttllll
 
 col2im_backward_tllll
   :: ForeignPtr Tensor
@@ -1274,18 +1274,18 @@ col2im_backward_tllll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-col2im_backward_tllll = cast5 Unmanaged.col2im_backward_tllll
+col2im_backward_tllll = _cast5 Unmanaged.col2im_backward_tllll
 
 column_stack_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr Tensor)
-column_stack_l = cast1 Unmanaged.column_stack_l
+column_stack_l = _cast1 Unmanaged.column_stack_l
 
 column_stack_out_tl
   :: ForeignPtr Tensor
   -> ForeignPtr TensorList
   -> IO (ForeignPtr Tensor)
-column_stack_out_tl = cast2 Unmanaged.column_stack_out_tl
+column_stack_out_tl = _cast2 Unmanaged.column_stack_out_tl
 
 im2col_out_ttllll
   :: ForeignPtr Tensor
@@ -1295,7 +1295,7 @@ im2col_out_ttllll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-im2col_out_ttllll = cast6 Unmanaged.im2col_out_ttllll
+im2col_out_ttllll = _cast6 Unmanaged.im2col_out_ttllll
 
 im2col_tllll
   :: ForeignPtr Tensor
@@ -1304,7 +1304,7 @@ im2col_tllll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-im2col_tllll = cast5 Unmanaged.im2col_tllll
+im2col_tllll = _cast5 Unmanaged.im2col_tllll
 
 im2col_backward_out_ttlllll
   :: ForeignPtr Tensor
@@ -1315,7 +1315,7 @@ im2col_backward_out_ttlllll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-im2col_backward_out_ttlllll = cast7 Unmanaged.im2col_backward_out_ttlllll
+im2col_backward_out_ttlllll = _cast7 Unmanaged.im2col_backward_out_ttlllll
 
 im2col_backward_tlllll
   :: ForeignPtr Tensor
@@ -1325,46 +1325,46 @@ im2col_backward_tlllll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-im2col_backward_tlllll = cast6 Unmanaged.im2col_backward_tlllll
+im2col_backward_tlllll = _cast6 Unmanaged.im2col_backward_tlllll
 
 isfinite_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-isfinite_t = cast1 Unmanaged.isfinite_t
+isfinite_t = _cast1 Unmanaged.isfinite_t
 
 isinf_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-isinf_t = cast1 Unmanaged.isinf_t
+isinf_t = _cast1 Unmanaged.isinf_t
 
 isposinf_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-isposinf_t = cast1 Unmanaged.isposinf_t
+isposinf_t = _cast1 Unmanaged.isposinf_t
 
 isposinf_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-isposinf_out_tt = cast2 Unmanaged.isposinf_out_tt
+isposinf_out_tt = _cast2 Unmanaged.isposinf_out_tt
 
 isneginf_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-isneginf_t = cast1 Unmanaged.isneginf_t
+isneginf_t = _cast1 Unmanaged.isneginf_t
 
 isneginf_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-isneginf_out_tt = cast2 Unmanaged.isneginf_out_tt
+isneginf_out_tt = _cast2 Unmanaged.isneginf_out_tt
 
 _add_batch_dim_tll
   :: ForeignPtr Tensor
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-_add_batch_dim_tll = cast3 Unmanaged._add_batch_dim_tll
+_add_batch_dim_tll = _cast3 Unmanaged._add_batch_dim_tll
 
 _remove_batch_dim_tlll
   :: ForeignPtr Tensor
@@ -1372,304 +1372,304 @@ _remove_batch_dim_tlll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-_remove_batch_dim_tlll = cast4 Unmanaged._remove_batch_dim_tlll
+_remove_batch_dim_tlll = _cast4 Unmanaged._remove_batch_dim_tlll
 
 special_entr_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_entr_t = cast1 Unmanaged.special_entr_t
+special_entr_t = _cast1 Unmanaged.special_entr_t
 
 special_entr_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_entr_out_tt = cast2 Unmanaged.special_entr_out_tt
+special_entr_out_tt = _cast2 Unmanaged.special_entr_out_tt
 
 special_ndtri_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_ndtri_t = cast1 Unmanaged.special_ndtri_t
+special_ndtri_t = _cast1 Unmanaged.special_ndtri_t
 
 special_ndtri_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_ndtri_out_tt = cast2 Unmanaged.special_ndtri_out_tt
+special_ndtri_out_tt = _cast2 Unmanaged.special_ndtri_out_tt
 
 special_expm1_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_expm1_t = cast1 Unmanaged.special_expm1_t
+special_expm1_t = _cast1 Unmanaged.special_expm1_t
 
 special_expm1_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_expm1_out_tt = cast2 Unmanaged.special_expm1_out_tt
+special_expm1_out_tt = _cast2 Unmanaged.special_expm1_out_tt
 
 special_exp2_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_exp2_t = cast1 Unmanaged.special_exp2_t
+special_exp2_t = _cast1 Unmanaged.special_exp2_t
 
 special_exp2_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_exp2_out_tt = cast2 Unmanaged.special_exp2_out_tt
+special_exp2_out_tt = _cast2 Unmanaged.special_exp2_out_tt
 
 special_psi_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_psi_t = cast1 Unmanaged.special_psi_t
+special_psi_t = _cast1 Unmanaged.special_psi_t
 
 special_psi_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_psi_out_tt = cast2 Unmanaged.special_psi_out_tt
+special_psi_out_tt = _cast2 Unmanaged.special_psi_out_tt
 
 special_digamma_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_digamma_t = cast1 Unmanaged.special_digamma_t
+special_digamma_t = _cast1 Unmanaged.special_digamma_t
 
 special_digamma_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_digamma_out_tt = cast2 Unmanaged.special_digamma_out_tt
+special_digamma_out_tt = _cast2 Unmanaged.special_digamma_out_tt
 
 special_gammaln_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_gammaln_t = cast1 Unmanaged.special_gammaln_t
+special_gammaln_t = _cast1 Unmanaged.special_gammaln_t
 
 special_gammaln_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_gammaln_out_tt = cast2 Unmanaged.special_gammaln_out_tt
+special_gammaln_out_tt = _cast2 Unmanaged.special_gammaln_out_tt
 
 special_erf_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_erf_t = cast1 Unmanaged.special_erf_t
+special_erf_t = _cast1 Unmanaged.special_erf_t
 
 special_erf_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_erf_out_tt = cast2 Unmanaged.special_erf_out_tt
+special_erf_out_tt = _cast2 Unmanaged.special_erf_out_tt
 
 special_erfc_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_erfc_t = cast1 Unmanaged.special_erfc_t
+special_erfc_t = _cast1 Unmanaged.special_erfc_t
 
 special_erfc_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_erfc_out_tt = cast2 Unmanaged.special_erfc_out_tt
+special_erfc_out_tt = _cast2 Unmanaged.special_erfc_out_tt
 
 special_erfcx_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_erfcx_t = cast1 Unmanaged.special_erfcx_t
+special_erfcx_t = _cast1 Unmanaged.special_erfcx_t
 
 special_erfcx_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_erfcx_out_tt = cast2 Unmanaged.special_erfcx_out_tt
+special_erfcx_out_tt = _cast2 Unmanaged.special_erfcx_out_tt
 
 special_erfinv_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_erfinv_t = cast1 Unmanaged.special_erfinv_t
+special_erfinv_t = _cast1 Unmanaged.special_erfinv_t
 
 special_erfinv_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_erfinv_out_tt = cast2 Unmanaged.special_erfinv_out_tt
+special_erfinv_out_tt = _cast2 Unmanaged.special_erfinv_out_tt
 
 special_ndtr_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_ndtr_t = cast1 Unmanaged.special_ndtr_t
+special_ndtr_t = _cast1 Unmanaged.special_ndtr_t
 
 special_ndtr_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_ndtr_out_tt = cast2 Unmanaged.special_ndtr_out_tt
+special_ndtr_out_tt = _cast2 Unmanaged.special_ndtr_out_tt
 
 special_xlog1py_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_xlog1py_tt = cast2 Unmanaged.special_xlog1py_tt
+special_xlog1py_tt = _cast2 Unmanaged.special_xlog1py_tt
 
 special_xlog1py_st
   :: ForeignPtr Scalar
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_xlog1py_st = cast2 Unmanaged.special_xlog1py_st
+special_xlog1py_st = _cast2 Unmanaged.special_xlog1py_st
 
 special_xlog1py_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-special_xlog1py_ts = cast2 Unmanaged.special_xlog1py_ts
+special_xlog1py_ts = _cast2 Unmanaged.special_xlog1py_ts
 
 special_xlog1py_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_xlog1py_out_ttt = cast3 Unmanaged.special_xlog1py_out_ttt
+special_xlog1py_out_ttt = _cast3 Unmanaged.special_xlog1py_out_ttt
 
 special_xlog1py_out_tst
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_xlog1py_out_tst = cast3 Unmanaged.special_xlog1py_out_tst
+special_xlog1py_out_tst = _cast3 Unmanaged.special_xlog1py_out_tst
 
 special_xlog1py_out_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-special_xlog1py_out_tts = cast3 Unmanaged.special_xlog1py_out_tts
+special_xlog1py_out_tts = _cast3 Unmanaged.special_xlog1py_out_tts
 
 special_xlogy_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_xlogy_tt = cast2 Unmanaged.special_xlogy_tt
+special_xlogy_tt = _cast2 Unmanaged.special_xlogy_tt
 
 special_xlogy_st
   :: ForeignPtr Scalar
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_xlogy_st = cast2 Unmanaged.special_xlogy_st
+special_xlogy_st = _cast2 Unmanaged.special_xlogy_st
 
 special_xlogy_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-special_xlogy_ts = cast2 Unmanaged.special_xlogy_ts
+special_xlogy_ts = _cast2 Unmanaged.special_xlogy_ts
 
 special_xlogy_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_xlogy_out_ttt = cast3 Unmanaged.special_xlogy_out_ttt
+special_xlogy_out_ttt = _cast3 Unmanaged.special_xlogy_out_ttt
 
 special_xlogy_out_tst
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_xlogy_out_tst = cast3 Unmanaged.special_xlogy_out_tst
+special_xlogy_out_tst = _cast3 Unmanaged.special_xlogy_out_tst
 
 special_xlogy_out_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-special_xlogy_out_tts = cast3 Unmanaged.special_xlogy_out_tts
+special_xlogy_out_tts = _cast3 Unmanaged.special_xlogy_out_tts
 
 special_zeta_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_zeta_tt = cast2 Unmanaged.special_zeta_tt
+special_zeta_tt = _cast2 Unmanaged.special_zeta_tt
 
 special_zeta_st
   :: ForeignPtr Scalar
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_zeta_st = cast2 Unmanaged.special_zeta_st
+special_zeta_st = _cast2 Unmanaged.special_zeta_st
 
 special_zeta_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-special_zeta_ts = cast2 Unmanaged.special_zeta_ts
+special_zeta_ts = _cast2 Unmanaged.special_zeta_ts
 
 special_zeta_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_zeta_out_ttt = cast3 Unmanaged.special_zeta_out_ttt
+special_zeta_out_ttt = _cast3 Unmanaged.special_zeta_out_ttt
 
 special_zeta_out_tst
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_zeta_out_tst = cast3 Unmanaged.special_zeta_out_tst
+special_zeta_out_tst = _cast3 Unmanaged.special_zeta_out_tst
 
 special_zeta_out_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-special_zeta_out_tts = cast3 Unmanaged.special_zeta_out_tts
+special_zeta_out_tts = _cast3 Unmanaged.special_zeta_out_tts
 
 special_i0_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_i0_t = cast1 Unmanaged.special_i0_t
+special_i0_t = _cast1 Unmanaged.special_i0_t
 
 special_i0_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_i0_out_tt = cast2 Unmanaged.special_i0_out_tt
+special_i0_out_tt = _cast2 Unmanaged.special_i0_out_tt
 
 special_i0e_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_i0e_t = cast1 Unmanaged.special_i0e_t
+special_i0e_t = _cast1 Unmanaged.special_i0e_t
 
 special_i0e_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_i0e_out_tt = cast2 Unmanaged.special_i0e_out_tt
+special_i0e_out_tt = _cast2 Unmanaged.special_i0e_out_tt
 
 special_i1_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_i1_t = cast1 Unmanaged.special_i1_t
+special_i1_t = _cast1 Unmanaged.special_i1_t
 
 special_i1_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_i1_out_tt = cast2 Unmanaged.special_i1_out_tt
+special_i1_out_tt = _cast2 Unmanaged.special_i1_out_tt
 
 special_i1e_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_i1e_t = cast1 Unmanaged.special_i1e_t
+special_i1e_t = _cast1 Unmanaged.special_i1e_t
 
 special_i1e_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_i1e_out_tt = cast2 Unmanaged.special_i1e_out_tt
+special_i1e_out_tt = _cast2 Unmanaged.special_i1e_out_tt
 
 special_logit_td
   :: ForeignPtr Tensor
   -> CDouble
   -> IO (ForeignPtr Tensor)
-special_logit_td = cast2 Unmanaged.special_logit_td
+special_logit_td = _cast2 Unmanaged.special_logit_td
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Native/Native14.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Native/Native14.hs
@@ -24,46 +24,46 @@ import qualified Torch.Internal.Unmanaged.Native.Native14 as Unmanaged
 special_logit_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_logit_t = cast1 Unmanaged.special_logit_t
+special_logit_t = _cast1 Unmanaged.special_logit_t
 
 special_logit_out_ttd
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> CDouble
   -> IO (ForeignPtr Tensor)
-special_logit_out_ttd = cast3 Unmanaged.special_logit_out_ttd
+special_logit_out_ttd = _cast3 Unmanaged.special_logit_out_ttd
 
 special_logit_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_logit_out_tt = cast2 Unmanaged.special_logit_out_tt
+special_logit_out_tt = _cast2 Unmanaged.special_logit_out_tt
 
 special_polygamma_lt
   :: Int64
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_polygamma_lt = cast2 Unmanaged.special_polygamma_lt
+special_polygamma_lt = _cast2 Unmanaged.special_polygamma_lt
 
 special_polygamma_out_tlt
   :: ForeignPtr Tensor
   -> Int64
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_polygamma_out_tlt = cast3 Unmanaged.special_polygamma_out_tlt
+special_polygamma_out_tlt = _cast3 Unmanaged.special_polygamma_out_tlt
 
 special_logsumexp_tlb
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-special_logsumexp_tlb = cast3 Unmanaged.special_logsumexp_tlb
+special_logsumexp_tlb = _cast3 Unmanaged.special_logsumexp_tlb
 
 special_logsumexp_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-special_logsumexp_tl = cast2 Unmanaged.special_logsumexp_tl
+special_logsumexp_tl = _cast2 Unmanaged.special_logsumexp_tl
 
 special_logsumexp_out_ttlb
   :: ForeignPtr Tensor
@@ -71,136 +71,136 @@ special_logsumexp_out_ttlb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-special_logsumexp_out_ttlb = cast4 Unmanaged.special_logsumexp_out_ttlb
+special_logsumexp_out_ttlb = _cast4 Unmanaged.special_logsumexp_out_ttlb
 
 special_logsumexp_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-special_logsumexp_out_ttl = cast3 Unmanaged.special_logsumexp_out_ttl
+special_logsumexp_out_ttl = _cast3 Unmanaged.special_logsumexp_out_ttl
 
 special_expit_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_expit_t = cast1 Unmanaged.special_expit_t
+special_expit_t = _cast1 Unmanaged.special_expit_t
 
 special_expit_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_expit_out_tt = cast2 Unmanaged.special_expit_out_tt
+special_expit_out_tt = _cast2 Unmanaged.special_expit_out_tt
 
 special_sinc_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_sinc_t = cast1 Unmanaged.special_sinc_t
+special_sinc_t = _cast1 Unmanaged.special_sinc_t
 
 special_sinc_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_sinc_out_tt = cast2 Unmanaged.special_sinc_out_tt
+special_sinc_out_tt = _cast2 Unmanaged.special_sinc_out_tt
 
 special_round_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-special_round_tl = cast2 Unmanaged.special_round_tl
+special_round_tl = _cast2 Unmanaged.special_round_tl
 
 special_round_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_round_t = cast1 Unmanaged.special_round_t
+special_round_t = _cast1 Unmanaged.special_round_t
 
 special_round_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-special_round_out_ttl = cast3 Unmanaged.special_round_out_ttl
+special_round_out_ttl = _cast3 Unmanaged.special_round_out_ttl
 
 special_round_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_round_out_tt = cast2 Unmanaged.special_round_out_tt
+special_round_out_tt = _cast2 Unmanaged.special_round_out_tt
 
 special_log1p_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_log1p_t = cast1 Unmanaged.special_log1p_t
+special_log1p_t = _cast1 Unmanaged.special_log1p_t
 
 special_log1p_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_log1p_out_tt = cast2 Unmanaged.special_log1p_out_tt
+special_log1p_out_tt = _cast2 Unmanaged.special_log1p_out_tt
 
 special_log_softmax_tls
   :: ForeignPtr Tensor
   -> Int64
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-special_log_softmax_tls = cast3 Unmanaged.special_log_softmax_tls
+special_log_softmax_tls = _cast3 Unmanaged.special_log_softmax_tls
 
 special_log_softmax_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-special_log_softmax_tl = cast2 Unmanaged.special_log_softmax_tl
+special_log_softmax_tl = _cast2 Unmanaged.special_log_softmax_tl
 
 special_gammainc_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_gammainc_out_ttt = cast3 Unmanaged.special_gammainc_out_ttt
+special_gammainc_out_ttt = _cast3 Unmanaged.special_gammainc_out_ttt
 
 special_gammainc_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_gammainc_tt = cast2 Unmanaged.special_gammainc_tt
+special_gammainc_tt = _cast2 Unmanaged.special_gammainc_tt
 
 special_gammaincc_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_gammaincc_out_ttt = cast3 Unmanaged.special_gammaincc_out_ttt
+special_gammaincc_out_ttt = _cast3 Unmanaged.special_gammaincc_out_ttt
 
 special_gammaincc_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-special_gammaincc_tt = cast2 Unmanaged.special_gammaincc_tt
+special_gammaincc_tt = _cast2 Unmanaged.special_gammaincc_tt
 
 special_multigammaln_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-special_multigammaln_tl = cast2 Unmanaged.special_multigammaln_tl
+special_multigammaln_tl = _cast2 Unmanaged.special_multigammaln_tl
 
 special_multigammaln_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-special_multigammaln_out_ttl = cast3 Unmanaged.special_multigammaln_out_ttl
+special_multigammaln_out_ttl = _cast3 Unmanaged.special_multigammaln_out_ttl
 
 special_softmax_tls
   :: ForeignPtr Tensor
   -> Int64
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-special_softmax_tls = cast3 Unmanaged.special_softmax_tls
+special_softmax_tls = _cast3 Unmanaged.special_softmax_tls
 
 special_softmax_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-special_softmax_tl = cast2 Unmanaged.special_softmax_tl
+special_softmax_tl = _cast2 Unmanaged.special_softmax_tl
 
 fft_fft_tlls
   :: ForeignPtr Tensor
@@ -208,25 +208,25 @@ fft_fft_tlls
   -> Int64
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-fft_fft_tlls = cast4 Unmanaged.fft_fft_tlls
+fft_fft_tlls = _cast4 Unmanaged.fft_fft_tlls
 
 fft_fft_tll
   :: ForeignPtr Tensor
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-fft_fft_tll = cast3 Unmanaged.fft_fft_tll
+fft_fft_tll = _cast3 Unmanaged.fft_fft_tll
 
 fft_fft_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-fft_fft_tl = cast2 Unmanaged.fft_fft_tl
+fft_fft_tl = _cast2 Unmanaged.fft_fft_tl
 
 fft_fft_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fft_fft_t = cast1 Unmanaged.fft_fft_t
+fft_fft_t = _cast1 Unmanaged.fft_fft_t
 
 fft_fft_out_ttlls
   :: ForeignPtr Tensor
@@ -235,7 +235,7 @@ fft_fft_out_ttlls
   -> Int64
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-fft_fft_out_ttlls = cast5 Unmanaged.fft_fft_out_ttlls
+fft_fft_out_ttlls = _cast5 Unmanaged.fft_fft_out_ttlls
 
 fft_fft_out_ttll
   :: ForeignPtr Tensor
@@ -243,20 +243,20 @@ fft_fft_out_ttll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-fft_fft_out_ttll = cast4 Unmanaged.fft_fft_out_ttll
+fft_fft_out_ttll = _cast4 Unmanaged.fft_fft_out_ttll
 
 fft_fft_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-fft_fft_out_ttl = cast3 Unmanaged.fft_fft_out_ttl
+fft_fft_out_ttl = _cast3 Unmanaged.fft_fft_out_ttl
 
 fft_fft_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fft_fft_out_tt = cast2 Unmanaged.fft_fft_out_tt
+fft_fft_out_tt = _cast2 Unmanaged.fft_fft_out_tt
 
 fft_ifft_tlls
   :: ForeignPtr Tensor
@@ -264,25 +264,25 @@ fft_ifft_tlls
   -> Int64
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-fft_ifft_tlls = cast4 Unmanaged.fft_ifft_tlls
+fft_ifft_tlls = _cast4 Unmanaged.fft_ifft_tlls
 
 fft_ifft_tll
   :: ForeignPtr Tensor
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-fft_ifft_tll = cast3 Unmanaged.fft_ifft_tll
+fft_ifft_tll = _cast3 Unmanaged.fft_ifft_tll
 
 fft_ifft_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-fft_ifft_tl = cast2 Unmanaged.fft_ifft_tl
+fft_ifft_tl = _cast2 Unmanaged.fft_ifft_tl
 
 fft_ifft_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fft_ifft_t = cast1 Unmanaged.fft_ifft_t
+fft_ifft_t = _cast1 Unmanaged.fft_ifft_t
 
 fft_ifft_out_ttlls
   :: ForeignPtr Tensor
@@ -291,7 +291,7 @@ fft_ifft_out_ttlls
   -> Int64
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-fft_ifft_out_ttlls = cast5 Unmanaged.fft_ifft_out_ttlls
+fft_ifft_out_ttlls = _cast5 Unmanaged.fft_ifft_out_ttlls
 
 fft_ifft_out_ttll
   :: ForeignPtr Tensor
@@ -299,20 +299,20 @@ fft_ifft_out_ttll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-fft_ifft_out_ttll = cast4 Unmanaged.fft_ifft_out_ttll
+fft_ifft_out_ttll = _cast4 Unmanaged.fft_ifft_out_ttll
 
 fft_ifft_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-fft_ifft_out_ttl = cast3 Unmanaged.fft_ifft_out_ttl
+fft_ifft_out_ttl = _cast3 Unmanaged.fft_ifft_out_ttl
 
 fft_ifft_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fft_ifft_out_tt = cast2 Unmanaged.fft_ifft_out_tt
+fft_ifft_out_tt = _cast2 Unmanaged.fft_ifft_out_tt
 
 fft_rfft_tlls
   :: ForeignPtr Tensor
@@ -320,25 +320,25 @@ fft_rfft_tlls
   -> Int64
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-fft_rfft_tlls = cast4 Unmanaged.fft_rfft_tlls
+fft_rfft_tlls = _cast4 Unmanaged.fft_rfft_tlls
 
 fft_rfft_tll
   :: ForeignPtr Tensor
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-fft_rfft_tll = cast3 Unmanaged.fft_rfft_tll
+fft_rfft_tll = _cast3 Unmanaged.fft_rfft_tll
 
 fft_rfft_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-fft_rfft_tl = cast2 Unmanaged.fft_rfft_tl
+fft_rfft_tl = _cast2 Unmanaged.fft_rfft_tl
 
 fft_rfft_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fft_rfft_t = cast1 Unmanaged.fft_rfft_t
+fft_rfft_t = _cast1 Unmanaged.fft_rfft_t
 
 fft_rfft_out_ttlls
   :: ForeignPtr Tensor
@@ -347,7 +347,7 @@ fft_rfft_out_ttlls
   -> Int64
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-fft_rfft_out_ttlls = cast5 Unmanaged.fft_rfft_out_ttlls
+fft_rfft_out_ttlls = _cast5 Unmanaged.fft_rfft_out_ttlls
 
 fft_rfft_out_ttll
   :: ForeignPtr Tensor
@@ -355,20 +355,20 @@ fft_rfft_out_ttll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-fft_rfft_out_ttll = cast4 Unmanaged.fft_rfft_out_ttll
+fft_rfft_out_ttll = _cast4 Unmanaged.fft_rfft_out_ttll
 
 fft_rfft_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-fft_rfft_out_ttl = cast3 Unmanaged.fft_rfft_out_ttl
+fft_rfft_out_ttl = _cast3 Unmanaged.fft_rfft_out_ttl
 
 fft_rfft_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fft_rfft_out_tt = cast2 Unmanaged.fft_rfft_out_tt
+fft_rfft_out_tt = _cast2 Unmanaged.fft_rfft_out_tt
 
 fft_irfft_tlls
   :: ForeignPtr Tensor
@@ -376,25 +376,25 @@ fft_irfft_tlls
   -> Int64
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-fft_irfft_tlls = cast4 Unmanaged.fft_irfft_tlls
+fft_irfft_tlls = _cast4 Unmanaged.fft_irfft_tlls
 
 fft_irfft_tll
   :: ForeignPtr Tensor
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-fft_irfft_tll = cast3 Unmanaged.fft_irfft_tll
+fft_irfft_tll = _cast3 Unmanaged.fft_irfft_tll
 
 fft_irfft_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-fft_irfft_tl = cast2 Unmanaged.fft_irfft_tl
+fft_irfft_tl = _cast2 Unmanaged.fft_irfft_tl
 
 fft_irfft_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fft_irfft_t = cast1 Unmanaged.fft_irfft_t
+fft_irfft_t = _cast1 Unmanaged.fft_irfft_t
 
 fft_irfft_out_ttlls
   :: ForeignPtr Tensor
@@ -403,7 +403,7 @@ fft_irfft_out_ttlls
   -> Int64
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-fft_irfft_out_ttlls = cast5 Unmanaged.fft_irfft_out_ttlls
+fft_irfft_out_ttlls = _cast5 Unmanaged.fft_irfft_out_ttlls
 
 fft_irfft_out_ttll
   :: ForeignPtr Tensor
@@ -411,20 +411,20 @@ fft_irfft_out_ttll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-fft_irfft_out_ttll = cast4 Unmanaged.fft_irfft_out_ttll
+fft_irfft_out_ttll = _cast4 Unmanaged.fft_irfft_out_ttll
 
 fft_irfft_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-fft_irfft_out_ttl = cast3 Unmanaged.fft_irfft_out_ttl
+fft_irfft_out_ttl = _cast3 Unmanaged.fft_irfft_out_ttl
 
 fft_irfft_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fft_irfft_out_tt = cast2 Unmanaged.fft_irfft_out_tt
+fft_irfft_out_tt = _cast2 Unmanaged.fft_irfft_out_tt
 
 fft_hfft_tlls
   :: ForeignPtr Tensor
@@ -432,25 +432,25 @@ fft_hfft_tlls
   -> Int64
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-fft_hfft_tlls = cast4 Unmanaged.fft_hfft_tlls
+fft_hfft_tlls = _cast4 Unmanaged.fft_hfft_tlls
 
 fft_hfft_tll
   :: ForeignPtr Tensor
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-fft_hfft_tll = cast3 Unmanaged.fft_hfft_tll
+fft_hfft_tll = _cast3 Unmanaged.fft_hfft_tll
 
 fft_hfft_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-fft_hfft_tl = cast2 Unmanaged.fft_hfft_tl
+fft_hfft_tl = _cast2 Unmanaged.fft_hfft_tl
 
 fft_hfft_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fft_hfft_t = cast1 Unmanaged.fft_hfft_t
+fft_hfft_t = _cast1 Unmanaged.fft_hfft_t
 
 fft_hfft_out_ttlls
   :: ForeignPtr Tensor
@@ -459,7 +459,7 @@ fft_hfft_out_ttlls
   -> Int64
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-fft_hfft_out_ttlls = cast5 Unmanaged.fft_hfft_out_ttlls
+fft_hfft_out_ttlls = _cast5 Unmanaged.fft_hfft_out_ttlls
 
 fft_hfft_out_ttll
   :: ForeignPtr Tensor
@@ -467,20 +467,20 @@ fft_hfft_out_ttll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-fft_hfft_out_ttll = cast4 Unmanaged.fft_hfft_out_ttll
+fft_hfft_out_ttll = _cast4 Unmanaged.fft_hfft_out_ttll
 
 fft_hfft_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-fft_hfft_out_ttl = cast3 Unmanaged.fft_hfft_out_ttl
+fft_hfft_out_ttl = _cast3 Unmanaged.fft_hfft_out_ttl
 
 fft_hfft_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fft_hfft_out_tt = cast2 Unmanaged.fft_hfft_out_tt
+fft_hfft_out_tt = _cast2 Unmanaged.fft_hfft_out_tt
 
 fft_ihfft_tlls
   :: ForeignPtr Tensor
@@ -488,25 +488,25 @@ fft_ihfft_tlls
   -> Int64
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-fft_ihfft_tlls = cast4 Unmanaged.fft_ihfft_tlls
+fft_ihfft_tlls = _cast4 Unmanaged.fft_ihfft_tlls
 
 fft_ihfft_tll
   :: ForeignPtr Tensor
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-fft_ihfft_tll = cast3 Unmanaged.fft_ihfft_tll
+fft_ihfft_tll = _cast3 Unmanaged.fft_ihfft_tll
 
 fft_ihfft_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-fft_ihfft_tl = cast2 Unmanaged.fft_ihfft_tl
+fft_ihfft_tl = _cast2 Unmanaged.fft_ihfft_tl
 
 fft_ihfft_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fft_ihfft_t = cast1 Unmanaged.fft_ihfft_t
+fft_ihfft_t = _cast1 Unmanaged.fft_ihfft_t
 
 fft_ihfft_out_ttlls
   :: ForeignPtr Tensor
@@ -515,7 +515,7 @@ fft_ihfft_out_ttlls
   -> Int64
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-fft_ihfft_out_ttlls = cast5 Unmanaged.fft_ihfft_out_ttlls
+fft_ihfft_out_ttlls = _cast5 Unmanaged.fft_ihfft_out_ttlls
 
 fft_ihfft_out_ttll
   :: ForeignPtr Tensor
@@ -523,20 +523,20 @@ fft_ihfft_out_ttll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-fft_ihfft_out_ttll = cast4 Unmanaged.fft_ihfft_out_ttll
+fft_ihfft_out_ttll = _cast4 Unmanaged.fft_ihfft_out_ttll
 
 fft_ihfft_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-fft_ihfft_out_ttl = cast3 Unmanaged.fft_ihfft_out_ttl
+fft_ihfft_out_ttl = _cast3 Unmanaged.fft_ihfft_out_ttl
 
 fft_ihfft_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fft_ihfft_out_tt = cast2 Unmanaged.fft_ihfft_out_tt
+fft_ihfft_out_tt = _cast2 Unmanaged.fft_ihfft_out_tt
 
 fft_fft2_tlls
   :: ForeignPtr Tensor
@@ -544,25 +544,25 @@ fft_fft2_tlls
   -> ForeignPtr IntArray
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-fft_fft2_tlls = cast4 Unmanaged.fft_fft2_tlls
+fft_fft2_tlls = _cast4 Unmanaged.fft_fft2_tlls
 
 fft_fft2_tll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_fft2_tll = cast3 Unmanaged.fft_fft2_tll
+fft_fft2_tll = _cast3 Unmanaged.fft_fft2_tll
 
 fft_fft2_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_fft2_tl = cast2 Unmanaged.fft_fft2_tl
+fft_fft2_tl = _cast2 Unmanaged.fft_fft2_tl
 
 fft_fft2_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fft_fft2_t = cast1 Unmanaged.fft_fft2_t
+fft_fft2_t = _cast1 Unmanaged.fft_fft2_t
 
 fft_fft2_out_ttlls
   :: ForeignPtr Tensor
@@ -571,7 +571,7 @@ fft_fft2_out_ttlls
   -> ForeignPtr IntArray
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-fft_fft2_out_ttlls = cast5 Unmanaged.fft_fft2_out_ttlls
+fft_fft2_out_ttlls = _cast5 Unmanaged.fft_fft2_out_ttlls
 
 fft_fft2_out_ttll
   :: ForeignPtr Tensor
@@ -579,20 +579,20 @@ fft_fft2_out_ttll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_fft2_out_ttll = cast4 Unmanaged.fft_fft2_out_ttll
+fft_fft2_out_ttll = _cast4 Unmanaged.fft_fft2_out_ttll
 
 fft_fft2_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_fft2_out_ttl = cast3 Unmanaged.fft_fft2_out_ttl
+fft_fft2_out_ttl = _cast3 Unmanaged.fft_fft2_out_ttl
 
 fft_fft2_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fft_fft2_out_tt = cast2 Unmanaged.fft_fft2_out_tt
+fft_fft2_out_tt = _cast2 Unmanaged.fft_fft2_out_tt
 
 fft_ifft2_tlls
   :: ForeignPtr Tensor
@@ -600,25 +600,25 @@ fft_ifft2_tlls
   -> ForeignPtr IntArray
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-fft_ifft2_tlls = cast4 Unmanaged.fft_ifft2_tlls
+fft_ifft2_tlls = _cast4 Unmanaged.fft_ifft2_tlls
 
 fft_ifft2_tll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_ifft2_tll = cast3 Unmanaged.fft_ifft2_tll
+fft_ifft2_tll = _cast3 Unmanaged.fft_ifft2_tll
 
 fft_ifft2_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_ifft2_tl = cast2 Unmanaged.fft_ifft2_tl
+fft_ifft2_tl = _cast2 Unmanaged.fft_ifft2_tl
 
 fft_ifft2_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fft_ifft2_t = cast1 Unmanaged.fft_ifft2_t
+fft_ifft2_t = _cast1 Unmanaged.fft_ifft2_t
 
 fft_ifft2_out_ttlls
   :: ForeignPtr Tensor
@@ -627,7 +627,7 @@ fft_ifft2_out_ttlls
   -> ForeignPtr IntArray
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-fft_ifft2_out_ttlls = cast5 Unmanaged.fft_ifft2_out_ttlls
+fft_ifft2_out_ttlls = _cast5 Unmanaged.fft_ifft2_out_ttlls
 
 fft_ifft2_out_ttll
   :: ForeignPtr Tensor
@@ -635,20 +635,20 @@ fft_ifft2_out_ttll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_ifft2_out_ttll = cast4 Unmanaged.fft_ifft2_out_ttll
+fft_ifft2_out_ttll = _cast4 Unmanaged.fft_ifft2_out_ttll
 
 fft_ifft2_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_ifft2_out_ttl = cast3 Unmanaged.fft_ifft2_out_ttl
+fft_ifft2_out_ttl = _cast3 Unmanaged.fft_ifft2_out_ttl
 
 fft_ifft2_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fft_ifft2_out_tt = cast2 Unmanaged.fft_ifft2_out_tt
+fft_ifft2_out_tt = _cast2 Unmanaged.fft_ifft2_out_tt
 
 fft_rfft2_tlls
   :: ForeignPtr Tensor
@@ -656,25 +656,25 @@ fft_rfft2_tlls
   -> ForeignPtr IntArray
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-fft_rfft2_tlls = cast4 Unmanaged.fft_rfft2_tlls
+fft_rfft2_tlls = _cast4 Unmanaged.fft_rfft2_tlls
 
 fft_rfft2_tll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_rfft2_tll = cast3 Unmanaged.fft_rfft2_tll
+fft_rfft2_tll = _cast3 Unmanaged.fft_rfft2_tll
 
 fft_rfft2_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_rfft2_tl = cast2 Unmanaged.fft_rfft2_tl
+fft_rfft2_tl = _cast2 Unmanaged.fft_rfft2_tl
 
 fft_rfft2_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fft_rfft2_t = cast1 Unmanaged.fft_rfft2_t
+fft_rfft2_t = _cast1 Unmanaged.fft_rfft2_t
 
 fft_rfft2_out_ttlls
   :: ForeignPtr Tensor
@@ -683,7 +683,7 @@ fft_rfft2_out_ttlls
   -> ForeignPtr IntArray
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-fft_rfft2_out_ttlls = cast5 Unmanaged.fft_rfft2_out_ttlls
+fft_rfft2_out_ttlls = _cast5 Unmanaged.fft_rfft2_out_ttlls
 
 fft_rfft2_out_ttll
   :: ForeignPtr Tensor
@@ -691,20 +691,20 @@ fft_rfft2_out_ttll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_rfft2_out_ttll = cast4 Unmanaged.fft_rfft2_out_ttll
+fft_rfft2_out_ttll = _cast4 Unmanaged.fft_rfft2_out_ttll
 
 fft_rfft2_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_rfft2_out_ttl = cast3 Unmanaged.fft_rfft2_out_ttl
+fft_rfft2_out_ttl = _cast3 Unmanaged.fft_rfft2_out_ttl
 
 fft_rfft2_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fft_rfft2_out_tt = cast2 Unmanaged.fft_rfft2_out_tt
+fft_rfft2_out_tt = _cast2 Unmanaged.fft_rfft2_out_tt
 
 fft_irfft2_tlls
   :: ForeignPtr Tensor
@@ -712,25 +712,25 @@ fft_irfft2_tlls
   -> ForeignPtr IntArray
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-fft_irfft2_tlls = cast4 Unmanaged.fft_irfft2_tlls
+fft_irfft2_tlls = _cast4 Unmanaged.fft_irfft2_tlls
 
 fft_irfft2_tll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_irfft2_tll = cast3 Unmanaged.fft_irfft2_tll
+fft_irfft2_tll = _cast3 Unmanaged.fft_irfft2_tll
 
 fft_irfft2_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_irfft2_tl = cast2 Unmanaged.fft_irfft2_tl
+fft_irfft2_tl = _cast2 Unmanaged.fft_irfft2_tl
 
 fft_irfft2_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fft_irfft2_t = cast1 Unmanaged.fft_irfft2_t
+fft_irfft2_t = _cast1 Unmanaged.fft_irfft2_t
 
 fft_irfft2_out_ttlls
   :: ForeignPtr Tensor
@@ -739,7 +739,7 @@ fft_irfft2_out_ttlls
   -> ForeignPtr IntArray
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-fft_irfft2_out_ttlls = cast5 Unmanaged.fft_irfft2_out_ttlls
+fft_irfft2_out_ttlls = _cast5 Unmanaged.fft_irfft2_out_ttlls
 
 fft_irfft2_out_ttll
   :: ForeignPtr Tensor
@@ -747,20 +747,20 @@ fft_irfft2_out_ttll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_irfft2_out_ttll = cast4 Unmanaged.fft_irfft2_out_ttll
+fft_irfft2_out_ttll = _cast4 Unmanaged.fft_irfft2_out_ttll
 
 fft_irfft2_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_irfft2_out_ttl = cast3 Unmanaged.fft_irfft2_out_ttl
+fft_irfft2_out_ttl = _cast3 Unmanaged.fft_irfft2_out_ttl
 
 fft_irfft2_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fft_irfft2_out_tt = cast2 Unmanaged.fft_irfft2_out_tt
+fft_irfft2_out_tt = _cast2 Unmanaged.fft_irfft2_out_tt
 
 fft_hfft2_tlls
   :: ForeignPtr Tensor
@@ -768,25 +768,25 @@ fft_hfft2_tlls
   -> ForeignPtr IntArray
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-fft_hfft2_tlls = cast4 Unmanaged.fft_hfft2_tlls
+fft_hfft2_tlls = _cast4 Unmanaged.fft_hfft2_tlls
 
 fft_hfft2_tll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_hfft2_tll = cast3 Unmanaged.fft_hfft2_tll
+fft_hfft2_tll = _cast3 Unmanaged.fft_hfft2_tll
 
 fft_hfft2_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_hfft2_tl = cast2 Unmanaged.fft_hfft2_tl
+fft_hfft2_tl = _cast2 Unmanaged.fft_hfft2_tl
 
 fft_hfft2_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fft_hfft2_t = cast1 Unmanaged.fft_hfft2_t
+fft_hfft2_t = _cast1 Unmanaged.fft_hfft2_t
 
 fft_hfft2_out_ttlls
   :: ForeignPtr Tensor
@@ -795,7 +795,7 @@ fft_hfft2_out_ttlls
   -> ForeignPtr IntArray
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-fft_hfft2_out_ttlls = cast5 Unmanaged.fft_hfft2_out_ttlls
+fft_hfft2_out_ttlls = _cast5 Unmanaged.fft_hfft2_out_ttlls
 
 fft_hfft2_out_ttll
   :: ForeignPtr Tensor
@@ -803,20 +803,20 @@ fft_hfft2_out_ttll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_hfft2_out_ttll = cast4 Unmanaged.fft_hfft2_out_ttll
+fft_hfft2_out_ttll = _cast4 Unmanaged.fft_hfft2_out_ttll
 
 fft_hfft2_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_hfft2_out_ttl = cast3 Unmanaged.fft_hfft2_out_ttl
+fft_hfft2_out_ttl = _cast3 Unmanaged.fft_hfft2_out_ttl
 
 fft_hfft2_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fft_hfft2_out_tt = cast2 Unmanaged.fft_hfft2_out_tt
+fft_hfft2_out_tt = _cast2 Unmanaged.fft_hfft2_out_tt
 
 fft_ihfft2_tlls
   :: ForeignPtr Tensor
@@ -824,25 +824,25 @@ fft_ihfft2_tlls
   -> ForeignPtr IntArray
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-fft_ihfft2_tlls = cast4 Unmanaged.fft_ihfft2_tlls
+fft_ihfft2_tlls = _cast4 Unmanaged.fft_ihfft2_tlls
 
 fft_ihfft2_tll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_ihfft2_tll = cast3 Unmanaged.fft_ihfft2_tll
+fft_ihfft2_tll = _cast3 Unmanaged.fft_ihfft2_tll
 
 fft_ihfft2_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_ihfft2_tl = cast2 Unmanaged.fft_ihfft2_tl
+fft_ihfft2_tl = _cast2 Unmanaged.fft_ihfft2_tl
 
 fft_ihfft2_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fft_ihfft2_t = cast1 Unmanaged.fft_ihfft2_t
+fft_ihfft2_t = _cast1 Unmanaged.fft_ihfft2_t
 
 fft_ihfft2_out_ttlls
   :: ForeignPtr Tensor
@@ -851,7 +851,7 @@ fft_ihfft2_out_ttlls
   -> ForeignPtr IntArray
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-fft_ihfft2_out_ttlls = cast5 Unmanaged.fft_ihfft2_out_ttlls
+fft_ihfft2_out_ttlls = _cast5 Unmanaged.fft_ihfft2_out_ttlls
 
 fft_ihfft2_out_ttll
   :: ForeignPtr Tensor
@@ -859,20 +859,20 @@ fft_ihfft2_out_ttll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_ihfft2_out_ttll = cast4 Unmanaged.fft_ihfft2_out_ttll
+fft_ihfft2_out_ttll = _cast4 Unmanaged.fft_ihfft2_out_ttll
 
 fft_ihfft2_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_ihfft2_out_ttl = cast3 Unmanaged.fft_ihfft2_out_ttl
+fft_ihfft2_out_ttl = _cast3 Unmanaged.fft_ihfft2_out_ttl
 
 fft_ihfft2_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fft_ihfft2_out_tt = cast2 Unmanaged.fft_ihfft2_out_tt
+fft_ihfft2_out_tt = _cast2 Unmanaged.fft_ihfft2_out_tt
 
 fft_fftn_tlls
   :: ForeignPtr Tensor
@@ -880,25 +880,25 @@ fft_fftn_tlls
   -> ForeignPtr IntArray
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-fft_fftn_tlls = cast4 Unmanaged.fft_fftn_tlls
+fft_fftn_tlls = _cast4 Unmanaged.fft_fftn_tlls
 
 fft_fftn_tll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_fftn_tll = cast3 Unmanaged.fft_fftn_tll
+fft_fftn_tll = _cast3 Unmanaged.fft_fftn_tll
 
 fft_fftn_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_fftn_tl = cast2 Unmanaged.fft_fftn_tl
+fft_fftn_tl = _cast2 Unmanaged.fft_fftn_tl
 
 fft_fftn_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fft_fftn_t = cast1 Unmanaged.fft_fftn_t
+fft_fftn_t = _cast1 Unmanaged.fft_fftn_t
 
 fft_fftn_out_ttlls
   :: ForeignPtr Tensor
@@ -907,7 +907,7 @@ fft_fftn_out_ttlls
   -> ForeignPtr IntArray
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-fft_fftn_out_ttlls = cast5 Unmanaged.fft_fftn_out_ttlls
+fft_fftn_out_ttlls = _cast5 Unmanaged.fft_fftn_out_ttlls
 
 fft_fftn_out_ttll
   :: ForeignPtr Tensor
@@ -915,20 +915,20 @@ fft_fftn_out_ttll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_fftn_out_ttll = cast4 Unmanaged.fft_fftn_out_ttll
+fft_fftn_out_ttll = _cast4 Unmanaged.fft_fftn_out_ttll
 
 fft_fftn_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_fftn_out_ttl = cast3 Unmanaged.fft_fftn_out_ttl
+fft_fftn_out_ttl = _cast3 Unmanaged.fft_fftn_out_ttl
 
 fft_fftn_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fft_fftn_out_tt = cast2 Unmanaged.fft_fftn_out_tt
+fft_fftn_out_tt = _cast2 Unmanaged.fft_fftn_out_tt
 
 fft_ifftn_tlls
   :: ForeignPtr Tensor
@@ -936,25 +936,25 @@ fft_ifftn_tlls
   -> ForeignPtr IntArray
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-fft_ifftn_tlls = cast4 Unmanaged.fft_ifftn_tlls
+fft_ifftn_tlls = _cast4 Unmanaged.fft_ifftn_tlls
 
 fft_ifftn_tll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_ifftn_tll = cast3 Unmanaged.fft_ifftn_tll
+fft_ifftn_tll = _cast3 Unmanaged.fft_ifftn_tll
 
 fft_ifftn_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_ifftn_tl = cast2 Unmanaged.fft_ifftn_tl
+fft_ifftn_tl = _cast2 Unmanaged.fft_ifftn_tl
 
 fft_ifftn_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fft_ifftn_t = cast1 Unmanaged.fft_ifftn_t
+fft_ifftn_t = _cast1 Unmanaged.fft_ifftn_t
 
 fft_ifftn_out_ttlls
   :: ForeignPtr Tensor
@@ -963,7 +963,7 @@ fft_ifftn_out_ttlls
   -> ForeignPtr IntArray
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-fft_ifftn_out_ttlls = cast5 Unmanaged.fft_ifftn_out_ttlls
+fft_ifftn_out_ttlls = _cast5 Unmanaged.fft_ifftn_out_ttlls
 
 fft_ifftn_out_ttll
   :: ForeignPtr Tensor
@@ -971,20 +971,20 @@ fft_ifftn_out_ttll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_ifftn_out_ttll = cast4 Unmanaged.fft_ifftn_out_ttll
+fft_ifftn_out_ttll = _cast4 Unmanaged.fft_ifftn_out_ttll
 
 fft_ifftn_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_ifftn_out_ttl = cast3 Unmanaged.fft_ifftn_out_ttl
+fft_ifftn_out_ttl = _cast3 Unmanaged.fft_ifftn_out_ttl
 
 fft_ifftn_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fft_ifftn_out_tt = cast2 Unmanaged.fft_ifftn_out_tt
+fft_ifftn_out_tt = _cast2 Unmanaged.fft_ifftn_out_tt
 
 fft_rfftn_tlls
   :: ForeignPtr Tensor
@@ -992,25 +992,25 @@ fft_rfftn_tlls
   -> ForeignPtr IntArray
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-fft_rfftn_tlls = cast4 Unmanaged.fft_rfftn_tlls
+fft_rfftn_tlls = _cast4 Unmanaged.fft_rfftn_tlls
 
 fft_rfftn_tll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_rfftn_tll = cast3 Unmanaged.fft_rfftn_tll
+fft_rfftn_tll = _cast3 Unmanaged.fft_rfftn_tll
 
 fft_rfftn_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_rfftn_tl = cast2 Unmanaged.fft_rfftn_tl
+fft_rfftn_tl = _cast2 Unmanaged.fft_rfftn_tl
 
 fft_rfftn_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fft_rfftn_t = cast1 Unmanaged.fft_rfftn_t
+fft_rfftn_t = _cast1 Unmanaged.fft_rfftn_t
 
 fft_rfftn_out_ttlls
   :: ForeignPtr Tensor
@@ -1019,7 +1019,7 @@ fft_rfftn_out_ttlls
   -> ForeignPtr IntArray
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-fft_rfftn_out_ttlls = cast5 Unmanaged.fft_rfftn_out_ttlls
+fft_rfftn_out_ttlls = _cast5 Unmanaged.fft_rfftn_out_ttlls
 
 fft_rfftn_out_ttll
   :: ForeignPtr Tensor
@@ -1027,20 +1027,20 @@ fft_rfftn_out_ttll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_rfftn_out_ttll = cast4 Unmanaged.fft_rfftn_out_ttll
+fft_rfftn_out_ttll = _cast4 Unmanaged.fft_rfftn_out_ttll
 
 fft_rfftn_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_rfftn_out_ttl = cast3 Unmanaged.fft_rfftn_out_ttl
+fft_rfftn_out_ttl = _cast3 Unmanaged.fft_rfftn_out_ttl
 
 fft_rfftn_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fft_rfftn_out_tt = cast2 Unmanaged.fft_rfftn_out_tt
+fft_rfftn_out_tt = _cast2 Unmanaged.fft_rfftn_out_tt
 
 fft_irfftn_tlls
   :: ForeignPtr Tensor
@@ -1048,25 +1048,25 @@ fft_irfftn_tlls
   -> ForeignPtr IntArray
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-fft_irfftn_tlls = cast4 Unmanaged.fft_irfftn_tlls
+fft_irfftn_tlls = _cast4 Unmanaged.fft_irfftn_tlls
 
 fft_irfftn_tll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_irfftn_tll = cast3 Unmanaged.fft_irfftn_tll
+fft_irfftn_tll = _cast3 Unmanaged.fft_irfftn_tll
 
 fft_irfftn_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_irfftn_tl = cast2 Unmanaged.fft_irfftn_tl
+fft_irfftn_tl = _cast2 Unmanaged.fft_irfftn_tl
 
 fft_irfftn_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fft_irfftn_t = cast1 Unmanaged.fft_irfftn_t
+fft_irfftn_t = _cast1 Unmanaged.fft_irfftn_t
 
 fft_irfftn_out_ttlls
   :: ForeignPtr Tensor
@@ -1075,7 +1075,7 @@ fft_irfftn_out_ttlls
   -> ForeignPtr IntArray
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-fft_irfftn_out_ttlls = cast5 Unmanaged.fft_irfftn_out_ttlls
+fft_irfftn_out_ttlls = _cast5 Unmanaged.fft_irfftn_out_ttlls
 
 fft_irfftn_out_ttll
   :: ForeignPtr Tensor
@@ -1083,20 +1083,20 @@ fft_irfftn_out_ttll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_irfftn_out_ttll = cast4 Unmanaged.fft_irfftn_out_ttll
+fft_irfftn_out_ttll = _cast4 Unmanaged.fft_irfftn_out_ttll
 
 fft_irfftn_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_irfftn_out_ttl = cast3 Unmanaged.fft_irfftn_out_ttl
+fft_irfftn_out_ttl = _cast3 Unmanaged.fft_irfftn_out_ttl
 
 fft_irfftn_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fft_irfftn_out_tt = cast2 Unmanaged.fft_irfftn_out_tt
+fft_irfftn_out_tt = _cast2 Unmanaged.fft_irfftn_out_tt
 
 fft_hfftn_tlls
   :: ForeignPtr Tensor
@@ -1104,25 +1104,25 @@ fft_hfftn_tlls
   -> ForeignPtr IntArray
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-fft_hfftn_tlls = cast4 Unmanaged.fft_hfftn_tlls
+fft_hfftn_tlls = _cast4 Unmanaged.fft_hfftn_tlls
 
 fft_hfftn_tll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_hfftn_tll = cast3 Unmanaged.fft_hfftn_tll
+fft_hfftn_tll = _cast3 Unmanaged.fft_hfftn_tll
 
 fft_hfftn_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_hfftn_tl = cast2 Unmanaged.fft_hfftn_tl
+fft_hfftn_tl = _cast2 Unmanaged.fft_hfftn_tl
 
 fft_hfftn_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fft_hfftn_t = cast1 Unmanaged.fft_hfftn_t
+fft_hfftn_t = _cast1 Unmanaged.fft_hfftn_t
 
 fft_hfftn_out_ttlls
   :: ForeignPtr Tensor
@@ -1131,7 +1131,7 @@ fft_hfftn_out_ttlls
   -> ForeignPtr IntArray
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-fft_hfftn_out_ttlls = cast5 Unmanaged.fft_hfftn_out_ttlls
+fft_hfftn_out_ttlls = _cast5 Unmanaged.fft_hfftn_out_ttlls
 
 fft_hfftn_out_ttll
   :: ForeignPtr Tensor
@@ -1139,20 +1139,20 @@ fft_hfftn_out_ttll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_hfftn_out_ttll = cast4 Unmanaged.fft_hfftn_out_ttll
+fft_hfftn_out_ttll = _cast4 Unmanaged.fft_hfftn_out_ttll
 
 fft_hfftn_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_hfftn_out_ttl = cast3 Unmanaged.fft_hfftn_out_ttl
+fft_hfftn_out_ttl = _cast3 Unmanaged.fft_hfftn_out_ttl
 
 fft_hfftn_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fft_hfftn_out_tt = cast2 Unmanaged.fft_hfftn_out_tt
+fft_hfftn_out_tt = _cast2 Unmanaged.fft_hfftn_out_tt
 
 fft_ihfftn_tlls
   :: ForeignPtr Tensor
@@ -1160,25 +1160,25 @@ fft_ihfftn_tlls
   -> ForeignPtr IntArray
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-fft_ihfftn_tlls = cast4 Unmanaged.fft_ihfftn_tlls
+fft_ihfftn_tlls = _cast4 Unmanaged.fft_ihfftn_tlls
 
 fft_ihfftn_tll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_ihfftn_tll = cast3 Unmanaged.fft_ihfftn_tll
+fft_ihfftn_tll = _cast3 Unmanaged.fft_ihfftn_tll
 
 fft_ihfftn_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_ihfftn_tl = cast2 Unmanaged.fft_ihfftn_tl
+fft_ihfftn_tl = _cast2 Unmanaged.fft_ihfftn_tl
 
 fft_ihfftn_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fft_ihfftn_t = cast1 Unmanaged.fft_ihfftn_t
+fft_ihfftn_t = _cast1 Unmanaged.fft_ihfftn_t
 
 fft_ihfftn_out_ttlls
   :: ForeignPtr Tensor
@@ -1187,7 +1187,7 @@ fft_ihfftn_out_ttlls
   -> ForeignPtr IntArray
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-fft_ihfftn_out_ttlls = cast5 Unmanaged.fft_ihfftn_out_ttlls
+fft_ihfftn_out_ttlls = _cast5 Unmanaged.fft_ihfftn_out_ttlls
 
 fft_ihfftn_out_ttll
   :: ForeignPtr Tensor
@@ -1195,122 +1195,122 @@ fft_ihfftn_out_ttll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_ihfftn_out_ttll = cast4 Unmanaged.fft_ihfftn_out_ttll
+fft_ihfftn_out_ttll = _cast4 Unmanaged.fft_ihfftn_out_ttll
 
 fft_ihfftn_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_ihfftn_out_ttl = cast3 Unmanaged.fft_ihfftn_out_ttl
+fft_ihfftn_out_ttl = _cast3 Unmanaged.fft_ihfftn_out_ttl
 
 fft_ihfftn_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fft_ihfftn_out_tt = cast2 Unmanaged.fft_ihfftn_out_tt
+fft_ihfftn_out_tt = _cast2 Unmanaged.fft_ihfftn_out_tt
 
 fft_fftfreq_ldo
   :: Int64
   -> CDouble
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-fft_fftfreq_ldo = cast3 Unmanaged.fft_fftfreq_ldo
+fft_fftfreq_ldo = _cast3 Unmanaged.fft_fftfreq_ldo
 
 fft_fftfreq_ld
   :: Int64
   -> CDouble
   -> IO (ForeignPtr Tensor)
-fft_fftfreq_ld = cast2 Unmanaged.fft_fftfreq_ld
+fft_fftfreq_ld = _cast2 Unmanaged.fft_fftfreq_ld
 
 fft_fftfreq_l
   :: Int64
   -> IO (ForeignPtr Tensor)
-fft_fftfreq_l = cast1 Unmanaged.fft_fftfreq_l
+fft_fftfreq_l = _cast1 Unmanaged.fft_fftfreq_l
 
 fft_fftfreq_out_tld
   :: ForeignPtr Tensor
   -> Int64
   -> CDouble
   -> IO (ForeignPtr Tensor)
-fft_fftfreq_out_tld = cast3 Unmanaged.fft_fftfreq_out_tld
+fft_fftfreq_out_tld = _cast3 Unmanaged.fft_fftfreq_out_tld
 
 fft_fftfreq_out_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-fft_fftfreq_out_tl = cast2 Unmanaged.fft_fftfreq_out_tl
+fft_fftfreq_out_tl = _cast2 Unmanaged.fft_fftfreq_out_tl
 
 fft_rfftfreq_ldo
   :: Int64
   -> CDouble
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-fft_rfftfreq_ldo = cast3 Unmanaged.fft_rfftfreq_ldo
+fft_rfftfreq_ldo = _cast3 Unmanaged.fft_rfftfreq_ldo
 
 fft_rfftfreq_ld
   :: Int64
   -> CDouble
   -> IO (ForeignPtr Tensor)
-fft_rfftfreq_ld = cast2 Unmanaged.fft_rfftfreq_ld
+fft_rfftfreq_ld = _cast2 Unmanaged.fft_rfftfreq_ld
 
 fft_rfftfreq_l
   :: Int64
   -> IO (ForeignPtr Tensor)
-fft_rfftfreq_l = cast1 Unmanaged.fft_rfftfreq_l
+fft_rfftfreq_l = _cast1 Unmanaged.fft_rfftfreq_l
 
 fft_rfftfreq_out_tld
   :: ForeignPtr Tensor
   -> Int64
   -> CDouble
   -> IO (ForeignPtr Tensor)
-fft_rfftfreq_out_tld = cast3 Unmanaged.fft_rfftfreq_out_tld
+fft_rfftfreq_out_tld = _cast3 Unmanaged.fft_rfftfreq_out_tld
 
 fft_rfftfreq_out_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-fft_rfftfreq_out_tl = cast2 Unmanaged.fft_rfftfreq_out_tl
+fft_rfftfreq_out_tl = _cast2 Unmanaged.fft_rfftfreq_out_tl
 
 fft_fftshift_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_fftshift_tl = cast2 Unmanaged.fft_fftshift_tl
+fft_fftshift_tl = _cast2 Unmanaged.fft_fftshift_tl
 
 fft_fftshift_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fft_fftshift_t = cast1 Unmanaged.fft_fftshift_t
+fft_fftshift_t = _cast1 Unmanaged.fft_fftshift_t
 
 fft_ifftshift_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-fft_ifftshift_tl = cast2 Unmanaged.fft_ifftshift_tl
+fft_ifftshift_tl = _cast2 Unmanaged.fft_ifftshift_tl
 
 fft_ifftshift_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fft_ifftshift_t = cast1 Unmanaged.fft_ifftshift_t
+fft_ifftshift_t = _cast1 Unmanaged.fft_ifftshift_t
 
 linalg_cholesky_ex_tbb
   :: ForeignPtr Tensor
   -> CBool
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-linalg_cholesky_ex_tbb = cast3 Unmanaged.linalg_cholesky_ex_tbb
+linalg_cholesky_ex_tbb = _cast3 Unmanaged.linalg_cholesky_ex_tbb
 
 linalg_cholesky_ex_tb
   :: ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-linalg_cholesky_ex_tb = cast2 Unmanaged.linalg_cholesky_ex_tb
+linalg_cholesky_ex_tb = _cast2 Unmanaged.linalg_cholesky_ex_tb
 
 linalg_cholesky_ex_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-linalg_cholesky_ex_t = cast1 Unmanaged.linalg_cholesky_ex_t
+linalg_cholesky_ex_t = _cast1 Unmanaged.linalg_cholesky_ex_t
 
 linalg_cholesky_ex_out_tttbb
   :: ForeignPtr Tensor
@@ -1319,7 +1319,7 @@ linalg_cholesky_ex_out_tttbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-linalg_cholesky_ex_out_tttbb = cast5 Unmanaged.linalg_cholesky_ex_out_tttbb
+linalg_cholesky_ex_out_tttbb = _cast5 Unmanaged.linalg_cholesky_ex_out_tttbb
 
 linalg_cholesky_ex_out_tttb
   :: ForeignPtr Tensor
@@ -1327,51 +1327,51 @@ linalg_cholesky_ex_out_tttb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-linalg_cholesky_ex_out_tttb = cast4 Unmanaged.linalg_cholesky_ex_out_tttb
+linalg_cholesky_ex_out_tttb = _cast4 Unmanaged.linalg_cholesky_ex_out_tttb
 
 linalg_cholesky_ex_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-linalg_cholesky_ex_out_ttt = cast3 Unmanaged.linalg_cholesky_ex_out_ttt
+linalg_cholesky_ex_out_ttt = _cast3 Unmanaged.linalg_cholesky_ex_out_ttt
 
 linalg_cholesky_tb
   :: ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-linalg_cholesky_tb = cast2 Unmanaged.linalg_cholesky_tb
+linalg_cholesky_tb = _cast2 Unmanaged.linalg_cholesky_tb
 
 linalg_cholesky_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linalg_cholesky_t = cast1 Unmanaged.linalg_cholesky_t
+linalg_cholesky_t = _cast1 Unmanaged.linalg_cholesky_t
 
 linalg_cholesky_out_ttb
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-linalg_cholesky_out_ttb = cast3 Unmanaged.linalg_cholesky_out_ttb
+linalg_cholesky_out_ttb = _cast3 Unmanaged.linalg_cholesky_out_ttb
 
 linalg_cholesky_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linalg_cholesky_out_tt = cast2 Unmanaged.linalg_cholesky_out_tt
+linalg_cholesky_out_tt = _cast2 Unmanaged.linalg_cholesky_out_tt
 
 linalg_cross_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-linalg_cross_ttl = cast3 Unmanaged.linalg_cross_ttl
+linalg_cross_ttl = _cast3 Unmanaged.linalg_cross_ttl
 
 linalg_cross_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linalg_cross_tt = cast2 Unmanaged.linalg_cross_tt
+linalg_cross_tt = _cast2 Unmanaged.linalg_cross_tt
 
 linalg_cross_out_tttl
   :: ForeignPtr Tensor
@@ -1379,25 +1379,25 @@ linalg_cross_out_tttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-linalg_cross_out_tttl = cast4 Unmanaged.linalg_cross_out_tttl
+linalg_cross_out_tttl = _cast4 Unmanaged.linalg_cross_out_tttl
 
 linalg_cross_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linalg_cross_out_ttt = cast3 Unmanaged.linalg_cross_out_ttt
+linalg_cross_out_ttt = _cast3 Unmanaged.linalg_cross_out_ttt
 
 linalg_lu_factor_tb
   :: ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-linalg_lu_factor_tb = cast2 Unmanaged.linalg_lu_factor_tb
+linalg_lu_factor_tb = _cast2 Unmanaged.linalg_lu_factor_tb
 
 linalg_lu_factor_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-linalg_lu_factor_t = cast1 Unmanaged.linalg_lu_factor_t
+linalg_lu_factor_t = _cast1 Unmanaged.linalg_lu_factor_t
 
 linalg_lu_factor_out_tttb
   :: ForeignPtr Tensor
@@ -1405,32 +1405,32 @@ linalg_lu_factor_out_tttb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-linalg_lu_factor_out_tttb = cast4 Unmanaged.linalg_lu_factor_out_tttb
+linalg_lu_factor_out_tttb = _cast4 Unmanaged.linalg_lu_factor_out_tttb
 
 linalg_lu_factor_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-linalg_lu_factor_out_ttt = cast3 Unmanaged.linalg_lu_factor_out_ttt
+linalg_lu_factor_out_ttt = _cast3 Unmanaged.linalg_lu_factor_out_ttt
 
 linalg_lu_factor_ex_tbb
   :: ForeignPtr Tensor
   -> CBool
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-linalg_lu_factor_ex_tbb = cast3 Unmanaged.linalg_lu_factor_ex_tbb
+linalg_lu_factor_ex_tbb = _cast3 Unmanaged.linalg_lu_factor_ex_tbb
 
 linalg_lu_factor_ex_tb
   :: ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-linalg_lu_factor_ex_tb = cast2 Unmanaged.linalg_lu_factor_ex_tb
+linalg_lu_factor_ex_tb = _cast2 Unmanaged.linalg_lu_factor_ex_tb
 
 linalg_lu_factor_ex_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-linalg_lu_factor_ex_t = cast1 Unmanaged.linalg_lu_factor_ex_t
+linalg_lu_factor_ex_t = _cast1 Unmanaged.linalg_lu_factor_ex_t
 
 linalg_lu_factor_ex_out_ttttbb
   :: ForeignPtr Tensor
@@ -1440,7 +1440,7 @@ linalg_lu_factor_ex_out_ttttbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-linalg_lu_factor_ex_out_ttttbb = cast6 Unmanaged.linalg_lu_factor_ex_out_ttttbb
+linalg_lu_factor_ex_out_ttttbb = _cast6 Unmanaged.linalg_lu_factor_ex_out_ttttbb
 
 linalg_lu_factor_ex_out_ttttb
   :: ForeignPtr Tensor
@@ -1449,7 +1449,7 @@ linalg_lu_factor_ex_out_ttttb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-linalg_lu_factor_ex_out_ttttb = cast5 Unmanaged.linalg_lu_factor_ex_out_ttttb
+linalg_lu_factor_ex_out_ttttb = _cast5 Unmanaged.linalg_lu_factor_ex_out_ttttb
 
 linalg_lu_factor_ex_out_tttt
   :: ForeignPtr Tensor
@@ -1457,21 +1457,21 @@ linalg_lu_factor_ex_out_tttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-linalg_lu_factor_ex_out_tttt = cast4 Unmanaged.linalg_lu_factor_ex_out_tttt
+linalg_lu_factor_ex_out_tttt = _cast4 Unmanaged.linalg_lu_factor_ex_out_tttt
 
 linalg_det_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linalg_det_t = cast1 Unmanaged.linalg_det_t
+linalg_det_t = _cast1 Unmanaged.linalg_det_t
 
 linalg_det_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linalg_det_out_tt = cast2 Unmanaged.linalg_det_out_tt
+linalg_det_out_tt = _cast2 Unmanaged.linalg_det_out_tt
 
 det_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-det_t = cast1 Unmanaged.det_t
+det_t = _cast1 Unmanaged.det_t
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Native/Native15.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Native/Native15.hs
@@ -24,7 +24,7 @@ import qualified Torch.Internal.Unmanaged.Native.Native15 as Unmanaged
 _det_lu_based_helper_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-_det_lu_based_helper_t = cast1 Unmanaged._det_lu_based_helper_t
+_det_lu_based_helper_t = _cast1 Unmanaged._det_lu_based_helper_t
 
 _det_lu_based_helper_backward_helper_ttttt
   :: ForeignPtr Tensor
@@ -33,7 +33,7 @@ _det_lu_based_helper_backward_helper_ttttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_det_lu_based_helper_backward_helper_ttttt = cast5 Unmanaged._det_lu_based_helper_backward_helper_ttttt
+_det_lu_based_helper_backward_helper_ttttt = _cast5 Unmanaged._det_lu_based_helper_backward_helper_ttttt
 
 linalg_lstsq_ttds
   :: ForeignPtr Tensor
@@ -41,20 +41,20 @@ linalg_lstsq_ttds
   -> CDouble
   -> ForeignPtr StdString
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
-linalg_lstsq_ttds = cast4 Unmanaged.linalg_lstsq_ttds
+linalg_lstsq_ttds = _cast4 Unmanaged.linalg_lstsq_ttds
 
 linalg_lstsq_ttd
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> CDouble
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
-linalg_lstsq_ttd = cast3 Unmanaged.linalg_lstsq_ttd
+linalg_lstsq_ttd = _cast3 Unmanaged.linalg_lstsq_ttd
 
 linalg_lstsq_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
-linalg_lstsq_tt = cast2 Unmanaged.linalg_lstsq_tt
+linalg_lstsq_tt = _cast2 Unmanaged.linalg_lstsq_tt
 
 linalg_lstsq_out_ttttttds
   :: ForeignPtr Tensor
@@ -66,7 +66,7 @@ linalg_lstsq_out_ttttttds
   -> CDouble
   -> ForeignPtr StdString
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
-linalg_lstsq_out_ttttttds = cast8 Unmanaged.linalg_lstsq_out_ttttttds
+linalg_lstsq_out_ttttttds = _cast8 Unmanaged.linalg_lstsq_out_ttttttds
 
 linalg_lstsq_out_ttttttd
   :: ForeignPtr Tensor
@@ -77,7 +77,7 @@ linalg_lstsq_out_ttttttd
   -> ForeignPtr Tensor
   -> CDouble
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
-linalg_lstsq_out_ttttttd = cast7 Unmanaged.linalg_lstsq_out_ttttttd
+linalg_lstsq_out_ttttttd = _cast7 Unmanaged.linalg_lstsq_out_ttttttd
 
 linalg_lstsq_out_tttttt
   :: ForeignPtr Tensor
@@ -87,71 +87,71 @@ linalg_lstsq_out_tttttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
-linalg_lstsq_out_tttttt = cast6 Unmanaged.linalg_lstsq_out_tttttt
+linalg_lstsq_out_tttttt = _cast6 Unmanaged.linalg_lstsq_out_tttttt
 
 linalg_matmul_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linalg_matmul_tt = cast2 Unmanaged.linalg_matmul_tt
+linalg_matmul_tt = _cast2 Unmanaged.linalg_matmul_tt
 
 linalg_matmul_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linalg_matmul_out_ttt = cast3 Unmanaged.linalg_matmul_out_ttt
+linalg_matmul_out_ttt = _cast3 Unmanaged.linalg_matmul_out_ttt
 
 linalg_matrix_exp_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linalg_matrix_exp_t = cast1 Unmanaged.linalg_matrix_exp_t
+linalg_matrix_exp_t = _cast1 Unmanaged.linalg_matrix_exp_t
 
 linalg_slogdet_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-linalg_slogdet_t = cast1 Unmanaged.linalg_slogdet_t
+linalg_slogdet_t = _cast1 Unmanaged.linalg_slogdet_t
 
 linalg_slogdet_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-linalg_slogdet_out_ttt = cast3 Unmanaged.linalg_slogdet_out_ttt
+linalg_slogdet_out_ttt = _cast3 Unmanaged.linalg_slogdet_out_ttt
 
 linalg_eig_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-linalg_eig_t = cast1 Unmanaged.linalg_eig_t
+linalg_eig_t = _cast1 Unmanaged.linalg_eig_t
 
 linalg_eig_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-linalg_eig_out_ttt = cast3 Unmanaged.linalg_eig_out_ttt
+linalg_eig_out_ttt = _cast3 Unmanaged.linalg_eig_out_ttt
 
 linalg_eigvals_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linalg_eigvals_t = cast1 Unmanaged.linalg_eigvals_t
+linalg_eigvals_t = _cast1 Unmanaged.linalg_eigvals_t
 
 linalg_eigvals_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linalg_eigvals_out_tt = cast2 Unmanaged.linalg_eigvals_out_tt
+linalg_eigvals_out_tt = _cast2 Unmanaged.linalg_eigvals_out_tt
 
 linalg_eigh_ts
   :: ForeignPtr Tensor
   -> ForeignPtr StdString
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-linalg_eigh_ts = cast2 Unmanaged.linalg_eigh_ts
+linalg_eigh_ts = _cast2 Unmanaged.linalg_eigh_ts
 
 linalg_eigh_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-linalg_eigh_t = cast1 Unmanaged.linalg_eigh_t
+linalg_eigh_t = _cast1 Unmanaged.linalg_eigh_t
 
 linalg_eigh_out_ttts
   :: ForeignPtr Tensor
@@ -159,69 +159,69 @@ linalg_eigh_out_ttts
   -> ForeignPtr Tensor
   -> ForeignPtr StdString
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-linalg_eigh_out_ttts = cast4 Unmanaged.linalg_eigh_out_ttts
+linalg_eigh_out_ttts = _cast4 Unmanaged.linalg_eigh_out_ttts
 
 linalg_eigh_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-linalg_eigh_out_ttt = cast3 Unmanaged.linalg_eigh_out_ttt
+linalg_eigh_out_ttt = _cast3 Unmanaged.linalg_eigh_out_ttt
 
 linalg_eigvalsh_ts
   :: ForeignPtr Tensor
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-linalg_eigvalsh_ts = cast2 Unmanaged.linalg_eigvalsh_ts
+linalg_eigvalsh_ts = _cast2 Unmanaged.linalg_eigvalsh_ts
 
 linalg_eigvalsh_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linalg_eigvalsh_t = cast1 Unmanaged.linalg_eigvalsh_t
+linalg_eigvalsh_t = _cast1 Unmanaged.linalg_eigvalsh_t
 
 linalg_eigvalsh_out_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-linalg_eigvalsh_out_tts = cast3 Unmanaged.linalg_eigvalsh_out_tts
+linalg_eigvalsh_out_tts = _cast3 Unmanaged.linalg_eigvalsh_out_tts
 
 linalg_eigvalsh_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linalg_eigvalsh_out_tt = cast2 Unmanaged.linalg_eigvalsh_out_tt
+linalg_eigvalsh_out_tt = _cast2 Unmanaged.linalg_eigvalsh_out_tt
 
 linalg_householder_product_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linalg_householder_product_tt = cast2 Unmanaged.linalg_householder_product_tt
+linalg_householder_product_tt = _cast2 Unmanaged.linalg_householder_product_tt
 
 linalg_householder_product_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linalg_householder_product_out_ttt = cast3 Unmanaged.linalg_householder_product_out_ttt
+linalg_householder_product_out_ttt = _cast3 Unmanaged.linalg_householder_product_out_ttt
 
 _linalg_inv_out_helper__ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_linalg_inv_out_helper__ttt = cast3 Unmanaged._linalg_inv_out_helper__ttt
+_linalg_inv_out_helper__ttt = _cast3 Unmanaged._linalg_inv_out_helper__ttt
 
 linalg_inv_ex_tb
   :: ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-linalg_inv_ex_tb = cast2 Unmanaged.linalg_inv_ex_tb
+linalg_inv_ex_tb = _cast2 Unmanaged.linalg_inv_ex_tb
 
 linalg_inv_ex_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-linalg_inv_ex_t = cast1 Unmanaged.linalg_inv_ex_t
+linalg_inv_ex_t = _cast1 Unmanaged.linalg_inv_ex_t
 
 linalg_inv_ex_out_tttb
   :: ForeignPtr Tensor
@@ -229,64 +229,64 @@ linalg_inv_ex_out_tttb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-linalg_inv_ex_out_tttb = cast4 Unmanaged.linalg_inv_ex_out_tttb
+linalg_inv_ex_out_tttb = _cast4 Unmanaged.linalg_inv_ex_out_tttb
 
 linalg_inv_ex_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-linalg_inv_ex_out_ttt = cast3 Unmanaged.linalg_inv_ex_out_ttt
+linalg_inv_ex_out_ttt = _cast3 Unmanaged.linalg_inv_ex_out_ttt
 
 linalg_inv_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linalg_inv_t = cast1 Unmanaged.linalg_inv_t
+linalg_inv_t = _cast1 Unmanaged.linalg_inv_t
 
 linalg_inv_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linalg_inv_out_tt = cast2 Unmanaged.linalg_inv_out_tt
+linalg_inv_out_tt = _cast2 Unmanaged.linalg_inv_out_tt
 
 inner_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-inner_tt = cast2 Unmanaged.inner_tt
+inner_tt = _cast2 Unmanaged.inner_tt
 
 inner_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-inner_out_ttt = cast3 Unmanaged.inner_out_ttt
+inner_out_ttt = _cast3 Unmanaged.inner_out_ttt
 
 outer_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-outer_tt = cast2 Unmanaged.outer_tt
+outer_tt = _cast2 Unmanaged.outer_tt
 
 outer_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-outer_out_ttt = cast3 Unmanaged.outer_out_ttt
+outer_out_ttt = _cast3 Unmanaged.outer_out_ttt
 
 ger_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-ger_tt = cast2 Unmanaged.ger_tt
+ger_tt = _cast2 Unmanaged.ger_tt
 
 ger_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-ger_out_ttt = cast3 Unmanaged.ger_out_ttt
+ger_out_ttt = _cast3 Unmanaged.ger_out_ttt
 
 linalg_norm_tslbs
   :: ForeignPtr Tensor
@@ -295,7 +295,7 @@ linalg_norm_tslbs
   -> CBool
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-linalg_norm_tslbs = cast5 Unmanaged.linalg_norm_tslbs
+linalg_norm_tslbs = _cast5 Unmanaged.linalg_norm_tslbs
 
 linalg_norm_tslb
   :: ForeignPtr Tensor
@@ -303,25 +303,25 @@ linalg_norm_tslb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-linalg_norm_tslb = cast4 Unmanaged.linalg_norm_tslb
+linalg_norm_tslb = _cast4 Unmanaged.linalg_norm_tslb
 
 linalg_norm_tsl
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-linalg_norm_tsl = cast3 Unmanaged.linalg_norm_tsl
+linalg_norm_tsl = _cast3 Unmanaged.linalg_norm_tsl
 
 linalg_norm_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-linalg_norm_ts = cast2 Unmanaged.linalg_norm_ts
+linalg_norm_ts = _cast2 Unmanaged.linalg_norm_ts
 
 linalg_norm_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linalg_norm_t = cast1 Unmanaged.linalg_norm_t
+linalg_norm_t = _cast1 Unmanaged.linalg_norm_t
 
 linalg_norm_out_ttslbs
   :: ForeignPtr Tensor
@@ -331,7 +331,7 @@ linalg_norm_out_ttslbs
   -> CBool
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-linalg_norm_out_ttslbs = cast6 Unmanaged.linalg_norm_out_ttslbs
+linalg_norm_out_ttslbs = _cast6 Unmanaged.linalg_norm_out_ttslbs
 
 linalg_norm_out_ttslb
   :: ForeignPtr Tensor
@@ -340,7 +340,7 @@ linalg_norm_out_ttslb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-linalg_norm_out_ttslb = cast5 Unmanaged.linalg_norm_out_ttslb
+linalg_norm_out_ttslb = _cast5 Unmanaged.linalg_norm_out_ttslb
 
 linalg_norm_out_ttsl
   :: ForeignPtr Tensor
@@ -348,20 +348,20 @@ linalg_norm_out_ttsl
   -> ForeignPtr Scalar
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-linalg_norm_out_ttsl = cast4 Unmanaged.linalg_norm_out_ttsl
+linalg_norm_out_ttsl = _cast4 Unmanaged.linalg_norm_out_ttsl
 
 linalg_norm_out_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-linalg_norm_out_tts = cast3 Unmanaged.linalg_norm_out_tts
+linalg_norm_out_tts = _cast3 Unmanaged.linalg_norm_out_tts
 
 linalg_norm_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linalg_norm_out_tt = cast2 Unmanaged.linalg_norm_out_tt
+linalg_norm_out_tt = _cast2 Unmanaged.linalg_norm_out_tt
 
 linalg_vector_norm_tslbs
   :: ForeignPtr Tensor
@@ -370,7 +370,7 @@ linalg_vector_norm_tslbs
   -> CBool
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-linalg_vector_norm_tslbs = cast5 Unmanaged.linalg_vector_norm_tslbs
+linalg_vector_norm_tslbs = _cast5 Unmanaged.linalg_vector_norm_tslbs
 
 linalg_vector_norm_tslb
   :: ForeignPtr Tensor
@@ -378,25 +378,25 @@ linalg_vector_norm_tslb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-linalg_vector_norm_tslb = cast4 Unmanaged.linalg_vector_norm_tslb
+linalg_vector_norm_tslb = _cast4 Unmanaged.linalg_vector_norm_tslb
 
 linalg_vector_norm_tsl
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-linalg_vector_norm_tsl = cast3 Unmanaged.linalg_vector_norm_tsl
+linalg_vector_norm_tsl = _cast3 Unmanaged.linalg_vector_norm_tsl
 
 linalg_vector_norm_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-linalg_vector_norm_ts = cast2 Unmanaged.linalg_vector_norm_ts
+linalg_vector_norm_ts = _cast2 Unmanaged.linalg_vector_norm_ts
 
 linalg_vector_norm_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linalg_vector_norm_t = cast1 Unmanaged.linalg_vector_norm_t
+linalg_vector_norm_t = _cast1 Unmanaged.linalg_vector_norm_t
 
 linalg_vector_norm_out_ttslbs
   :: ForeignPtr Tensor
@@ -406,7 +406,7 @@ linalg_vector_norm_out_ttslbs
   -> CBool
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-linalg_vector_norm_out_ttslbs = cast6 Unmanaged.linalg_vector_norm_out_ttslbs
+linalg_vector_norm_out_ttslbs = _cast6 Unmanaged.linalg_vector_norm_out_ttslbs
 
 linalg_vector_norm_out_ttslb
   :: ForeignPtr Tensor
@@ -415,7 +415,7 @@ linalg_vector_norm_out_ttslb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-linalg_vector_norm_out_ttslb = cast5 Unmanaged.linalg_vector_norm_out_ttslb
+linalg_vector_norm_out_ttslb = _cast5 Unmanaged.linalg_vector_norm_out_ttslb
 
 linalg_vector_norm_out_ttsl
   :: ForeignPtr Tensor
@@ -423,20 +423,20 @@ linalg_vector_norm_out_ttsl
   -> ForeignPtr Scalar
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-linalg_vector_norm_out_ttsl = cast4 Unmanaged.linalg_vector_norm_out_ttsl
+linalg_vector_norm_out_ttsl = _cast4 Unmanaged.linalg_vector_norm_out_ttsl
 
 linalg_vector_norm_out_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-linalg_vector_norm_out_tts = cast3 Unmanaged.linalg_vector_norm_out_tts
+linalg_vector_norm_out_tts = _cast3 Unmanaged.linalg_vector_norm_out_tts
 
 linalg_vector_norm_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linalg_vector_norm_out_tt = cast2 Unmanaged.linalg_vector_norm_out_tt
+linalg_vector_norm_out_tt = _cast2 Unmanaged.linalg_vector_norm_out_tt
 
 linalg_matrix_norm_tslbs
   :: ForeignPtr Tensor
@@ -445,7 +445,7 @@ linalg_matrix_norm_tslbs
   -> CBool
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-linalg_matrix_norm_tslbs = cast5 Unmanaged.linalg_matrix_norm_tslbs
+linalg_matrix_norm_tslbs = _cast5 Unmanaged.linalg_matrix_norm_tslbs
 
 linalg_matrix_norm_tslb
   :: ForeignPtr Tensor
@@ -453,20 +453,20 @@ linalg_matrix_norm_tslb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-linalg_matrix_norm_tslb = cast4 Unmanaged.linalg_matrix_norm_tslb
+linalg_matrix_norm_tslb = _cast4 Unmanaged.linalg_matrix_norm_tslb
 
 linalg_matrix_norm_tsl
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-linalg_matrix_norm_tsl = cast3 Unmanaged.linalg_matrix_norm_tsl
+linalg_matrix_norm_tsl = _cast3 Unmanaged.linalg_matrix_norm_tsl
 
 linalg_matrix_norm_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-linalg_matrix_norm_ts = cast2 Unmanaged.linalg_matrix_norm_ts
+linalg_matrix_norm_ts = _cast2 Unmanaged.linalg_matrix_norm_ts
 
 linalg_matrix_norm_out_ttslbs
   :: ForeignPtr Tensor
@@ -476,7 +476,7 @@ linalg_matrix_norm_out_ttslbs
   -> CBool
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-linalg_matrix_norm_out_ttslbs = cast6 Unmanaged.linalg_matrix_norm_out_ttslbs
+linalg_matrix_norm_out_ttslbs = _cast6 Unmanaged.linalg_matrix_norm_out_ttslbs
 
 linalg_matrix_norm_out_ttslb
   :: ForeignPtr Tensor
@@ -485,7 +485,7 @@ linalg_matrix_norm_out_ttslb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-linalg_matrix_norm_out_ttslb = cast5 Unmanaged.linalg_matrix_norm_out_ttslb
+linalg_matrix_norm_out_ttslb = _cast5 Unmanaged.linalg_matrix_norm_out_ttslb
 
 linalg_matrix_norm_out_ttsl
   :: ForeignPtr Tensor
@@ -493,43 +493,43 @@ linalg_matrix_norm_out_ttsl
   -> ForeignPtr Scalar
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-linalg_matrix_norm_out_ttsl = cast4 Unmanaged.linalg_matrix_norm_out_ttsl
+linalg_matrix_norm_out_ttsl = _cast4 Unmanaged.linalg_matrix_norm_out_ttsl
 
 linalg_matrix_norm_out_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-linalg_matrix_norm_out_tts = cast3 Unmanaged.linalg_matrix_norm_out_tts
+linalg_matrix_norm_out_tts = _cast3 Unmanaged.linalg_matrix_norm_out_tts
 
 linalg_matrix_norm_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linalg_matrix_norm_t = cast1 Unmanaged.linalg_matrix_norm_t
+linalg_matrix_norm_t = _cast1 Unmanaged.linalg_matrix_norm_t
 
 linalg_matrix_norm_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linalg_matrix_norm_out_tt = cast2 Unmanaged.linalg_matrix_norm_out_tt
+linalg_matrix_norm_out_tt = _cast2 Unmanaged.linalg_matrix_norm_out_tt
 
 _linalg_svd_tbb
   :: ForeignPtr Tensor
   -> CBool
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-_linalg_svd_tbb = cast3 Unmanaged._linalg_svd_tbb
+_linalg_svd_tbb = _cast3 Unmanaged._linalg_svd_tbb
 
 _linalg_svd_tb
   :: ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-_linalg_svd_tb = cast2 Unmanaged._linalg_svd_tb
+_linalg_svd_tb = _cast2 Unmanaged._linalg_svd_tb
 
 _linalg_svd_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-_linalg_svd_t = cast1 Unmanaged._linalg_svd_t
+_linalg_svd_t = _cast1 Unmanaged._linalg_svd_t
 
 _linalg_svd_out_ttttbb
   :: ForeignPtr Tensor
@@ -539,7 +539,7 @@ _linalg_svd_out_ttttbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-_linalg_svd_out_ttttbb = cast6 Unmanaged._linalg_svd_out_ttttbb
+_linalg_svd_out_ttttbb = _cast6 Unmanaged._linalg_svd_out_ttttbb
 
 _linalg_svd_out_ttttb
   :: ForeignPtr Tensor
@@ -548,7 +548,7 @@ _linalg_svd_out_ttttb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-_linalg_svd_out_ttttb = cast5 Unmanaged._linalg_svd_out_ttttb
+_linalg_svd_out_ttttb = _cast5 Unmanaged._linalg_svd_out_ttttb
 
 _linalg_svd_out_tttt
   :: ForeignPtr Tensor
@@ -556,18 +556,18 @@ _linalg_svd_out_tttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-_linalg_svd_out_tttt = cast4 Unmanaged._linalg_svd_out_tttt
+_linalg_svd_out_tttt = _cast4 Unmanaged._linalg_svd_out_tttt
 
 linalg_svd_tb
   :: ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-linalg_svd_tb = cast2 Unmanaged.linalg_svd_tb
+linalg_svd_tb = _cast2 Unmanaged.linalg_svd_tb
 
 linalg_svd_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-linalg_svd_t = cast1 Unmanaged.linalg_svd_t
+linalg_svd_t = _cast1 Unmanaged.linalg_svd_t
 
 linalg_svd_out_ttttb
   :: ForeignPtr Tensor
@@ -576,7 +576,7 @@ linalg_svd_out_ttttb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-linalg_svd_out_ttttb = cast5 Unmanaged.linalg_svd_out_ttttb
+linalg_svd_out_ttttb = _cast5 Unmanaged.linalg_svd_out_ttttb
 
 linalg_svd_out_tttt
   :: ForeignPtr Tensor
@@ -584,42 +584,42 @@ linalg_svd_out_tttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-linalg_svd_out_tttt = cast4 Unmanaged.linalg_svd_out_tttt
+linalg_svd_out_tttt = _cast4 Unmanaged.linalg_svd_out_tttt
 
 linalg_svdvals_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linalg_svdvals_t = cast1 Unmanaged.linalg_svdvals_t
+linalg_svdvals_t = _cast1 Unmanaged.linalg_svdvals_t
 
 linalg_svdvals_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linalg_svdvals_out_tt = cast2 Unmanaged.linalg_svdvals_out_tt
+linalg_svdvals_out_tt = _cast2 Unmanaged.linalg_svdvals_out_tt
 
 linalg_cond_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-linalg_cond_ts = cast2 Unmanaged.linalg_cond_ts
+linalg_cond_ts = _cast2 Unmanaged.linalg_cond_ts
 
 linalg_cond_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linalg_cond_t = cast1 Unmanaged.linalg_cond_t
+linalg_cond_t = _cast1 Unmanaged.linalg_cond_t
 
 linalg_cond_out_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-linalg_cond_out_tts = cast3 Unmanaged.linalg_cond_out_tts
+linalg_cond_out_tts = _cast3 Unmanaged.linalg_cond_out_tts
 
 linalg_cond_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linalg_cond_out_tt = cast2 Unmanaged.linalg_cond_out_tt
+linalg_cond_out_tt = _cast2 Unmanaged.linalg_cond_out_tt
 
 linalg_pinv_tttb
   :: ForeignPtr Tensor
@@ -627,25 +627,25 @@ linalg_pinv_tttb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-linalg_pinv_tttb = cast4 Unmanaged.linalg_pinv_tttb
+linalg_pinv_tttb = _cast4 Unmanaged.linalg_pinv_tttb
 
 linalg_pinv_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linalg_pinv_ttt = cast3 Unmanaged.linalg_pinv_ttt
+linalg_pinv_ttt = _cast3 Unmanaged.linalg_pinv_ttt
 
 linalg_pinv_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linalg_pinv_tt = cast2 Unmanaged.linalg_pinv_tt
+linalg_pinv_tt = _cast2 Unmanaged.linalg_pinv_tt
 
 linalg_pinv_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linalg_pinv_t = cast1 Unmanaged.linalg_pinv_t
+linalg_pinv_t = _cast1 Unmanaged.linalg_pinv_t
 
 linalg_pinv_out_ttttb
   :: ForeignPtr Tensor
@@ -654,7 +654,7 @@ linalg_pinv_out_ttttb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-linalg_pinv_out_ttttb = cast5 Unmanaged.linalg_pinv_out_ttttb
+linalg_pinv_out_ttttb = _cast5 Unmanaged.linalg_pinv_out_ttttb
 
 linalg_pinv_out_tttt
   :: ForeignPtr Tensor
@@ -662,20 +662,20 @@ linalg_pinv_out_tttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linalg_pinv_out_tttt = cast4 Unmanaged.linalg_pinv_out_tttt
+linalg_pinv_out_tttt = _cast4 Unmanaged.linalg_pinv_out_tttt
 
 linalg_pinv_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linalg_pinv_out_ttt = cast3 Unmanaged.linalg_pinv_out_ttt
+linalg_pinv_out_ttt = _cast3 Unmanaged.linalg_pinv_out_ttt
 
 linalg_pinv_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linalg_pinv_out_tt = cast2 Unmanaged.linalg_pinv_out_tt
+linalg_pinv_out_tt = _cast2 Unmanaged.linalg_pinv_out_tt
 
 linalg_pinv_tddb
   :: ForeignPtr Tensor
@@ -683,20 +683,20 @@ linalg_pinv_tddb
   -> CDouble
   -> CBool
   -> IO (ForeignPtr Tensor)
-linalg_pinv_tddb = cast4 Unmanaged.linalg_pinv_tddb
+linalg_pinv_tddb = _cast4 Unmanaged.linalg_pinv_tddb
 
 linalg_pinv_tdd
   :: ForeignPtr Tensor
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-linalg_pinv_tdd = cast3 Unmanaged.linalg_pinv_tdd
+linalg_pinv_tdd = _cast3 Unmanaged.linalg_pinv_tdd
 
 linalg_pinv_td
   :: ForeignPtr Tensor
   -> CDouble
   -> IO (ForeignPtr Tensor)
-linalg_pinv_td = cast2 Unmanaged.linalg_pinv_td
+linalg_pinv_td = _cast2 Unmanaged.linalg_pinv_td
 
 linalg_pinv_out_ttddb
   :: ForeignPtr Tensor
@@ -705,7 +705,7 @@ linalg_pinv_out_ttddb
   -> CDouble
   -> CBool
   -> IO (ForeignPtr Tensor)
-linalg_pinv_out_ttddb = cast5 Unmanaged.linalg_pinv_out_ttddb
+linalg_pinv_out_ttddb = _cast5 Unmanaged.linalg_pinv_out_ttddb
 
 linalg_pinv_out_ttdd
   :: ForeignPtr Tensor
@@ -713,28 +713,28 @@ linalg_pinv_out_ttdd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-linalg_pinv_out_ttdd = cast4 Unmanaged.linalg_pinv_out_ttdd
+linalg_pinv_out_ttdd = _cast4 Unmanaged.linalg_pinv_out_ttdd
 
 linalg_pinv_out_ttd
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> CDouble
   -> IO (ForeignPtr Tensor)
-linalg_pinv_out_ttd = cast3 Unmanaged.linalg_pinv_out_ttd
+linalg_pinv_out_ttd = _cast3 Unmanaged.linalg_pinv_out_ttd
 
 linalg_pinv_tdb
   :: ForeignPtr Tensor
   -> CDouble
   -> CBool
   -> IO (ForeignPtr Tensor)
-linalg_pinv_tdb = cast3 Unmanaged.linalg_pinv_tdb
+linalg_pinv_tdb = _cast3 Unmanaged.linalg_pinv_tdb
 
 linalg_pinv_ttb
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-linalg_pinv_ttb = cast3 Unmanaged.linalg_pinv_ttb
+linalg_pinv_ttb = _cast3 Unmanaged.linalg_pinv_ttb
 
 linalg_pinv_out_ttdb
   :: ForeignPtr Tensor
@@ -742,7 +742,7 @@ linalg_pinv_out_ttdb
   -> CDouble
   -> CBool
   -> IO (ForeignPtr Tensor)
-linalg_pinv_out_ttdb = cast4 Unmanaged.linalg_pinv_out_ttdb
+linalg_pinv_out_ttdb = _cast4 Unmanaged.linalg_pinv_out_ttdb
 
 linalg_pinv_out_tttb
   :: ForeignPtr Tensor
@@ -750,57 +750,57 @@ linalg_pinv_out_tttb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-linalg_pinv_out_tttb = cast4 Unmanaged.linalg_pinv_out_tttb
+linalg_pinv_out_tttb = _cast4 Unmanaged.linalg_pinv_out_tttb
 
 linalg_solve_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linalg_solve_tt = cast2 Unmanaged.linalg_solve_tt
+linalg_solve_tt = _cast2 Unmanaged.linalg_solve_tt
 
 linalg_solve_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linalg_solve_out_ttt = cast3 Unmanaged.linalg_solve_out_ttt
+linalg_solve_out_ttt = _cast3 Unmanaged.linalg_solve_out_ttt
 
 linalg_tensorinv_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-linalg_tensorinv_tl = cast2 Unmanaged.linalg_tensorinv_tl
+linalg_tensorinv_tl = _cast2 Unmanaged.linalg_tensorinv_tl
 
 linalg_tensorinv_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linalg_tensorinv_t = cast1 Unmanaged.linalg_tensorinv_t
+linalg_tensorinv_t = _cast1 Unmanaged.linalg_tensorinv_t
 
 linalg_tensorinv_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-linalg_tensorinv_out_ttl = cast3 Unmanaged.linalg_tensorinv_out_ttl
+linalg_tensorinv_out_ttl = _cast3 Unmanaged.linalg_tensorinv_out_ttl
 
 linalg_tensorinv_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linalg_tensorinv_out_tt = cast2 Unmanaged.linalg_tensorinv_out_tt
+linalg_tensorinv_out_tt = _cast2 Unmanaged.linalg_tensorinv_out_tt
 
 linalg_tensorsolve_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-linalg_tensorsolve_ttl = cast3 Unmanaged.linalg_tensorsolve_ttl
+linalg_tensorsolve_ttl = _cast3 Unmanaged.linalg_tensorsolve_ttl
 
 linalg_tensorsolve_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linalg_tensorsolve_tt = cast2 Unmanaged.linalg_tensorsolve_tt
+linalg_tensorsolve_tt = _cast2 Unmanaged.linalg_tensorsolve_tt
 
 linalg_tensorsolve_out_tttl
   :: ForeignPtr Tensor
@@ -808,25 +808,25 @@ linalg_tensorsolve_out_tttl
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-linalg_tensorsolve_out_tttl = cast4 Unmanaged.linalg_tensorsolve_out_tttl
+linalg_tensorsolve_out_tttl = _cast4 Unmanaged.linalg_tensorsolve_out_tttl
 
 linalg_tensorsolve_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linalg_tensorsolve_out_ttt = cast3 Unmanaged.linalg_tensorsolve_out_ttt
+linalg_tensorsolve_out_ttt = _cast3 Unmanaged.linalg_tensorsolve_out_ttt
 
 linalg_qr_ts
   :: ForeignPtr Tensor
   -> ForeignPtr StdString
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-linalg_qr_ts = cast2 Unmanaged.linalg_qr_ts
+linalg_qr_ts = _cast2 Unmanaged.linalg_qr_ts
 
 linalg_qr_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-linalg_qr_t = cast1 Unmanaged.linalg_qr_t
+linalg_qr_t = _cast1 Unmanaged.linalg_qr_t
 
 linalg_qr_out_ttts
   :: ForeignPtr Tensor
@@ -834,33 +834,33 @@ linalg_qr_out_ttts
   -> ForeignPtr Tensor
   -> ForeignPtr StdString
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-linalg_qr_out_ttts = cast4 Unmanaged.linalg_qr_out_ttts
+linalg_qr_out_ttts = _cast4 Unmanaged.linalg_qr_out_ttts
 
 linalg_qr_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-linalg_qr_out_ttt = cast3 Unmanaged.linalg_qr_out_ttt
+linalg_qr_out_ttt = _cast3 Unmanaged.linalg_qr_out_ttt
 
 _linalg_qr_helper_ts
   :: ForeignPtr Tensor
   -> ForeignPtr StdString
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-_linalg_qr_helper_ts = cast2 Unmanaged._linalg_qr_helper_ts
+_linalg_qr_helper_ts = _cast2 Unmanaged._linalg_qr_helper_ts
 
 linalg_matrix_power_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-linalg_matrix_power_tl = cast2 Unmanaged.linalg_matrix_power_tl
+linalg_matrix_power_tl = _cast2 Unmanaged.linalg_matrix_power_tl
 
 linalg_matrix_power_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-linalg_matrix_power_out_ttl = cast3 Unmanaged.linalg_matrix_power_out_ttl
+linalg_matrix_power_out_ttl = _cast3 Unmanaged.linalg_matrix_power_out_ttl
 
 linalg_matrix_rank_tttb
   :: ForeignPtr Tensor
@@ -868,25 +868,25 @@ linalg_matrix_rank_tttb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-linalg_matrix_rank_tttb = cast4 Unmanaged.linalg_matrix_rank_tttb
+linalg_matrix_rank_tttb = _cast4 Unmanaged.linalg_matrix_rank_tttb
 
 linalg_matrix_rank_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linalg_matrix_rank_ttt = cast3 Unmanaged.linalg_matrix_rank_ttt
+linalg_matrix_rank_ttt = _cast3 Unmanaged.linalg_matrix_rank_ttt
 
 linalg_matrix_rank_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linalg_matrix_rank_tt = cast2 Unmanaged.linalg_matrix_rank_tt
+linalg_matrix_rank_tt = _cast2 Unmanaged.linalg_matrix_rank_tt
 
 linalg_matrix_rank_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linalg_matrix_rank_t = cast1 Unmanaged.linalg_matrix_rank_t
+linalg_matrix_rank_t = _cast1 Unmanaged.linalg_matrix_rank_t
 
 linalg_matrix_rank_out_ttttb
   :: ForeignPtr Tensor
@@ -895,7 +895,7 @@ linalg_matrix_rank_out_ttttb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-linalg_matrix_rank_out_ttttb = cast5 Unmanaged.linalg_matrix_rank_out_ttttb
+linalg_matrix_rank_out_ttttb = _cast5 Unmanaged.linalg_matrix_rank_out_ttttb
 
 linalg_matrix_rank_out_tttt
   :: ForeignPtr Tensor
@@ -903,20 +903,20 @@ linalg_matrix_rank_out_tttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linalg_matrix_rank_out_tttt = cast4 Unmanaged.linalg_matrix_rank_out_tttt
+linalg_matrix_rank_out_tttt = _cast4 Unmanaged.linalg_matrix_rank_out_tttt
 
 linalg_matrix_rank_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linalg_matrix_rank_out_ttt = cast3 Unmanaged.linalg_matrix_rank_out_ttt
+linalg_matrix_rank_out_ttt = _cast3 Unmanaged.linalg_matrix_rank_out_ttt
 
 linalg_matrix_rank_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linalg_matrix_rank_out_tt = cast2 Unmanaged.linalg_matrix_rank_out_tt
+linalg_matrix_rank_out_tt = _cast2 Unmanaged.linalg_matrix_rank_out_tt
 
 linalg_matrix_rank_tddb
   :: ForeignPtr Tensor
@@ -924,20 +924,20 @@ linalg_matrix_rank_tddb
   -> CDouble
   -> CBool
   -> IO (ForeignPtr Tensor)
-linalg_matrix_rank_tddb = cast4 Unmanaged.linalg_matrix_rank_tddb
+linalg_matrix_rank_tddb = _cast4 Unmanaged.linalg_matrix_rank_tddb
 
 linalg_matrix_rank_tdd
   :: ForeignPtr Tensor
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-linalg_matrix_rank_tdd = cast3 Unmanaged.linalg_matrix_rank_tdd
+linalg_matrix_rank_tdd = _cast3 Unmanaged.linalg_matrix_rank_tdd
 
 linalg_matrix_rank_td
   :: ForeignPtr Tensor
   -> CDouble
   -> IO (ForeignPtr Tensor)
-linalg_matrix_rank_td = cast2 Unmanaged.linalg_matrix_rank_td
+linalg_matrix_rank_td = _cast2 Unmanaged.linalg_matrix_rank_td
 
 linalg_matrix_rank_out_ttddb
   :: ForeignPtr Tensor
@@ -946,7 +946,7 @@ linalg_matrix_rank_out_ttddb
   -> CDouble
   -> CBool
   -> IO (ForeignPtr Tensor)
-linalg_matrix_rank_out_ttddb = cast5 Unmanaged.linalg_matrix_rank_out_ttddb
+linalg_matrix_rank_out_ttddb = _cast5 Unmanaged.linalg_matrix_rank_out_ttddb
 
 linalg_matrix_rank_out_ttdd
   :: ForeignPtr Tensor
@@ -954,21 +954,21 @@ linalg_matrix_rank_out_ttdd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-linalg_matrix_rank_out_ttdd = cast4 Unmanaged.linalg_matrix_rank_out_ttdd
+linalg_matrix_rank_out_ttdd = _cast4 Unmanaged.linalg_matrix_rank_out_ttdd
 
 linalg_matrix_rank_out_ttd
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> CDouble
   -> IO (ForeignPtr Tensor)
-linalg_matrix_rank_out_ttd = cast3 Unmanaged.linalg_matrix_rank_out_ttd
+linalg_matrix_rank_out_ttd = _cast3 Unmanaged.linalg_matrix_rank_out_ttd
 
 linalg_matrix_rank_tdb
   :: ForeignPtr Tensor
   -> CDouble
   -> CBool
   -> IO (ForeignPtr Tensor)
-linalg_matrix_rank_tdb = cast3 Unmanaged.linalg_matrix_rank_tdb
+linalg_matrix_rank_tdb = _cast3 Unmanaged.linalg_matrix_rank_tdb
 
 linalg_matrix_rank_out_ttdb
   :: ForeignPtr Tensor
@@ -976,14 +976,14 @@ linalg_matrix_rank_out_ttdb
   -> CDouble
   -> CBool
   -> IO (ForeignPtr Tensor)
-linalg_matrix_rank_out_ttdb = cast4 Unmanaged.linalg_matrix_rank_out_ttdb
+linalg_matrix_rank_out_ttdb = _cast4 Unmanaged.linalg_matrix_rank_out_ttdb
 
 linalg_matrix_rank_ttb
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-linalg_matrix_rank_ttb = cast3 Unmanaged.linalg_matrix_rank_ttb
+linalg_matrix_rank_ttb = _cast3 Unmanaged.linalg_matrix_rank_ttb
 
 linalg_matrix_rank_out_tttb
   :: ForeignPtr Tensor
@@ -991,97 +991,97 @@ linalg_matrix_rank_out_tttb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-linalg_matrix_rank_out_tttb = cast4 Unmanaged.linalg_matrix_rank_out_tttb
+linalg_matrix_rank_out_tttb = _cast4 Unmanaged.linalg_matrix_rank_out_tttb
 
 linalg_multi_dot_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr Tensor)
-linalg_multi_dot_l = cast1 Unmanaged.linalg_multi_dot_l
+linalg_multi_dot_l = _cast1 Unmanaged.linalg_multi_dot_l
 
 linalg_multi_dot_out_tl
   :: ForeignPtr Tensor
   -> ForeignPtr TensorList
   -> IO (ForeignPtr Tensor)
-linalg_multi_dot_out_tl = cast2 Unmanaged.linalg_multi_dot_out_tl
+linalg_multi_dot_out_tl = _cast2 Unmanaged.linalg_multi_dot_out_tl
 
 _test_serialization_subcmul_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-_test_serialization_subcmul_tts = cast3 Unmanaged._test_serialization_subcmul_tts
+_test_serialization_subcmul_tts = _cast3 Unmanaged._test_serialization_subcmul_tts
 
 _test_serialization_subcmul_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_test_serialization_subcmul_tt = cast2 Unmanaged._test_serialization_subcmul_tt
+_test_serialization_subcmul_tt = _cast2 Unmanaged._test_serialization_subcmul_tt
 
 _test_optional_intlist_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-_test_optional_intlist_tl = cast2 Unmanaged._test_optional_intlist_tl
+_test_optional_intlist_tl = _cast2 Unmanaged._test_optional_intlist_tl
 
 _test_optional_filled_intlist_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-_test_optional_filled_intlist_tl = cast2 Unmanaged._test_optional_filled_intlist_tl
+_test_optional_filled_intlist_tl = _cast2 Unmanaged._test_optional_filled_intlist_tl
 
 _test_optional_floatlist_ta
   :: ForeignPtr Tensor
   -> ForeignPtr (StdVector CDouble)
   -> IO (ForeignPtr Tensor)
-_test_optional_floatlist_ta = cast2 Unmanaged._test_optional_floatlist_ta
+_test_optional_floatlist_ta = _cast2 Unmanaged._test_optional_floatlist_ta
 
 _test_string_default_tss
   :: ForeignPtr Tensor
   -> ForeignPtr StdString
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-_test_string_default_tss = cast3 Unmanaged._test_string_default_tss
+_test_string_default_tss = _cast3 Unmanaged._test_string_default_tss
 
 _test_string_default_ts
   :: ForeignPtr Tensor
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-_test_string_default_ts = cast2 Unmanaged._test_string_default_ts
+_test_string_default_ts = _cast2 Unmanaged._test_string_default_ts
 
 _test_string_default_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_test_string_default_t = cast1 Unmanaged._test_string_default_t
+_test_string_default_t = _cast1 Unmanaged._test_string_default_t
 
 _test_ambiguous_defaults_tll
   :: ForeignPtr Tensor
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-_test_ambiguous_defaults_tll = cast3 Unmanaged._test_ambiguous_defaults_tll
+_test_ambiguous_defaults_tll = _cast3 Unmanaged._test_ambiguous_defaults_tll
 
 _test_ambiguous_defaults_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-_test_ambiguous_defaults_tl = cast2 Unmanaged._test_ambiguous_defaults_tl
+_test_ambiguous_defaults_tl = _cast2 Unmanaged._test_ambiguous_defaults_tl
 
 _test_ambiguous_defaults_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_test_ambiguous_defaults_t = cast1 Unmanaged._test_ambiguous_defaults_t
+_test_ambiguous_defaults_t = _cast1 Unmanaged._test_ambiguous_defaults_t
 
 _test_ambiguous_defaults_tls
   :: ForeignPtr Tensor
   -> Int64
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-_test_ambiguous_defaults_tls = cast3 Unmanaged._test_ambiguous_defaults_tls
+_test_ambiguous_defaults_tls = _cast3 Unmanaged._test_ambiguous_defaults_tls
 
 _test_warn_in_autograd_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_test_warn_in_autograd_t = cast1 Unmanaged._test_warn_in_autograd_t
+_test_warn_in_autograd_t = _cast1 Unmanaged._test_warn_in_autograd_t
 
 segment_reduce_tsttlbs
   :: ForeignPtr Tensor
@@ -1092,7 +1092,7 @@ segment_reduce_tsttlbs
   -> CBool
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-segment_reduce_tsttlbs = cast7 Unmanaged.segment_reduce_tsttlbs
+segment_reduce_tsttlbs = _cast7 Unmanaged.segment_reduce_tsttlbs
 
 segment_reduce_tsttlb
   :: ForeignPtr Tensor
@@ -1102,7 +1102,7 @@ segment_reduce_tsttlb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-segment_reduce_tsttlb = cast6 Unmanaged.segment_reduce_tsttlb
+segment_reduce_tsttlb = _cast6 Unmanaged.segment_reduce_tsttlb
 
 segment_reduce_tsttl
   :: ForeignPtr Tensor
@@ -1111,7 +1111,7 @@ segment_reduce_tsttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-segment_reduce_tsttl = cast5 Unmanaged.segment_reduce_tsttl
+segment_reduce_tsttl = _cast5 Unmanaged.segment_reduce_tsttl
 
 segment_reduce_tstt
   :: ForeignPtr Tensor
@@ -1119,20 +1119,20 @@ segment_reduce_tstt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-segment_reduce_tstt = cast4 Unmanaged.segment_reduce_tstt
+segment_reduce_tstt = _cast4 Unmanaged.segment_reduce_tstt
 
 segment_reduce_tst
   :: ForeignPtr Tensor
   -> ForeignPtr StdString
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-segment_reduce_tst = cast3 Unmanaged.segment_reduce_tst
+segment_reduce_tst = _cast3 Unmanaged.segment_reduce_tst
 
 segment_reduce_ts
   :: ForeignPtr Tensor
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-segment_reduce_ts = cast2 Unmanaged.segment_reduce_ts
+segment_reduce_ts = _cast2 Unmanaged.segment_reduce_ts
 
 _segment_reduce_backward_tttstl
   :: ForeignPtr Tensor
@@ -1142,7 +1142,7 @@ _segment_reduce_backward_tttstl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-_segment_reduce_backward_tttstl = cast6 Unmanaged._segment_reduce_backward_tttstl
+_segment_reduce_backward_tttstl = _cast6 Unmanaged._segment_reduce_backward_tttstl
 
 _segment_reduce_backward_tttst
   :: ForeignPtr Tensor
@@ -1151,7 +1151,7 @@ _segment_reduce_backward_tttst
   -> ForeignPtr StdString
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_segment_reduce_backward_tttst = cast5 Unmanaged._segment_reduce_backward_tttst
+_segment_reduce_backward_tttst = _cast5 Unmanaged._segment_reduce_backward_tttst
 
 _segment_reduce_backward_ttts
   :: ForeignPtr Tensor
@@ -1159,34 +1159,34 @@ _segment_reduce_backward_ttts
   -> ForeignPtr Tensor
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-_segment_reduce_backward_ttts = cast4 Unmanaged._segment_reduce_backward_ttts
+_segment_reduce_backward_ttts = _cast4 Unmanaged._segment_reduce_backward_ttts
 
 pad_sequence_lbd
   :: ForeignPtr TensorList
   -> CBool
   -> CDouble
   -> IO (ForeignPtr Tensor)
-pad_sequence_lbd = cast3 Unmanaged.pad_sequence_lbd
+pad_sequence_lbd = _cast3 Unmanaged.pad_sequence_lbd
 
 pad_sequence_lb
   :: ForeignPtr TensorList
   -> CBool
   -> IO (ForeignPtr Tensor)
-pad_sequence_lb = cast2 Unmanaged.pad_sequence_lb
+pad_sequence_lb = _cast2 Unmanaged.pad_sequence_lb
 
 pad_sequence_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr Tensor)
-pad_sequence_l = cast1 Unmanaged.pad_sequence_l
+pad_sequence_l = _cast1 Unmanaged.pad_sequence_l
 
 flatten_dense_tensors_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr Tensor)
-flatten_dense_tensors_l = cast1 Unmanaged.flatten_dense_tensors_l
+flatten_dense_tensors_l = _cast1 Unmanaged.flatten_dense_tensors_l
 
 unflatten_dense_tensors_tl
   :: ForeignPtr Tensor
   -> ForeignPtr TensorList
   -> IO (ForeignPtr TensorList)
-unflatten_dense_tensors_tl = cast2 Unmanaged.unflatten_dense_tensors_tl
+unflatten_dense_tensors_tl = _cast2 Unmanaged.unflatten_dense_tensors_tl
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Native/Native2.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Native/Native2.hs
@@ -28,7 +28,7 @@ cosine_embedding_loss_tttdl
   -> CDouble
   -> Int64
   -> IO (ForeignPtr Tensor)
-cosine_embedding_loss_tttdl = cast5 Unmanaged.cosine_embedding_loss_tttdl
+cosine_embedding_loss_tttdl = _cast5 Unmanaged.cosine_embedding_loss_tttdl
 
 cosine_embedding_loss_tttd
   :: ForeignPtr Tensor
@@ -36,25 +36,25 @@ cosine_embedding_loss_tttd
   -> ForeignPtr Tensor
   -> CDouble
   -> IO (ForeignPtr Tensor)
-cosine_embedding_loss_tttd = cast4 Unmanaged.cosine_embedding_loss_tttd
+cosine_embedding_loss_tttd = _cast4 Unmanaged.cosine_embedding_loss_tttd
 
 cosine_embedding_loss_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-cosine_embedding_loss_ttt = cast3 Unmanaged.cosine_embedding_loss_ttt
+cosine_embedding_loss_ttt = _cast3 Unmanaged.cosine_embedding_loss_ttt
 
 count_nonzero_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-count_nonzero_tl = cast2 Unmanaged.count_nonzero_tl
+count_nonzero_tl = _cast2 Unmanaged.count_nonzero_tl
 
 count_nonzero_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-count_nonzero_t = cast1 Unmanaged.count_nonzero_t
+count_nonzero_t = _cast1 Unmanaged.count_nonzero_t
 
 cov_tltt
   :: ForeignPtr Tensor
@@ -62,30 +62,30 @@ cov_tltt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-cov_tltt = cast4 Unmanaged.cov_tltt
+cov_tltt = _cast4 Unmanaged.cov_tltt
 
 cov_tlt
   :: ForeignPtr Tensor
   -> Int64
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-cov_tlt = cast3 Unmanaged.cov_tlt
+cov_tlt = _cast3 Unmanaged.cov_tlt
 
 cov_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-cov_tl = cast2 Unmanaged.cov_tl
+cov_tl = _cast2 Unmanaged.cov_tl
 
 cov_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-cov_t = cast1 Unmanaged.cov_t
+cov_t = _cast1 Unmanaged.cov_t
 
 corrcoef_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-corrcoef_t = cast1 Unmanaged.corrcoef_t
+corrcoef_t = _cast1 Unmanaged.corrcoef_t
 
 cudnn_affine_grid_generator_tllll
   :: ForeignPtr Tensor
@@ -94,7 +94,7 @@ cudnn_affine_grid_generator_tllll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-cudnn_affine_grid_generator_tllll = cast5 Unmanaged.cudnn_affine_grid_generator_tllll
+cudnn_affine_grid_generator_tllll = _cast5 Unmanaged.cudnn_affine_grid_generator_tllll
 
 cudnn_affine_grid_generator_backward_tllll
   :: ForeignPtr Tensor
@@ -103,7 +103,7 @@ cudnn_affine_grid_generator_backward_tllll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-cudnn_affine_grid_generator_backward_tllll = cast5 Unmanaged.cudnn_affine_grid_generator_backward_tllll
+cudnn_affine_grid_generator_backward_tllll = _cast5 Unmanaged.cudnn_affine_grid_generator_backward_tllll
 
 cudnn_batch_norm_tttttbdd
   :: ForeignPtr Tensor
@@ -115,7 +115,7 @@ cudnn_batch_norm_tttttbdd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
-cudnn_batch_norm_tttttbdd = cast8 Unmanaged.cudnn_batch_norm_tttttbdd
+cudnn_batch_norm_tttttbdd = _cast8 Unmanaged.cudnn_batch_norm_tttttbdd
 
 cudnn_batch_norm_backward_tttttttdt
   :: ForeignPtr Tensor
@@ -128,7 +128,7 @@ cudnn_batch_norm_backward_tttttttdt
   -> CDouble
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-cudnn_batch_norm_backward_tttttttdt = cast9 Unmanaged.cudnn_batch_norm_backward_tttttttdt
+cudnn_batch_norm_backward_tttttttdt = _cast9 Unmanaged.cudnn_batch_norm_backward_tttttttdt
 
 cudnn_convolution_ttllllbbb
   :: ForeignPtr Tensor
@@ -141,7 +141,7 @@ cudnn_convolution_ttllllbbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-cudnn_convolution_ttllllbbb = cast9 Unmanaged.cudnn_convolution_ttllllbbb
+cudnn_convolution_ttllllbbb = _cast9 Unmanaged.cudnn_convolution_ttllllbbb
 
 cudnn_convolution_transpose_ttlllllbbb
   :: ForeignPtr Tensor
@@ -155,7 +155,7 @@ cudnn_convolution_transpose_ttlllllbbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-cudnn_convolution_transpose_ttlllllbbb = cast10 Unmanaged.cudnn_convolution_transpose_ttlllllbbb
+cudnn_convolution_transpose_ttlllllbbb = _cast10 Unmanaged.cudnn_convolution_transpose_ttlllllbbb
 
 cudnn_convolution_relu_tttllll
   :: ForeignPtr Tensor
@@ -166,7 +166,7 @@ cudnn_convolution_relu_tttllll
   -> ForeignPtr IntArray
   -> Int64
   -> IO (ForeignPtr Tensor)
-cudnn_convolution_relu_tttllll = cast7 Unmanaged.cudnn_convolution_relu_tttllll
+cudnn_convolution_relu_tttllll = _cast7 Unmanaged.cudnn_convolution_relu_tttllll
 
 cudnn_convolution_add_relu_tttstllll
   :: ForeignPtr Tensor
@@ -179,26 +179,26 @@ cudnn_convolution_add_relu_tttstllll
   -> ForeignPtr IntArray
   -> Int64
   -> IO (ForeignPtr Tensor)
-cudnn_convolution_add_relu_tttstllll = cast9 Unmanaged.cudnn_convolution_add_relu_tttstllll
+cudnn_convolution_add_relu_tttstllll = _cast9 Unmanaged.cudnn_convolution_add_relu_tttstllll
 
 cudnn_grid_sampler_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-cudnn_grid_sampler_tt = cast2 Unmanaged.cudnn_grid_sampler_tt
+cudnn_grid_sampler_tt = _cast2 Unmanaged.cudnn_grid_sampler_tt
 
 cudnn_grid_sampler_backward_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-cudnn_grid_sampler_backward_ttt = cast3 Unmanaged.cudnn_grid_sampler_backward_ttt
+cudnn_grid_sampler_backward_ttt = _cast3 Unmanaged.cudnn_grid_sampler_backward_ttt
 
 cummax_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-cummax_tl = cast2 Unmanaged.cummax_tl
+cummax_tl = _cast2 Unmanaged.cummax_tl
 
 cummax_out_tttl
   :: ForeignPtr Tensor
@@ -206,13 +206,13 @@ cummax_out_tttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-cummax_out_tttl = cast4 Unmanaged.cummax_out_tttl
+cummax_out_tttl = _cast4 Unmanaged.cummax_out_tttl
 
 cummax_tn
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-cummax_tn = cast2 Unmanaged.cummax_tn
+cummax_tn = _cast2 Unmanaged.cummax_tn
 
 cummax_out_tttn
   :: ForeignPtr Tensor
@@ -220,7 +220,7 @@ cummax_out_tttn
   -> ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-cummax_out_tttn = cast4 Unmanaged.cummax_out_tttn
+cummax_out_tttn = _cast4 Unmanaged.cummax_out_tttn
 
 _cummax_helper_tttl
   :: ForeignPtr Tensor
@@ -228,13 +228,13 @@ _cummax_helper_tttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (())
-_cummax_helper_tttl = cast4 Unmanaged._cummax_helper_tttl
+_cummax_helper_tttl = _cast4 Unmanaged._cummax_helper_tttl
 
 cummin_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-cummin_tl = cast2 Unmanaged.cummin_tl
+cummin_tl = _cast2 Unmanaged.cummin_tl
 
 cummin_out_tttl
   :: ForeignPtr Tensor
@@ -242,13 +242,13 @@ cummin_out_tttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-cummin_out_tttl = cast4 Unmanaged.cummin_out_tttl
+cummin_out_tttl = _cast4 Unmanaged.cummin_out_tttl
 
 cummin_tn
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-cummin_tn = cast2 Unmanaged.cummin_tn
+cummin_tn = _cast2 Unmanaged.cummin_tn
 
 cummin_out_tttn
   :: ForeignPtr Tensor
@@ -256,7 +256,7 @@ cummin_out_tttn
   -> ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-cummin_out_tttn = cast4 Unmanaged.cummin_out_tttn
+cummin_out_tttn = _cast4 Unmanaged.cummin_out_tttn
 
 _cummin_helper_tttl
   :: ForeignPtr Tensor
@@ -264,7 +264,7 @@ _cummin_helper_tttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (())
-_cummin_helper_tttl = cast4 Unmanaged._cummin_helper_tttl
+_cummin_helper_tttl = _cast4 Unmanaged._cummin_helper_tttl
 
 cummaxmin_backward_tttl
   :: ForeignPtr Tensor
@@ -272,20 +272,20 @@ cummaxmin_backward_tttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-cummaxmin_backward_tttl = cast4 Unmanaged.cummaxmin_backward_tttl
+cummaxmin_backward_tttl = _cast4 Unmanaged.cummaxmin_backward_tttl
 
 cumprod_tls
   :: ForeignPtr Tensor
   -> Int64
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-cumprod_tls = cast3 Unmanaged.cumprod_tls
+cumprod_tls = _cast3 Unmanaged.cumprod_tls
 
 cumprod_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-cumprod_tl = cast2 Unmanaged.cumprod_tl
+cumprod_tl = _cast2 Unmanaged.cumprod_tl
 
 cumprod_out_ttls
   :: ForeignPtr Tensor
@@ -293,27 +293,27 @@ cumprod_out_ttls
   -> Int64
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-cumprod_out_ttls = cast4 Unmanaged.cumprod_out_ttls
+cumprod_out_ttls = _cast4 Unmanaged.cumprod_out_ttls
 
 cumprod_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-cumprod_out_ttl = cast3 Unmanaged.cumprod_out_ttl
+cumprod_out_ttl = _cast3 Unmanaged.cumprod_out_ttl
 
 cumprod_tns
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-cumprod_tns = cast3 Unmanaged.cumprod_tns
+cumprod_tns = _cast3 Unmanaged.cumprod_tns
 
 cumprod_tn
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> IO (ForeignPtr Tensor)
-cumprod_tn = cast2 Unmanaged.cumprod_tn
+cumprod_tn = _cast2 Unmanaged.cumprod_tn
 
 cumprod_out_ttns
   :: ForeignPtr Tensor
@@ -321,14 +321,14 @@ cumprod_out_ttns
   -> ForeignPtr Dimname
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-cumprod_out_ttns = cast4 Unmanaged.cumprod_out_ttns
+cumprod_out_ttns = _cast4 Unmanaged.cumprod_out_ttns
 
 cumprod_out_ttn
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> IO (ForeignPtr Tensor)
-cumprod_out_ttn = cast3 Unmanaged.cumprod_out_ttn
+cumprod_out_ttn = _cast3 Unmanaged.cumprod_out_ttn
 
 cumprod_backward_ttlt
   :: ForeignPtr Tensor
@@ -336,20 +336,20 @@ cumprod_backward_ttlt
   -> Int64
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-cumprod_backward_ttlt = cast4 Unmanaged.cumprod_backward_ttlt
+cumprod_backward_ttlt = _cast4 Unmanaged.cumprod_backward_ttlt
 
 cumsum_tls
   :: ForeignPtr Tensor
   -> Int64
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-cumsum_tls = cast3 Unmanaged.cumsum_tls
+cumsum_tls = _cast3 Unmanaged.cumsum_tls
 
 cumsum_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-cumsum_tl = cast2 Unmanaged.cumsum_tl
+cumsum_tl = _cast2 Unmanaged.cumsum_tl
 
 cumsum_out_ttls
   :: ForeignPtr Tensor
@@ -357,27 +357,27 @@ cumsum_out_ttls
   -> Int64
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-cumsum_out_ttls = cast4 Unmanaged.cumsum_out_ttls
+cumsum_out_ttls = _cast4 Unmanaged.cumsum_out_ttls
 
 cumsum_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-cumsum_out_ttl = cast3 Unmanaged.cumsum_out_ttl
+cumsum_out_ttl = _cast3 Unmanaged.cumsum_out_ttl
 
 cumsum_tns
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-cumsum_tns = cast3 Unmanaged.cumsum_tns
+cumsum_tns = _cast3 Unmanaged.cumsum_tns
 
 cumsum_tn
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> IO (ForeignPtr Tensor)
-cumsum_tn = cast2 Unmanaged.cumsum_tn
+cumsum_tn = _cast2 Unmanaged.cumsum_tn
 
 cumsum_out_ttns
   :: ForeignPtr Tensor
@@ -385,45 +385,45 @@ cumsum_out_ttns
   -> ForeignPtr Dimname
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-cumsum_out_ttns = cast4 Unmanaged.cumsum_out_ttns
+cumsum_out_ttns = _cast4 Unmanaged.cumsum_out_ttns
 
 cumsum_out_ttn
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> IO (ForeignPtr Tensor)
-cumsum_out_ttn = cast3 Unmanaged.cumsum_out_ttn
+cumsum_out_ttn = _cast3 Unmanaged.cumsum_out_ttn
 
 cumulative_trapezoid_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-cumulative_trapezoid_ttl = cast3 Unmanaged.cumulative_trapezoid_ttl
+cumulative_trapezoid_ttl = _cast3 Unmanaged.cumulative_trapezoid_ttl
 
 cumulative_trapezoid_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-cumulative_trapezoid_tt = cast2 Unmanaged.cumulative_trapezoid_tt
+cumulative_trapezoid_tt = _cast2 Unmanaged.cumulative_trapezoid_tt
 
 cumulative_trapezoid_tsl
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> Int64
   -> IO (ForeignPtr Tensor)
-cumulative_trapezoid_tsl = cast3 Unmanaged.cumulative_trapezoid_tsl
+cumulative_trapezoid_tsl = _cast3 Unmanaged.cumulative_trapezoid_tsl
 
 cumulative_trapezoid_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-cumulative_trapezoid_ts = cast2 Unmanaged.cumulative_trapezoid_ts
+cumulative_trapezoid_ts = _cast2 Unmanaged.cumulative_trapezoid_ts
 
 cumulative_trapezoid_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-cumulative_trapezoid_t = cast1 Unmanaged.cumulative_trapezoid_t
+cumulative_trapezoid_t = _cast1 Unmanaged.cumulative_trapezoid_t
 
 ctc_loss_ttllllb
   :: ForeignPtr Tensor
@@ -434,7 +434,7 @@ ctc_loss_ttllllb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-ctc_loss_ttllllb = cast7 Unmanaged.ctc_loss_ttllllb
+ctc_loss_ttllllb = _cast7 Unmanaged.ctc_loss_ttllllb
 
 ctc_loss_ttllll
   :: ForeignPtr Tensor
@@ -444,7 +444,7 @@ ctc_loss_ttllll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-ctc_loss_ttllll = cast6 Unmanaged.ctc_loss_ttllll
+ctc_loss_ttllll = _cast6 Unmanaged.ctc_loss_ttllll
 
 ctc_loss_ttlll
   :: ForeignPtr Tensor
@@ -453,7 +453,7 @@ ctc_loss_ttlll
   -> ForeignPtr IntArray
   -> Int64
   -> IO (ForeignPtr Tensor)
-ctc_loss_ttlll = cast5 Unmanaged.ctc_loss_ttlll
+ctc_loss_ttlll = _cast5 Unmanaged.ctc_loss_ttlll
 
 ctc_loss_ttll
   :: ForeignPtr Tensor
@@ -461,7 +461,7 @@ ctc_loss_ttll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-ctc_loss_ttll = cast4 Unmanaged.ctc_loss_ttll
+ctc_loss_ttll = _cast4 Unmanaged.ctc_loss_ttll
 
 ctc_loss_ttttllb
   :: ForeignPtr Tensor
@@ -472,7 +472,7 @@ ctc_loss_ttttllb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-ctc_loss_ttttllb = cast7 Unmanaged.ctc_loss_ttttllb
+ctc_loss_ttttllb = _cast7 Unmanaged.ctc_loss_ttttllb
 
 ctc_loss_ttttll
   :: ForeignPtr Tensor
@@ -482,7 +482,7 @@ ctc_loss_ttttll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-ctc_loss_ttttll = cast6 Unmanaged.ctc_loss_ttttll
+ctc_loss_ttttll = _cast6 Unmanaged.ctc_loss_ttttll
 
 ctc_loss_ttttl
   :: ForeignPtr Tensor
@@ -491,7 +491,7 @@ ctc_loss_ttttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-ctc_loss_ttttl = cast5 Unmanaged.ctc_loss_ttttl
+ctc_loss_ttttl = _cast5 Unmanaged.ctc_loss_ttttl
 
 ctc_loss_tttt
   :: ForeignPtr Tensor
@@ -499,7 +499,7 @@ ctc_loss_tttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-ctc_loss_tttt = cast4 Unmanaged.ctc_loss_tttt
+ctc_loss_tttt = _cast4 Unmanaged.ctc_loss_tttt
 
 _ctc_loss_ttlllb
   :: ForeignPtr Tensor
@@ -509,7 +509,7 @@ _ctc_loss_ttlllb
   -> Int64
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-_ctc_loss_ttlllb = cast6 Unmanaged._ctc_loss_ttlllb
+_ctc_loss_ttlllb = _cast6 Unmanaged._ctc_loss_ttlllb
 
 _ctc_loss_ttlll
   :: ForeignPtr Tensor
@@ -518,7 +518,7 @@ _ctc_loss_ttlll
   -> ForeignPtr IntArray
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-_ctc_loss_ttlll = cast5 Unmanaged._ctc_loss_ttlll
+_ctc_loss_ttlll = _cast5 Unmanaged._ctc_loss_ttlll
 
 _ctc_loss_ttll
   :: ForeignPtr Tensor
@@ -526,7 +526,7 @@ _ctc_loss_ttll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-_ctc_loss_ttll = cast4 Unmanaged._ctc_loss_ttll
+_ctc_loss_ttll = _cast4 Unmanaged._ctc_loss_ttll
 
 _ctc_loss_backward_tttllttlb
   :: ForeignPtr Tensor
@@ -539,7 +539,7 @@ _ctc_loss_backward_tttllttlb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-_ctc_loss_backward_tttllttlb = cast9 Unmanaged._ctc_loss_backward_tttllttlb
+_ctc_loss_backward_tttllttlb = _cast9 Unmanaged._ctc_loss_backward_tttllttlb
 
 _ctc_loss_backward_tttllttl
   :: ForeignPtr Tensor
@@ -551,7 +551,7 @@ _ctc_loss_backward_tttllttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-_ctc_loss_backward_tttllttl = cast8 Unmanaged._ctc_loss_backward_tttllttl
+_ctc_loss_backward_tttllttl = _cast8 Unmanaged._ctc_loss_backward_tttllttl
 
 diag_embed_tlll
   :: ForeignPtr Tensor
@@ -559,36 +559,36 @@ diag_embed_tlll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-diag_embed_tlll = cast4 Unmanaged.diag_embed_tlll
+diag_embed_tlll = _cast4 Unmanaged.diag_embed_tlll
 
 diag_embed_tll
   :: ForeignPtr Tensor
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-diag_embed_tll = cast3 Unmanaged.diag_embed_tll
+diag_embed_tll = _cast3 Unmanaged.diag_embed_tll
 
 diag_embed_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-diag_embed_tl = cast2 Unmanaged.diag_embed_tl
+diag_embed_tl = _cast2 Unmanaged.diag_embed_tl
 
 diag_embed_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-diag_embed_t = cast1 Unmanaged.diag_embed_t
+diag_embed_t = _cast1 Unmanaged.diag_embed_t
 
 diagflat_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-diagflat_tl = cast2 Unmanaged.diagflat_tl
+diagflat_tl = _cast2 Unmanaged.diagflat_tl
 
 diagflat_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-diagflat_t = cast1 Unmanaged.diagflat_t
+diagflat_t = _cast1 Unmanaged.diagflat_t
 
 diagonal_tlll
   :: ForeignPtr Tensor
@@ -596,25 +596,25 @@ diagonal_tlll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-diagonal_tlll = cast4 Unmanaged.diagonal_tlll
+diagonal_tlll = _cast4 Unmanaged.diagonal_tlll
 
 diagonal_tll
   :: ForeignPtr Tensor
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-diagonal_tll = cast3 Unmanaged.diagonal_tll
+diagonal_tll = _cast3 Unmanaged.diagonal_tll
 
 diagonal_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-diagonal_tl = cast2 Unmanaged.diagonal_tl
+diagonal_tl = _cast2 Unmanaged.diagonal_tl
 
 diagonal_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-diagonal_t = cast1 Unmanaged.diagonal_t
+diagonal_t = _cast1 Unmanaged.diagonal_t
 
 linalg_diagonal_tlll
   :: ForeignPtr Tensor
@@ -622,25 +622,25 @@ linalg_diagonal_tlll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-linalg_diagonal_tlll = cast4 Unmanaged.linalg_diagonal_tlll
+linalg_diagonal_tlll = _cast4 Unmanaged.linalg_diagonal_tlll
 
 linalg_diagonal_tll
   :: ForeignPtr Tensor
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-linalg_diagonal_tll = cast3 Unmanaged.linalg_diagonal_tll
+linalg_diagonal_tll = _cast3 Unmanaged.linalg_diagonal_tll
 
 linalg_diagonal_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-linalg_diagonal_tl = cast2 Unmanaged.linalg_diagonal_tl
+linalg_diagonal_tl = _cast2 Unmanaged.linalg_diagonal_tl
 
 linalg_diagonal_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linalg_diagonal_t = cast1 Unmanaged.linalg_diagonal_t
+linalg_diagonal_t = _cast1 Unmanaged.linalg_diagonal_t
 
 diagonal_tnnnl
   :: ForeignPtr Tensor
@@ -649,7 +649,7 @@ diagonal_tnnnl
   -> ForeignPtr Dimname
   -> Int64
   -> IO (ForeignPtr Tensor)
-diagonal_tnnnl = cast5 Unmanaged.diagonal_tnnnl
+diagonal_tnnnl = _cast5 Unmanaged.diagonal_tnnnl
 
 diagonal_tnnn
   :: ForeignPtr Tensor
@@ -657,7 +657,7 @@ diagonal_tnnn
   -> ForeignPtr Dimname
   -> ForeignPtr Dimname
   -> IO (ForeignPtr Tensor)
-diagonal_tnnn = cast4 Unmanaged.diagonal_tnnn
+diagonal_tnnn = _cast4 Unmanaged.diagonal_tnnn
 
 diagonal_backward_tllll
   :: ForeignPtr Tensor
@@ -666,7 +666,7 @@ diagonal_backward_tllll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-diagonal_backward_tllll = cast5 Unmanaged.diagonal_backward_tllll
+diagonal_backward_tllll = _cast5 Unmanaged.diagonal_backward_tllll
 
 diff_tlltt
   :: ForeignPtr Tensor
@@ -675,7 +675,7 @@ diff_tlltt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-diff_tlltt = cast5 Unmanaged.diff_tlltt
+diff_tlltt = _cast5 Unmanaged.diff_tlltt
 
 diff_tllt
   :: ForeignPtr Tensor
@@ -683,25 +683,25 @@ diff_tllt
   -> Int64
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-diff_tllt = cast4 Unmanaged.diff_tllt
+diff_tllt = _cast4 Unmanaged.diff_tllt
 
 diff_tll
   :: ForeignPtr Tensor
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-diff_tll = cast3 Unmanaged.diff_tll
+diff_tll = _cast3 Unmanaged.diff_tll
 
 diff_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-diff_tl = cast2 Unmanaged.diff_tl
+diff_tl = _cast2 Unmanaged.diff_tl
 
 diff_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-diff_t = cast1 Unmanaged.diff_t
+diff_t = _cast1 Unmanaged.diff_t
 
 diff_out_ttlltt
   :: ForeignPtr Tensor
@@ -711,7 +711,7 @@ diff_out_ttlltt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-diff_out_ttlltt = cast6 Unmanaged.diff_out_ttlltt
+diff_out_ttlltt = _cast6 Unmanaged.diff_out_ttlltt
 
 diff_out_ttllt
   :: ForeignPtr Tensor
@@ -720,7 +720,7 @@ diff_out_ttllt
   -> Int64
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-diff_out_ttllt = cast5 Unmanaged.diff_out_ttllt
+diff_out_ttllt = _cast5 Unmanaged.diff_out_ttllt
 
 diff_out_ttll
   :: ForeignPtr Tensor
@@ -728,20 +728,20 @@ diff_out_ttll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-diff_out_ttll = cast4 Unmanaged.diff_out_ttll
+diff_out_ttll = _cast4 Unmanaged.diff_out_ttll
 
 diff_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-diff_out_ttl = cast3 Unmanaged.diff_out_ttl
+diff_out_ttl = _cast3 Unmanaged.diff_out_ttl
 
 diff_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-diff_out_tt = cast2 Unmanaged.diff_out_tt
+diff_out_tt = _cast2 Unmanaged.diff_out_tt
 
 gradient_tsll
   :: ForeignPtr Tensor
@@ -749,58 +749,58 @@ gradient_tsll
   -> Int64
   -> Int64
   -> IO (ForeignPtr TensorList)
-gradient_tsll = cast4 Unmanaged.gradient_tsll
+gradient_tsll = _cast4 Unmanaged.gradient_tsll
 
 gradient_tsl
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> Int64
   -> IO (ForeignPtr TensorList)
-gradient_tsl = cast3 Unmanaged.gradient_tsl
+gradient_tsl = _cast3 Unmanaged.gradient_tsl
 
 gradient_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr TensorList)
-gradient_t = cast1 Unmanaged.gradient_t
+gradient_t = _cast1 Unmanaged.gradient_t
 
 gradient_tll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> Int64
   -> IO (ForeignPtr TensorList)
-gradient_tll = cast3 Unmanaged.gradient_tll
+gradient_tll = _cast3 Unmanaged.gradient_tll
 
 gradient_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr TensorList)
-gradient_tl = cast2 Unmanaged.gradient_tl
+gradient_tl = _cast2 Unmanaged.gradient_tl
 
 gradient_tA
   :: ForeignPtr Tensor
   -> ForeignPtr (StdVector Scalar)
   -> IO (ForeignPtr TensorList)
-gradient_tA = cast2 Unmanaged.gradient_tA
+gradient_tA = _cast2 Unmanaged.gradient_tA
 
 div_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-div_tt = cast2 Unmanaged.div_tt
+div_tt = _cast2 Unmanaged.div_tt
 
 div_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-div_out_ttt = cast3 Unmanaged.div_out_ttt
+div_out_ttt = _cast3 Unmanaged.div_out_ttt
 
 div_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-div_tts = cast3 Unmanaged.div_tts
+div_tts = _cast3 Unmanaged.div_tts
 
 div_out_ttts
   :: ForeignPtr Tensor
@@ -808,46 +808,46 @@ div_out_ttts
   -> ForeignPtr Tensor
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-div_out_ttts = cast4 Unmanaged.div_out_ttts
+div_out_ttts = _cast4 Unmanaged.div_out_ttts
 
 div_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-div_ts = cast2 Unmanaged.div_ts
+div_ts = _cast2 Unmanaged.div_ts
 
 div_tss
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-div_tss = cast3 Unmanaged.div_tss
+div_tss = _cast3 Unmanaged.div_tss
 
 divide_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-divide_tt = cast2 Unmanaged.divide_tt
+divide_tt = _cast2 Unmanaged.divide_tt
 
 divide_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-divide_out_ttt = cast3 Unmanaged.divide_out_ttt
+divide_out_ttt = _cast3 Unmanaged.divide_out_ttt
 
 divide_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-divide_ts = cast2 Unmanaged.divide_ts
+divide_ts = _cast2 Unmanaged.divide_ts
 
 divide_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-divide_tts = cast3 Unmanaged.divide_tts
+divide_tts = _cast3 Unmanaged.divide_tts
 
 divide_out_ttts
   :: ForeignPtr Tensor
@@ -855,65 +855,65 @@ divide_out_ttts
   -> ForeignPtr Tensor
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-divide_out_ttts = cast4 Unmanaged.divide_out_ttts
+divide_out_ttts = _cast4 Unmanaged.divide_out_ttts
 
 divide_tss
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-divide_tss = cast3 Unmanaged.divide_tss
+divide_tss = _cast3 Unmanaged.divide_tss
 
 true_divide_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-true_divide_tt = cast2 Unmanaged.true_divide_tt
+true_divide_tt = _cast2 Unmanaged.true_divide_tt
 
 true_divide_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-true_divide_out_ttt = cast3 Unmanaged.true_divide_out_ttt
+true_divide_out_ttt = _cast3 Unmanaged.true_divide_out_ttt
 
 true_divide_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-true_divide_ts = cast2 Unmanaged.true_divide_ts
+true_divide_ts = _cast2 Unmanaged.true_divide_ts
 
 dot_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-dot_tt = cast2 Unmanaged.dot_tt
+dot_tt = _cast2 Unmanaged.dot_tt
 
 dot_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-dot_out_ttt = cast3 Unmanaged.dot_out_ttt
+dot_out_ttt = _cast3 Unmanaged.dot_out_ttt
 
 vdot_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-vdot_tt = cast2 Unmanaged.vdot_tt
+vdot_tt = _cast2 Unmanaged.vdot_tt
 
 vdot_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-vdot_out_ttt = cast3 Unmanaged.vdot_out_ttt
+vdot_out_ttt = _cast3 Unmanaged.vdot_out_ttt
 
 einsum_sl
   :: ForeignPtr StdString
   -> ForeignPtr TensorList
   -> IO (ForeignPtr Tensor)
-einsum_sl = cast2 Unmanaged.einsum_sl
+einsum_sl = _cast2 Unmanaged.einsum_sl
 
 embedding_ttlbb
   :: ForeignPtr Tensor
@@ -922,7 +922,7 @@ embedding_ttlbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-embedding_ttlbb = cast5 Unmanaged.embedding_ttlbb
+embedding_ttlbb = _cast5 Unmanaged.embedding_ttlbb
 
 embedding_ttlb
   :: ForeignPtr Tensor
@@ -930,20 +930,20 @@ embedding_ttlb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-embedding_ttlb = cast4 Unmanaged.embedding_ttlb
+embedding_ttlb = _cast4 Unmanaged.embedding_ttlb
 
 embedding_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-embedding_ttl = cast3 Unmanaged.embedding_ttl
+embedding_ttl = _cast3 Unmanaged.embedding_ttl
 
 embedding_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-embedding_tt = cast2 Unmanaged.embedding_tt
+embedding_tt = _cast2 Unmanaged.embedding_tt
 
 embedding_backward_ttllbb
   :: ForeignPtr Tensor
@@ -953,7 +953,7 @@ embedding_backward_ttllbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-embedding_backward_ttllbb = cast6 Unmanaged.embedding_backward_ttllbb
+embedding_backward_ttllbb = _cast6 Unmanaged.embedding_backward_ttllbb
 
 embedding_dense_backward_ttllb
   :: ForeignPtr Tensor
@@ -962,7 +962,7 @@ embedding_dense_backward_ttllb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-embedding_dense_backward_ttllb = cast5 Unmanaged.embedding_dense_backward_ttllb
+embedding_dense_backward_ttllb = _cast5 Unmanaged.embedding_dense_backward_ttllb
 
 embedding_renorm__ttdd
   :: ForeignPtr Tensor
@@ -970,7 +970,7 @@ embedding_renorm__ttdd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-embedding_renorm__ttdd = cast4 Unmanaged.embedding_renorm__ttdd
+embedding_renorm__ttdd = _cast4 Unmanaged.embedding_renorm__ttdd
 
 embedding_sparse_backward_ttllb
   :: ForeignPtr Tensor
@@ -979,7 +979,7 @@ embedding_sparse_backward_ttllb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-embedding_sparse_backward_ttllb = cast5 Unmanaged.embedding_sparse_backward_ttllb
+embedding_sparse_backward_ttllb = _cast5 Unmanaged.embedding_sparse_backward_ttllb
 
 _embedding_bag_forward_only_tttblbtbl
   :: ForeignPtr Tensor
@@ -992,7 +992,7 @@ _embedding_bag_forward_only_tttblbtbl
   -> CBool
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
-_embedding_bag_forward_only_tttblbtbl = cast9 Unmanaged._embedding_bag_forward_only_tttblbtbl
+_embedding_bag_forward_only_tttblbtbl = _cast9 Unmanaged._embedding_bag_forward_only_tttblbtbl
 
 _embedding_bag_forward_only_tttblbtb
   :: ForeignPtr Tensor
@@ -1004,7 +1004,7 @@ _embedding_bag_forward_only_tttblbtb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
-_embedding_bag_forward_only_tttblbtb = cast8 Unmanaged._embedding_bag_forward_only_tttblbtb
+_embedding_bag_forward_only_tttblbtb = _cast8 Unmanaged._embedding_bag_forward_only_tttblbtb
 
 _embedding_bag_forward_only_tttblbt
   :: ForeignPtr Tensor
@@ -1015,7 +1015,7 @@ _embedding_bag_forward_only_tttblbt
   -> CBool
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
-_embedding_bag_forward_only_tttblbt = cast7 Unmanaged._embedding_bag_forward_only_tttblbt
+_embedding_bag_forward_only_tttblbt = _cast7 Unmanaged._embedding_bag_forward_only_tttblbt
 
 _embedding_bag_forward_only_tttblb
   :: ForeignPtr Tensor
@@ -1025,7 +1025,7 @@ _embedding_bag_forward_only_tttblb
   -> Int64
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
-_embedding_bag_forward_only_tttblb = cast6 Unmanaged._embedding_bag_forward_only_tttblb
+_embedding_bag_forward_only_tttblb = _cast6 Unmanaged._embedding_bag_forward_only_tttblb
 
 _embedding_bag_forward_only_tttbl
   :: ForeignPtr Tensor
@@ -1034,7 +1034,7 @@ _embedding_bag_forward_only_tttbl
   -> CBool
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
-_embedding_bag_forward_only_tttbl = cast5 Unmanaged._embedding_bag_forward_only_tttbl
+_embedding_bag_forward_only_tttbl = _cast5 Unmanaged._embedding_bag_forward_only_tttbl
 
 _embedding_bag_forward_only_tttb
   :: ForeignPtr Tensor
@@ -1042,32 +1042,32 @@ _embedding_bag_forward_only_tttb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
-_embedding_bag_forward_only_tttb = cast4 Unmanaged._embedding_bag_forward_only_tttb
+_embedding_bag_forward_only_tttb = _cast4 Unmanaged._embedding_bag_forward_only_tttb
 
 _embedding_bag_forward_only_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
-_embedding_bag_forward_only_ttt = cast3 Unmanaged._embedding_bag_forward_only_ttt
+_embedding_bag_forward_only_ttt = _cast3 Unmanaged._embedding_bag_forward_only_ttt
 
 _rowwise_prune_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ScalarType
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-_rowwise_prune_tts = cast3 Unmanaged._rowwise_prune_tts
+_rowwise_prune_tts = _cast3 Unmanaged._rowwise_prune_tts
 
 row_stack_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr Tensor)
-row_stack_l = cast1 Unmanaged.row_stack_l
+row_stack_l = _cast1 Unmanaged.row_stack_l
 
 row_stack_out_tl
   :: ForeignPtr Tensor
   -> ForeignPtr TensorList
   -> IO (ForeignPtr Tensor)
-row_stack_out_tl = cast2 Unmanaged.row_stack_out_tl
+row_stack_out_tl = _cast2 Unmanaged.row_stack_out_tl
 
 embedding_bag_tttblbtb
   :: ForeignPtr Tensor
@@ -1079,7 +1079,7 @@ embedding_bag_tttblbtb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
-embedding_bag_tttblbtb = cast8 Unmanaged.embedding_bag_tttblbtb
+embedding_bag_tttblbtb = _cast8 Unmanaged.embedding_bag_tttblbtb
 
 embedding_bag_tttblbt
   :: ForeignPtr Tensor
@@ -1090,7 +1090,7 @@ embedding_bag_tttblbt
   -> CBool
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
-embedding_bag_tttblbt = cast7 Unmanaged.embedding_bag_tttblbt
+embedding_bag_tttblbt = _cast7 Unmanaged.embedding_bag_tttblbt
 
 embedding_bag_tttblb
   :: ForeignPtr Tensor
@@ -1100,7 +1100,7 @@ embedding_bag_tttblb
   -> Int64
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
-embedding_bag_tttblb = cast6 Unmanaged.embedding_bag_tttblb
+embedding_bag_tttblb = _cast6 Unmanaged.embedding_bag_tttblb
 
 embedding_bag_tttbl
   :: ForeignPtr Tensor
@@ -1109,7 +1109,7 @@ embedding_bag_tttbl
   -> CBool
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
-embedding_bag_tttbl = cast5 Unmanaged.embedding_bag_tttbl
+embedding_bag_tttbl = _cast5 Unmanaged.embedding_bag_tttbl
 
 embedding_bag_tttb
   :: ForeignPtr Tensor
@@ -1117,14 +1117,14 @@ embedding_bag_tttb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
-embedding_bag_tttb = cast4 Unmanaged.embedding_bag_tttb
+embedding_bag_tttb = _cast4 Unmanaged.embedding_bag_tttb
 
 embedding_bag_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
-embedding_bag_ttt = cast3 Unmanaged.embedding_bag_ttt
+embedding_bag_ttt = _cast3 Unmanaged.embedding_bag_ttt
 
 embedding_bag_tttblbtbl
   :: ForeignPtr Tensor
@@ -1137,7 +1137,7 @@ embedding_bag_tttblbtbl
   -> CBool
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
-embedding_bag_tttblbtbl = cast9 Unmanaged.embedding_bag_tttblbtbl
+embedding_bag_tttblbtbl = _cast9 Unmanaged.embedding_bag_tttblbtbl
 
 _embedding_bag_tttblbtbl
   :: ForeignPtr Tensor
@@ -1150,7 +1150,7 @@ _embedding_bag_tttblbtbl
   -> CBool
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
-_embedding_bag_tttblbtbl = cast9 Unmanaged._embedding_bag_tttblbtbl
+_embedding_bag_tttblbtbl = _cast9 Unmanaged._embedding_bag_tttblbtbl
 
 _embedding_bag_tttblbtb
   :: ForeignPtr Tensor
@@ -1162,7 +1162,7 @@ _embedding_bag_tttblbtb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
-_embedding_bag_tttblbtb = cast8 Unmanaged._embedding_bag_tttblbtb
+_embedding_bag_tttblbtb = _cast8 Unmanaged._embedding_bag_tttblbtb
 
 _embedding_bag_tttblbt
   :: ForeignPtr Tensor
@@ -1173,7 +1173,7 @@ _embedding_bag_tttblbt
   -> CBool
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
-_embedding_bag_tttblbt = cast7 Unmanaged._embedding_bag_tttblbt
+_embedding_bag_tttblbt = _cast7 Unmanaged._embedding_bag_tttblbt
 
 _embedding_bag_tttblb
   :: ForeignPtr Tensor
@@ -1183,7 +1183,7 @@ _embedding_bag_tttblb
   -> Int64
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
-_embedding_bag_tttblb = cast6 Unmanaged._embedding_bag_tttblb
+_embedding_bag_tttblb = _cast6 Unmanaged._embedding_bag_tttblb
 
 _embedding_bag_tttbl
   :: ForeignPtr Tensor
@@ -1192,7 +1192,7 @@ _embedding_bag_tttbl
   -> CBool
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
-_embedding_bag_tttbl = cast5 Unmanaged._embedding_bag_tttbl
+_embedding_bag_tttbl = _cast5 Unmanaged._embedding_bag_tttbl
 
 _embedding_bag_tttb
   :: ForeignPtr Tensor
@@ -1200,14 +1200,14 @@ _embedding_bag_tttb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
-_embedding_bag_tttb = cast4 Unmanaged._embedding_bag_tttb
+_embedding_bag_tttb = _cast4 Unmanaged._embedding_bag_tttb
 
 _embedding_bag_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
-_embedding_bag_ttt = cast3 Unmanaged._embedding_bag_ttt
+_embedding_bag_ttt = _cast3 Unmanaged._embedding_bag_ttt
 
 _embedding_bag_backward_ttttttlblbtl
   :: ForeignPtr Tensor
@@ -1223,7 +1223,7 @@ _embedding_bag_backward_ttttttlblbtl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-_embedding_bag_backward_ttttttlblbtl = cast12 Unmanaged._embedding_bag_backward_ttttttlblbtl
+_embedding_bag_backward_ttttttlblbtl = _cast12 Unmanaged._embedding_bag_backward_ttttttlblbtl
 
 _embedding_bag_backward_ttttttlblbt
   :: ForeignPtr Tensor
@@ -1238,7 +1238,7 @@ _embedding_bag_backward_ttttttlblbt
   -> CBool
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_embedding_bag_backward_ttttttlblbt = cast11 Unmanaged._embedding_bag_backward_ttttttlblbt
+_embedding_bag_backward_ttttttlblbt = _cast11 Unmanaged._embedding_bag_backward_ttttttlblbt
 
 _embedding_bag_sparse_backward_tttttlbltl
   :: ForeignPtr Tensor
@@ -1252,7 +1252,7 @@ _embedding_bag_sparse_backward_tttttlbltl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-_embedding_bag_sparse_backward_tttttlbltl = cast10 Unmanaged._embedding_bag_sparse_backward_tttttlbltl
+_embedding_bag_sparse_backward_tttttlbltl = _cast10 Unmanaged._embedding_bag_sparse_backward_tttttlbltl
 
 _embedding_bag_sparse_backward_tttttlblt
   :: ForeignPtr Tensor
@@ -1265,7 +1265,7 @@ _embedding_bag_sparse_backward_tttttlblt
   -> Int64
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_embedding_bag_sparse_backward_tttttlblt = cast9 Unmanaged._embedding_bag_sparse_backward_tttttlblt
+_embedding_bag_sparse_backward_tttttlblt = _cast9 Unmanaged._embedding_bag_sparse_backward_tttttlblt
 
 _embedding_bag_dense_backward_tttttlbltl
   :: ForeignPtr Tensor
@@ -1279,7 +1279,7 @@ _embedding_bag_dense_backward_tttttlbltl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-_embedding_bag_dense_backward_tttttlbltl = cast10 Unmanaged._embedding_bag_dense_backward_tttttlbltl
+_embedding_bag_dense_backward_tttttlbltl = _cast10 Unmanaged._embedding_bag_dense_backward_tttttlbltl
 
 _embedding_bag_dense_backward_tttttlblt
   :: ForeignPtr Tensor
@@ -1292,7 +1292,7 @@ _embedding_bag_dense_backward_tttttlblt
   -> Int64
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_embedding_bag_dense_backward_tttttlblt = cast9 Unmanaged._embedding_bag_dense_backward_tttttlblt
+_embedding_bag_dense_backward_tttttlblt = _cast9 Unmanaged._embedding_bag_dense_backward_tttttlblt
 
 _embedding_bag_per_sample_weights_backward_tttttll
   :: ForeignPtr Tensor
@@ -1303,7 +1303,7 @@ _embedding_bag_per_sample_weights_backward_tttttll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-_embedding_bag_per_sample_weights_backward_tttttll = cast7 Unmanaged._embedding_bag_per_sample_weights_backward_tttttll
+_embedding_bag_per_sample_weights_backward_tttttll = _cast7 Unmanaged._embedding_bag_per_sample_weights_backward_tttttll
 
 _embedding_bag_per_sample_weights_backward_tttttl
   :: ForeignPtr Tensor
@@ -1313,7 +1313,7 @@ _embedding_bag_per_sample_weights_backward_tttttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-_embedding_bag_per_sample_weights_backward_tttttl = cast6 Unmanaged._embedding_bag_per_sample_weights_backward_tttttl
+_embedding_bag_per_sample_weights_backward_tttttl = _cast6 Unmanaged._embedding_bag_per_sample_weights_backward_tttttl
 
 empty_lNoM
   :: ForeignPtr IntArray
@@ -1321,38 +1321,38 @@ empty_lNoM
   -> ForeignPtr TensorOptions
   -> MemoryFormat
   -> IO (ForeignPtr Tensor)
-empty_lNoM = cast4 Unmanaged.empty_lNoM
+empty_lNoM = _cast4 Unmanaged.empty_lNoM
 
 empty_lNo
   :: ForeignPtr IntArray
   -> ForeignPtr DimnameList
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-empty_lNo = cast3 Unmanaged.empty_lNo
+empty_lNo = _cast3 Unmanaged.empty_lNo
 
 empty_lN
   :: ForeignPtr IntArray
   -> ForeignPtr DimnameList
   -> IO (ForeignPtr Tensor)
-empty_lN = cast2 Unmanaged.empty_lN
+empty_lN = _cast2 Unmanaged.empty_lN
 
 empty_loM
   :: ForeignPtr IntArray
   -> ForeignPtr TensorOptions
   -> MemoryFormat
   -> IO (ForeignPtr Tensor)
-empty_loM = cast3 Unmanaged.empty_loM
+empty_loM = _cast3 Unmanaged.empty_loM
 
 empty_lo
   :: ForeignPtr IntArray
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-empty_lo = cast2 Unmanaged.empty_lo
+empty_lo = _cast2 Unmanaged.empty_lo
 
 empty_l
   :: ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-empty_l = cast1 Unmanaged.empty_l
+empty_l = _cast1 Unmanaged.empty_l
 
 _empty_affine_quantized_lodlM
   :: ForeignPtr IntArray
@@ -1361,7 +1361,7 @@ _empty_affine_quantized_lodlM
   -> Int64
   -> MemoryFormat
   -> IO (ForeignPtr Tensor)
-_empty_affine_quantized_lodlM = cast5 Unmanaged._empty_affine_quantized_lodlM
+_empty_affine_quantized_lodlM = _cast5 Unmanaged._empty_affine_quantized_lodlM
 
 _empty_affine_quantized_lodl
   :: ForeignPtr IntArray
@@ -1369,25 +1369,25 @@ _empty_affine_quantized_lodl
   -> CDouble
   -> Int64
   -> IO (ForeignPtr Tensor)
-_empty_affine_quantized_lodl = cast4 Unmanaged._empty_affine_quantized_lodl
+_empty_affine_quantized_lodl = _cast4 Unmanaged._empty_affine_quantized_lodl
 
 _empty_affine_quantized_lod
   :: ForeignPtr IntArray
   -> ForeignPtr TensorOptions
   -> CDouble
   -> IO (ForeignPtr Tensor)
-_empty_affine_quantized_lod = cast3 Unmanaged._empty_affine_quantized_lod
+_empty_affine_quantized_lod = _cast3 Unmanaged._empty_affine_quantized_lod
 
 _empty_affine_quantized_lo
   :: ForeignPtr IntArray
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-_empty_affine_quantized_lo = cast2 Unmanaged._empty_affine_quantized_lo
+_empty_affine_quantized_lo = _cast2 Unmanaged._empty_affine_quantized_lo
 
 _empty_affine_quantized_l
   :: ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-_empty_affine_quantized_l = cast1 Unmanaged._empty_affine_quantized_l
+_empty_affine_quantized_l = _cast1 Unmanaged._empty_affine_quantized_l
 
 _empty_per_channel_affine_quantized_lttloM
   :: ForeignPtr IntArray
@@ -1397,7 +1397,7 @@ _empty_per_channel_affine_quantized_lttloM
   -> ForeignPtr TensorOptions
   -> MemoryFormat
   -> IO (ForeignPtr Tensor)
-_empty_per_channel_affine_quantized_lttloM = cast6 Unmanaged._empty_per_channel_affine_quantized_lttloM
+_empty_per_channel_affine_quantized_lttloM = _cast6 Unmanaged._empty_per_channel_affine_quantized_lttloM
 
 _empty_per_channel_affine_quantized_lttlo
   :: ForeignPtr IntArray
@@ -1406,7 +1406,7 @@ _empty_per_channel_affine_quantized_lttlo
   -> Int64
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-_empty_per_channel_affine_quantized_lttlo = cast5 Unmanaged._empty_per_channel_affine_quantized_lttlo
+_empty_per_channel_affine_quantized_lttlo = _cast5 Unmanaged._empty_per_channel_affine_quantized_lttlo
 
 _empty_per_channel_affine_quantized_lttl
   :: ForeignPtr IntArray
@@ -1414,7 +1414,7 @@ _empty_per_channel_affine_quantized_lttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-_empty_per_channel_affine_quantized_lttl = cast4 Unmanaged._empty_per_channel_affine_quantized_lttl
+_empty_per_channel_affine_quantized_lttl = _cast4 Unmanaged._empty_per_channel_affine_quantized_lttl
 
 empty_quantized_ltoM
   :: ForeignPtr IntArray
@@ -1422,160 +1422,160 @@ empty_quantized_ltoM
   -> ForeignPtr TensorOptions
   -> MemoryFormat
   -> IO (ForeignPtr Tensor)
-empty_quantized_ltoM = cast4 Unmanaged.empty_quantized_ltoM
+empty_quantized_ltoM = _cast4 Unmanaged.empty_quantized_ltoM
 
 empty_quantized_lto
   :: ForeignPtr IntArray
   -> ForeignPtr Tensor
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-empty_quantized_lto = cast3 Unmanaged.empty_quantized_lto
+empty_quantized_lto = _cast3 Unmanaged.empty_quantized_lto
 
 empty_quantized_lt
   :: ForeignPtr IntArray
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-empty_quantized_lt = cast2 Unmanaged.empty_quantized_lt
+empty_quantized_lt = _cast2 Unmanaged.empty_quantized_lt
 
 empty_out_tlM
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> MemoryFormat
   -> IO (ForeignPtr Tensor)
-empty_out_tlM = cast3 Unmanaged.empty_out_tlM
+empty_out_tlM = _cast3 Unmanaged.empty_out_tlM
 
 empty_out_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-empty_out_tl = cast2 Unmanaged.empty_out_tl
+empty_out_tl = _cast2 Unmanaged.empty_out_tl
 
 empty_like_toM
   :: ForeignPtr Tensor
   -> ForeignPtr TensorOptions
   -> MemoryFormat
   -> IO (ForeignPtr Tensor)
-empty_like_toM = cast3 Unmanaged.empty_like_toM
+empty_like_toM = _cast3 Unmanaged.empty_like_toM
 
 empty_like_to
   :: ForeignPtr Tensor
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-empty_like_to = cast2 Unmanaged.empty_like_to
+empty_like_to = _cast2 Unmanaged.empty_like_to
 
 empty_like_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-empty_like_t = cast1 Unmanaged.empty_like_t
+empty_like_t = _cast1 Unmanaged.empty_like_t
 
 empty_strided_llo
   :: ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-empty_strided_llo = cast3 Unmanaged.empty_strided_llo
+empty_strided_llo = _cast3 Unmanaged.empty_strided_llo
 
 empty_strided_ll
   :: ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-empty_strided_ll = cast2 Unmanaged.empty_strided_ll
+empty_strided_ll = _cast2 Unmanaged.empty_strided_ll
 
 erf_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-erf_t = cast1 Unmanaged.erf_t
+erf_t = _cast1 Unmanaged.erf_t
 
 erf__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-erf__t = cast1 Unmanaged.erf__t
+erf__t = _cast1 Unmanaged.erf__t
 
 erf_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-erf_out_tt = cast2 Unmanaged.erf_out_tt
+erf_out_tt = _cast2 Unmanaged.erf_out_tt
 
 erfc_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-erfc_t = cast1 Unmanaged.erfc_t
+erfc_t = _cast1 Unmanaged.erfc_t
 
 erfc__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-erfc__t = cast1 Unmanaged.erfc__t
+erfc__t = _cast1 Unmanaged.erfc__t
 
 erfc_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-erfc_out_tt = cast2 Unmanaged.erfc_out_tt
+erfc_out_tt = _cast2 Unmanaged.erfc_out_tt
 
 exp_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-exp_t = cast1 Unmanaged.exp_t
+exp_t = _cast1 Unmanaged.exp_t
 
 exp__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-exp__t = cast1 Unmanaged.exp__t
+exp__t = _cast1 Unmanaged.exp__t
 
 exp_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-exp_out_tt = cast2 Unmanaged.exp_out_tt
+exp_out_tt = _cast2 Unmanaged.exp_out_tt
 
 exp2_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-exp2_t = cast1 Unmanaged.exp2_t
+exp2_t = _cast1 Unmanaged.exp2_t
 
 exp2__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-exp2__t = cast1 Unmanaged.exp2__t
+exp2__t = _cast1 Unmanaged.exp2__t
 
 exp2_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-exp2_out_tt = cast2 Unmanaged.exp2_out_tt
+exp2_out_tt = _cast2 Unmanaged.exp2_out_tt
 
 expm1_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-expm1_t = cast1 Unmanaged.expm1_t
+expm1_t = _cast1 Unmanaged.expm1_t
 
 expm1__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-expm1__t = cast1 Unmanaged.expm1__t
+expm1__t = _cast1 Unmanaged.expm1__t
 
 expm1_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-expm1_out_tt = cast2 Unmanaged.expm1_out_tt
+expm1_out_tt = _cast2 Unmanaged.expm1_out_tt
 
 eye_lo
   :: Int64
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-eye_lo = cast2 Unmanaged.eye_lo
+eye_lo = _cast2 Unmanaged.eye_lo
 
 eye_l
   :: Int64
   -> IO (ForeignPtr Tensor)
-eye_l = cast1 Unmanaged.eye_l
+eye_l = _cast1 Unmanaged.eye_l
 
 eye_llo
   :: Int64
   -> Int64
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-eye_llo = cast3 Unmanaged.eye_llo
+eye_llo = _cast3 Unmanaged.eye_llo
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Native/Native3.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Native/Native3.hs
@@ -25,38 +25,38 @@ eye_ll
   :: Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-eye_ll = cast2 Unmanaged.eye_ll
+eye_ll = _cast2 Unmanaged.eye_ll
 
 eye_out_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-eye_out_tl = cast2 Unmanaged.eye_out_tl
+eye_out_tl = _cast2 Unmanaged.eye_out_tl
 
 eye_out_tll
   :: ForeignPtr Tensor
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-eye_out_tll = cast3 Unmanaged.eye_out_tll
+eye_out_tll = _cast3 Unmanaged.eye_out_tll
 
 flatten_tll
   :: ForeignPtr Tensor
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-flatten_tll = cast3 Unmanaged.flatten_tll
+flatten_tll = _cast3 Unmanaged.flatten_tll
 
 flatten_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-flatten_tl = cast2 Unmanaged.flatten_tl
+flatten_tl = _cast2 Unmanaged.flatten_tl
 
 flatten_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-flatten_t = cast1 Unmanaged.flatten_t
+flatten_t = _cast1 Unmanaged.flatten_t
 
 flatten_tlln
   :: ForeignPtr Tensor
@@ -64,7 +64,7 @@ flatten_tlln
   -> Int64
   -> ForeignPtr Dimname
   -> IO (ForeignPtr Tensor)
-flatten_tlln = cast4 Unmanaged.flatten_tlln
+flatten_tlln = _cast4 Unmanaged.flatten_tlln
 
 flatten_tnnn
   :: ForeignPtr Tensor
@@ -72,77 +72,77 @@ flatten_tnnn
   -> ForeignPtr Dimname
   -> ForeignPtr Dimname
   -> IO (ForeignPtr Tensor)
-flatten_tnnn = cast4 Unmanaged.flatten_tnnn
+flatten_tnnn = _cast4 Unmanaged.flatten_tnnn
 
 flatten_tNn
   :: ForeignPtr Tensor
   -> ForeignPtr DimnameList
   -> ForeignPtr Dimname
   -> IO (ForeignPtr Tensor)
-flatten_tNn = cast3 Unmanaged.flatten_tNn
+flatten_tNn = _cast3 Unmanaged.flatten_tNn
 
 fill__ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-fill__ts = cast2 Unmanaged.fill__ts
+fill__ts = _cast2 Unmanaged.fill__ts
 
 fill__tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fill__tt = cast2 Unmanaged.fill__tt
+fill__tt = _cast2 Unmanaged.fill__tt
 
 floor_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-floor_t = cast1 Unmanaged.floor_t
+floor_t = _cast1 Unmanaged.floor_t
 
 floor__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-floor__t = cast1 Unmanaged.floor__t
+floor__t = _cast1 Unmanaged.floor__t
 
 floor_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-floor_out_tt = cast2 Unmanaged.floor_out_tt
+floor_out_tt = _cast2 Unmanaged.floor_out_tt
 
 floor_divide_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-floor_divide_tt = cast2 Unmanaged.floor_divide_tt
+floor_divide_tt = _cast2 Unmanaged.floor_divide_tt
 
 floor_divide_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-floor_divide_out_ttt = cast3 Unmanaged.floor_divide_out_ttt
+floor_divide_out_ttt = _cast3 Unmanaged.floor_divide_out_ttt
 
 floor_divide_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-floor_divide_ts = cast2 Unmanaged.floor_divide_ts
+floor_divide_ts = _cast2 Unmanaged.floor_divide_ts
 
 frac_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-frac_t = cast1 Unmanaged.frac_t
+frac_t = _cast1 Unmanaged.frac_t
 
 frac__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-frac__t = cast1 Unmanaged.frac__t
+frac__t = _cast1 Unmanaged.frac__t
 
 frac_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-frac_out_tt = cast2 Unmanaged.frac_out_tt
+frac_out_tt = _cast2 Unmanaged.frac_out_tt
 
 full_lsNo
   :: ForeignPtr IntArray
@@ -150,34 +150,34 @@ full_lsNo
   -> ForeignPtr DimnameList
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-full_lsNo = cast4 Unmanaged.full_lsNo
+full_lsNo = _cast4 Unmanaged.full_lsNo
 
 full_lsN
   :: ForeignPtr IntArray
   -> ForeignPtr Scalar
   -> ForeignPtr DimnameList
   -> IO (ForeignPtr Tensor)
-full_lsN = cast3 Unmanaged.full_lsN
+full_lsN = _cast3 Unmanaged.full_lsN
 
 full_lso
   :: ForeignPtr IntArray
   -> ForeignPtr Scalar
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-full_lso = cast3 Unmanaged.full_lso
+full_lso = _cast3 Unmanaged.full_lso
 
 full_ls
   :: ForeignPtr IntArray
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-full_ls = cast2 Unmanaged.full_ls
+full_ls = _cast2 Unmanaged.full_ls
 
 full_out_tls
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-full_out_tls = cast3 Unmanaged.full_out_tls
+full_out_tls = _cast3 Unmanaged.full_out_tls
 
 full_like_tsoM
   :: ForeignPtr Tensor
@@ -185,20 +185,20 @@ full_like_tsoM
   -> ForeignPtr TensorOptions
   -> MemoryFormat
   -> IO (ForeignPtr Tensor)
-full_like_tsoM = cast4 Unmanaged.full_like_tsoM
+full_like_tsoM = _cast4 Unmanaged.full_like_tsoM
 
 full_like_tso
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-full_like_tso = cast3 Unmanaged.full_like_tso
+full_like_tso = _cast3 Unmanaged.full_like_tso
 
 full_like_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-full_like_ts = cast2 Unmanaged.full_like_ts
+full_like_ts = _cast2 Unmanaged.full_like_ts
 
 from_file_sblo
   :: ForeignPtr StdString
@@ -206,63 +206,63 @@ from_file_sblo
   -> Int64
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-from_file_sblo = cast4 Unmanaged.from_file_sblo
+from_file_sblo = _cast4 Unmanaged.from_file_sblo
 
 from_file_sbl
   :: ForeignPtr StdString
   -> CBool
   -> Int64
   -> IO (ForeignPtr Tensor)
-from_file_sbl = cast3 Unmanaged.from_file_sbl
+from_file_sbl = _cast3 Unmanaged.from_file_sbl
 
 from_file_sb
   :: ForeignPtr StdString
   -> CBool
   -> IO (ForeignPtr Tensor)
-from_file_sb = cast2 Unmanaged.from_file_sb
+from_file_sb = _cast2 Unmanaged.from_file_sb
 
 from_file_s
   :: ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-from_file_s = cast1 Unmanaged.from_file_s
+from_file_s = _cast1 Unmanaged.from_file_s
 
 gcd_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-gcd_out_ttt = cast3 Unmanaged.gcd_out_ttt
+gcd_out_ttt = _cast3 Unmanaged.gcd_out_ttt
 
 gcd_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-gcd_tt = cast2 Unmanaged.gcd_tt
+gcd_tt = _cast2 Unmanaged.gcd_tt
 
 gcd__tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-gcd__tt = cast2 Unmanaged.gcd__tt
+gcd__tt = _cast2 Unmanaged.gcd__tt
 
 lcm_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-lcm_out_ttt = cast3 Unmanaged.lcm_out_ttt
+lcm_out_ttt = _cast3 Unmanaged.lcm_out_ttt
 
 lcm_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-lcm_tt = cast2 Unmanaged.lcm_tt
+lcm_tt = _cast2 Unmanaged.lcm_tt
 
 lcm__tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-lcm__tt = cast2 Unmanaged.lcm__tt
+lcm__tt = _cast2 Unmanaged.lcm__tt
 
 grid_sampler_ttllb
   :: ForeignPtr Tensor
@@ -271,7 +271,7 @@ grid_sampler_ttllb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-grid_sampler_ttllb = cast5 Unmanaged.grid_sampler_ttllb
+grid_sampler_ttllb = _cast5 Unmanaged.grid_sampler_ttllb
 
 grid_sampler_2d_ttllb
   :: ForeignPtr Tensor
@@ -280,7 +280,7 @@ grid_sampler_2d_ttllb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-grid_sampler_2d_ttllb = cast5 Unmanaged.grid_sampler_2d_ttllb
+grid_sampler_2d_ttllb = _cast5 Unmanaged.grid_sampler_2d_ttllb
 
 grid_sampler_2d_backward_tttllba
   :: ForeignPtr Tensor
@@ -291,7 +291,7 @@ grid_sampler_2d_backward_tttllba
   -> CBool
   -> ForeignPtr (StdArray '(CBool,2))
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-grid_sampler_2d_backward_tttllba = cast7 Unmanaged.grid_sampler_2d_backward_tttllba
+grid_sampler_2d_backward_tttllba = _cast7 Unmanaged.grid_sampler_2d_backward_tttllba
 
 _grid_sampler_2d_cpu_fallback_ttllb
   :: ForeignPtr Tensor
@@ -300,7 +300,7 @@ _grid_sampler_2d_cpu_fallback_ttllb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-_grid_sampler_2d_cpu_fallback_ttllb = cast5 Unmanaged._grid_sampler_2d_cpu_fallback_ttllb
+_grid_sampler_2d_cpu_fallback_ttllb = _cast5 Unmanaged._grid_sampler_2d_cpu_fallback_ttllb
 
 _grid_sampler_2d_cpu_fallback_backward_tttllb
   :: ForeignPtr Tensor
@@ -310,7 +310,7 @@ _grid_sampler_2d_cpu_fallback_backward_tttllb
   -> Int64
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-_grid_sampler_2d_cpu_fallback_backward_tttllb = cast6 Unmanaged._grid_sampler_2d_cpu_fallback_backward_tttllb
+_grid_sampler_2d_cpu_fallback_backward_tttllb = _cast6 Unmanaged._grid_sampler_2d_cpu_fallback_backward_tttllb
 
 grid_sampler_3d_ttllb
   :: ForeignPtr Tensor
@@ -319,7 +319,7 @@ grid_sampler_3d_ttllb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-grid_sampler_3d_ttllb = cast5 Unmanaged.grid_sampler_3d_ttllb
+grid_sampler_3d_ttllb = _cast5 Unmanaged.grid_sampler_3d_ttllb
 
 grid_sampler_3d_backward_tttllb
   :: ForeignPtr Tensor
@@ -329,55 +329,55 @@ grid_sampler_3d_backward_tttllb
   -> Int64
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-grid_sampler_3d_backward_tttllb = cast6 Unmanaged.grid_sampler_3d_backward_tttllb
+grid_sampler_3d_backward_tttllb = _cast6 Unmanaged.grid_sampler_3d_backward_tttllb
 
 hann_window_lo
   :: Int64
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-hann_window_lo = cast2 Unmanaged.hann_window_lo
+hann_window_lo = _cast2 Unmanaged.hann_window_lo
 
 hann_window_l
   :: Int64
   -> IO (ForeignPtr Tensor)
-hann_window_l = cast1 Unmanaged.hann_window_l
+hann_window_l = _cast1 Unmanaged.hann_window_l
 
 hann_window_lbo
   :: Int64
   -> CBool
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-hann_window_lbo = cast3 Unmanaged.hann_window_lbo
+hann_window_lbo = _cast3 Unmanaged.hann_window_lbo
 
 hann_window_lb
   :: Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-hann_window_lb = cast2 Unmanaged.hann_window_lb
+hann_window_lb = _cast2 Unmanaged.hann_window_lb
 
 hamming_window_lo
   :: Int64
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-hamming_window_lo = cast2 Unmanaged.hamming_window_lo
+hamming_window_lo = _cast2 Unmanaged.hamming_window_lo
 
 hamming_window_l
   :: Int64
   -> IO (ForeignPtr Tensor)
-hamming_window_l = cast1 Unmanaged.hamming_window_l
+hamming_window_l = _cast1 Unmanaged.hamming_window_l
 
 hamming_window_lbo
   :: Int64
   -> CBool
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-hamming_window_lbo = cast3 Unmanaged.hamming_window_lbo
+hamming_window_lbo = _cast3 Unmanaged.hamming_window_lbo
 
 hamming_window_lb
   :: Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-hamming_window_lb = cast2 Unmanaged.hamming_window_lb
+hamming_window_lb = _cast2 Unmanaged.hamming_window_lb
 
 hamming_window_lbdo
   :: Int64
@@ -385,14 +385,14 @@ hamming_window_lbdo
   -> CDouble
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-hamming_window_lbdo = cast4 Unmanaged.hamming_window_lbdo
+hamming_window_lbdo = _cast4 Unmanaged.hamming_window_lbdo
 
 hamming_window_lbd
   :: Int64
   -> CBool
   -> CDouble
   -> IO (ForeignPtr Tensor)
-hamming_window_lbd = cast3 Unmanaged.hamming_window_lbd
+hamming_window_lbd = _cast3 Unmanaged.hamming_window_lbd
 
 hamming_window_lbddo
   :: Int64
@@ -401,7 +401,7 @@ hamming_window_lbddo
   -> CDouble
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-hamming_window_lbddo = cast5 Unmanaged.hamming_window_lbddo
+hamming_window_lbddo = _cast5 Unmanaged.hamming_window_lbddo
 
 hamming_window_lbdd
   :: Int64
@@ -409,31 +409,31 @@ hamming_window_lbdd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-hamming_window_lbdd = cast4 Unmanaged.hamming_window_lbdd
+hamming_window_lbdd = _cast4 Unmanaged.hamming_window_lbdd
 
 kaiser_window_lo
   :: Int64
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-kaiser_window_lo = cast2 Unmanaged.kaiser_window_lo
+kaiser_window_lo = _cast2 Unmanaged.kaiser_window_lo
 
 kaiser_window_l
   :: Int64
   -> IO (ForeignPtr Tensor)
-kaiser_window_l = cast1 Unmanaged.kaiser_window_l
+kaiser_window_l = _cast1 Unmanaged.kaiser_window_l
 
 kaiser_window_lbo
   :: Int64
   -> CBool
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-kaiser_window_lbo = cast3 Unmanaged.kaiser_window_lbo
+kaiser_window_lbo = _cast3 Unmanaged.kaiser_window_lbo
 
 kaiser_window_lb
   :: Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-kaiser_window_lb = cast2 Unmanaged.kaiser_window_lb
+kaiser_window_lb = _cast2 Unmanaged.kaiser_window_lb
 
 kaiser_window_lbdo
   :: Int64
@@ -441,14 +441,14 @@ kaiser_window_lbdo
   -> CDouble
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-kaiser_window_lbdo = cast4 Unmanaged.kaiser_window_lbdo
+kaiser_window_lbdo = _cast4 Unmanaged.kaiser_window_lbdo
 
 kaiser_window_lbd
   :: Int64
   -> CBool
   -> CDouble
   -> IO (ForeignPtr Tensor)
-kaiser_window_lbd = cast3 Unmanaged.kaiser_window_lbd
+kaiser_window_lbd = _cast3 Unmanaged.kaiser_window_lbd
 
 hinge_embedding_loss_ttdl
   :: ForeignPtr Tensor
@@ -456,20 +456,20 @@ hinge_embedding_loss_ttdl
   -> CDouble
   -> Int64
   -> IO (ForeignPtr Tensor)
-hinge_embedding_loss_ttdl = cast4 Unmanaged.hinge_embedding_loss_ttdl
+hinge_embedding_loss_ttdl = _cast4 Unmanaged.hinge_embedding_loss_ttdl
 
 hinge_embedding_loss_ttd
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> CDouble
   -> IO (ForeignPtr Tensor)
-hinge_embedding_loss_ttd = cast3 Unmanaged.hinge_embedding_loss_ttd
+hinge_embedding_loss_ttd = _cast3 Unmanaged.hinge_embedding_loss_ttd
 
 hinge_embedding_loss_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-hinge_embedding_loss_tt = cast2 Unmanaged.hinge_embedding_loss_tt
+hinge_embedding_loss_tt = _cast2 Unmanaged.hinge_embedding_loss_tt
 
 group_norm_tlttdb
   :: ForeignPtr Tensor
@@ -479,7 +479,7 @@ group_norm_tlttdb
   -> CDouble
   -> CBool
   -> IO (ForeignPtr Tensor)
-group_norm_tlttdb = cast6 Unmanaged.group_norm_tlttdb
+group_norm_tlttdb = _cast6 Unmanaged.group_norm_tlttdb
 
 group_norm_tlttd
   :: ForeignPtr Tensor
@@ -488,7 +488,7 @@ group_norm_tlttd
   -> ForeignPtr Tensor
   -> CDouble
   -> IO (ForeignPtr Tensor)
-group_norm_tlttd = cast5 Unmanaged.group_norm_tlttd
+group_norm_tlttd = _cast5 Unmanaged.group_norm_tlttd
 
 group_norm_tltt
   :: ForeignPtr Tensor
@@ -496,20 +496,20 @@ group_norm_tltt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-group_norm_tltt = cast4 Unmanaged.group_norm_tltt
+group_norm_tltt = _cast4 Unmanaged.group_norm_tltt
 
 group_norm_tlt
   :: ForeignPtr Tensor
   -> Int64
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-group_norm_tlt = cast3 Unmanaged.group_norm_tlt
+group_norm_tlt = _cast3 Unmanaged.group_norm_tlt
 
 group_norm_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-group_norm_tl = cast2 Unmanaged.group_norm_tl
+group_norm_tl = _cast2 Unmanaged.group_norm_tl
 
 native_group_norm_tttlllld
   :: ForeignPtr Tensor
@@ -521,7 +521,7 @@ native_group_norm_tttlllld
   -> Int64
   -> CDouble
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-native_group_norm_tttlllld = cast8 Unmanaged.native_group_norm_tttlllld
+native_group_norm_tttlllld = _cast8 Unmanaged.native_group_norm_tttlllld
 
 native_group_norm_backward_tttttlllla
   :: ForeignPtr Tensor
@@ -535,7 +535,7 @@ native_group_norm_backward_tttttlllla
   -> Int64
   -> ForeignPtr (StdArray '(CBool,3))
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-native_group_norm_backward_tttttlllla = cast10 Unmanaged.native_group_norm_backward_tttttlllla
+native_group_norm_backward_tttttlllla = _cast10 Unmanaged.native_group_norm_backward_tttttlllla
 
 _fft_r2c_tllb
   :: ForeignPtr Tensor
@@ -543,7 +543,7 @@ _fft_r2c_tllb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-_fft_r2c_tllb = cast4 Unmanaged._fft_r2c_tllb
+_fft_r2c_tllb = _cast4 Unmanaged._fft_r2c_tllb
 
 _fft_r2c_out_ttllb
   :: ForeignPtr Tensor
@@ -552,7 +552,7 @@ _fft_r2c_out_ttllb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-_fft_r2c_out_ttllb = cast5 Unmanaged._fft_r2c_out_ttllb
+_fft_r2c_out_ttllb = _cast5 Unmanaged._fft_r2c_out_ttllb
 
 _fft_c2r_tlll
   :: ForeignPtr Tensor
@@ -560,7 +560,7 @@ _fft_c2r_tlll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-_fft_c2r_tlll = cast4 Unmanaged._fft_c2r_tlll
+_fft_c2r_tlll = _cast4 Unmanaged._fft_c2r_tlll
 
 _fft_c2r_out_ttlll
   :: ForeignPtr Tensor
@@ -569,7 +569,7 @@ _fft_c2r_out_ttlll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-_fft_c2r_out_ttlll = cast5 Unmanaged._fft_c2r_out_ttlll
+_fft_c2r_out_ttlll = _cast5 Unmanaged._fft_c2r_out_ttlll
 
 _fft_c2c_tllb
   :: ForeignPtr Tensor
@@ -577,7 +577,7 @@ _fft_c2c_tllb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-_fft_c2c_tllb = cast4 Unmanaged._fft_c2c_tllb
+_fft_c2c_tllb = _cast4 Unmanaged._fft_c2c_tllb
 
 _fft_c2c_out_ttllb
   :: ForeignPtr Tensor
@@ -586,34 +586,34 @@ _fft_c2c_out_ttllb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-_fft_c2c_out_ttllb = cast5 Unmanaged._fft_c2c_out_ttllb
+_fft_c2c_out_ttllb = _cast5 Unmanaged._fft_c2c_out_ttllb
 
 _cufft_get_plan_cache_size_l
   :: Int64
   -> IO (Int64)
-_cufft_get_plan_cache_size_l = cast1 Unmanaged._cufft_get_plan_cache_size_l
+_cufft_get_plan_cache_size_l = _cast1 Unmanaged._cufft_get_plan_cache_size_l
 
 _cufft_get_plan_cache_max_size_l
   :: Int64
   -> IO (Int64)
-_cufft_get_plan_cache_max_size_l = cast1 Unmanaged._cufft_get_plan_cache_max_size_l
+_cufft_get_plan_cache_max_size_l = _cast1 Unmanaged._cufft_get_plan_cache_max_size_l
 
 _cufft_set_plan_cache_max_size_ll
   :: Int64
   -> Int64
   -> IO (())
-_cufft_set_plan_cache_max_size_ll = cast2 Unmanaged._cufft_set_plan_cache_max_size_ll
+_cufft_set_plan_cache_max_size_ll = _cast2 Unmanaged._cufft_set_plan_cache_max_size_ll
 
 _cufft_clear_plan_cache_l
   :: Int64
   -> IO (())
-_cufft_clear_plan_cache_l = cast1 Unmanaged._cufft_clear_plan_cache_l
+_cufft_clear_plan_cache_l = _cast1 Unmanaged._cufft_clear_plan_cache_l
 
 index_tl
   :: ForeignPtr Tensor
   -> ForeignPtr (C10List (C10Optional Tensor))
   -> IO (ForeignPtr Tensor)
-index_tl = cast2 Unmanaged.index_tl
+index_tl = _cast2 Unmanaged.index_tl
 
 index_copy_tltt
   :: ForeignPtr Tensor
@@ -621,7 +621,7 @@ index_copy_tltt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-index_copy_tltt = cast4 Unmanaged.index_copy_tltt
+index_copy_tltt = _cast4 Unmanaged.index_copy_tltt
 
 index_copy_tntt
   :: ForeignPtr Tensor
@@ -629,7 +629,7 @@ index_copy_tntt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-index_copy_tntt = cast4 Unmanaged.index_copy_tntt
+index_copy_tntt = _cast4 Unmanaged.index_copy_tntt
 
 index_put__tltb
   :: ForeignPtr Tensor
@@ -637,14 +637,14 @@ index_put__tltb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-index_put__tltb = cast4 Unmanaged.index_put__tltb
+index_put__tltb = _cast4 Unmanaged.index_put__tltb
 
 index_put__tlt
   :: ForeignPtr Tensor
   -> ForeignPtr (C10List (C10Optional Tensor))
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-index_put__tlt = cast3 Unmanaged.index_put__tlt
+index_put__tlt = _cast3 Unmanaged.index_put__tlt
 
 index_put_tltb
   :: ForeignPtr Tensor
@@ -652,14 +652,14 @@ index_put_tltb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-index_put_tltb = cast4 Unmanaged.index_put_tltb
+index_put_tltb = _cast4 Unmanaged.index_put_tltb
 
 index_put_tlt
   :: ForeignPtr Tensor
   -> ForeignPtr (C10List (C10Optional Tensor))
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-index_put_tlt = cast3 Unmanaged.index_put_tlt
+index_put_tlt = _cast3 Unmanaged.index_put_tlt
 
 _index_put_impl__tltbb
   :: ForeignPtr Tensor
@@ -668,7 +668,7 @@ _index_put_impl__tltbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-_index_put_impl__tltbb = cast5 Unmanaged._index_put_impl__tltbb
+_index_put_impl__tltbb = _cast5 Unmanaged._index_put_impl__tltbb
 
 _index_put_impl__tltb
   :: ForeignPtr Tensor
@@ -676,14 +676,14 @@ _index_put_impl__tltb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-_index_put_impl__tltb = cast4 Unmanaged._index_put_impl__tltb
+_index_put_impl__tltb = _cast4 Unmanaged._index_put_impl__tltb
 
 _index_put_impl__tlt
   :: ForeignPtr Tensor
   -> ForeignPtr (C10List (C10Optional Tensor))
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_index_put_impl__tlt = cast3 Unmanaged._index_put_impl__tlt
+_index_put_impl__tlt = _cast3 Unmanaged._index_put_impl__tlt
 
 instance_norm_tttttbddb
   :: ForeignPtr Tensor
@@ -696,18 +696,18 @@ instance_norm_tttttbddb
   -> CDouble
   -> CBool
   -> IO (ForeignPtr Tensor)
-instance_norm_tttttbddb = cast9 Unmanaged.instance_norm_tttttbddb
+instance_norm_tttttbddb = _cast9 Unmanaged.instance_norm_tttttbddb
 
 inverse_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-inverse_t = cast1 Unmanaged.inverse_t
+inverse_t = _cast1 Unmanaged.inverse_t
 
 inverse_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-inverse_out_tt = cast2 Unmanaged.inverse_out_tt
+inverse_out_tt = _cast2 Unmanaged.inverse_out_tt
 
 isclose_ttddb
   :: ForeignPtr Tensor
@@ -716,7 +716,7 @@ isclose_ttddb
   -> CDouble
   -> CBool
   -> IO (ForeignPtr Tensor)
-isclose_ttddb = cast5 Unmanaged.isclose_ttddb
+isclose_ttddb = _cast5 Unmanaged.isclose_ttddb
 
 isclose_ttdd
   :: ForeignPtr Tensor
@@ -724,20 +724,20 @@ isclose_ttdd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-isclose_ttdd = cast4 Unmanaged.isclose_ttdd
+isclose_ttdd = _cast4 Unmanaged.isclose_ttdd
 
 isclose_ttd
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> CDouble
   -> IO (ForeignPtr Tensor)
-isclose_ttd = cast3 Unmanaged.isclose_ttd
+isclose_ttd = _cast3 Unmanaged.isclose_ttd
 
 isclose_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-isclose_tt = cast2 Unmanaged.isclose_tt
+isclose_tt = _cast2 Unmanaged.isclose_tt
 
 isin_out_tttbb
   :: ForeignPtr Tensor
@@ -746,7 +746,7 @@ isin_out_tttbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-isin_out_tttbb = cast5 Unmanaged.isin_out_tttbb
+isin_out_tttbb = _cast5 Unmanaged.isin_out_tttbb
 
 isin_out_tttb
   :: ForeignPtr Tensor
@@ -754,14 +754,14 @@ isin_out_tttb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-isin_out_tttb = cast4 Unmanaged.isin_out_tttb
+isin_out_tttb = _cast4 Unmanaged.isin_out_tttb
 
 isin_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-isin_out_ttt = cast3 Unmanaged.isin_out_ttt
+isin_out_ttt = _cast3 Unmanaged.isin_out_ttt
 
 isin_ttbb
   :: ForeignPtr Tensor
@@ -769,20 +769,20 @@ isin_ttbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-isin_ttbb = cast4 Unmanaged.isin_ttbb
+isin_ttbb = _cast4 Unmanaged.isin_ttbb
 
 isin_ttb
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-isin_ttb = cast3 Unmanaged.isin_ttb
+isin_ttb = _cast3 Unmanaged.isin_ttb
 
 isin_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-isin_tt = cast2 Unmanaged.isin_tt
+isin_tt = _cast2 Unmanaged.isin_tt
 
 isin_out_ttsbb
   :: ForeignPtr Tensor
@@ -791,7 +791,7 @@ isin_out_ttsbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-isin_out_ttsbb = cast5 Unmanaged.isin_out_ttsbb
+isin_out_ttsbb = _cast5 Unmanaged.isin_out_ttsbb
 
 isin_out_ttsb
   :: ForeignPtr Tensor
@@ -799,14 +799,14 @@ isin_out_ttsb
   -> ForeignPtr Scalar
   -> CBool
   -> IO (ForeignPtr Tensor)
-isin_out_ttsb = cast4 Unmanaged.isin_out_ttsb
+isin_out_ttsb = _cast4 Unmanaged.isin_out_ttsb
 
 isin_out_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-isin_out_tts = cast3 Unmanaged.isin_out_tts
+isin_out_tts = _cast3 Unmanaged.isin_out_tts
 
 isin_tsbb
   :: ForeignPtr Tensor
@@ -814,20 +814,20 @@ isin_tsbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-isin_tsbb = cast4 Unmanaged.isin_tsbb
+isin_tsbb = _cast4 Unmanaged.isin_tsbb
 
 isin_tsb
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> CBool
   -> IO (ForeignPtr Tensor)
-isin_tsb = cast3 Unmanaged.isin_tsb
+isin_tsb = _cast3 Unmanaged.isin_tsb
 
 isin_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-isin_ts = cast2 Unmanaged.isin_ts
+isin_ts = _cast2 Unmanaged.isin_ts
 
 isin_out_tstbb
   :: ForeignPtr Tensor
@@ -836,7 +836,7 @@ isin_out_tstbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-isin_out_tstbb = cast5 Unmanaged.isin_out_tstbb
+isin_out_tstbb = _cast5 Unmanaged.isin_out_tstbb
 
 isin_out_tstb
   :: ForeignPtr Tensor
@@ -844,14 +844,14 @@ isin_out_tstb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-isin_out_tstb = cast4 Unmanaged.isin_out_tstb
+isin_out_tstb = _cast4 Unmanaged.isin_out_tstb
 
 isin_out_tst
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-isin_out_tst = cast3 Unmanaged.isin_out_tst
+isin_out_tst = _cast3 Unmanaged.isin_out_tst
 
 isin_stbb
   :: ForeignPtr Scalar
@@ -859,81 +859,81 @@ isin_stbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-isin_stbb = cast4 Unmanaged.isin_stbb
+isin_stbb = _cast4 Unmanaged.isin_stbb
 
 isin_stb
   :: ForeignPtr Scalar
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-isin_stb = cast3 Unmanaged.isin_stb
+isin_stb = _cast3 Unmanaged.isin_stb
 
 isin_st
   :: ForeignPtr Scalar
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-isin_st = cast2 Unmanaged.isin_st
+isin_st = _cast2 Unmanaged.isin_st
 
 isnan_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-isnan_t = cast1 Unmanaged.isnan_t
+isnan_t = _cast1 Unmanaged.isnan_t
 
 is_distributed_t
   :: ForeignPtr Tensor
   -> IO (CBool)
-is_distributed_t = cast1 Unmanaged.is_distributed_t
+is_distributed_t = _cast1 Unmanaged.is_distributed_t
 
 is_floating_point_t
   :: ForeignPtr Tensor
   -> IO (CBool)
-is_floating_point_t = cast1 Unmanaged.is_floating_point_t
+is_floating_point_t = _cast1 Unmanaged.is_floating_point_t
 
 is_complex_t
   :: ForeignPtr Tensor
   -> IO (CBool)
-is_complex_t = cast1 Unmanaged.is_complex_t
+is_complex_t = _cast1 Unmanaged.is_complex_t
 
 is_conj_t
   :: ForeignPtr Tensor
   -> IO (CBool)
-is_conj_t = cast1 Unmanaged.is_conj_t
+is_conj_t = _cast1 Unmanaged.is_conj_t
 
 _is_zerotensor_t
   :: ForeignPtr Tensor
   -> IO (CBool)
-_is_zerotensor_t = cast1 Unmanaged._is_zerotensor_t
+_is_zerotensor_t = _cast1 Unmanaged._is_zerotensor_t
 
 is_neg_t
   :: ForeignPtr Tensor
   -> IO (CBool)
-is_neg_t = cast1 Unmanaged.is_neg_t
+is_neg_t = _cast1 Unmanaged.is_neg_t
 
 isreal_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-isreal_t = cast1 Unmanaged.isreal_t
+isreal_t = _cast1 Unmanaged.isreal_t
 
 is_nonzero_t
   :: ForeignPtr Tensor
   -> IO (CBool)
-is_nonzero_t = cast1 Unmanaged.is_nonzero_t
+is_nonzero_t = _cast1 Unmanaged.is_nonzero_t
 
 is_same_size_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (CBool)
-is_same_size_tt = cast2 Unmanaged.is_same_size_tt
+is_same_size_tt = _cast2 Unmanaged.is_same_size_tt
 
 is_signed_t
   :: ForeignPtr Tensor
   -> IO (CBool)
-is_signed_t = cast1 Unmanaged.is_signed_t
+is_signed_t = _cast1 Unmanaged.is_signed_t
 
 is_inference_t
   :: ForeignPtr Tensor
   -> IO (CBool)
-is_inference_t = cast1 Unmanaged.is_inference_t
+is_inference_t = _cast1 Unmanaged.is_inference_t
 
 kl_div_ttlb
   :: ForeignPtr Tensor
@@ -941,20 +941,20 @@ kl_div_ttlb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-kl_div_ttlb = cast4 Unmanaged.kl_div_ttlb
+kl_div_ttlb = _cast4 Unmanaged.kl_div_ttlb
 
 kl_div_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-kl_div_ttl = cast3 Unmanaged.kl_div_ttl
+kl_div_ttl = _cast3 Unmanaged.kl_div_ttl
 
 kl_div_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-kl_div_tt = cast2 Unmanaged.kl_div_tt
+kl_div_tt = _cast2 Unmanaged.kl_div_tt
 
 kl_div_backward_tttlb
   :: ForeignPtr Tensor
@@ -963,7 +963,7 @@ kl_div_backward_tttlb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-kl_div_backward_tttlb = cast5 Unmanaged.kl_div_backward_tttlb
+kl_div_backward_tttlb = _cast5 Unmanaged.kl_div_backward_tttlb
 
 kl_div_backward_tttl
   :: ForeignPtr Tensor
@@ -971,27 +971,27 @@ kl_div_backward_tttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-kl_div_backward_tttl = cast4 Unmanaged.kl_div_backward_tttl
+kl_div_backward_tttl = _cast4 Unmanaged.kl_div_backward_tttl
 
 kl_div_backward_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-kl_div_backward_ttt = cast3 Unmanaged.kl_div_backward_ttt
+kl_div_backward_ttt = _cast3 Unmanaged.kl_div_backward_ttt
 
 kron_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-kron_tt = cast2 Unmanaged.kron_tt
+kron_tt = _cast2 Unmanaged.kron_tt
 
 kron_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-kron_out_ttt = cast3 Unmanaged.kron_out_ttt
+kron_out_ttt = _cast3 Unmanaged.kron_out_ttt
 
 kthvalue_tllb
   :: ForeignPtr Tensor
@@ -999,20 +999,20 @@ kthvalue_tllb
   -> Int64
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-kthvalue_tllb = cast4 Unmanaged.kthvalue_tllb
+kthvalue_tllb = _cast4 Unmanaged.kthvalue_tllb
 
 kthvalue_tll
   :: ForeignPtr Tensor
   -> Int64
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-kthvalue_tll = cast3 Unmanaged.kthvalue_tll
+kthvalue_tll = _cast3 Unmanaged.kthvalue_tll
 
 kthvalue_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-kthvalue_tl = cast2 Unmanaged.kthvalue_tl
+kthvalue_tl = _cast2 Unmanaged.kthvalue_tl
 
 kthvalue_out_tttllb
   :: ForeignPtr Tensor
@@ -1022,7 +1022,7 @@ kthvalue_out_tttllb
   -> Int64
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-kthvalue_out_tttllb = cast6 Unmanaged.kthvalue_out_tttllb
+kthvalue_out_tttllb = _cast6 Unmanaged.kthvalue_out_tttllb
 
 kthvalue_out_tttll
   :: ForeignPtr Tensor
@@ -1031,7 +1031,7 @@ kthvalue_out_tttll
   -> Int64
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-kthvalue_out_tttll = cast5 Unmanaged.kthvalue_out_tttll
+kthvalue_out_tttll = _cast5 Unmanaged.kthvalue_out_tttll
 
 kthvalue_out_tttl
   :: ForeignPtr Tensor
@@ -1039,7 +1039,7 @@ kthvalue_out_tttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-kthvalue_out_tttl = cast4 Unmanaged.kthvalue_out_tttl
+kthvalue_out_tttl = _cast4 Unmanaged.kthvalue_out_tttl
 
 kthvalue_tlnb
   :: ForeignPtr Tensor
@@ -1047,14 +1047,14 @@ kthvalue_tlnb
   -> ForeignPtr Dimname
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-kthvalue_tlnb = cast4 Unmanaged.kthvalue_tlnb
+kthvalue_tlnb = _cast4 Unmanaged.kthvalue_tlnb
 
 kthvalue_tln
   :: ForeignPtr Tensor
   -> Int64
   -> ForeignPtr Dimname
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-kthvalue_tln = cast3 Unmanaged.kthvalue_tln
+kthvalue_tln = _cast3 Unmanaged.kthvalue_tln
 
 kthvalue_out_tttlnb
   :: ForeignPtr Tensor
@@ -1064,7 +1064,7 @@ kthvalue_out_tttlnb
   -> ForeignPtr Dimname
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-kthvalue_out_tttlnb = cast6 Unmanaged.kthvalue_out_tttlnb
+kthvalue_out_tttlnb = _cast6 Unmanaged.kthvalue_out_tttlnb
 
 kthvalue_out_tttln
   :: ForeignPtr Tensor
@@ -1073,7 +1073,7 @@ kthvalue_out_tttln
   -> Int64
   -> ForeignPtr Dimname
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-kthvalue_out_tttln = cast5 Unmanaged.kthvalue_out_tttln
+kthvalue_out_tttln = _cast5 Unmanaged.kthvalue_out_tttln
 
 layer_norm_tlttdb
   :: ForeignPtr Tensor
@@ -1083,7 +1083,7 @@ layer_norm_tlttdb
   -> CDouble
   -> CBool
   -> IO (ForeignPtr Tensor)
-layer_norm_tlttdb = cast6 Unmanaged.layer_norm_tlttdb
+layer_norm_tlttdb = _cast6 Unmanaged.layer_norm_tlttdb
 
 layer_norm_tlttd
   :: ForeignPtr Tensor
@@ -1092,7 +1092,7 @@ layer_norm_tlttd
   -> ForeignPtr Tensor
   -> CDouble
   -> IO (ForeignPtr Tensor)
-layer_norm_tlttd = cast5 Unmanaged.layer_norm_tlttd
+layer_norm_tlttd = _cast5 Unmanaged.layer_norm_tlttd
 
 layer_norm_tltt
   :: ForeignPtr Tensor
@@ -1100,20 +1100,20 @@ layer_norm_tltt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-layer_norm_tltt = cast4 Unmanaged.layer_norm_tltt
+layer_norm_tltt = _cast4 Unmanaged.layer_norm_tltt
 
 layer_norm_tlt
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-layer_norm_tlt = cast3 Unmanaged.layer_norm_tlt
+layer_norm_tlt = _cast3 Unmanaged.layer_norm_tlt
 
 layer_norm_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-layer_norm_tl = cast2 Unmanaged.layer_norm_tl
+layer_norm_tl = _cast2 Unmanaged.layer_norm_tl
 
 native_layer_norm_tlttd
   :: ForeignPtr Tensor
@@ -1122,7 +1122,7 @@ native_layer_norm_tlttd
   -> ForeignPtr Tensor
   -> CDouble
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-native_layer_norm_tlttd = cast5 Unmanaged.native_layer_norm_tlttd
+native_layer_norm_tlttd = _cast5 Unmanaged.native_layer_norm_tlttd
 
 _native_multi_head_self_attention_tttttt
   :: ForeignPtr Tensor
@@ -1132,7 +1132,7 @@ _native_multi_head_self_attention_tttttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_native_multi_head_self_attention_tttttt = cast6 Unmanaged._native_multi_head_self_attention_tttttt
+_native_multi_head_self_attention_tttttt = _cast6 Unmanaged._native_multi_head_self_attention_tttttt
 
 _native_multi_head_self_attention_ttttt
   :: ForeignPtr Tensor
@@ -1141,7 +1141,7 @@ _native_multi_head_self_attention_ttttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_native_multi_head_self_attention_ttttt = cast5 Unmanaged._native_multi_head_self_attention_ttttt
+_native_multi_head_self_attention_ttttt = _cast5 Unmanaged._native_multi_head_self_attention_ttttt
 
 native_layer_norm_backward_ttltttta
   :: ForeignPtr Tensor
@@ -1153,7 +1153,7 @@ native_layer_norm_backward_ttltttta
   -> ForeignPtr Tensor
   -> ForeignPtr (StdArray '(CBool,3))
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-native_layer_norm_backward_ttltttta = cast8 Unmanaged.native_layer_norm_backward_ttltttta
+native_layer_norm_backward_ttltttta = _cast8 Unmanaged.native_layer_norm_backward_ttltttta
 
 nan_to_num_tddd
   :: ForeignPtr Tensor
@@ -1161,25 +1161,25 @@ nan_to_num_tddd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-nan_to_num_tddd = cast4 Unmanaged.nan_to_num_tddd
+nan_to_num_tddd = _cast4 Unmanaged.nan_to_num_tddd
 
 nan_to_num_tdd
   :: ForeignPtr Tensor
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-nan_to_num_tdd = cast3 Unmanaged.nan_to_num_tdd
+nan_to_num_tdd = _cast3 Unmanaged.nan_to_num_tdd
 
 nan_to_num_td
   :: ForeignPtr Tensor
   -> CDouble
   -> IO (ForeignPtr Tensor)
-nan_to_num_td = cast2 Unmanaged.nan_to_num_td
+nan_to_num_td = _cast2 Unmanaged.nan_to_num_td
 
 nan_to_num_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-nan_to_num_t = cast1 Unmanaged.nan_to_num_t
+nan_to_num_t = _cast1 Unmanaged.nan_to_num_t
 
 nan_to_num__tddd
   :: ForeignPtr Tensor
@@ -1187,25 +1187,25 @@ nan_to_num__tddd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-nan_to_num__tddd = cast4 Unmanaged.nan_to_num__tddd
+nan_to_num__tddd = _cast4 Unmanaged.nan_to_num__tddd
 
 nan_to_num__tdd
   :: ForeignPtr Tensor
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-nan_to_num__tdd = cast3 Unmanaged.nan_to_num__tdd
+nan_to_num__tdd = _cast3 Unmanaged.nan_to_num__tdd
 
 nan_to_num__td
   :: ForeignPtr Tensor
   -> CDouble
   -> IO (ForeignPtr Tensor)
-nan_to_num__td = cast2 Unmanaged.nan_to_num__td
+nan_to_num__td = _cast2 Unmanaged.nan_to_num__td
 
 nan_to_num__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-nan_to_num__t = cast1 Unmanaged.nan_to_num__t
+nan_to_num__t = _cast1 Unmanaged.nan_to_num__t
 
 nan_to_num_out_ttddd
   :: ForeignPtr Tensor
@@ -1214,7 +1214,7 @@ nan_to_num_out_ttddd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-nan_to_num_out_ttddd = cast5 Unmanaged.nan_to_num_out_ttddd
+nan_to_num_out_ttddd = _cast5 Unmanaged.nan_to_num_out_ttddd
 
 nan_to_num_out_ttdd
   :: ForeignPtr Tensor
@@ -1222,33 +1222,33 @@ nan_to_num_out_ttdd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-nan_to_num_out_ttdd = cast4 Unmanaged.nan_to_num_out_ttdd
+nan_to_num_out_ttdd = _cast4 Unmanaged.nan_to_num_out_ttdd
 
 nan_to_num_out_ttd
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> CDouble
   -> IO (ForeignPtr Tensor)
-nan_to_num_out_ttd = cast3 Unmanaged.nan_to_num_out_ttd
+nan_to_num_out_ttd = _cast3 Unmanaged.nan_to_num_out_ttd
 
 nan_to_num_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-nan_to_num_out_tt = cast2 Unmanaged.nan_to_num_out_tt
+nan_to_num_out_tt = _cast2 Unmanaged.nan_to_num_out_tt
 
 linear_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linear_ttt = cast3 Unmanaged.linear_ttt
+linear_ttt = _cast3 Unmanaged.linear_ttt
 
 linear_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linear_tt = cast2 Unmanaged.linear_tt
+linear_tt = _cast2 Unmanaged.linear_tt
 
 linear_out_tttt
   :: ForeignPtr Tensor
@@ -1256,34 +1256,34 @@ linear_out_tttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linear_out_tttt = cast4 Unmanaged.linear_out_tttt
+linear_out_tttt = _cast4 Unmanaged.linear_out_tttt
 
 linear_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-linear_out_ttt = cast3 Unmanaged.linear_out_ttt
+linear_out_ttt = _cast3 Unmanaged.linear_out_ttt
 
 mkldnn_linear_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-mkldnn_linear_ttt = cast3 Unmanaged.mkldnn_linear_ttt
+mkldnn_linear_ttt = _cast3 Unmanaged.mkldnn_linear_ttt
 
 mkldnn_linear_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-mkldnn_linear_tt = cast2 Unmanaged.mkldnn_linear_tt
+mkldnn_linear_tt = _cast2 Unmanaged.mkldnn_linear_tt
 
 mkldnn_linear_backward_input_ltt
   :: ForeignPtr IntArray
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-mkldnn_linear_backward_input_ltt = cast3 Unmanaged.mkldnn_linear_backward_input_ltt
+mkldnn_linear_backward_input_ltt = _cast3 Unmanaged.mkldnn_linear_backward_input_ltt
 
 mkldnn_linear_backward_weights_tttb
   :: ForeignPtr Tensor
@@ -1291,7 +1291,7 @@ mkldnn_linear_backward_weights_tttb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-mkldnn_linear_backward_weights_tttb = cast4 Unmanaged.mkldnn_linear_backward_weights_tttb
+mkldnn_linear_backward_weights_tttb = _cast4 Unmanaged.mkldnn_linear_backward_weights_tttb
 
 mkldnn_linear_backward_ttta
   :: ForeignPtr Tensor
@@ -1299,7 +1299,7 @@ mkldnn_linear_backward_ttta
   -> ForeignPtr Tensor
   -> ForeignPtr (StdArray '(CBool,3))
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-mkldnn_linear_backward_ttta = cast4 Unmanaged.mkldnn_linear_backward_ttta
+mkldnn_linear_backward_ttta = _cast4 Unmanaged.mkldnn_linear_backward_ttta
 
 fbgemm_linear_int8_weight_fp32_activation_ttttsst
   :: ForeignPtr Tensor
@@ -1310,7 +1310,7 @@ fbgemm_linear_int8_weight_fp32_activation_ttttsst
   -> ForeignPtr Scalar
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fbgemm_linear_int8_weight_fp32_activation_ttttsst = cast7 Unmanaged.fbgemm_linear_int8_weight_fp32_activation_ttttsst
+fbgemm_linear_int8_weight_fp32_activation_ttttsst = _cast7 Unmanaged.fbgemm_linear_int8_weight_fp32_activation_ttttsst
 
 fbgemm_linear_int8_weight_ttttsst
   :: ForeignPtr Tensor
@@ -1321,62 +1321,62 @@ fbgemm_linear_int8_weight_ttttsst
   -> ForeignPtr Scalar
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fbgemm_linear_int8_weight_ttttsst = cast7 Unmanaged.fbgemm_linear_int8_weight_ttttsst
+fbgemm_linear_int8_weight_ttttsst = _cast7 Unmanaged.fbgemm_linear_int8_weight_ttttsst
 
 fbgemm_linear_quantize_weight_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,CDouble,Int64)))
-fbgemm_linear_quantize_weight_t = cast1 Unmanaged.fbgemm_linear_quantize_weight_t
+fbgemm_linear_quantize_weight_t = _cast1 Unmanaged.fbgemm_linear_quantize_weight_t
 
 fbgemm_pack_gemm_matrix_fp16_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fbgemm_pack_gemm_matrix_fp16_t = cast1 Unmanaged.fbgemm_pack_gemm_matrix_fp16_t
+fbgemm_pack_gemm_matrix_fp16_t = _cast1 Unmanaged.fbgemm_pack_gemm_matrix_fp16_t
 
 fbgemm_linear_fp16_weight_fp32_activation_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fbgemm_linear_fp16_weight_fp32_activation_ttt = cast3 Unmanaged.fbgemm_linear_fp16_weight_fp32_activation_ttt
+fbgemm_linear_fp16_weight_fp32_activation_ttt = _cast3 Unmanaged.fbgemm_linear_fp16_weight_fp32_activation_ttt
 
 fbgemm_linear_fp16_weight_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fbgemm_linear_fp16_weight_ttt = cast3 Unmanaged.fbgemm_linear_fp16_weight_ttt
+fbgemm_linear_fp16_weight_ttt = _cast3 Unmanaged.fbgemm_linear_fp16_weight_ttt
 
 fbgemm_pack_quantized_matrix_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fbgemm_pack_quantized_matrix_t = cast1 Unmanaged.fbgemm_pack_quantized_matrix_t
+fbgemm_pack_quantized_matrix_t = _cast1 Unmanaged.fbgemm_pack_quantized_matrix_t
 
 fbgemm_pack_quantized_matrix_tll
   :: ForeignPtr Tensor
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-fbgemm_pack_quantized_matrix_tll = cast3 Unmanaged.fbgemm_pack_quantized_matrix_tll
+fbgemm_pack_quantized_matrix_tll = _cast3 Unmanaged.fbgemm_pack_quantized_matrix_tll
 
 ldexp_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-ldexp_tt = cast2 Unmanaged.ldexp_tt
+ldexp_tt = _cast2 Unmanaged.ldexp_tt
 
 ldexp__tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-ldexp__tt = cast2 Unmanaged.ldexp__tt
+ldexp__tt = _cast2 Unmanaged.ldexp__tt
 
 ldexp_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-ldexp_out_ttt = cast3 Unmanaged.ldexp_out_ttt
+ldexp_out_ttt = _cast3 Unmanaged.ldexp_out_ttt
 
 linspace_sslo
   :: ForeignPtr Scalar
@@ -1384,14 +1384,14 @@ linspace_sslo
   -> Int64
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-linspace_sslo = cast4 Unmanaged.linspace_sslo
+linspace_sslo = _cast4 Unmanaged.linspace_sslo
 
 linspace_ssl
   :: ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> Int64
   -> IO (ForeignPtr Tensor)
-linspace_ssl = cast3 Unmanaged.linspace_ssl
+linspace_ssl = _cast3 Unmanaged.linspace_ssl
 
 linspace_out_tssl
   :: ForeignPtr Tensor
@@ -1399,132 +1399,132 @@ linspace_out_tssl
   -> ForeignPtr Scalar
   -> Int64
   -> IO (ForeignPtr Tensor)
-linspace_out_tssl = cast4 Unmanaged.linspace_out_tssl
+linspace_out_tssl = _cast4 Unmanaged.linspace_out_tssl
 
 log_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-log_t = cast1 Unmanaged.log_t
+log_t = _cast1 Unmanaged.log_t
 
 log__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-log__t = cast1 Unmanaged.log__t
+log__t = _cast1 Unmanaged.log__t
 
 log_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-log_out_tt = cast2 Unmanaged.log_out_tt
+log_out_tt = _cast2 Unmanaged.log_out_tt
 
 log10_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-log10_t = cast1 Unmanaged.log10_t
+log10_t = _cast1 Unmanaged.log10_t
 
 log10__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-log10__t = cast1 Unmanaged.log10__t
+log10__t = _cast1 Unmanaged.log10__t
 
 log10_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-log10_out_tt = cast2 Unmanaged.log10_out_tt
+log10_out_tt = _cast2 Unmanaged.log10_out_tt
 
 log1p_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-log1p_t = cast1 Unmanaged.log1p_t
+log1p_t = _cast1 Unmanaged.log1p_t
 
 log1p__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-log1p__t = cast1 Unmanaged.log1p__t
+log1p__t = _cast1 Unmanaged.log1p__t
 
 log1p_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-log1p_out_tt = cast2 Unmanaged.log1p_out_tt
+log1p_out_tt = _cast2 Unmanaged.log1p_out_tt
 
 log2_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-log2_t = cast1 Unmanaged.log2_t
+log2_t = _cast1 Unmanaged.log2_t
 
 log2__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-log2__t = cast1 Unmanaged.log2__t
+log2__t = _cast1 Unmanaged.log2__t
 
 log2_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-log2_out_tt = cast2 Unmanaged.log2_out_tt
+log2_out_tt = _cast2 Unmanaged.log2_out_tt
 
 logaddexp_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-logaddexp_out_ttt = cast3 Unmanaged.logaddexp_out_ttt
+logaddexp_out_ttt = _cast3 Unmanaged.logaddexp_out_ttt
 
 logaddexp_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-logaddexp_tt = cast2 Unmanaged.logaddexp_tt
+logaddexp_tt = _cast2 Unmanaged.logaddexp_tt
 
 logaddexp2_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-logaddexp2_out_ttt = cast3 Unmanaged.logaddexp2_out_ttt
+logaddexp2_out_ttt = _cast3 Unmanaged.logaddexp2_out_ttt
 
 logaddexp2_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-logaddexp2_tt = cast2 Unmanaged.logaddexp2_tt
+logaddexp2_tt = _cast2 Unmanaged.logaddexp2_tt
 
 xlogy_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-xlogy_tt = cast2 Unmanaged.xlogy_tt
+xlogy_tt = _cast2 Unmanaged.xlogy_tt
 
 xlogy_st
   :: ForeignPtr Scalar
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-xlogy_st = cast2 Unmanaged.xlogy_st
+xlogy_st = _cast2 Unmanaged.xlogy_st
 
 xlogy_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-xlogy_ts = cast2 Unmanaged.xlogy_ts
+xlogy_ts = _cast2 Unmanaged.xlogy_ts
 
 xlogy__tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-xlogy__tt = cast2 Unmanaged.xlogy__tt
+xlogy__tt = _cast2 Unmanaged.xlogy__tt
 
 xlogy__ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-xlogy__ts = cast2 Unmanaged.xlogy__ts
+xlogy__ts = _cast2 Unmanaged.xlogy__ts
 
 xlogy_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-xlogy_out_ttt = cast3 Unmanaged.xlogy_out_ttt
+xlogy_out_ttt = _cast3 Unmanaged.xlogy_out_ttt
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Native/Native4.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Native/Native4.hs
@@ -26,19 +26,19 @@ xlogy_out_tst
   -> ForeignPtr Scalar
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-xlogy_out_tst = cast3 Unmanaged.xlogy_out_tst
+xlogy_out_tst = _cast3 Unmanaged.xlogy_out_tst
 
 xlogy_out_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-xlogy_out_tts = cast3 Unmanaged.xlogy_out_tts
+xlogy_out_tts = _cast3 Unmanaged.xlogy_out_tts
 
 logdet_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-logdet_t = cast1 Unmanaged.logdet_t
+logdet_t = _cast1 Unmanaged.logdet_t
 
 logspace_ssldo
   :: ForeignPtr Scalar
@@ -47,7 +47,7 @@ logspace_ssldo
   -> CDouble
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-logspace_ssldo = cast5 Unmanaged.logspace_ssldo
+logspace_ssldo = _cast5 Unmanaged.logspace_ssldo
 
 logspace_ssld
   :: ForeignPtr Scalar
@@ -55,14 +55,14 @@ logspace_ssld
   -> Int64
   -> CDouble
   -> IO (ForeignPtr Tensor)
-logspace_ssld = cast4 Unmanaged.logspace_ssld
+logspace_ssld = _cast4 Unmanaged.logspace_ssld
 
 logspace_ssl
   :: ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> Int64
   -> IO (ForeignPtr Tensor)
-logspace_ssl = cast3 Unmanaged.logspace_ssl
+logspace_ssl = _cast3 Unmanaged.logspace_ssl
 
 logspace_out_tssld
   :: ForeignPtr Tensor
@@ -71,7 +71,7 @@ logspace_out_tssld
   -> Int64
   -> CDouble
   -> IO (ForeignPtr Tensor)
-logspace_out_tssld = cast5 Unmanaged.logspace_out_tssld
+logspace_out_tssld = _cast5 Unmanaged.logspace_out_tssld
 
 logspace_out_tssl
   :: ForeignPtr Tensor
@@ -79,40 +79,40 @@ logspace_out_tssl
   -> ForeignPtr Scalar
   -> Int64
   -> IO (ForeignPtr Tensor)
-logspace_out_tssl = cast4 Unmanaged.logspace_out_tssl
+logspace_out_tssl = _cast4 Unmanaged.logspace_out_tssl
 
 log_softmax_tls
   :: ForeignPtr Tensor
   -> Int64
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-log_softmax_tls = cast3 Unmanaged.log_softmax_tls
+log_softmax_tls = _cast3 Unmanaged.log_softmax_tls
 
 log_softmax_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-log_softmax_tl = cast2 Unmanaged.log_softmax_tl
+log_softmax_tl = _cast2 Unmanaged.log_softmax_tl
 
 log_softmax_tns
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-log_softmax_tns = cast3 Unmanaged.log_softmax_tns
+log_softmax_tns = _cast3 Unmanaged.log_softmax_tns
 
 log_softmax_tn
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> IO (ForeignPtr Tensor)
-log_softmax_tn = cast2 Unmanaged.log_softmax_tn
+log_softmax_tn = _cast2 Unmanaged.log_softmax_tn
 
 _log_softmax_tlb
   :: ForeignPtr Tensor
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-_log_softmax_tlb = cast3 Unmanaged._log_softmax_tlb
+_log_softmax_tlb = _cast3 Unmanaged._log_softmax_tlb
 
 _log_softmax_out_ttlb
   :: ForeignPtr Tensor
@@ -120,7 +120,7 @@ _log_softmax_out_ttlb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-_log_softmax_out_ttlb = cast4 Unmanaged._log_softmax_out_ttlb
+_log_softmax_out_ttlb = _cast4 Unmanaged._log_softmax_out_ttlb
 
 _log_softmax_backward_data_ttls
   :: ForeignPtr Tensor
@@ -128,7 +128,7 @@ _log_softmax_backward_data_ttls
   -> Int64
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-_log_softmax_backward_data_ttls = cast4 Unmanaged._log_softmax_backward_data_ttls
+_log_softmax_backward_data_ttls = _cast4 Unmanaged._log_softmax_backward_data_ttls
 
 _log_softmax_backward_data_out_tttls
   :: ForeignPtr Tensor
@@ -137,59 +137,59 @@ _log_softmax_backward_data_out_tttls
   -> Int64
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-_log_softmax_backward_data_out_tttls = cast5 Unmanaged._log_softmax_backward_data_out_tttls
+_log_softmax_backward_data_out_tttls = _cast5 Unmanaged._log_softmax_backward_data_out_tttls
 
 _logcumsumexp_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-_logcumsumexp_tl = cast2 Unmanaged._logcumsumexp_tl
+_logcumsumexp_tl = _cast2 Unmanaged._logcumsumexp_tl
 
 _logcumsumexp_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-_logcumsumexp_out_ttl = cast3 Unmanaged._logcumsumexp_out_ttl
+_logcumsumexp_out_ttl = _cast3 Unmanaged._logcumsumexp_out_ttl
 
 logcumsumexp_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-logcumsumexp_tl = cast2 Unmanaged.logcumsumexp_tl
+logcumsumexp_tl = _cast2 Unmanaged.logcumsumexp_tl
 
 logcumsumexp_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-logcumsumexp_out_ttl = cast3 Unmanaged.logcumsumexp_out_ttl
+logcumsumexp_out_ttl = _cast3 Unmanaged.logcumsumexp_out_ttl
 
 logcumsumexp_tn
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> IO (ForeignPtr Tensor)
-logcumsumexp_tn = cast2 Unmanaged.logcumsumexp_tn
+logcumsumexp_tn = _cast2 Unmanaged.logcumsumexp_tn
 
 logcumsumexp_out_ttn
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> IO (ForeignPtr Tensor)
-logcumsumexp_out_ttn = cast3 Unmanaged.logcumsumexp_out_ttn
+logcumsumexp_out_ttn = _cast3 Unmanaged.logcumsumexp_out_ttn
 
 logsumexp_tlb
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-logsumexp_tlb = cast3 Unmanaged.logsumexp_tlb
+logsumexp_tlb = _cast3 Unmanaged.logsumexp_tlb
 
 logsumexp_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-logsumexp_tl = cast2 Unmanaged.logsumexp_tl
+logsumexp_tl = _cast2 Unmanaged.logsumexp_tl
 
 logsumexp_out_ttlb
   :: ForeignPtr Tensor
@@ -197,27 +197,27 @@ logsumexp_out_ttlb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-logsumexp_out_ttlb = cast4 Unmanaged.logsumexp_out_ttlb
+logsumexp_out_ttlb = _cast4 Unmanaged.logsumexp_out_ttlb
 
 logsumexp_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-logsumexp_out_ttl = cast3 Unmanaged.logsumexp_out_ttl
+logsumexp_out_ttl = _cast3 Unmanaged.logsumexp_out_ttl
 
 logsumexp_tNb
   :: ForeignPtr Tensor
   -> ForeignPtr DimnameList
   -> CBool
   -> IO (ForeignPtr Tensor)
-logsumexp_tNb = cast3 Unmanaged.logsumexp_tNb
+logsumexp_tNb = _cast3 Unmanaged.logsumexp_tNb
 
 logsumexp_tN
   :: ForeignPtr Tensor
   -> ForeignPtr DimnameList
   -> IO (ForeignPtr Tensor)
-logsumexp_tN = cast2 Unmanaged.logsumexp_tN
+logsumexp_tN = _cast2 Unmanaged.logsumexp_tN
 
 logsumexp_out_ttNb
   :: ForeignPtr Tensor
@@ -225,14 +225,14 @@ logsumexp_out_ttNb
   -> ForeignPtr DimnameList
   -> CBool
   -> IO (ForeignPtr Tensor)
-logsumexp_out_ttNb = cast4 Unmanaged.logsumexp_out_ttNb
+logsumexp_out_ttNb = _cast4 Unmanaged.logsumexp_out_ttNb
 
 logsumexp_out_ttN
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr DimnameList
   -> IO (ForeignPtr Tensor)
-logsumexp_out_ttN = cast3 Unmanaged.logsumexp_out_ttN
+logsumexp_out_ttN = _cast3 Unmanaged.logsumexp_out_ttN
 
 margin_ranking_loss_tttdl
   :: ForeignPtr Tensor
@@ -241,7 +241,7 @@ margin_ranking_loss_tttdl
   -> CDouble
   -> Int64
   -> IO (ForeignPtr Tensor)
-margin_ranking_loss_tttdl = cast5 Unmanaged.margin_ranking_loss_tttdl
+margin_ranking_loss_tttdl = _cast5 Unmanaged.margin_ranking_loss_tttdl
 
 margin_ranking_loss_tttd
   :: ForeignPtr Tensor
@@ -249,111 +249,111 @@ margin_ranking_loss_tttd
   -> ForeignPtr Tensor
   -> CDouble
   -> IO (ForeignPtr Tensor)
-margin_ranking_loss_tttd = cast4 Unmanaged.margin_ranking_loss_tttd
+margin_ranking_loss_tttd = _cast4 Unmanaged.margin_ranking_loss_tttd
 
 margin_ranking_loss_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-margin_ranking_loss_ttt = cast3 Unmanaged.margin_ranking_loss_ttt
+margin_ranking_loss_ttt = _cast3 Unmanaged.margin_ranking_loss_ttt
 
 matmul_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-matmul_tt = cast2 Unmanaged.matmul_tt
+matmul_tt = _cast2 Unmanaged.matmul_tt
 
 matmul_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-matmul_out_ttt = cast3 Unmanaged.matmul_out_ttt
+matmul_out_ttt = _cast3 Unmanaged.matmul_out_ttt
 
 matrix_rank_tdb
   :: ForeignPtr Tensor
   -> CDouble
   -> CBool
   -> IO (ForeignPtr Tensor)
-matrix_rank_tdb = cast3 Unmanaged.matrix_rank_tdb
+matrix_rank_tdb = _cast3 Unmanaged.matrix_rank_tdb
 
 matrix_rank_td
   :: ForeignPtr Tensor
   -> CDouble
   -> IO (ForeignPtr Tensor)
-matrix_rank_td = cast2 Unmanaged.matrix_rank_td
+matrix_rank_td = _cast2 Unmanaged.matrix_rank_td
 
 matrix_rank_tb
   :: ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-matrix_rank_tb = cast2 Unmanaged.matrix_rank_tb
+matrix_rank_tb = _cast2 Unmanaged.matrix_rank_tb
 
 matrix_rank_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-matrix_rank_t = cast1 Unmanaged.matrix_rank_t
+matrix_rank_t = _cast1 Unmanaged.matrix_rank_t
 
 matrix_power_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-matrix_power_tl = cast2 Unmanaged.matrix_power_tl
+matrix_power_tl = _cast2 Unmanaged.matrix_power_tl
 
 matrix_power_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-matrix_power_out_ttl = cast3 Unmanaged.matrix_power_out_ttl
+matrix_power_out_ttl = _cast3 Unmanaged.matrix_power_out_ttl
 
 matrix_exp_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-matrix_exp_t = cast1 Unmanaged.matrix_exp_t
+matrix_exp_t = _cast1 Unmanaged.matrix_exp_t
 
 matrix_exp_backward_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-matrix_exp_backward_tt = cast2 Unmanaged.matrix_exp_backward_tt
+matrix_exp_backward_tt = _cast2 Unmanaged.matrix_exp_backward_tt
 
 _aminmax_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-_aminmax_t = cast1 Unmanaged._aminmax_t
+_aminmax_t = _cast1 Unmanaged._aminmax_t
 
 _aminmax_tlb
   :: ForeignPtr Tensor
   -> Int64
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-_aminmax_tlb = cast3 Unmanaged._aminmax_tlb
+_aminmax_tlb = _cast3 Unmanaged._aminmax_tlb
 
 _aminmax_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-_aminmax_tl = cast2 Unmanaged._aminmax_tl
+_aminmax_tl = _cast2 Unmanaged._aminmax_tl
 
 aminmax_tlb
   :: ForeignPtr Tensor
   -> Int64
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-aminmax_tlb = cast3 Unmanaged.aminmax_tlb
+aminmax_tlb = _cast3 Unmanaged.aminmax_tlb
 
 aminmax_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-aminmax_tl = cast2 Unmanaged.aminmax_tl
+aminmax_tl = _cast2 Unmanaged.aminmax_tl
 
 aminmax_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-aminmax_t = cast1 Unmanaged.aminmax_t
+aminmax_t = _cast1 Unmanaged.aminmax_t
 
 aminmax_out_tttlb
   :: ForeignPtr Tensor
@@ -362,7 +362,7 @@ aminmax_out_tttlb
   -> Int64
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-aminmax_out_tttlb = cast5 Unmanaged.aminmax_out_tttlb
+aminmax_out_tttlb = _cast5 Unmanaged.aminmax_out_tttlb
 
 aminmax_out_tttl
   :: ForeignPtr Tensor
@@ -370,40 +370,40 @@ aminmax_out_tttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-aminmax_out_tttl = cast4 Unmanaged.aminmax_out_tttl
+aminmax_out_tttl = _cast4 Unmanaged.aminmax_out_tttl
 
 aminmax_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-aminmax_out_ttt = cast3 Unmanaged.aminmax_out_ttt
+aminmax_out_ttt = _cast3 Unmanaged.aminmax_out_ttt
 
 _compute_linear_combination_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_compute_linear_combination_tt = cast2 Unmanaged._compute_linear_combination_tt
+_compute_linear_combination_tt = _cast2 Unmanaged._compute_linear_combination_tt
 
 _compute_linear_combination_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_compute_linear_combination_out_ttt = cast3 Unmanaged._compute_linear_combination_out_ttt
+_compute_linear_combination_out_ttt = _cast3 Unmanaged._compute_linear_combination_out_ttt
 
 max_tlb
   :: ForeignPtr Tensor
   -> Int64
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_tlb = cast3 Unmanaged.max_tlb
+max_tlb = _cast3 Unmanaged.max_tlb
 
 max_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_tl = cast2 Unmanaged.max_tl
+max_tl = _cast2 Unmanaged.max_tl
 
 max_out_tttlb
   :: ForeignPtr Tensor
@@ -412,7 +412,7 @@ max_out_tttlb
   -> Int64
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_out_tttlb = cast5 Unmanaged.max_out_tttlb
+max_out_tttlb = _cast5 Unmanaged.max_out_tttlb
 
 max_out_tttl
   :: ForeignPtr Tensor
@@ -420,20 +420,20 @@ max_out_tttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_out_tttl = cast4 Unmanaged.max_out_tttl
+max_out_tttl = _cast4 Unmanaged.max_out_tttl
 
 max_tnb
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_tnb = cast3 Unmanaged.max_tnb
+max_tnb = _cast3 Unmanaged.max_tnb
 
 max_tn
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_tn = cast2 Unmanaged.max_tn
+max_tn = _cast2 Unmanaged.max_tn
 
 max_out_tttnb
   :: ForeignPtr Tensor
@@ -442,7 +442,7 @@ max_out_tttnb
   -> ForeignPtr Dimname
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_out_tttnb = cast5 Unmanaged.max_out_tttnb
+max_out_tttnb = _cast5 Unmanaged.max_out_tttnb
 
 max_out_tttn
   :: ForeignPtr Tensor
@@ -450,7 +450,7 @@ max_out_tttn
   -> ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_out_tttn = cast4 Unmanaged.max_out_tttn
+max_out_tttn = _cast4 Unmanaged.max_out_tttn
 
 value_selecting_reduction_backward_tltlb
   :: ForeignPtr Tensor
@@ -459,25 +459,25 @@ value_selecting_reduction_backward_tltlb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-value_selecting_reduction_backward_tltlb = cast5 Unmanaged.value_selecting_reduction_backward_tltlb
+value_selecting_reduction_backward_tltlb = _cast5 Unmanaged.value_selecting_reduction_backward_tltlb
 
 amax_tlb
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-amax_tlb = cast3 Unmanaged.amax_tlb
+amax_tlb = _cast3 Unmanaged.amax_tlb
 
 amax_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-amax_tl = cast2 Unmanaged.amax_tl
+amax_tl = _cast2 Unmanaged.amax_tl
 
 amax_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-amax_t = cast1 Unmanaged.amax_t
+amax_t = _cast1 Unmanaged.amax_t
 
 amax_out_ttlb
   :: ForeignPtr Tensor
@@ -485,20 +485,20 @@ amax_out_ttlb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-amax_out_ttlb = cast4 Unmanaged.amax_out_ttlb
+amax_out_ttlb = _cast4 Unmanaged.amax_out_ttlb
 
 amax_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-amax_out_ttl = cast3 Unmanaged.amax_out_ttl
+amax_out_ttl = _cast3 Unmanaged.amax_out_ttl
 
 amax_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-amax_out_tt = cast2 Unmanaged.amax_out_tt
+amax_out_tt = _cast2 Unmanaged.amax_out_tt
 
 max_pool1d_with_indices_tllllb
   :: ForeignPtr Tensor
@@ -508,7 +508,7 @@ max_pool1d_with_indices_tllllb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_pool1d_with_indices_tllllb = cast6 Unmanaged.max_pool1d_with_indices_tllllb
+max_pool1d_with_indices_tllllb = _cast6 Unmanaged.max_pool1d_with_indices_tllllb
 
 max_pool1d_with_indices_tllll
   :: ForeignPtr Tensor
@@ -517,7 +517,7 @@ max_pool1d_with_indices_tllll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_pool1d_with_indices_tllll = cast5 Unmanaged.max_pool1d_with_indices_tllll
+max_pool1d_with_indices_tllll = _cast5 Unmanaged.max_pool1d_with_indices_tllll
 
 max_pool1d_with_indices_tlll
   :: ForeignPtr Tensor
@@ -525,20 +525,20 @@ max_pool1d_with_indices_tlll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_pool1d_with_indices_tlll = cast4 Unmanaged.max_pool1d_with_indices_tlll
+max_pool1d_with_indices_tlll = _cast4 Unmanaged.max_pool1d_with_indices_tlll
 
 max_pool1d_with_indices_tll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_pool1d_with_indices_tll = cast3 Unmanaged.max_pool1d_with_indices_tll
+max_pool1d_with_indices_tll = _cast3 Unmanaged.max_pool1d_with_indices_tll
 
 max_pool1d_with_indices_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-max_pool1d_with_indices_tl = cast2 Unmanaged.max_pool1d_with_indices_tl
+max_pool1d_with_indices_tl = _cast2 Unmanaged.max_pool1d_with_indices_tl
 
 max_pool1d_tllllb
   :: ForeignPtr Tensor
@@ -548,7 +548,7 @@ max_pool1d_tllllb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-max_pool1d_tllllb = cast6 Unmanaged.max_pool1d_tllllb
+max_pool1d_tllllb = _cast6 Unmanaged.max_pool1d_tllllb
 
 max_pool1d_tllll
   :: ForeignPtr Tensor
@@ -557,7 +557,7 @@ max_pool1d_tllll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-max_pool1d_tllll = cast5 Unmanaged.max_pool1d_tllll
+max_pool1d_tllll = _cast5 Unmanaged.max_pool1d_tllll
 
 max_pool1d_tlll
   :: ForeignPtr Tensor
@@ -565,20 +565,20 @@ max_pool1d_tlll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-max_pool1d_tlll = cast4 Unmanaged.max_pool1d_tlll
+max_pool1d_tlll = _cast4 Unmanaged.max_pool1d_tlll
 
 max_pool1d_tll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-max_pool1d_tll = cast3 Unmanaged.max_pool1d_tll
+max_pool1d_tll = _cast3 Unmanaged.max_pool1d_tll
 
 max_pool1d_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-max_pool1d_tl = cast2 Unmanaged.max_pool1d_tl
+max_pool1d_tl = _cast2 Unmanaged.max_pool1d_tl
 
 max_pool2d_tllllb
   :: ForeignPtr Tensor
@@ -588,7 +588,7 @@ max_pool2d_tllllb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-max_pool2d_tllllb = cast6 Unmanaged.max_pool2d_tllllb
+max_pool2d_tllllb = _cast6 Unmanaged.max_pool2d_tllllb
 
 max_pool2d_tllll
   :: ForeignPtr Tensor
@@ -597,7 +597,7 @@ max_pool2d_tllll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-max_pool2d_tllll = cast5 Unmanaged.max_pool2d_tllll
+max_pool2d_tllll = _cast5 Unmanaged.max_pool2d_tllll
 
 max_pool2d_tlll
   :: ForeignPtr Tensor
@@ -605,20 +605,20 @@ max_pool2d_tlll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-max_pool2d_tlll = cast4 Unmanaged.max_pool2d_tlll
+max_pool2d_tlll = _cast4 Unmanaged.max_pool2d_tlll
 
 max_pool2d_tll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-max_pool2d_tll = cast3 Unmanaged.max_pool2d_tll
+max_pool2d_tll = _cast3 Unmanaged.max_pool2d_tll
 
 max_pool2d_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-max_pool2d_tl = cast2 Unmanaged.max_pool2d_tl
+max_pool2d_tl = _cast2 Unmanaged.max_pool2d_tl
 
 mkldnn_max_pool2d_tllllb
   :: ForeignPtr Tensor
@@ -628,7 +628,7 @@ mkldnn_max_pool2d_tllllb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-mkldnn_max_pool2d_tllllb = cast6 Unmanaged.mkldnn_max_pool2d_tllllb
+mkldnn_max_pool2d_tllllb = _cast6 Unmanaged.mkldnn_max_pool2d_tllllb
 
 mkldnn_max_pool2d_tllll
   :: ForeignPtr Tensor
@@ -637,7 +637,7 @@ mkldnn_max_pool2d_tllll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-mkldnn_max_pool2d_tllll = cast5 Unmanaged.mkldnn_max_pool2d_tllll
+mkldnn_max_pool2d_tllll = _cast5 Unmanaged.mkldnn_max_pool2d_tllll
 
 mkldnn_max_pool2d_tlll
   :: ForeignPtr Tensor
@@ -645,20 +645,20 @@ mkldnn_max_pool2d_tlll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-mkldnn_max_pool2d_tlll = cast4 Unmanaged.mkldnn_max_pool2d_tlll
+mkldnn_max_pool2d_tlll = _cast4 Unmanaged.mkldnn_max_pool2d_tlll
 
 mkldnn_max_pool2d_tll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-mkldnn_max_pool2d_tll = cast3 Unmanaged.mkldnn_max_pool2d_tll
+mkldnn_max_pool2d_tll = _cast3 Unmanaged.mkldnn_max_pool2d_tll
 
 mkldnn_max_pool2d_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-mkldnn_max_pool2d_tl = cast2 Unmanaged.mkldnn_max_pool2d_tl
+mkldnn_max_pool2d_tl = _cast2 Unmanaged.mkldnn_max_pool2d_tl
 
 mkldnn_max_pool2d_backward_tttllllb
   :: ForeignPtr Tensor
@@ -670,7 +670,7 @@ mkldnn_max_pool2d_backward_tttllllb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-mkldnn_max_pool2d_backward_tttllllb = cast8 Unmanaged.mkldnn_max_pool2d_backward_tttllllb
+mkldnn_max_pool2d_backward_tttllllb = _cast8 Unmanaged.mkldnn_max_pool2d_backward_tttllllb
 
 mkldnn_max_pool2d_backward_tttllll
   :: ForeignPtr Tensor
@@ -681,7 +681,7 @@ mkldnn_max_pool2d_backward_tttllll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-mkldnn_max_pool2d_backward_tttllll = cast7 Unmanaged.mkldnn_max_pool2d_backward_tttllll
+mkldnn_max_pool2d_backward_tttllll = _cast7 Unmanaged.mkldnn_max_pool2d_backward_tttllll
 
 mkldnn_max_pool2d_backward_tttlll
   :: ForeignPtr Tensor
@@ -691,7 +691,7 @@ mkldnn_max_pool2d_backward_tttlll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-mkldnn_max_pool2d_backward_tttlll = cast6 Unmanaged.mkldnn_max_pool2d_backward_tttlll
+mkldnn_max_pool2d_backward_tttlll = _cast6 Unmanaged.mkldnn_max_pool2d_backward_tttlll
 
 mkldnn_max_pool2d_backward_tttll
   :: ForeignPtr Tensor
@@ -700,7 +700,7 @@ mkldnn_max_pool2d_backward_tttll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-mkldnn_max_pool2d_backward_tttll = cast5 Unmanaged.mkldnn_max_pool2d_backward_tttll
+mkldnn_max_pool2d_backward_tttll = _cast5 Unmanaged.mkldnn_max_pool2d_backward_tttll
 
 mkldnn_max_pool2d_backward_tttl
   :: ForeignPtr Tensor
@@ -708,7 +708,7 @@ mkldnn_max_pool2d_backward_tttl
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-mkldnn_max_pool2d_backward_tttl = cast4 Unmanaged.mkldnn_max_pool2d_backward_tttl
+mkldnn_max_pool2d_backward_tttl = _cast4 Unmanaged.mkldnn_max_pool2d_backward_tttl
 
 mkldnn_max_pool3d_tllllb
   :: ForeignPtr Tensor
@@ -718,7 +718,7 @@ mkldnn_max_pool3d_tllllb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-mkldnn_max_pool3d_tllllb = cast6 Unmanaged.mkldnn_max_pool3d_tllllb
+mkldnn_max_pool3d_tllllb = _cast6 Unmanaged.mkldnn_max_pool3d_tllllb
 
 mkldnn_max_pool3d_tllll
   :: ForeignPtr Tensor
@@ -727,7 +727,7 @@ mkldnn_max_pool3d_tllll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-mkldnn_max_pool3d_tllll = cast5 Unmanaged.mkldnn_max_pool3d_tllll
+mkldnn_max_pool3d_tllll = _cast5 Unmanaged.mkldnn_max_pool3d_tllll
 
 mkldnn_max_pool3d_tlll
   :: ForeignPtr Tensor
@@ -735,20 +735,20 @@ mkldnn_max_pool3d_tlll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-mkldnn_max_pool3d_tlll = cast4 Unmanaged.mkldnn_max_pool3d_tlll
+mkldnn_max_pool3d_tlll = _cast4 Unmanaged.mkldnn_max_pool3d_tlll
 
 mkldnn_max_pool3d_tll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-mkldnn_max_pool3d_tll = cast3 Unmanaged.mkldnn_max_pool3d_tll
+mkldnn_max_pool3d_tll = _cast3 Unmanaged.mkldnn_max_pool3d_tll
 
 mkldnn_max_pool3d_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-mkldnn_max_pool3d_tl = cast2 Unmanaged.mkldnn_max_pool3d_tl
+mkldnn_max_pool3d_tl = _cast2 Unmanaged.mkldnn_max_pool3d_tl
 
 mkldnn_max_pool3d_backward_tttllllb
   :: ForeignPtr Tensor
@@ -760,7 +760,7 @@ mkldnn_max_pool3d_backward_tttllllb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-mkldnn_max_pool3d_backward_tttllllb = cast8 Unmanaged.mkldnn_max_pool3d_backward_tttllllb
+mkldnn_max_pool3d_backward_tttllllb = _cast8 Unmanaged.mkldnn_max_pool3d_backward_tttllllb
 
 mkldnn_max_pool3d_backward_tttllll
   :: ForeignPtr Tensor
@@ -771,7 +771,7 @@ mkldnn_max_pool3d_backward_tttllll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-mkldnn_max_pool3d_backward_tttllll = cast7 Unmanaged.mkldnn_max_pool3d_backward_tttllll
+mkldnn_max_pool3d_backward_tttllll = _cast7 Unmanaged.mkldnn_max_pool3d_backward_tttllll
 
 mkldnn_max_pool3d_backward_tttlll
   :: ForeignPtr Tensor
@@ -781,7 +781,7 @@ mkldnn_max_pool3d_backward_tttlll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-mkldnn_max_pool3d_backward_tttlll = cast6 Unmanaged.mkldnn_max_pool3d_backward_tttlll
+mkldnn_max_pool3d_backward_tttlll = _cast6 Unmanaged.mkldnn_max_pool3d_backward_tttlll
 
 mkldnn_max_pool3d_backward_tttll
   :: ForeignPtr Tensor
@@ -790,7 +790,7 @@ mkldnn_max_pool3d_backward_tttll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-mkldnn_max_pool3d_backward_tttll = cast5 Unmanaged.mkldnn_max_pool3d_backward_tttll
+mkldnn_max_pool3d_backward_tttll = _cast5 Unmanaged.mkldnn_max_pool3d_backward_tttll
 
 mkldnn_max_pool3d_backward_tttl
   :: ForeignPtr Tensor
@@ -798,7 +798,7 @@ mkldnn_max_pool3d_backward_tttl
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-mkldnn_max_pool3d_backward_tttl = cast4 Unmanaged.mkldnn_max_pool3d_backward_tttl
+mkldnn_max_pool3d_backward_tttl = _cast4 Unmanaged.mkldnn_max_pool3d_backward_tttl
 
 quantized_max_pool1d_tllllb
   :: ForeignPtr Tensor
@@ -808,7 +808,7 @@ quantized_max_pool1d_tllllb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-quantized_max_pool1d_tllllb = cast6 Unmanaged.quantized_max_pool1d_tllllb
+quantized_max_pool1d_tllllb = _cast6 Unmanaged.quantized_max_pool1d_tllllb
 
 quantized_max_pool1d_tllll
   :: ForeignPtr Tensor
@@ -817,7 +817,7 @@ quantized_max_pool1d_tllll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-quantized_max_pool1d_tllll = cast5 Unmanaged.quantized_max_pool1d_tllll
+quantized_max_pool1d_tllll = _cast5 Unmanaged.quantized_max_pool1d_tllll
 
 quantized_max_pool1d_tlll
   :: ForeignPtr Tensor
@@ -825,20 +825,20 @@ quantized_max_pool1d_tlll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-quantized_max_pool1d_tlll = cast4 Unmanaged.quantized_max_pool1d_tlll
+quantized_max_pool1d_tlll = _cast4 Unmanaged.quantized_max_pool1d_tlll
 
 quantized_max_pool1d_tll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-quantized_max_pool1d_tll = cast3 Unmanaged.quantized_max_pool1d_tll
+quantized_max_pool1d_tll = _cast3 Unmanaged.quantized_max_pool1d_tll
 
 quantized_max_pool1d_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-quantized_max_pool1d_tl = cast2 Unmanaged.quantized_max_pool1d_tl
+quantized_max_pool1d_tl = _cast2 Unmanaged.quantized_max_pool1d_tl
 
 quantized_max_pool2d_tllllb
   :: ForeignPtr Tensor
@@ -848,7 +848,7 @@ quantized_max_pool2d_tllllb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-quantized_max_pool2d_tllllb = cast6 Unmanaged.quantized_max_pool2d_tllllb
+quantized_max_pool2d_tllllb = _cast6 Unmanaged.quantized_max_pool2d_tllllb
 
 quantized_max_pool2d_tllll
   :: ForeignPtr Tensor
@@ -857,7 +857,7 @@ quantized_max_pool2d_tllll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-quantized_max_pool2d_tllll = cast5 Unmanaged.quantized_max_pool2d_tllll
+quantized_max_pool2d_tllll = _cast5 Unmanaged.quantized_max_pool2d_tllll
 
 quantized_max_pool2d_tlll
   :: ForeignPtr Tensor
@@ -865,20 +865,20 @@ quantized_max_pool2d_tlll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-quantized_max_pool2d_tlll = cast4 Unmanaged.quantized_max_pool2d_tlll
+quantized_max_pool2d_tlll = _cast4 Unmanaged.quantized_max_pool2d_tlll
 
 quantized_max_pool2d_tll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-quantized_max_pool2d_tll = cast3 Unmanaged.quantized_max_pool2d_tll
+quantized_max_pool2d_tll = _cast3 Unmanaged.quantized_max_pool2d_tll
 
 quantized_max_pool2d_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-quantized_max_pool2d_tl = cast2 Unmanaged.quantized_max_pool2d_tl
+quantized_max_pool2d_tl = _cast2 Unmanaged.quantized_max_pool2d_tl
 
 max_pool3d_tllllb
   :: ForeignPtr Tensor
@@ -888,7 +888,7 @@ max_pool3d_tllllb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-max_pool3d_tllllb = cast6 Unmanaged.max_pool3d_tllllb
+max_pool3d_tllllb = _cast6 Unmanaged.max_pool3d_tllllb
 
 max_pool3d_tllll
   :: ForeignPtr Tensor
@@ -897,7 +897,7 @@ max_pool3d_tllll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-max_pool3d_tllll = cast5 Unmanaged.max_pool3d_tllll
+max_pool3d_tllll = _cast5 Unmanaged.max_pool3d_tllll
 
 max_pool3d_tlll
   :: ForeignPtr Tensor
@@ -905,31 +905,31 @@ max_pool3d_tlll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-max_pool3d_tlll = cast4 Unmanaged.max_pool3d_tlll
+max_pool3d_tlll = _cast4 Unmanaged.max_pool3d_tlll
 
 max_pool3d_tll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-max_pool3d_tll = cast3 Unmanaged.max_pool3d_tll
+max_pool3d_tll = _cast3 Unmanaged.max_pool3d_tll
 
 max_pool3d_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-max_pool3d_tl = cast2 Unmanaged.max_pool3d_tl
+max_pool3d_tl = _cast2 Unmanaged.max_pool3d_tl
 
 mean_ts
   :: ForeignPtr Tensor
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-mean_ts = cast2 Unmanaged.mean_ts
+mean_ts = _cast2 Unmanaged.mean_ts
 
 mean_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-mean_t = cast1 Unmanaged.mean_t
+mean_t = _cast1 Unmanaged.mean_t
 
 mean_tlbs
   :: ForeignPtr Tensor
@@ -937,20 +937,20 @@ mean_tlbs
   -> CBool
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-mean_tlbs = cast4 Unmanaged.mean_tlbs
+mean_tlbs = _cast4 Unmanaged.mean_tlbs
 
 mean_tlb
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-mean_tlb = cast3 Unmanaged.mean_tlb
+mean_tlb = _cast3 Unmanaged.mean_tlb
 
 mean_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-mean_tl = cast2 Unmanaged.mean_tl
+mean_tl = _cast2 Unmanaged.mean_tl
 
 mean_out_ttlbs
   :: ForeignPtr Tensor
@@ -959,7 +959,7 @@ mean_out_ttlbs
   -> CBool
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-mean_out_ttlbs = cast5 Unmanaged.mean_out_ttlbs
+mean_out_ttlbs = _cast5 Unmanaged.mean_out_ttlbs
 
 mean_out_ttlb
   :: ForeignPtr Tensor
@@ -967,14 +967,14 @@ mean_out_ttlb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-mean_out_ttlb = cast4 Unmanaged.mean_out_ttlb
+mean_out_ttlb = _cast4 Unmanaged.mean_out_ttlb
 
 mean_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-mean_out_ttl = cast3 Unmanaged.mean_out_ttl
+mean_out_ttl = _cast3 Unmanaged.mean_out_ttl
 
 mean_tNbs
   :: ForeignPtr Tensor
@@ -982,20 +982,20 @@ mean_tNbs
   -> CBool
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-mean_tNbs = cast4 Unmanaged.mean_tNbs
+mean_tNbs = _cast4 Unmanaged.mean_tNbs
 
 mean_tNb
   :: ForeignPtr Tensor
   -> ForeignPtr DimnameList
   -> CBool
   -> IO (ForeignPtr Tensor)
-mean_tNb = cast3 Unmanaged.mean_tNb
+mean_tNb = _cast3 Unmanaged.mean_tNb
 
 mean_tN
   :: ForeignPtr Tensor
   -> ForeignPtr DimnameList
   -> IO (ForeignPtr Tensor)
-mean_tN = cast2 Unmanaged.mean_tN
+mean_tN = _cast2 Unmanaged.mean_tN
 
 mean_out_ttNbs
   :: ForeignPtr Tensor
@@ -1004,7 +1004,7 @@ mean_out_ttNbs
   -> CBool
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-mean_out_ttNbs = cast5 Unmanaged.mean_out_ttNbs
+mean_out_ttNbs = _cast5 Unmanaged.mean_out_ttNbs
 
 mean_out_ttNb
   :: ForeignPtr Tensor
@@ -1012,14 +1012,14 @@ mean_out_ttNb
   -> ForeignPtr DimnameList
   -> CBool
   -> IO (ForeignPtr Tensor)
-mean_out_ttNb = cast4 Unmanaged.mean_out_ttNb
+mean_out_ttNb = _cast4 Unmanaged.mean_out_ttNb
 
 mean_out_ttN
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr DimnameList
   -> IO (ForeignPtr Tensor)
-mean_out_ttN = cast3 Unmanaged.mean_out_ttN
+mean_out_ttN = _cast3 Unmanaged.mean_out_ttN
 
 nanmean_tlbs
   :: ForeignPtr Tensor
@@ -1027,25 +1027,25 @@ nanmean_tlbs
   -> CBool
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-nanmean_tlbs = cast4 Unmanaged.nanmean_tlbs
+nanmean_tlbs = _cast4 Unmanaged.nanmean_tlbs
 
 nanmean_tlb
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-nanmean_tlb = cast3 Unmanaged.nanmean_tlb
+nanmean_tlb = _cast3 Unmanaged.nanmean_tlb
 
 nanmean_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-nanmean_tl = cast2 Unmanaged.nanmean_tl
+nanmean_tl = _cast2 Unmanaged.nanmean_tl
 
 nanmean_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-nanmean_t = cast1 Unmanaged.nanmean_t
+nanmean_t = _cast1 Unmanaged.nanmean_t
 
 nanmean_out_ttlbs
   :: ForeignPtr Tensor
@@ -1054,7 +1054,7 @@ nanmean_out_ttlbs
   -> CBool
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-nanmean_out_ttlbs = cast5 Unmanaged.nanmean_out_ttlbs
+nanmean_out_ttlbs = _cast5 Unmanaged.nanmean_out_ttlbs
 
 nanmean_out_ttlb
   :: ForeignPtr Tensor
@@ -1062,38 +1062,38 @@ nanmean_out_ttlb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-nanmean_out_ttlb = cast4 Unmanaged.nanmean_out_ttlb
+nanmean_out_ttlb = _cast4 Unmanaged.nanmean_out_ttlb
 
 nanmean_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-nanmean_out_ttl = cast3 Unmanaged.nanmean_out_ttl
+nanmean_out_ttl = _cast3 Unmanaged.nanmean_out_ttl
 
 nanmean_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-nanmean_out_tt = cast2 Unmanaged.nanmean_out_tt
+nanmean_out_tt = _cast2 Unmanaged.nanmean_out_tt
 
 median_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-median_t = cast1 Unmanaged.median_t
+median_t = _cast1 Unmanaged.median_t
 
 median_tlb
   :: ForeignPtr Tensor
   -> Int64
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-median_tlb = cast3 Unmanaged.median_tlb
+median_tlb = _cast3 Unmanaged.median_tlb
 
 median_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-median_tl = cast2 Unmanaged.median_tl
+median_tl = _cast2 Unmanaged.median_tl
 
 median_out_tttlb
   :: ForeignPtr Tensor
@@ -1102,7 +1102,7 @@ median_out_tttlb
   -> Int64
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-median_out_tttlb = cast5 Unmanaged.median_out_tttlb
+median_out_tttlb = _cast5 Unmanaged.median_out_tttlb
 
 median_out_tttl
   :: ForeignPtr Tensor
@@ -1110,20 +1110,20 @@ median_out_tttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-median_out_tttl = cast4 Unmanaged.median_out_tttl
+median_out_tttl = _cast4 Unmanaged.median_out_tttl
 
 median_tnb
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-median_tnb = cast3 Unmanaged.median_tnb
+median_tnb = _cast3 Unmanaged.median_tnb
 
 median_tn
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-median_tn = cast2 Unmanaged.median_tn
+median_tn = _cast2 Unmanaged.median_tn
 
 median_out_tttnb
   :: ForeignPtr Tensor
@@ -1132,7 +1132,7 @@ median_out_tttnb
   -> ForeignPtr Dimname
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-median_out_tttnb = cast5 Unmanaged.median_out_tttnb
+median_out_tttnb = _cast5 Unmanaged.median_out_tttnb
 
 median_out_tttn
   :: ForeignPtr Tensor
@@ -1140,25 +1140,25 @@ median_out_tttn
   -> ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-median_out_tttn = cast4 Unmanaged.median_out_tttn
+median_out_tttn = _cast4 Unmanaged.median_out_tttn
 
 nanmedian_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-nanmedian_t = cast1 Unmanaged.nanmedian_t
+nanmedian_t = _cast1 Unmanaged.nanmedian_t
 
 nanmedian_tlb
   :: ForeignPtr Tensor
   -> Int64
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-nanmedian_tlb = cast3 Unmanaged.nanmedian_tlb
+nanmedian_tlb = _cast3 Unmanaged.nanmedian_tlb
 
 nanmedian_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-nanmedian_tl = cast2 Unmanaged.nanmedian_tl
+nanmedian_tl = _cast2 Unmanaged.nanmedian_tl
 
 nanmedian_out_tttlb
   :: ForeignPtr Tensor
@@ -1167,7 +1167,7 @@ nanmedian_out_tttlb
   -> Int64
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-nanmedian_out_tttlb = cast5 Unmanaged.nanmedian_out_tttlb
+nanmedian_out_tttlb = _cast5 Unmanaged.nanmedian_out_tttlb
 
 nanmedian_out_tttl
   :: ForeignPtr Tensor
@@ -1175,20 +1175,20 @@ nanmedian_out_tttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-nanmedian_out_tttl = cast4 Unmanaged.nanmedian_out_tttl
+nanmedian_out_tttl = _cast4 Unmanaged.nanmedian_out_tttl
 
 nanmedian_tnb
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-nanmedian_tnb = cast3 Unmanaged.nanmedian_tnb
+nanmedian_tnb = _cast3 Unmanaged.nanmedian_tnb
 
 nanmedian_tn
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-nanmedian_tn = cast2 Unmanaged.nanmedian_tn
+nanmedian_tn = _cast2 Unmanaged.nanmedian_tn
 
 nanmedian_out_tttnb
   :: ForeignPtr Tensor
@@ -1197,7 +1197,7 @@ nanmedian_out_tttnb
   -> ForeignPtr Dimname
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-nanmedian_out_tttnb = cast5 Unmanaged.nanmedian_out_tttnb
+nanmedian_out_tttnb = _cast5 Unmanaged.nanmedian_out_tttnb
 
 nanmedian_out_tttn
   :: ForeignPtr Tensor
@@ -1205,20 +1205,20 @@ nanmedian_out_tttn
   -> ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-nanmedian_out_tttn = cast4 Unmanaged.nanmedian_out_tttn
+nanmedian_out_tttn = _cast4 Unmanaged.nanmedian_out_tttn
 
 min_tlb
   :: ForeignPtr Tensor
   -> Int64
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-min_tlb = cast3 Unmanaged.min_tlb
+min_tlb = _cast3 Unmanaged.min_tlb
 
 min_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-min_tl = cast2 Unmanaged.min_tl
+min_tl = _cast2 Unmanaged.min_tl
 
 min_out_tttlb
   :: ForeignPtr Tensor
@@ -1227,7 +1227,7 @@ min_out_tttlb
   -> Int64
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-min_out_tttlb = cast5 Unmanaged.min_out_tttlb
+min_out_tttlb = _cast5 Unmanaged.min_out_tttlb
 
 min_out_tttl
   :: ForeignPtr Tensor
@@ -1235,20 +1235,20 @@ min_out_tttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-min_out_tttl = cast4 Unmanaged.min_out_tttl
+min_out_tttl = _cast4 Unmanaged.min_out_tttl
 
 min_tnb
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-min_tnb = cast3 Unmanaged.min_tnb
+min_tnb = _cast3 Unmanaged.min_tnb
 
 min_tn
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-min_tn = cast2 Unmanaged.min_tn
+min_tn = _cast2 Unmanaged.min_tn
 
 min_out_tttnb
   :: ForeignPtr Tensor
@@ -1257,7 +1257,7 @@ min_out_tttnb
   -> ForeignPtr Dimname
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-min_out_tttnb = cast5 Unmanaged.min_out_tttnb
+min_out_tttnb = _cast5 Unmanaged.min_out_tttnb
 
 min_out_tttn
   :: ForeignPtr Tensor
@@ -1265,25 +1265,25 @@ min_out_tttn
   -> ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-min_out_tttn = cast4 Unmanaged.min_out_tttn
+min_out_tttn = _cast4 Unmanaged.min_out_tttn
 
 amin_tlb
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-amin_tlb = cast3 Unmanaged.amin_tlb
+amin_tlb = _cast3 Unmanaged.amin_tlb
 
 amin_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-amin_tl = cast2 Unmanaged.amin_tl
+amin_tl = _cast2 Unmanaged.amin_tl
 
 amin_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-amin_t = cast1 Unmanaged.amin_t
+amin_t = _cast1 Unmanaged.amin_t
 
 amin_out_ttlb
   :: ForeignPtr Tensor
@@ -1291,20 +1291,20 @@ amin_out_ttlb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-amin_out_ttlb = cast4 Unmanaged.amin_out_ttlb
+amin_out_ttlb = _cast4 Unmanaged.amin_out_ttlb
 
 amin_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-amin_out_ttl = cast3 Unmanaged.amin_out_ttl
+amin_out_ttl = _cast3 Unmanaged.amin_out_ttl
 
 amin_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-amin_out_tt = cast2 Unmanaged.amin_out_tt
+amin_out_tt = _cast2 Unmanaged.amin_out_tt
 
 mkldnn_convolution_tttllll
   :: ForeignPtr Tensor
@@ -1315,7 +1315,7 @@ mkldnn_convolution_tttllll
   -> ForeignPtr IntArray
   -> Int64
   -> IO (ForeignPtr Tensor)
-mkldnn_convolution_tttllll = cast7 Unmanaged.mkldnn_convolution_tttllll
+mkldnn_convolution_tttllll = _cast7 Unmanaged.mkldnn_convolution_tttllll
 
 miopen_batch_norm_tttttbdd
   :: ForeignPtr Tensor
@@ -1327,7 +1327,7 @@ miopen_batch_norm_tttttbdd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-miopen_batch_norm_tttttbdd = cast8 Unmanaged.miopen_batch_norm_tttttbdd
+miopen_batch_norm_tttttbdd = _cast8 Unmanaged.miopen_batch_norm_tttttbdd
 
 miopen_batch_norm_backward_tttttttd
   :: ForeignPtr Tensor
@@ -1339,7 +1339,7 @@ miopen_batch_norm_backward_tttttttd
   -> ForeignPtr Tensor
   -> CDouble
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-miopen_batch_norm_backward_tttttttd = cast8 Unmanaged.miopen_batch_norm_backward_tttttttd
+miopen_batch_norm_backward_tttttttd = _cast8 Unmanaged.miopen_batch_norm_backward_tttttttd
 
 miopen_convolution_tttllllbb
   :: ForeignPtr Tensor
@@ -1352,7 +1352,7 @@ miopen_convolution_tttllllbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-miopen_convolution_tttllllbb = cast9 Unmanaged.miopen_convolution_tttllllbb
+miopen_convolution_tttllllbb = _cast9 Unmanaged.miopen_convolution_tttllllbb
 
 miopen_convolution_transpose_tttlllllbb
   :: ForeignPtr Tensor
@@ -1366,7 +1366,7 @@ miopen_convolution_transpose_tttlllllbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-miopen_convolution_transpose_tttlllllbb = cast10 Unmanaged.miopen_convolution_transpose_tttlllllbb
+miopen_convolution_transpose_tttlllllbb = _cast10 Unmanaged.miopen_convolution_transpose_tttlllllbb
 
 miopen_depthwise_convolution_tttllllbb
   :: ForeignPtr Tensor
@@ -1379,7 +1379,7 @@ miopen_depthwise_convolution_tttllllbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-miopen_depthwise_convolution_tttllllbb = cast9 Unmanaged.miopen_depthwise_convolution_tttllllbb
+miopen_depthwise_convolution_tttllllbb = _cast9 Unmanaged.miopen_depthwise_convolution_tttllllbb
 
 miopen_rnn_tllttlllbdbblt
   :: ForeignPtr Tensor
@@ -1397,7 +1397,7 @@ miopen_rnn_tllttlllbdbblt
   -> ForeignPtr IntArray
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Tensor)))
-miopen_rnn_tllttlllbdbblt = cast14 Unmanaged.miopen_rnn_tllttlllbdbblt
+miopen_rnn_tllttlllbdbblt = _cast14 Unmanaged.miopen_rnn_tllttlllbdbblt
 
 miopen_rnn_backward_tlltttttttlllbdbbltta
   :: ForeignPtr Tensor
@@ -1422,56 +1422,56 @@ miopen_rnn_backward_tlltttttttlllbdbbltta
   -> ForeignPtr Tensor
   -> ForeignPtr (StdArray '(CBool,4))
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,TensorList)))
-miopen_rnn_backward_tlltttttttlllbdbbltta = cast21 Unmanaged.miopen_rnn_backward_tlltttttttlllbdbbltta
+miopen_rnn_backward_tlltttttttlllbdbbltta = _cast21 Unmanaged.miopen_rnn_backward_tlltttttttlllbdbbltta
 
 mm_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-mm_tt = cast2 Unmanaged.mm_tt
+mm_tt = _cast2 Unmanaged.mm_tt
 
 mm_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-mm_out_ttt = cast3 Unmanaged.mm_out_ttt
+mm_out_ttt = _cast3 Unmanaged.mm_out_ttt
 
 _sparse_mm_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_sparse_mm_tt = cast2 Unmanaged._sparse_mm_tt
+_sparse_mm_tt = _cast2 Unmanaged._sparse_mm_tt
 
 _sparse_sparse_matmul_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_sparse_sparse_matmul_tt = cast2 Unmanaged._sparse_sparse_matmul_tt
+_sparse_sparse_matmul_tt = _cast2 Unmanaged._sparse_sparse_matmul_tt
 
 _sparse_mask_helper_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_sparse_mask_helper_tt = cast2 Unmanaged._sparse_mask_helper_tt
+_sparse_mask_helper_tt = _cast2 Unmanaged._sparse_mask_helper_tt
 
 mode_tlb
   :: ForeignPtr Tensor
   -> Int64
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-mode_tlb = cast3 Unmanaged.mode_tlb
+mode_tlb = _cast3 Unmanaged.mode_tlb
 
 mode_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-mode_tl = cast2 Unmanaged.mode_tl
+mode_tl = _cast2 Unmanaged.mode_tl
 
 mode_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-mode_t = cast1 Unmanaged.mode_t
+mode_t = _cast1 Unmanaged.mode_t
 
 mode_out_tttlb
   :: ForeignPtr Tensor
@@ -1480,7 +1480,7 @@ mode_out_tttlb
   -> Int64
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-mode_out_tttlb = cast5 Unmanaged.mode_out_tttlb
+mode_out_tttlb = _cast5 Unmanaged.mode_out_tttlb
 
 mode_out_tttl
   :: ForeignPtr Tensor
@@ -1488,27 +1488,27 @@ mode_out_tttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-mode_out_tttl = cast4 Unmanaged.mode_out_tttl
+mode_out_tttl = _cast4 Unmanaged.mode_out_tttl
 
 mode_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-mode_out_ttt = cast3 Unmanaged.mode_out_ttt
+mode_out_ttt = _cast3 Unmanaged.mode_out_ttt
 
 mode_tnb
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-mode_tnb = cast3 Unmanaged.mode_tnb
+mode_tnb = _cast3 Unmanaged.mode_tnb
 
 mode_tn
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-mode_tn = cast2 Unmanaged.mode_tn
+mode_tn = _cast2 Unmanaged.mode_tn
 
 mode_out_tttnb
   :: ForeignPtr Tensor
@@ -1517,7 +1517,7 @@ mode_out_tttnb
   -> ForeignPtr Dimname
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-mode_out_tttnb = cast5 Unmanaged.mode_out_tttnb
+mode_out_tttnb = _cast5 Unmanaged.mode_out_tttnb
 
 mode_out_tttn
   :: ForeignPtr Tensor
@@ -1525,71 +1525,71 @@ mode_out_tttn
   -> ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-mode_out_tttn = cast4 Unmanaged.mode_out_tttn
+mode_out_tttn = _cast4 Unmanaged.mode_out_tttn
 
 mul_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-mul_tt = cast2 Unmanaged.mul_tt
+mul_tt = _cast2 Unmanaged.mul_tt
 
 mul_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-mul_out_ttt = cast3 Unmanaged.mul_out_ttt
+mul_out_ttt = _cast3 Unmanaged.mul_out_ttt
 
 mul_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-mul_ts = cast2 Unmanaged.mul_ts
+mul_ts = _cast2 Unmanaged.mul_ts
 
 multiply_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-multiply_tt = cast2 Unmanaged.multiply_tt
+multiply_tt = _cast2 Unmanaged.multiply_tt
 
 multiply_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-multiply_out_ttt = cast3 Unmanaged.multiply_out_ttt
+multiply_out_ttt = _cast3 Unmanaged.multiply_out_ttt
 
 multiply_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-multiply_ts = cast2 Unmanaged.multiply_ts
+multiply_ts = _cast2 Unmanaged.multiply_ts
 
 mv_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-mv_tt = cast2 Unmanaged.mv_tt
+mv_tt = _cast2 Unmanaged.mv_tt
 
 mv_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-mv_out_ttt = cast3 Unmanaged.mv_out_ttt
+mv_out_ttt = _cast3 Unmanaged.mv_out_ttt
 
 mvlgamma_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-mvlgamma_out_ttl = cast3 Unmanaged.mvlgamma_out_ttl
+mvlgamma_out_ttl = _cast3 Unmanaged.mvlgamma_out_ttl
 
 mvlgamma_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-mvlgamma_tl = cast2 Unmanaged.mvlgamma_tl
+mvlgamma_tl = _cast2 Unmanaged.mvlgamma_tl
 
 narrow_copy_tlll
   :: ForeignPtr Tensor
@@ -1597,7 +1597,7 @@ narrow_copy_tlll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-narrow_copy_tlll = cast4 Unmanaged.narrow_copy_tlll
+narrow_copy_tlll = _cast4 Unmanaged.narrow_copy_tlll
 
 narrow_copy_out_ttlll
   :: ForeignPtr Tensor
@@ -1606,7 +1606,7 @@ narrow_copy_out_ttlll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-narrow_copy_out_ttlll = cast5 Unmanaged.narrow_copy_out_ttlll
+narrow_copy_out_ttlll = _cast5 Unmanaged.narrow_copy_out_ttlll
 
 narrow_tlll
   :: ForeignPtr Tensor
@@ -1614,7 +1614,7 @@ narrow_tlll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-narrow_tlll = cast4 Unmanaged.narrow_tlll
+narrow_tlll = _cast4 Unmanaged.narrow_tlll
 
 narrow_tltl
   :: ForeignPtr Tensor
@@ -1622,7 +1622,7 @@ narrow_tltl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-narrow_tltl = cast4 Unmanaged.narrow_tltl
+narrow_tltl = _cast4 Unmanaged.narrow_tltl
 
 native_batch_norm_tttttbdd
   :: ForeignPtr Tensor
@@ -1634,7 +1634,7 @@ native_batch_norm_tttttbdd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-native_batch_norm_tttttbdd = cast8 Unmanaged.native_batch_norm_tttttbdd
+native_batch_norm_tttttbdd = _cast8 Unmanaged.native_batch_norm_tttttbdd
 
 native_batch_norm_out_ttttttttbdd
   :: ForeignPtr Tensor
@@ -1649,13 +1649,13 @@ native_batch_norm_out_ttttttttbdd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-native_batch_norm_out_ttttttttbdd = cast11 Unmanaged.native_batch_norm_out_ttttttttbdd
+native_batch_norm_out_ttttttttbdd = _cast11 Unmanaged.native_batch_norm_out_ttttttttbdd
 
 batch_norm_stats_td
   :: ForeignPtr Tensor
   -> CDouble
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-batch_norm_stats_td = cast2 Unmanaged.batch_norm_stats_td
+batch_norm_stats_td = _cast2 Unmanaged.batch_norm_stats_td
 
 batch_norm_elemt_tttttd
   :: ForeignPtr Tensor
@@ -1665,5 +1665,5 @@ batch_norm_elemt_tttttd
   -> ForeignPtr Tensor
   -> CDouble
   -> IO (ForeignPtr Tensor)
-batch_norm_elemt_tttttd = cast6 Unmanaged.batch_norm_elemt_tttttd
+batch_norm_elemt_tttttd = _cast6 Unmanaged.batch_norm_elemt_tttttd
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Native/Native5.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Native/Native5.hs
@@ -30,7 +30,7 @@ batch_norm_elemt_out_ttttttd
   -> ForeignPtr Tensor
   -> CDouble
   -> IO (ForeignPtr Tensor)
-batch_norm_elemt_out_ttttttd = cast7 Unmanaged.batch_norm_elemt_out_ttttttd
+batch_norm_elemt_out_ttttttd = _cast7 Unmanaged.batch_norm_elemt_out_ttttttd
 
 batch_norm_gather_stats_tttttddl
   :: ForeignPtr Tensor
@@ -42,7 +42,7 @@ batch_norm_gather_stats_tttttddl
   -> CDouble
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-batch_norm_gather_stats_tttttddl = cast8 Unmanaged.batch_norm_gather_stats_tttttddl
+batch_norm_gather_stats_tttttddl = _cast8 Unmanaged.batch_norm_gather_stats_tttttddl
 
 batch_norm_gather_stats_with_counts_tttttddt
   :: ForeignPtr Tensor
@@ -54,7 +54,7 @@ batch_norm_gather_stats_with_counts_tttttddt
   -> CDouble
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-batch_norm_gather_stats_with_counts_tttttddt = cast8 Unmanaged.batch_norm_gather_stats_with_counts_tttttddt
+batch_norm_gather_stats_with_counts_tttttddt = _cast8 Unmanaged.batch_norm_gather_stats_with_counts_tttttddt
 
 native_batch_norm_backward_tttttttbda
   :: ForeignPtr Tensor
@@ -68,7 +68,7 @@ native_batch_norm_backward_tttttttbda
   -> CDouble
   -> ForeignPtr (StdArray '(CBool,3))
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-native_batch_norm_backward_tttttttbda = cast10 Unmanaged.native_batch_norm_backward_tttttttbda
+native_batch_norm_backward_tttttttbda = _cast10 Unmanaged.native_batch_norm_backward_tttttttbda
 
 batch_norm_backward_reduce_tttttbbb
   :: ForeignPtr Tensor
@@ -80,7 +80,7 @@ batch_norm_backward_reduce_tttttbbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor)))
-batch_norm_backward_reduce_tttttbbb = cast8 Unmanaged.batch_norm_backward_reduce_tttttbbb
+batch_norm_backward_reduce_tttttbbb = _cast8 Unmanaged.batch_norm_backward_reduce_tttttbbb
 
 batch_norm_backward_elemt_tttttttt
   :: ForeignPtr Tensor
@@ -92,7 +92,7 @@ batch_norm_backward_elemt_tttttttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-batch_norm_backward_elemt_tttttttt = cast8 Unmanaged.batch_norm_backward_elemt_tttttttt
+batch_norm_backward_elemt_tttttttt = _cast8 Unmanaged.batch_norm_backward_elemt_tttttttt
 
 batch_norm_update_stats_tttd
   :: ForeignPtr Tensor
@@ -100,15 +100,15 @@ batch_norm_update_stats_tttd
   -> ForeignPtr Tensor
   -> CDouble
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-batch_norm_update_stats_tttd = cast4 Unmanaged.batch_norm_update_stats_tttd
+batch_norm_update_stats_tttd = _cast4 Unmanaged.batch_norm_update_stats_tttd
 
 is_vulkan_available
   :: IO (CBool)
-is_vulkan_available = cast0 Unmanaged.is_vulkan_available
+is_vulkan_available = _cast0 Unmanaged.is_vulkan_available
 
 _nnpack_available
   :: IO (CBool)
-_nnpack_available = cast0 Unmanaged._nnpack_available
+_nnpack_available = _cast0 Unmanaged._nnpack_available
 
 _nnpack_spatial_convolution_tttll
   :: ForeignPtr Tensor
@@ -117,7 +117,7 @@ _nnpack_spatial_convolution_tttll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-_nnpack_spatial_convolution_tttll = cast5 Unmanaged._nnpack_spatial_convolution_tttll
+_nnpack_spatial_convolution_tttll = _cast5 Unmanaged._nnpack_spatial_convolution_tttll
 
 _nnpack_spatial_convolution_tttl
   :: ForeignPtr Tensor
@@ -125,55 +125,55 @@ _nnpack_spatial_convolution_tttl
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-_nnpack_spatial_convolution_tttl = cast4 Unmanaged._nnpack_spatial_convolution_tttl
+_nnpack_spatial_convolution_tttl = _cast4 Unmanaged._nnpack_spatial_convolution_tttl
 
 ones_lNo
   :: ForeignPtr IntArray
   -> ForeignPtr DimnameList
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-ones_lNo = cast3 Unmanaged.ones_lNo
+ones_lNo = _cast3 Unmanaged.ones_lNo
 
 ones_lN
   :: ForeignPtr IntArray
   -> ForeignPtr DimnameList
   -> IO (ForeignPtr Tensor)
-ones_lN = cast2 Unmanaged.ones_lN
+ones_lN = _cast2 Unmanaged.ones_lN
 
 ones_lo
   :: ForeignPtr IntArray
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-ones_lo = cast2 Unmanaged.ones_lo
+ones_lo = _cast2 Unmanaged.ones_lo
 
 ones_l
   :: ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-ones_l = cast1 Unmanaged.ones_l
+ones_l = _cast1 Unmanaged.ones_l
 
 ones_out_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-ones_out_tl = cast2 Unmanaged.ones_out_tl
+ones_out_tl = _cast2 Unmanaged.ones_out_tl
 
 ones_like_toM
   :: ForeignPtr Tensor
   -> ForeignPtr TensorOptions
   -> MemoryFormat
   -> IO (ForeignPtr Tensor)
-ones_like_toM = cast3 Unmanaged.ones_like_toM
+ones_like_toM = _cast3 Unmanaged.ones_like_toM
 
 ones_like_to
   :: ForeignPtr Tensor
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-ones_like_to = cast2 Unmanaged.ones_like_to
+ones_like_to = _cast2 Unmanaged.ones_like_to
 
 ones_like_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-ones_like_t = cast1 Unmanaged.ones_like_t
+ones_like_t = _cast1 Unmanaged.ones_like_t
 
 pairwise_distance_ttddb
   :: ForeignPtr Tensor
@@ -182,7 +182,7 @@ pairwise_distance_ttddb
   -> CDouble
   -> CBool
   -> IO (ForeignPtr Tensor)
-pairwise_distance_ttddb = cast5 Unmanaged.pairwise_distance_ttddb
+pairwise_distance_ttddb = _cast5 Unmanaged.pairwise_distance_ttddb
 
 pairwise_distance_ttdd
   :: ForeignPtr Tensor
@@ -190,20 +190,20 @@ pairwise_distance_ttdd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-pairwise_distance_ttdd = cast4 Unmanaged.pairwise_distance_ttdd
+pairwise_distance_ttdd = _cast4 Unmanaged.pairwise_distance_ttdd
 
 pairwise_distance_ttd
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> CDouble
   -> IO (ForeignPtr Tensor)
-pairwise_distance_ttd = cast3 Unmanaged.pairwise_distance_ttd
+pairwise_distance_ttd = _cast3 Unmanaged.pairwise_distance_ttd
 
 pairwise_distance_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-pairwise_distance_tt = cast2 Unmanaged.pairwise_distance_tt
+pairwise_distance_tt = _cast2 Unmanaged.pairwise_distance_tt
 
 cdist_ttdl
   :: ForeignPtr Tensor
@@ -211,26 +211,26 @@ cdist_ttdl
   -> CDouble
   -> Int64
   -> IO (ForeignPtr Tensor)
-cdist_ttdl = cast4 Unmanaged.cdist_ttdl
+cdist_ttdl = _cast4 Unmanaged.cdist_ttdl
 
 cdist_ttd
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> CDouble
   -> IO (ForeignPtr Tensor)
-cdist_ttd = cast3 Unmanaged.cdist_ttd
+cdist_ttd = _cast3 Unmanaged.cdist_ttd
 
 cdist_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-cdist_tt = cast2 Unmanaged.cdist_tt
+cdist_tt = _cast2 Unmanaged.cdist_tt
 
 _euclidean_dist_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_euclidean_dist_tt = cast2 Unmanaged._euclidean_dist_tt
+_euclidean_dist_tt = _cast2 Unmanaged._euclidean_dist_tt
 
 _cdist_forward_ttdl
   :: ForeignPtr Tensor
@@ -238,7 +238,7 @@ _cdist_forward_ttdl
   -> CDouble
   -> Int64
   -> IO (ForeignPtr Tensor)
-_cdist_forward_ttdl = cast4 Unmanaged._cdist_forward_ttdl
+_cdist_forward_ttdl = _cast4 Unmanaged._cdist_forward_ttdl
 
 _cdist_backward_tttdt
   :: ForeignPtr Tensor
@@ -247,29 +247,29 @@ _cdist_backward_tttdt
   -> CDouble
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_cdist_backward_tttdt = cast5 Unmanaged._cdist_backward_tttdt
+_cdist_backward_tttdt = _cast5 Unmanaged._cdist_backward_tttdt
 
 pdist_td
   :: ForeignPtr Tensor
   -> CDouble
   -> IO (ForeignPtr Tensor)
-pdist_td = cast2 Unmanaged.pdist_td
+pdist_td = _cast2 Unmanaged.pdist_td
 
 pdist_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-pdist_t = cast1 Unmanaged.pdist_t
+pdist_t = _cast1 Unmanaged.pdist_t
 
 _pdist_forward_td
   :: ForeignPtr Tensor
   -> CDouble
   -> IO (ForeignPtr Tensor)
-_pdist_forward_td = cast2 Unmanaged._pdist_forward_td
+_pdist_forward_td = _cast2 Unmanaged._pdist_forward_td
 
 _pdist_forward_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_pdist_forward_t = cast1 Unmanaged._pdist_forward_t
+_pdist_forward_t = _cast1 Unmanaged._pdist_forward_t
 
 _pdist_backward_ttdt
   :: ForeignPtr Tensor
@@ -277,7 +277,7 @@ _pdist_backward_ttdt
   -> CDouble
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_pdist_backward_ttdt = cast4 Unmanaged._pdist_backward_ttdt
+_pdist_backward_ttdt = _cast4 Unmanaged._pdist_backward_ttdt
 
 cosine_similarity_ttld
   :: ForeignPtr Tensor
@@ -285,91 +285,91 @@ cosine_similarity_ttld
   -> Int64
   -> CDouble
   -> IO (ForeignPtr Tensor)
-cosine_similarity_ttld = cast4 Unmanaged.cosine_similarity_ttld
+cosine_similarity_ttld = _cast4 Unmanaged.cosine_similarity_ttld
 
 cosine_similarity_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-cosine_similarity_ttl = cast3 Unmanaged.cosine_similarity_ttl
+cosine_similarity_ttl = _cast3 Unmanaged.cosine_similarity_ttl
 
 cosine_similarity_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-cosine_similarity_tt = cast2 Unmanaged.cosine_similarity_tt
+cosine_similarity_tt = _cast2 Unmanaged.cosine_similarity_tt
 
 permute_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-permute_tl = cast2 Unmanaged.permute_tl
+permute_tl = _cast2 Unmanaged.permute_tl
 
 movedim_tll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-movedim_tll = cast3 Unmanaged.movedim_tll
+movedim_tll = _cast3 Unmanaged.movedim_tll
 
 moveaxis_tll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-moveaxis_tll = cast3 Unmanaged.moveaxis_tll
+moveaxis_tll = _cast3 Unmanaged.moveaxis_tll
 
 adjoint_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-adjoint_t = cast1 Unmanaged.adjoint_t
+adjoint_t = _cast1 Unmanaged.adjoint_t
 
 pixel_shuffle_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-pixel_shuffle_tl = cast2 Unmanaged.pixel_shuffle_tl
+pixel_shuffle_tl = _cast2 Unmanaged.pixel_shuffle_tl
 
 pixel_unshuffle_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-pixel_unshuffle_tl = cast2 Unmanaged.pixel_unshuffle_tl
+pixel_unshuffle_tl = _cast2 Unmanaged.pixel_unshuffle_tl
 
 channel_shuffle_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-channel_shuffle_tl = cast2 Unmanaged.channel_shuffle_tl
+channel_shuffle_tl = _cast2 Unmanaged.channel_shuffle_tl
 
 native_channel_shuffle_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-native_channel_shuffle_tl = cast2 Unmanaged.native_channel_shuffle_tl
+native_channel_shuffle_tl = _cast2 Unmanaged.native_channel_shuffle_tl
 
 _pin_memory_tD
   :: ForeignPtr Tensor
   -> DeviceType
   -> IO (ForeignPtr Tensor)
-_pin_memory_tD = cast2 Unmanaged._pin_memory_tD
+_pin_memory_tD = _cast2 Unmanaged._pin_memory_tD
 
 _pin_memory_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_pin_memory_t = cast1 Unmanaged._pin_memory_t
+_pin_memory_t = _cast1 Unmanaged._pin_memory_t
 
 pinverse_td
   :: ForeignPtr Tensor
   -> CDouble
   -> IO (ForeignPtr Tensor)
-pinverse_td = cast2 Unmanaged.pinverse_td
+pinverse_td = _cast2 Unmanaged.pinverse_td
 
 pinverse_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-pinverse_t = cast1 Unmanaged.pinverse_t
+pinverse_t = _cast1 Unmanaged.pinverse_t
 
 poisson_nll_loss_ttbbdl
   :: ForeignPtr Tensor
@@ -379,63 +379,63 @@ poisson_nll_loss_ttbbdl
   -> CDouble
   -> Int64
   -> IO (ForeignPtr Tensor)
-poisson_nll_loss_ttbbdl = cast6 Unmanaged.poisson_nll_loss_ttbbdl
+poisson_nll_loss_ttbbdl = _cast6 Unmanaged.poisson_nll_loss_ttbbdl
 
 rad2deg_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-rad2deg_t = cast1 Unmanaged.rad2deg_t
+rad2deg_t = _cast1 Unmanaged.rad2deg_t
 
 rad2deg__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-rad2deg__t = cast1 Unmanaged.rad2deg__t
+rad2deg__t = _cast1 Unmanaged.rad2deg__t
 
 rad2deg_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-rad2deg_out_tt = cast2 Unmanaged.rad2deg_out_tt
+rad2deg_out_tt = _cast2 Unmanaged.rad2deg_out_tt
 
 deg2rad_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-deg2rad_t = cast1 Unmanaged.deg2rad_t
+deg2rad_t = _cast1 Unmanaged.deg2rad_t
 
 deg2rad__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-deg2rad__t = cast1 Unmanaged.deg2rad__t
+deg2rad__t = _cast1 Unmanaged.deg2rad__t
 
 deg2rad_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-deg2rad_out_tt = cast2 Unmanaged.deg2rad_out_tt
+deg2rad_out_tt = _cast2 Unmanaged.deg2rad_out_tt
 
 scalar_tensor_so
   :: ForeignPtr Scalar
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-scalar_tensor_so = cast2 Unmanaged.scalar_tensor_so
+scalar_tensor_so = _cast2 Unmanaged.scalar_tensor_so
 
 scalar_tensor_s
   :: ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-scalar_tensor_s = cast1 Unmanaged.scalar_tensor_s
+scalar_tensor_s = _cast1 Unmanaged.scalar_tensor_s
 
 rand_lNo
   :: ForeignPtr IntArray
   -> ForeignPtr DimnameList
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-rand_lNo = cast3 Unmanaged.rand_lNo
+rand_lNo = _cast3 Unmanaged.rand_lNo
 
 rand_lN
   :: ForeignPtr IntArray
   -> ForeignPtr DimnameList
   -> IO (ForeignPtr Tensor)
-rand_lN = cast2 Unmanaged.rand_lN
+rand_lN = _cast2 Unmanaged.rand_lN
 
 rand_lGNo
   :: ForeignPtr IntArray
@@ -443,82 +443,82 @@ rand_lGNo
   -> ForeignPtr DimnameList
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-rand_lGNo = cast4 Unmanaged.rand_lGNo
+rand_lGNo = _cast4 Unmanaged.rand_lGNo
 
 rand_lGN
   :: ForeignPtr IntArray
   -> ForeignPtr Generator
   -> ForeignPtr DimnameList
   -> IO (ForeignPtr Tensor)
-rand_lGN = cast3 Unmanaged.rand_lGN
+rand_lGN = _cast3 Unmanaged.rand_lGN
 
 rand_lo
   :: ForeignPtr IntArray
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-rand_lo = cast2 Unmanaged.rand_lo
+rand_lo = _cast2 Unmanaged.rand_lo
 
 rand_l
   :: ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-rand_l = cast1 Unmanaged.rand_l
+rand_l = _cast1 Unmanaged.rand_l
 
 rand_lGo
   :: ForeignPtr IntArray
   -> ForeignPtr Generator
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-rand_lGo = cast3 Unmanaged.rand_lGo
+rand_lGo = _cast3 Unmanaged.rand_lGo
 
 rand_lG
   :: ForeignPtr IntArray
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-rand_lG = cast2 Unmanaged.rand_lG
+rand_lG = _cast2 Unmanaged.rand_lG
 
 rand_out_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-rand_out_tl = cast2 Unmanaged.rand_out_tl
+rand_out_tl = _cast2 Unmanaged.rand_out_tl
 
 rand_out_tlG
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-rand_out_tlG = cast3 Unmanaged.rand_out_tlG
+rand_out_tlG = _cast3 Unmanaged.rand_out_tlG
 
 rand_like_toM
   :: ForeignPtr Tensor
   -> ForeignPtr TensorOptions
   -> MemoryFormat
   -> IO (ForeignPtr Tensor)
-rand_like_toM = cast3 Unmanaged.rand_like_toM
+rand_like_toM = _cast3 Unmanaged.rand_like_toM
 
 rand_like_to
   :: ForeignPtr Tensor
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-rand_like_to = cast2 Unmanaged.rand_like_to
+rand_like_to = _cast2 Unmanaged.rand_like_to
 
 rand_like_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-rand_like_t = cast1 Unmanaged.rand_like_t
+rand_like_t = _cast1 Unmanaged.rand_like_t
 
 randint_llo
   :: Int64
   -> ForeignPtr IntArray
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-randint_llo = cast3 Unmanaged.randint_llo
+randint_llo = _cast3 Unmanaged.randint_llo
 
 randint_ll
   :: Int64
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-randint_ll = cast2 Unmanaged.randint_ll
+randint_ll = _cast2 Unmanaged.randint_ll
 
 randint_llGo
   :: Int64
@@ -526,14 +526,14 @@ randint_llGo
   -> ForeignPtr Generator
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-randint_llGo = cast4 Unmanaged.randint_llGo
+randint_llGo = _cast4 Unmanaged.randint_llGo
 
 randint_llG
   :: Int64
   -> ForeignPtr IntArray
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-randint_llG = cast3 Unmanaged.randint_llG
+randint_llG = _cast3 Unmanaged.randint_llG
 
 randint_lllo
   :: Int64
@@ -541,14 +541,14 @@ randint_lllo
   -> ForeignPtr IntArray
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-randint_lllo = cast4 Unmanaged.randint_lllo
+randint_lllo = _cast4 Unmanaged.randint_lllo
 
 randint_lll
   :: Int64
   -> Int64
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-randint_lll = cast3 Unmanaged.randint_lll
+randint_lll = _cast3 Unmanaged.randint_lll
 
 randint_lllGo
   :: Int64
@@ -557,7 +557,7 @@ randint_lllGo
   -> ForeignPtr Generator
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-randint_lllGo = cast5 Unmanaged.randint_lllGo
+randint_lllGo = _cast5 Unmanaged.randint_lllGo
 
 randint_lllG
   :: Int64
@@ -565,14 +565,14 @@ randint_lllG
   -> ForeignPtr IntArray
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-randint_lllG = cast4 Unmanaged.randint_lllG
+randint_lllG = _cast4 Unmanaged.randint_lllG
 
 randint_out_tll
   :: ForeignPtr Tensor
   -> Int64
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-randint_out_tll = cast3 Unmanaged.randint_out_tll
+randint_out_tll = _cast3 Unmanaged.randint_out_tll
 
 randint_out_tllG
   :: ForeignPtr Tensor
@@ -580,7 +580,7 @@ randint_out_tllG
   -> ForeignPtr IntArray
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-randint_out_tllG = cast4 Unmanaged.randint_out_tllG
+randint_out_tllG = _cast4 Unmanaged.randint_out_tllG
 
 randint_out_tlll
   :: ForeignPtr Tensor
@@ -588,7 +588,7 @@ randint_out_tlll
   -> Int64
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-randint_out_tlll = cast4 Unmanaged.randint_out_tlll
+randint_out_tlll = _cast4 Unmanaged.randint_out_tlll
 
 randint_out_tlllG
   :: ForeignPtr Tensor
@@ -597,7 +597,7 @@ randint_out_tlllG
   -> ForeignPtr IntArray
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-randint_out_tlllG = cast5 Unmanaged.randint_out_tlllG
+randint_out_tlllG = _cast5 Unmanaged.randint_out_tlllG
 
 randint_like_tloM
   :: ForeignPtr Tensor
@@ -605,20 +605,20 @@ randint_like_tloM
   -> ForeignPtr TensorOptions
   -> MemoryFormat
   -> IO (ForeignPtr Tensor)
-randint_like_tloM = cast4 Unmanaged.randint_like_tloM
+randint_like_tloM = _cast4 Unmanaged.randint_like_tloM
 
 randint_like_tlo
   :: ForeignPtr Tensor
   -> Int64
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-randint_like_tlo = cast3 Unmanaged.randint_like_tlo
+randint_like_tlo = _cast3 Unmanaged.randint_like_tlo
 
 randint_like_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-randint_like_tl = cast2 Unmanaged.randint_like_tl
+randint_like_tl = _cast2 Unmanaged.randint_like_tl
 
 randint_like_tlloM
   :: ForeignPtr Tensor
@@ -627,7 +627,7 @@ randint_like_tlloM
   -> ForeignPtr TensorOptions
   -> MemoryFormat
   -> IO (ForeignPtr Tensor)
-randint_like_tlloM = cast5 Unmanaged.randint_like_tlloM
+randint_like_tlloM = _cast5 Unmanaged.randint_like_tlloM
 
 randint_like_tllo
   :: ForeignPtr Tensor
@@ -635,51 +635,51 @@ randint_like_tllo
   -> Int64
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-randint_like_tllo = cast4 Unmanaged.randint_like_tllo
+randint_like_tllo = _cast4 Unmanaged.randint_like_tllo
 
 randint_like_tll
   :: ForeignPtr Tensor
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-randint_like_tll = cast3 Unmanaged.randint_like_tll
+randint_like_tll = _cast3 Unmanaged.randint_like_tll
 
 randn_lo
   :: ForeignPtr IntArray
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-randn_lo = cast2 Unmanaged.randn_lo
+randn_lo = _cast2 Unmanaged.randn_lo
 
 randn_l
   :: ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-randn_l = cast1 Unmanaged.randn_l
+randn_l = _cast1 Unmanaged.randn_l
 
 randn_lGo
   :: ForeignPtr IntArray
   -> ForeignPtr Generator
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-randn_lGo = cast3 Unmanaged.randn_lGo
+randn_lGo = _cast3 Unmanaged.randn_lGo
 
 randn_lG
   :: ForeignPtr IntArray
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-randn_lG = cast2 Unmanaged.randn_lG
+randn_lG = _cast2 Unmanaged.randn_lG
 
 randn_lNo
   :: ForeignPtr IntArray
   -> ForeignPtr DimnameList
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-randn_lNo = cast3 Unmanaged.randn_lNo
+randn_lNo = _cast3 Unmanaged.randn_lNo
 
 randn_lN
   :: ForeignPtr IntArray
   -> ForeignPtr DimnameList
   -> IO (ForeignPtr Tensor)
-randn_lN = cast2 Unmanaged.randn_lN
+randn_lN = _cast2 Unmanaged.randn_lN
 
 randn_lGNo
   :: ForeignPtr IntArray
@@ -687,82 +687,82 @@ randn_lGNo
   -> ForeignPtr DimnameList
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-randn_lGNo = cast4 Unmanaged.randn_lGNo
+randn_lGNo = _cast4 Unmanaged.randn_lGNo
 
 randn_lGN
   :: ForeignPtr IntArray
   -> ForeignPtr Generator
   -> ForeignPtr DimnameList
   -> IO (ForeignPtr Tensor)
-randn_lGN = cast3 Unmanaged.randn_lGN
+randn_lGN = _cast3 Unmanaged.randn_lGN
 
 randn_out_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-randn_out_tl = cast2 Unmanaged.randn_out_tl
+randn_out_tl = _cast2 Unmanaged.randn_out_tl
 
 randn_out_tlG
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-randn_out_tlG = cast3 Unmanaged.randn_out_tlG
+randn_out_tlG = _cast3 Unmanaged.randn_out_tlG
 
 randn_like_toM
   :: ForeignPtr Tensor
   -> ForeignPtr TensorOptions
   -> MemoryFormat
   -> IO (ForeignPtr Tensor)
-randn_like_toM = cast3 Unmanaged.randn_like_toM
+randn_like_toM = _cast3 Unmanaged.randn_like_toM
 
 randn_like_to
   :: ForeignPtr Tensor
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-randn_like_to = cast2 Unmanaged.randn_like_to
+randn_like_to = _cast2 Unmanaged.randn_like_to
 
 randn_like_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-randn_like_t = cast1 Unmanaged.randn_like_t
+randn_like_t = _cast1 Unmanaged.randn_like_t
 
 randperm_lo
   :: Int64
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-randperm_lo = cast2 Unmanaged.randperm_lo
+randperm_lo = _cast2 Unmanaged.randperm_lo
 
 randperm_l
   :: Int64
   -> IO (ForeignPtr Tensor)
-randperm_l = cast1 Unmanaged.randperm_l
+randperm_l = _cast1 Unmanaged.randperm_l
 
 randperm_lGo
   :: Int64
   -> ForeignPtr Generator
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-randperm_lGo = cast3 Unmanaged.randperm_lGo
+randperm_lGo = _cast3 Unmanaged.randperm_lGo
 
 randperm_lG
   :: Int64
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-randperm_lG = cast2 Unmanaged.randperm_lG
+randperm_lG = _cast2 Unmanaged.randperm_lG
 
 randperm_out_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-randperm_out_tl = cast2 Unmanaged.randperm_out_tl
+randperm_out_tl = _cast2 Unmanaged.randperm_out_tl
 
 randperm_out_tlG
   :: ForeignPtr Tensor
   -> Int64
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-randperm_out_tlG = cast3 Unmanaged.randperm_out_tlG
+randperm_out_tlG = _cast3 Unmanaged.randperm_out_tlG
 
 range_ssso
   :: ForeignPtr Scalar
@@ -770,14 +770,14 @@ range_ssso
   -> ForeignPtr Scalar
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-range_ssso = cast4 Unmanaged.range_ssso
+range_ssso = _cast4 Unmanaged.range_ssso
 
 range_sss
   :: ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-range_sss = cast3 Unmanaged.range_sss
+range_sss = _cast3 Unmanaged.range_sss
 
 range_out_tsss
   :: ForeignPtr Tensor
@@ -785,78 +785,78 @@ range_out_tsss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-range_out_tsss = cast4 Unmanaged.range_out_tsss
+range_out_tsss = _cast4 Unmanaged.range_out_tsss
 
 range_out_tss
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-range_out_tss = cast3 Unmanaged.range_out_tss
+range_out_tss = _cast3 Unmanaged.range_out_tss
 
 ravel_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-ravel_t = cast1 Unmanaged.ravel_t
+ravel_t = _cast1 Unmanaged.ravel_t
 
 reciprocal_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-reciprocal_t = cast1 Unmanaged.reciprocal_t
+reciprocal_t = _cast1 Unmanaged.reciprocal_t
 
 reciprocal__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-reciprocal__t = cast1 Unmanaged.reciprocal__t
+reciprocal__t = _cast1 Unmanaged.reciprocal__t
 
 reciprocal_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-reciprocal_out_tt = cast2 Unmanaged.reciprocal_out_tt
+reciprocal_out_tt = _cast2 Unmanaged.reciprocal_out_tt
 
 neg_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-neg_t = cast1 Unmanaged.neg_t
+neg_t = _cast1 Unmanaged.neg_t
 
 neg__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-neg__t = cast1 Unmanaged.neg__t
+neg__t = _cast1 Unmanaged.neg__t
 
 neg_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-neg_out_tt = cast2 Unmanaged.neg_out_tt
+neg_out_tt = _cast2 Unmanaged.neg_out_tt
 
 negative_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-negative_t = cast1 Unmanaged.negative_t
+negative_t = _cast1 Unmanaged.negative_t
 
 negative__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-negative__t = cast1 Unmanaged.negative__t
+negative__t = _cast1 Unmanaged.negative__t
 
 negative_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-negative_out_tt = cast2 Unmanaged.negative_out_tt
+negative_out_tt = _cast2 Unmanaged.negative_out_tt
 
 repeat_interleave_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-repeat_interleave_tl = cast2 Unmanaged.repeat_interleave_tl
+repeat_interleave_tl = _cast2 Unmanaged.repeat_interleave_tl
 
 repeat_interleave_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-repeat_interleave_t = cast1 Unmanaged.repeat_interleave_t
+repeat_interleave_t = _cast1 Unmanaged.repeat_interleave_t
 
 repeat_interleave_ttll
   :: ForeignPtr Tensor
@@ -864,20 +864,20 @@ repeat_interleave_ttll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-repeat_interleave_ttll = cast4 Unmanaged.repeat_interleave_ttll
+repeat_interleave_ttll = _cast4 Unmanaged.repeat_interleave_ttll
 
 repeat_interleave_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-repeat_interleave_ttl = cast3 Unmanaged.repeat_interleave_ttl
+repeat_interleave_ttl = _cast3 Unmanaged.repeat_interleave_ttl
 
 repeat_interleave_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-repeat_interleave_tt = cast2 Unmanaged.repeat_interleave_tt
+repeat_interleave_tt = _cast2 Unmanaged.repeat_interleave_tt
 
 repeat_interleave_tlll
   :: ForeignPtr Tensor
@@ -885,68 +885,68 @@ repeat_interleave_tlll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-repeat_interleave_tlll = cast4 Unmanaged.repeat_interleave_tlll
+repeat_interleave_tlll = _cast4 Unmanaged.repeat_interleave_tlll
 
 repeat_interleave_tll
   :: ForeignPtr Tensor
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-repeat_interleave_tll = cast3 Unmanaged.repeat_interleave_tll
+repeat_interleave_tll = _cast3 Unmanaged.repeat_interleave_tll
 
 reshape_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-reshape_tl = cast2 Unmanaged.reshape_tl
+reshape_tl = _cast2 Unmanaged.reshape_tl
 
 _reshape_alias_tll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-_reshape_alias_tll = cast3 Unmanaged._reshape_alias_tll
+_reshape_alias_tll = _cast3 Unmanaged._reshape_alias_tll
 
 _mkldnn_reshape_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-_mkldnn_reshape_tl = cast2 Unmanaged._mkldnn_reshape_tl
+_mkldnn_reshape_tl = _cast2 Unmanaged._mkldnn_reshape_tl
 
 round_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-round_t = cast1 Unmanaged.round_t
+round_t = _cast1 Unmanaged.round_t
 
 round__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-round__t = cast1 Unmanaged.round__t
+round__t = _cast1 Unmanaged.round__t
 
 round_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-round_out_tt = cast2 Unmanaged.round_out_tt
+round_out_tt = _cast2 Unmanaged.round_out_tt
 
 round_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-round_tl = cast2 Unmanaged.round_tl
+round_tl = _cast2 Unmanaged.round_tl
 
 round__tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-round__tl = cast2 Unmanaged.round__tl
+round__tl = _cast2 Unmanaged.round__tl
 
 round_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-round_out_ttl = cast3 Unmanaged.round_out_ttl
+round_out_ttl = _cast3 Unmanaged.round_out_ttl
 
 rrelu_tssbG
   :: ForeignPtr Tensor
@@ -955,7 +955,7 @@ rrelu_tssbG
   -> CBool
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-rrelu_tssbG = cast5 Unmanaged.rrelu_tssbG
+rrelu_tssbG = _cast5 Unmanaged.rrelu_tssbG
 
 rrelu_tssb
   :: ForeignPtr Tensor
@@ -963,25 +963,25 @@ rrelu_tssb
   -> ForeignPtr Scalar
   -> CBool
   -> IO (ForeignPtr Tensor)
-rrelu_tssb = cast4 Unmanaged.rrelu_tssb
+rrelu_tssb = _cast4 Unmanaged.rrelu_tssb
 
 rrelu_tss
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-rrelu_tss = cast3 Unmanaged.rrelu_tss
+rrelu_tss = _cast3 Unmanaged.rrelu_tss
 
 rrelu_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-rrelu_ts = cast2 Unmanaged.rrelu_ts
+rrelu_ts = _cast2 Unmanaged.rrelu_ts
 
 rrelu_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-rrelu_t = cast1 Unmanaged.rrelu_t
+rrelu_t = _cast1 Unmanaged.rrelu_t
 
 rrelu__tssbG
   :: ForeignPtr Tensor
@@ -990,7 +990,7 @@ rrelu__tssbG
   -> CBool
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-rrelu__tssbG = cast5 Unmanaged.rrelu__tssbG
+rrelu__tssbG = _cast5 Unmanaged.rrelu__tssbG
 
 rrelu__tssb
   :: ForeignPtr Tensor
@@ -998,112 +998,112 @@ rrelu__tssb
   -> ForeignPtr Scalar
   -> CBool
   -> IO (ForeignPtr Tensor)
-rrelu__tssb = cast4 Unmanaged.rrelu__tssb
+rrelu__tssb = _cast4 Unmanaged.rrelu__tssb
 
 rrelu__tss
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-rrelu__tss = cast3 Unmanaged.rrelu__tss
+rrelu__tss = _cast3 Unmanaged.rrelu__tss
 
 rrelu__ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-rrelu__ts = cast2 Unmanaged.rrelu__ts
+rrelu__ts = _cast2 Unmanaged.rrelu__ts
 
 rrelu__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-rrelu__t = cast1 Unmanaged.rrelu__t
+rrelu__t = _cast1 Unmanaged.rrelu__t
 
 relu_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-relu_t = cast1 Unmanaged.relu_t
+relu_t = _cast1 Unmanaged.relu_t
 
 relu__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-relu__t = cast1 Unmanaged.relu__t
+relu__t = _cast1 Unmanaged.relu__t
 
 relu6_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-relu6_t = cast1 Unmanaged.relu6_t
+relu6_t = _cast1 Unmanaged.relu6_t
 
 relu6__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-relu6__t = cast1 Unmanaged.relu6__t
+relu6__t = _cast1 Unmanaged.relu6__t
 
 prelu_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-prelu_tt = cast2 Unmanaged.prelu_tt
+prelu_tt = _cast2 Unmanaged.prelu_tt
 
 prelu_backward_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-prelu_backward_ttt = cast3 Unmanaged.prelu_backward_ttt
+prelu_backward_ttt = _cast3 Unmanaged.prelu_backward_ttt
 
 gelu_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-gelu_out_tt = cast2 Unmanaged.gelu_out_tt
+gelu_out_tt = _cast2 Unmanaged.gelu_out_tt
 
 gelu_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-gelu_t = cast1 Unmanaged.gelu_t
+gelu_t = _cast1 Unmanaged.gelu_t
 
 gelu_backward_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-gelu_backward_out_ttt = cast3 Unmanaged.gelu_backward_out_ttt
+gelu_backward_out_ttt = _cast3 Unmanaged.gelu_backward_out_ttt
 
 gelu_backward_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-gelu_backward_tt = cast2 Unmanaged.gelu_backward_tt
+gelu_backward_tt = _cast2 Unmanaged.gelu_backward_tt
 
 infinitely_differentiable_gelu_backward_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-infinitely_differentiable_gelu_backward_tt = cast2 Unmanaged.infinitely_differentiable_gelu_backward_tt
+infinitely_differentiable_gelu_backward_tt = _cast2 Unmanaged.infinitely_differentiable_gelu_backward_tt
 
 hardshrink_out_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-hardshrink_out_tts = cast3 Unmanaged.hardshrink_out_tts
+hardshrink_out_tts = _cast3 Unmanaged.hardshrink_out_tts
 
 hardshrink_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-hardshrink_out_tt = cast2 Unmanaged.hardshrink_out_tt
+hardshrink_out_tt = _cast2 Unmanaged.hardshrink_out_tt
 
 hardshrink_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-hardshrink_ts = cast2 Unmanaged.hardshrink_ts
+hardshrink_ts = _cast2 Unmanaged.hardshrink_ts
 
 hardshrink_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-hardshrink_t = cast1 Unmanaged.hardshrink_t
+hardshrink_t = _cast1 Unmanaged.hardshrink_t
 
 hardshrink_backward_out_ttts
   :: ForeignPtr Tensor
@@ -1111,44 +1111,44 @@ hardshrink_backward_out_ttts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-hardshrink_backward_out_ttts = cast4 Unmanaged.hardshrink_backward_out_ttts
+hardshrink_backward_out_ttts = _cast4 Unmanaged.hardshrink_backward_out_ttts
 
 hardshrink_backward_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-hardshrink_backward_tts = cast3 Unmanaged.hardshrink_backward_tts
+hardshrink_backward_tts = _cast3 Unmanaged.hardshrink_backward_tts
 
 rsqrt_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-rsqrt_t = cast1 Unmanaged.rsqrt_t
+rsqrt_t = _cast1 Unmanaged.rsqrt_t
 
 rsqrt__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-rsqrt__t = cast1 Unmanaged.rsqrt__t
+rsqrt__t = _cast1 Unmanaged.rsqrt__t
 
 rsqrt_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-rsqrt_out_tt = cast2 Unmanaged.rsqrt_out_tt
+rsqrt_out_tt = _cast2 Unmanaged.rsqrt_out_tt
 
 select_tnl
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> Int64
   -> IO (ForeignPtr Tensor)
-select_tnl = cast3 Unmanaged.select_tnl
+select_tnl = _cast3 Unmanaged.select_tnl
 
 select_tll
   :: ForeignPtr Tensor
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-select_tll = cast3 Unmanaged.select_tll
+select_tll = _cast3 Unmanaged.select_tll
 
 select_backward_tlll
   :: ForeignPtr Tensor
@@ -1156,209 +1156,209 @@ select_backward_tlll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-select_backward_tlll = cast4 Unmanaged.select_backward_tlll
+select_backward_tlll = _cast4 Unmanaged.select_backward_tlll
 
 selu_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-selu_t = cast1 Unmanaged.selu_t
+selu_t = _cast1 Unmanaged.selu_t
 
 selu__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-selu__t = cast1 Unmanaged.selu__t
+selu__t = _cast1 Unmanaged.selu__t
 
 celu_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-celu_ts = cast2 Unmanaged.celu_ts
+celu_ts = _cast2 Unmanaged.celu_ts
 
 celu_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-celu_t = cast1 Unmanaged.celu_t
+celu_t = _cast1 Unmanaged.celu_t
 
 celu__ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-celu__ts = cast2 Unmanaged.celu__ts
+celu__ts = _cast2 Unmanaged.celu__ts
 
 celu__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-celu__t = cast1 Unmanaged.celu__t
+celu__t = _cast1 Unmanaged.celu__t
 
 silu_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-silu_t = cast1 Unmanaged.silu_t
+silu_t = _cast1 Unmanaged.silu_t
 
 silu__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-silu__t = cast1 Unmanaged.silu__t
+silu__t = _cast1 Unmanaged.silu__t
 
 silu_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-silu_out_tt = cast2 Unmanaged.silu_out_tt
+silu_out_tt = _cast2 Unmanaged.silu_out_tt
 
 silu_backward_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-silu_backward_out_ttt = cast3 Unmanaged.silu_backward_out_ttt
+silu_backward_out_ttt = _cast3 Unmanaged.silu_backward_out_ttt
 
 silu_backward_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-silu_backward_tt = cast2 Unmanaged.silu_backward_tt
+silu_backward_tt = _cast2 Unmanaged.silu_backward_tt
 
 mish_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-mish_t = cast1 Unmanaged.mish_t
+mish_t = _cast1 Unmanaged.mish_t
 
 mish__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-mish__t = cast1 Unmanaged.mish__t
+mish__t = _cast1 Unmanaged.mish__t
 
 mish_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-mish_out_tt = cast2 Unmanaged.mish_out_tt
+mish_out_tt = _cast2 Unmanaged.mish_out_tt
 
 mish_backward_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-mish_backward_tt = cast2 Unmanaged.mish_backward_tt
+mish_backward_tt = _cast2 Unmanaged.mish_backward_tt
 
 sigmoid_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-sigmoid_t = cast1 Unmanaged.sigmoid_t
+sigmoid_t = _cast1 Unmanaged.sigmoid_t
 
 sigmoid__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-sigmoid__t = cast1 Unmanaged.sigmoid__t
+sigmoid__t = _cast1 Unmanaged.sigmoid__t
 
 sigmoid_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-sigmoid_out_tt = cast2 Unmanaged.sigmoid_out_tt
+sigmoid_out_tt = _cast2 Unmanaged.sigmoid_out_tt
 
 logit_td
   :: ForeignPtr Tensor
   -> CDouble
   -> IO (ForeignPtr Tensor)
-logit_td = cast2 Unmanaged.logit_td
+logit_td = _cast2 Unmanaged.logit_td
 
 logit_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-logit_t = cast1 Unmanaged.logit_t
+logit_t = _cast1 Unmanaged.logit_t
 
 logit__td
   :: ForeignPtr Tensor
   -> CDouble
   -> IO (ForeignPtr Tensor)
-logit__td = cast2 Unmanaged.logit__td
+logit__td = _cast2 Unmanaged.logit__td
 
 logit__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-logit__t = cast1 Unmanaged.logit__t
+logit__t = _cast1 Unmanaged.logit__t
 
 logit_out_ttd
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> CDouble
   -> IO (ForeignPtr Tensor)
-logit_out_ttd = cast3 Unmanaged.logit_out_ttd
+logit_out_ttd = _cast3 Unmanaged.logit_out_ttd
 
 logit_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-logit_out_tt = cast2 Unmanaged.logit_out_tt
+logit_out_tt = _cast2 Unmanaged.logit_out_tt
 
 sin_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-sin_t = cast1 Unmanaged.sin_t
+sin_t = _cast1 Unmanaged.sin_t
 
 sin__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-sin__t = cast1 Unmanaged.sin__t
+sin__t = _cast1 Unmanaged.sin__t
 
 sin_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-sin_out_tt = cast2 Unmanaged.sin_out_tt
+sin_out_tt = _cast2 Unmanaged.sin_out_tt
 
 sinc_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-sinc_t = cast1 Unmanaged.sinc_t
+sinc_t = _cast1 Unmanaged.sinc_t
 
 sinc__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-sinc__t = cast1 Unmanaged.sinc__t
+sinc__t = _cast1 Unmanaged.sinc__t
 
 sinc_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-sinc_out_tt = cast2 Unmanaged.sinc_out_tt
+sinc_out_tt = _cast2 Unmanaged.sinc_out_tt
 
 sinh_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-sinh_t = cast1 Unmanaged.sinh_t
+sinh_t = _cast1 Unmanaged.sinh_t
 
 sinh__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-sinh__t = cast1 Unmanaged.sinh__t
+sinh__t = _cast1 Unmanaged.sinh__t
 
 sinh_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-sinh_out_tt = cast2 Unmanaged.sinh_out_tt
+sinh_out_tt = _cast2 Unmanaged.sinh_out_tt
 
 detach_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-detach_t = cast1 Unmanaged.detach_t
+detach_t = _cast1 Unmanaged.detach_t
 
 detach__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-detach__t = cast1 Unmanaged.detach__t
+detach__t = _cast1 Unmanaged.detach__t
 
 size_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (Int64)
-size_tl = cast2 Unmanaged.size_tl
+size_tl = _cast2 Unmanaged.size_tl
 
 size_tn
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> IO (Int64)
-size_tn = cast2 Unmanaged.size_tn
+size_tn = _cast2 Unmanaged.size_tn
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Native/Native6.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Native/Native6.hs
@@ -28,7 +28,7 @@ slice_tllll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-slice_tllll = cast5 Unmanaged.slice_tllll
+slice_tllll = _cast5 Unmanaged.slice_tllll
 
 slice_tlll
   :: ForeignPtr Tensor
@@ -36,25 +36,25 @@ slice_tlll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-slice_tlll = cast4 Unmanaged.slice_tlll
+slice_tlll = _cast4 Unmanaged.slice_tlll
 
 slice_tll
   :: ForeignPtr Tensor
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-slice_tll = cast3 Unmanaged.slice_tll
+slice_tll = _cast3 Unmanaged.slice_tll
 
 slice_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-slice_tl = cast2 Unmanaged.slice_tl
+slice_tl = _cast2 Unmanaged.slice_tl
 
 slice_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-slice_t = cast1 Unmanaged.slice_t
+slice_t = _cast1 Unmanaged.slice_t
 
 slice_backward_tlllll
   :: ForeignPtr Tensor
@@ -64,7 +64,7 @@ slice_backward_tlllll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-slice_backward_tlllll = cast6 Unmanaged.slice_backward_tlllll
+slice_backward_tlllll = _cast6 Unmanaged.slice_backward_tlllll
 
 slice_scatter_ttllll
   :: ForeignPtr Tensor
@@ -74,7 +74,7 @@ slice_scatter_ttllll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-slice_scatter_ttllll = cast6 Unmanaged.slice_scatter_ttllll
+slice_scatter_ttllll = _cast6 Unmanaged.slice_scatter_ttllll
 
 slice_scatter_ttlll
   :: ForeignPtr Tensor
@@ -83,7 +83,7 @@ slice_scatter_ttlll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-slice_scatter_ttlll = cast5 Unmanaged.slice_scatter_ttlll
+slice_scatter_ttlll = _cast5 Unmanaged.slice_scatter_ttlll
 
 slice_scatter_ttll
   :: ForeignPtr Tensor
@@ -91,20 +91,20 @@ slice_scatter_ttll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-slice_scatter_ttll = cast4 Unmanaged.slice_scatter_ttll
+slice_scatter_ttll = _cast4 Unmanaged.slice_scatter_ttll
 
 slice_scatter_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-slice_scatter_ttl = cast3 Unmanaged.slice_scatter_ttl
+slice_scatter_ttl = _cast3 Unmanaged.slice_scatter_ttl
 
 slice_scatter_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-slice_scatter_tt = cast2 Unmanaged.slice_scatter_tt
+slice_scatter_tt = _cast2 Unmanaged.slice_scatter_tt
 
 select_scatter_ttll
   :: ForeignPtr Tensor
@@ -112,7 +112,7 @@ select_scatter_ttll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-select_scatter_ttll = cast4 Unmanaged.select_scatter_ttll
+select_scatter_ttll = _cast4 Unmanaged.select_scatter_ttll
 
 diagonal_scatter_ttlll
   :: ForeignPtr Tensor
@@ -121,7 +121,7 @@ diagonal_scatter_ttlll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-diagonal_scatter_ttlll = cast5 Unmanaged.diagonal_scatter_ttlll
+diagonal_scatter_ttlll = _cast5 Unmanaged.diagonal_scatter_ttlll
 
 diagonal_scatter_ttll
   :: ForeignPtr Tensor
@@ -129,64 +129,64 @@ diagonal_scatter_ttll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-diagonal_scatter_ttll = cast4 Unmanaged.diagonal_scatter_ttll
+diagonal_scatter_ttll = _cast4 Unmanaged.diagonal_scatter_ttll
 
 diagonal_scatter_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-diagonal_scatter_ttl = cast3 Unmanaged.diagonal_scatter_ttl
+diagonal_scatter_ttl = _cast3 Unmanaged.diagonal_scatter_ttl
 
 diagonal_scatter_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-diagonal_scatter_tt = cast2 Unmanaged.diagonal_scatter_tt
+diagonal_scatter_tt = _cast2 Unmanaged.diagonal_scatter_tt
 
 slogdet_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-slogdet_t = cast1 Unmanaged.slogdet_t
+slogdet_t = _cast1 Unmanaged.slogdet_t
 
 smm_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-smm_tt = cast2 Unmanaged.smm_tt
+smm_tt = _cast2 Unmanaged.smm_tt
 
 softmax_tls
   :: ForeignPtr Tensor
   -> Int64
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-softmax_tls = cast3 Unmanaged.softmax_tls
+softmax_tls = _cast3 Unmanaged.softmax_tls
 
 softmax_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-softmax_tl = cast2 Unmanaged.softmax_tl
+softmax_tl = _cast2 Unmanaged.softmax_tl
 
 softmax_tns
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-softmax_tns = cast3 Unmanaged.softmax_tns
+softmax_tns = _cast3 Unmanaged.softmax_tns
 
 softmax_tn
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> IO (ForeignPtr Tensor)
-softmax_tn = cast2 Unmanaged.softmax_tn
+softmax_tn = _cast2 Unmanaged.softmax_tn
 
 _softmax_tlb
   :: ForeignPtr Tensor
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-_softmax_tlb = cast3 Unmanaged._softmax_tlb
+_softmax_tlb = _cast3 Unmanaged._softmax_tlb
 
 _softmax_out_ttlb
   :: ForeignPtr Tensor
@@ -194,7 +194,7 @@ _softmax_out_ttlb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-_softmax_out_ttlb = cast4 Unmanaged._softmax_out_ttlb
+_softmax_out_ttlb = _cast4 Unmanaged._softmax_out_ttlb
 
 _softmax_backward_data_ttls
   :: ForeignPtr Tensor
@@ -202,7 +202,7 @@ _softmax_backward_data_ttls
   -> Int64
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-_softmax_backward_data_ttls = cast4 Unmanaged._softmax_backward_data_ttls
+_softmax_backward_data_ttls = _cast4 Unmanaged._softmax_backward_data_ttls
 
 _softmax_backward_data_out_tttls
   :: ForeignPtr Tensor
@@ -211,94 +211,94 @@ _softmax_backward_data_out_tttls
   -> Int64
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-_softmax_backward_data_out_tttls = cast5 Unmanaged._softmax_backward_data_out_tttls
+_softmax_backward_data_out_tttls = _cast5 Unmanaged._softmax_backward_data_out_tttls
 
 unsafe_split_tll
   :: ForeignPtr Tensor
   -> Int64
   -> Int64
   -> IO (ForeignPtr TensorList)
-unsafe_split_tll = cast3 Unmanaged.unsafe_split_tll
+unsafe_split_tll = _cast3 Unmanaged.unsafe_split_tll
 
 unsafe_split_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr TensorList)
-unsafe_split_tl = cast2 Unmanaged.unsafe_split_tl
+unsafe_split_tl = _cast2 Unmanaged.unsafe_split_tl
 
 split_tll
   :: ForeignPtr Tensor
   -> Int64
   -> Int64
   -> IO (ForeignPtr TensorList)
-split_tll = cast3 Unmanaged.split_tll
+split_tll = _cast3 Unmanaged.split_tll
 
 split_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr TensorList)
-split_tl = cast2 Unmanaged.split_tl
+split_tl = _cast2 Unmanaged.split_tl
 
 unsafe_split_with_sizes_tll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> Int64
   -> IO (ForeignPtr TensorList)
-unsafe_split_with_sizes_tll = cast3 Unmanaged.unsafe_split_with_sizes_tll
+unsafe_split_with_sizes_tll = _cast3 Unmanaged.unsafe_split_with_sizes_tll
 
 unsafe_split_with_sizes_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr TensorList)
-unsafe_split_with_sizes_tl = cast2 Unmanaged.unsafe_split_with_sizes_tl
+unsafe_split_with_sizes_tl = _cast2 Unmanaged.unsafe_split_with_sizes_tl
 
 split_with_sizes_tll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> Int64
   -> IO (ForeignPtr TensorList)
-split_with_sizes_tll = cast3 Unmanaged.split_with_sizes_tll
+split_with_sizes_tll = _cast3 Unmanaged.split_with_sizes_tll
 
 split_with_sizes_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr TensorList)
-split_with_sizes_tl = cast2 Unmanaged.split_with_sizes_tl
+split_with_sizes_tl = _cast2 Unmanaged.split_with_sizes_tl
 
 hsplit_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr TensorList)
-hsplit_tl = cast2 Unmanaged.hsplit_tl
+hsplit_tl = _cast2 Unmanaged.hsplit_tl
 
 vsplit_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr TensorList)
-vsplit_tl = cast2 Unmanaged.vsplit_tl
+vsplit_tl = _cast2 Unmanaged.vsplit_tl
 
 dsplit_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr TensorList)
-dsplit_tl = cast2 Unmanaged.dsplit_tl
+dsplit_tl = _cast2 Unmanaged.dsplit_tl
 
 squeeze_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-squeeze_t = cast1 Unmanaged.squeeze_t
+squeeze_t = _cast1 Unmanaged.squeeze_t
 
 squeeze_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-squeeze_tl = cast2 Unmanaged.squeeze_tl
+squeeze_tl = _cast2 Unmanaged.squeeze_tl
 
 squeeze_tn
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> IO (ForeignPtr Tensor)
-squeeze_tn = cast2 Unmanaged.squeeze_tn
+squeeze_tn = _cast2 Unmanaged.squeeze_tn
 
 sspaddmm_tttss
   :: ForeignPtr Tensor
@@ -307,7 +307,7 @@ sspaddmm_tttss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-sspaddmm_tttss = cast5 Unmanaged.sspaddmm_tttss
+sspaddmm_tttss = _cast5 Unmanaged.sspaddmm_tttss
 
 sspaddmm_ttts
   :: ForeignPtr Tensor
@@ -315,14 +315,14 @@ sspaddmm_ttts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-sspaddmm_ttts = cast4 Unmanaged.sspaddmm_ttts
+sspaddmm_ttts = _cast4 Unmanaged.sspaddmm_ttts
 
 sspaddmm_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-sspaddmm_ttt = cast3 Unmanaged.sspaddmm_ttt
+sspaddmm_ttt = _cast3 Unmanaged.sspaddmm_ttt
 
 sspaddmm_out_ttttss
   :: ForeignPtr Tensor
@@ -332,7 +332,7 @@ sspaddmm_out_ttttss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-sspaddmm_out_ttttss = cast6 Unmanaged.sspaddmm_out_ttttss
+sspaddmm_out_ttttss = _cast6 Unmanaged.sspaddmm_out_ttttss
 
 sspaddmm_out_tttts
   :: ForeignPtr Tensor
@@ -341,7 +341,7 @@ sspaddmm_out_tttts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-sspaddmm_out_tttts = cast5 Unmanaged.sspaddmm_out_tttts
+sspaddmm_out_tttts = _cast5 Unmanaged.sspaddmm_out_tttts
 
 sspaddmm_out_tttt
   :: ForeignPtr Tensor
@@ -349,88 +349,88 @@ sspaddmm_out_tttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-sspaddmm_out_tttt = cast4 Unmanaged.sspaddmm_out_tttt
+sspaddmm_out_tttt = _cast4 Unmanaged.sspaddmm_out_tttt
 
 stack_ll
   :: ForeignPtr TensorList
   -> Int64
   -> IO (ForeignPtr Tensor)
-stack_ll = cast2 Unmanaged.stack_ll
+stack_ll = _cast2 Unmanaged.stack_ll
 
 stack_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr Tensor)
-stack_l = cast1 Unmanaged.stack_l
+stack_l = _cast1 Unmanaged.stack_l
 
 stack_out_tll
   :: ForeignPtr Tensor
   -> ForeignPtr TensorList
   -> Int64
   -> IO (ForeignPtr Tensor)
-stack_out_tll = cast3 Unmanaged.stack_out_tll
+stack_out_tll = _cast3 Unmanaged.stack_out_tll
 
 stack_out_tl
   :: ForeignPtr Tensor
   -> ForeignPtr TensorList
   -> IO (ForeignPtr Tensor)
-stack_out_tl = cast2 Unmanaged.stack_out_tl
+stack_out_tl = _cast2 Unmanaged.stack_out_tl
 
 _stack_ll
   :: ForeignPtr TensorList
   -> Int64
   -> IO (ForeignPtr Tensor)
-_stack_ll = cast2 Unmanaged._stack_ll
+_stack_ll = _cast2 Unmanaged._stack_ll
 
 _stack_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr Tensor)
-_stack_l = cast1 Unmanaged._stack_l
+_stack_l = _cast1 Unmanaged._stack_l
 
 _stack_out_tll
   :: ForeignPtr Tensor
   -> ForeignPtr TensorList
   -> Int64
   -> IO (ForeignPtr Tensor)
-_stack_out_tll = cast3 Unmanaged._stack_out_tll
+_stack_out_tll = _cast3 Unmanaged._stack_out_tll
 
 _stack_out_tl
   :: ForeignPtr Tensor
   -> ForeignPtr TensorList
   -> IO (ForeignPtr Tensor)
-_stack_out_tl = cast2 Unmanaged._stack_out_tl
+_stack_out_tl = _cast2 Unmanaged._stack_out_tl
 
 hstack_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr Tensor)
-hstack_l = cast1 Unmanaged.hstack_l
+hstack_l = _cast1 Unmanaged.hstack_l
 
 hstack_out_tl
   :: ForeignPtr Tensor
   -> ForeignPtr TensorList
   -> IO (ForeignPtr Tensor)
-hstack_out_tl = cast2 Unmanaged.hstack_out_tl
+hstack_out_tl = _cast2 Unmanaged.hstack_out_tl
 
 vstack_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr Tensor)
-vstack_l = cast1 Unmanaged.vstack_l
+vstack_l = _cast1 Unmanaged.vstack_l
 
 vstack_out_tl
   :: ForeignPtr Tensor
   -> ForeignPtr TensorList
   -> IO (ForeignPtr Tensor)
-vstack_out_tl = cast2 Unmanaged.vstack_out_tl
+vstack_out_tl = _cast2 Unmanaged.vstack_out_tl
 
 dstack_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr Tensor)
-dstack_l = cast1 Unmanaged.dstack_l
+dstack_l = _cast1 Unmanaged.dstack_l
 
 dstack_out_tl
   :: ForeignPtr Tensor
   -> ForeignPtr TensorList
   -> IO (ForeignPtr Tensor)
-dstack_out_tl = cast2 Unmanaged.dstack_out_tl
+dstack_out_tl = _cast2 Unmanaged.dstack_out_tl
 
 stft_tllltbbb
   :: ForeignPtr Tensor
@@ -442,7 +442,7 @@ stft_tllltbbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-stft_tllltbbb = cast8 Unmanaged.stft_tllltbbb
+stft_tllltbbb = _cast8 Unmanaged.stft_tllltbbb
 
 stft_tllltbb
   :: ForeignPtr Tensor
@@ -453,7 +453,7 @@ stft_tllltbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-stft_tllltbb = cast7 Unmanaged.stft_tllltbb
+stft_tllltbb = _cast7 Unmanaged.stft_tllltbb
 
 stft_tllltb
   :: ForeignPtr Tensor
@@ -463,7 +463,7 @@ stft_tllltb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-stft_tllltb = cast6 Unmanaged.stft_tllltb
+stft_tllltb = _cast6 Unmanaged.stft_tllltb
 
 stft_tlllt
   :: ForeignPtr Tensor
@@ -472,7 +472,7 @@ stft_tlllt
   -> Int64
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-stft_tlllt = cast5 Unmanaged.stft_tlllt
+stft_tlllt = _cast5 Unmanaged.stft_tlllt
 
 stft_tlll
   :: ForeignPtr Tensor
@@ -480,20 +480,20 @@ stft_tlll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-stft_tlll = cast4 Unmanaged.stft_tlll
+stft_tlll = _cast4 Unmanaged.stft_tlll
 
 stft_tll
   :: ForeignPtr Tensor
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-stft_tll = cast3 Unmanaged.stft_tll
+stft_tll = _cast3 Unmanaged.stft_tll
 
 stft_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-stft_tl = cast2 Unmanaged.stft_tl
+stft_tl = _cast2 Unmanaged.stft_tl
 
 istft_tllltbbblb
   :: ForeignPtr Tensor
@@ -507,7 +507,7 @@ istft_tllltbbblb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-istft_tllltbbblb = cast10 Unmanaged.istft_tllltbbblb
+istft_tllltbbblb = _cast10 Unmanaged.istft_tllltbbblb
 
 istft_tllltbbbl
   :: ForeignPtr Tensor
@@ -520,7 +520,7 @@ istft_tllltbbbl
   -> CBool
   -> Int64
   -> IO (ForeignPtr Tensor)
-istft_tllltbbbl = cast9 Unmanaged.istft_tllltbbbl
+istft_tllltbbbl = _cast9 Unmanaged.istft_tllltbbbl
 
 istft_tllltbbb
   :: ForeignPtr Tensor
@@ -532,7 +532,7 @@ istft_tllltbbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-istft_tllltbbb = cast8 Unmanaged.istft_tllltbbb
+istft_tllltbbb = _cast8 Unmanaged.istft_tllltbbb
 
 istft_tllltbb
   :: ForeignPtr Tensor
@@ -543,7 +543,7 @@ istft_tllltbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-istft_tllltbb = cast7 Unmanaged.istft_tllltbb
+istft_tllltbb = _cast7 Unmanaged.istft_tllltbb
 
 istft_tllltb
   :: ForeignPtr Tensor
@@ -553,7 +553,7 @@ istft_tllltb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-istft_tllltb = cast6 Unmanaged.istft_tllltb
+istft_tllltb = _cast6 Unmanaged.istft_tllltb
 
 istft_tlllt
   :: ForeignPtr Tensor
@@ -562,7 +562,7 @@ istft_tlllt
   -> Int64
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-istft_tlllt = cast5 Unmanaged.istft_tlllt
+istft_tlllt = _cast5 Unmanaged.istft_tlllt
 
 istft_tlll
   :: ForeignPtr Tensor
@@ -570,43 +570,43 @@ istft_tlll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-istft_tlll = cast4 Unmanaged.istft_tlll
+istft_tlll = _cast4 Unmanaged.istft_tlll
 
 istft_tll
   :: ForeignPtr Tensor
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-istft_tll = cast3 Unmanaged.istft_tll
+istft_tll = _cast3 Unmanaged.istft_tll
 
 istft_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-istft_tl = cast2 Unmanaged.istft_tl
+istft_tl = _cast2 Unmanaged.istft_tl
 
 stride_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (Int64)
-stride_tl = cast2 Unmanaged.stride_tl
+stride_tl = _cast2 Unmanaged.stride_tl
 
 stride_tn
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> IO (Int64)
-stride_tn = cast2 Unmanaged.stride_tn
+stride_tn = _cast2 Unmanaged.stride_tn
 
 sum_ts
   :: ForeignPtr Tensor
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-sum_ts = cast2 Unmanaged.sum_ts
+sum_ts = _cast2 Unmanaged.sum_ts
 
 sum_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-sum_t = cast1 Unmanaged.sum_t
+sum_t = _cast1 Unmanaged.sum_t
 
 sum_tlbs
   :: ForeignPtr Tensor
@@ -614,20 +614,20 @@ sum_tlbs
   -> CBool
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-sum_tlbs = cast4 Unmanaged.sum_tlbs
+sum_tlbs = _cast4 Unmanaged.sum_tlbs
 
 sum_tlb
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-sum_tlb = cast3 Unmanaged.sum_tlb
+sum_tlb = _cast3 Unmanaged.sum_tlb
 
 sum_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-sum_tl = cast2 Unmanaged.sum_tl
+sum_tl = _cast2 Unmanaged.sum_tl
 
 sum_tNbs
   :: ForeignPtr Tensor
@@ -635,20 +635,20 @@ sum_tNbs
   -> CBool
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-sum_tNbs = cast4 Unmanaged.sum_tNbs
+sum_tNbs = _cast4 Unmanaged.sum_tNbs
 
 sum_tNb
   :: ForeignPtr Tensor
   -> ForeignPtr DimnameList
   -> CBool
   -> IO (ForeignPtr Tensor)
-sum_tNb = cast3 Unmanaged.sum_tNb
+sum_tNb = _cast3 Unmanaged.sum_tNb
 
 sum_tN
   :: ForeignPtr Tensor
   -> ForeignPtr DimnameList
   -> IO (ForeignPtr Tensor)
-sum_tN = cast2 Unmanaged.sum_tN
+sum_tN = _cast2 Unmanaged.sum_tN
 
 sum_out_ttlbs
   :: ForeignPtr Tensor
@@ -657,7 +657,7 @@ sum_out_ttlbs
   -> CBool
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-sum_out_ttlbs = cast5 Unmanaged.sum_out_ttlbs
+sum_out_ttlbs = _cast5 Unmanaged.sum_out_ttlbs
 
 sum_out_ttlb
   :: ForeignPtr Tensor
@@ -665,14 +665,14 @@ sum_out_ttlb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-sum_out_ttlb = cast4 Unmanaged.sum_out_ttlb
+sum_out_ttlb = _cast4 Unmanaged.sum_out_ttlb
 
 sum_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-sum_out_ttl = cast3 Unmanaged.sum_out_ttl
+sum_out_ttl = _cast3 Unmanaged.sum_out_ttl
 
 sum_out_ttNbs
   :: ForeignPtr Tensor
@@ -681,7 +681,7 @@ sum_out_ttNbs
   -> CBool
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-sum_out_ttNbs = cast5 Unmanaged.sum_out_ttNbs
+sum_out_ttNbs = _cast5 Unmanaged.sum_out_ttNbs
 
 sum_out_ttNb
   :: ForeignPtr Tensor
@@ -689,25 +689,25 @@ sum_out_ttNb
   -> ForeignPtr DimnameList
   -> CBool
   -> IO (ForeignPtr Tensor)
-sum_out_ttNb = cast4 Unmanaged.sum_out_ttNb
+sum_out_ttNb = _cast4 Unmanaged.sum_out_ttNb
 
 sum_out_ttN
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr DimnameList
   -> IO (ForeignPtr Tensor)
-sum_out_ttN = cast3 Unmanaged.sum_out_ttN
+sum_out_ttN = _cast3 Unmanaged.sum_out_ttN
 
 nansum_ts
   :: ForeignPtr Tensor
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-nansum_ts = cast2 Unmanaged.nansum_ts
+nansum_ts = _cast2 Unmanaged.nansum_ts
 
 nansum_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-nansum_t = cast1 Unmanaged.nansum_t
+nansum_t = _cast1 Unmanaged.nansum_t
 
 nansum_tlbs
   :: ForeignPtr Tensor
@@ -715,20 +715,20 @@ nansum_tlbs
   -> CBool
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-nansum_tlbs = cast4 Unmanaged.nansum_tlbs
+nansum_tlbs = _cast4 Unmanaged.nansum_tlbs
 
 nansum_tlb
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-nansum_tlb = cast3 Unmanaged.nansum_tlb
+nansum_tlb = _cast3 Unmanaged.nansum_tlb
 
 nansum_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-nansum_tl = cast2 Unmanaged.nansum_tl
+nansum_tl = _cast2 Unmanaged.nansum_tl
 
 nansum_out_ttlbs
   :: ForeignPtr Tensor
@@ -737,7 +737,7 @@ nansum_out_ttlbs
   -> CBool
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-nansum_out_ttlbs = cast5 Unmanaged.nansum_out_ttlbs
+nansum_out_ttlbs = _cast5 Unmanaged.nansum_out_ttlbs
 
 nansum_out_ttlb
   :: ForeignPtr Tensor
@@ -745,57 +745,57 @@ nansum_out_ttlb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-nansum_out_ttlb = cast4 Unmanaged.nansum_out_ttlb
+nansum_out_ttlb = _cast4 Unmanaged.nansum_out_ttlb
 
 nansum_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-nansum_out_ttl = cast3 Unmanaged.nansum_out_ttl
+nansum_out_ttl = _cast3 Unmanaged.nansum_out_ttl
 
 sqrt_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-sqrt_t = cast1 Unmanaged.sqrt_t
+sqrt_t = _cast1 Unmanaged.sqrt_t
 
 sqrt__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-sqrt__t = cast1 Unmanaged.sqrt__t
+sqrt__t = _cast1 Unmanaged.sqrt__t
 
 sqrt_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-sqrt_out_tt = cast2 Unmanaged.sqrt_out_tt
+sqrt_out_tt = _cast2 Unmanaged.sqrt_out_tt
 
 square_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-square_t = cast1 Unmanaged.square_t
+square_t = _cast1 Unmanaged.square_t
 
 square__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-square__t = cast1 Unmanaged.square__t
+square__t = _cast1 Unmanaged.square__t
 
 square_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-square_out_tt = cast2 Unmanaged.square_out_tt
+square_out_tt = _cast2 Unmanaged.square_out_tt
 
 std_tb
   :: ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-std_tb = cast2 Unmanaged.std_tb
+std_tb = _cast2 Unmanaged.std_tb
 
 std_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-std_t = cast1 Unmanaged.std_t
+std_t = _cast1 Unmanaged.std_t
 
 std_tlbb
   :: ForeignPtr Tensor
@@ -803,20 +803,20 @@ std_tlbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-std_tlbb = cast4 Unmanaged.std_tlbb
+std_tlbb = _cast4 Unmanaged.std_tlbb
 
 std_tlb
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-std_tlb = cast3 Unmanaged.std_tlb
+std_tlb = _cast3 Unmanaged.std_tlb
 
 std_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-std_tl = cast2 Unmanaged.std_tl
+std_tl = _cast2 Unmanaged.std_tl
 
 std_tllb
   :: ForeignPtr Tensor
@@ -824,25 +824,25 @@ std_tllb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-std_tllb = cast4 Unmanaged.std_tllb
+std_tllb = _cast4 Unmanaged.std_tllb
 
 std_tll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> Int64
   -> IO (ForeignPtr Tensor)
-std_tll = cast3 Unmanaged.std_tll
+std_tll = _cast3 Unmanaged.std_tll
 
 std_mean_tb
   :: ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-std_mean_tb = cast2 Unmanaged.std_mean_tb
+std_mean_tb = _cast2 Unmanaged.std_mean_tb
 
 std_mean_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-std_mean_t = cast1 Unmanaged.std_mean_t
+std_mean_t = _cast1 Unmanaged.std_mean_t
 
 std_mean_tlbb
   :: ForeignPtr Tensor
@@ -850,20 +850,20 @@ std_mean_tlbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-std_mean_tlbb = cast4 Unmanaged.std_mean_tlbb
+std_mean_tlbb = _cast4 Unmanaged.std_mean_tlbb
 
 std_mean_tlb
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-std_mean_tlb = cast3 Unmanaged.std_mean_tlb
+std_mean_tlb = _cast3 Unmanaged.std_mean_tlb
 
 std_mean_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-std_mean_tl = cast2 Unmanaged.std_mean_tl
+std_mean_tl = _cast2 Unmanaged.std_mean_tl
 
 std_mean_tllb
   :: ForeignPtr Tensor
@@ -871,14 +871,14 @@ std_mean_tllb
   -> Int64
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-std_mean_tllb = cast4 Unmanaged.std_mean_tllb
+std_mean_tllb = _cast4 Unmanaged.std_mean_tllb
 
 std_mean_tll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-std_mean_tll = cast3 Unmanaged.std_mean_tll
+std_mean_tll = _cast3 Unmanaged.std_mean_tll
 
 std_mean_tNbb
   :: ForeignPtr Tensor
@@ -886,20 +886,20 @@ std_mean_tNbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-std_mean_tNbb = cast4 Unmanaged.std_mean_tNbb
+std_mean_tNbb = _cast4 Unmanaged.std_mean_tNbb
 
 std_mean_tNb
   :: ForeignPtr Tensor
   -> ForeignPtr DimnameList
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-std_mean_tNb = cast3 Unmanaged.std_mean_tNb
+std_mean_tNb = _cast3 Unmanaged.std_mean_tNb
 
 std_mean_tN
   :: ForeignPtr Tensor
   -> ForeignPtr DimnameList
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-std_mean_tN = cast2 Unmanaged.std_mean_tN
+std_mean_tN = _cast2 Unmanaged.std_mean_tN
 
 std_mean_tNlb
   :: ForeignPtr Tensor
@@ -907,14 +907,14 @@ std_mean_tNlb
   -> Int64
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-std_mean_tNlb = cast4 Unmanaged.std_mean_tNlb
+std_mean_tNlb = _cast4 Unmanaged.std_mean_tNlb
 
 std_mean_tNl
   :: ForeignPtr Tensor
   -> ForeignPtr DimnameList
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-std_mean_tNl = cast3 Unmanaged.std_mean_tNl
+std_mean_tNl = _cast3 Unmanaged.std_mean_tNl
 
 std_out_ttlbb
   :: ForeignPtr Tensor
@@ -923,7 +923,7 @@ std_out_ttlbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-std_out_ttlbb = cast5 Unmanaged.std_out_ttlbb
+std_out_ttlbb = _cast5 Unmanaged.std_out_ttlbb
 
 std_out_ttlb
   :: ForeignPtr Tensor
@@ -931,14 +931,14 @@ std_out_ttlb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-std_out_ttlb = cast4 Unmanaged.std_out_ttlb
+std_out_ttlb = _cast4 Unmanaged.std_out_ttlb
 
 std_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-std_out_ttl = cast3 Unmanaged.std_out_ttl
+std_out_ttl = _cast3 Unmanaged.std_out_ttl
 
 std_out_ttllb
   :: ForeignPtr Tensor
@@ -947,7 +947,7 @@ std_out_ttllb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-std_out_ttllb = cast5 Unmanaged.std_out_ttllb
+std_out_ttllb = _cast5 Unmanaged.std_out_ttllb
 
 std_out_ttll
   :: ForeignPtr Tensor
@@ -955,7 +955,7 @@ std_out_ttll
   -> ForeignPtr IntArray
   -> Int64
   -> IO (ForeignPtr Tensor)
-std_out_ttll = cast4 Unmanaged.std_out_ttll
+std_out_ttll = _cast4 Unmanaged.std_out_ttll
 
 std_tNbb
   :: ForeignPtr Tensor
@@ -963,20 +963,20 @@ std_tNbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-std_tNbb = cast4 Unmanaged.std_tNbb
+std_tNbb = _cast4 Unmanaged.std_tNbb
 
 std_tNb
   :: ForeignPtr Tensor
   -> ForeignPtr DimnameList
   -> CBool
   -> IO (ForeignPtr Tensor)
-std_tNb = cast3 Unmanaged.std_tNb
+std_tNb = _cast3 Unmanaged.std_tNb
 
 std_tN
   :: ForeignPtr Tensor
   -> ForeignPtr DimnameList
   -> IO (ForeignPtr Tensor)
-std_tN = cast2 Unmanaged.std_tN
+std_tN = _cast2 Unmanaged.std_tN
 
 std_out_ttNbb
   :: ForeignPtr Tensor
@@ -985,7 +985,7 @@ std_out_ttNbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-std_out_ttNbb = cast5 Unmanaged.std_out_ttNbb
+std_out_ttNbb = _cast5 Unmanaged.std_out_ttNbb
 
 std_out_ttNb
   :: ForeignPtr Tensor
@@ -993,14 +993,14 @@ std_out_ttNb
   -> ForeignPtr DimnameList
   -> CBool
   -> IO (ForeignPtr Tensor)
-std_out_ttNb = cast4 Unmanaged.std_out_ttNb
+std_out_ttNb = _cast4 Unmanaged.std_out_ttNb
 
 std_out_ttN
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr DimnameList
   -> IO (ForeignPtr Tensor)
-std_out_ttN = cast3 Unmanaged.std_out_ttN
+std_out_ttN = _cast3 Unmanaged.std_out_ttN
 
 std_tNlb
   :: ForeignPtr Tensor
@@ -1008,14 +1008,14 @@ std_tNlb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-std_tNlb = cast4 Unmanaged.std_tNlb
+std_tNlb = _cast4 Unmanaged.std_tNlb
 
 std_tNl
   :: ForeignPtr Tensor
   -> ForeignPtr DimnameList
   -> Int64
   -> IO (ForeignPtr Tensor)
-std_tNl = cast3 Unmanaged.std_tNl
+std_tNl = _cast3 Unmanaged.std_tNl
 
 std_out_ttNlb
   :: ForeignPtr Tensor
@@ -1024,7 +1024,7 @@ std_out_ttNlb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-std_out_ttNlb = cast5 Unmanaged.std_out_ttNlb
+std_out_ttNlb = _cast5 Unmanaged.std_out_ttNlb
 
 std_out_ttNl
   :: ForeignPtr Tensor
@@ -1032,18 +1032,18 @@ std_out_ttNl
   -> ForeignPtr DimnameList
   -> Int64
   -> IO (ForeignPtr Tensor)
-std_out_ttNl = cast4 Unmanaged.std_out_ttNl
+std_out_ttNl = _cast4 Unmanaged.std_out_ttNl
 
 prod_ts
   :: ForeignPtr Tensor
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-prod_ts = cast2 Unmanaged.prod_ts
+prod_ts = _cast2 Unmanaged.prod_ts
 
 prod_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-prod_t = cast1 Unmanaged.prod_t
+prod_t = _cast1 Unmanaged.prod_t
 
 prod_tlbs
   :: ForeignPtr Tensor
@@ -1051,20 +1051,20 @@ prod_tlbs
   -> CBool
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-prod_tlbs = cast4 Unmanaged.prod_tlbs
+prod_tlbs = _cast4 Unmanaged.prod_tlbs
 
 prod_tlb
   :: ForeignPtr Tensor
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-prod_tlb = cast3 Unmanaged.prod_tlb
+prod_tlb = _cast3 Unmanaged.prod_tlb
 
 prod_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-prod_tl = cast2 Unmanaged.prod_tl
+prod_tl = _cast2 Unmanaged.prod_tl
 
 prod_out_ttlbs
   :: ForeignPtr Tensor
@@ -1073,7 +1073,7 @@ prod_out_ttlbs
   -> CBool
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-prod_out_ttlbs = cast5 Unmanaged.prod_out_ttlbs
+prod_out_ttlbs = _cast5 Unmanaged.prod_out_ttlbs
 
 prod_out_ttlb
   :: ForeignPtr Tensor
@@ -1081,14 +1081,14 @@ prod_out_ttlb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-prod_out_ttlb = cast4 Unmanaged.prod_out_ttlb
+prod_out_ttlb = _cast4 Unmanaged.prod_out_ttlb
 
 prod_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-prod_out_ttl = cast3 Unmanaged.prod_out_ttl
+prod_out_ttl = _cast3 Unmanaged.prod_out_ttl
 
 prod_tnbs
   :: ForeignPtr Tensor
@@ -1096,20 +1096,20 @@ prod_tnbs
   -> CBool
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-prod_tnbs = cast4 Unmanaged.prod_tnbs
+prod_tnbs = _cast4 Unmanaged.prod_tnbs
 
 prod_tnb
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> CBool
   -> IO (ForeignPtr Tensor)
-prod_tnb = cast3 Unmanaged.prod_tnb
+prod_tnb = _cast3 Unmanaged.prod_tnb
 
 prod_tn
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> IO (ForeignPtr Tensor)
-prod_tn = cast2 Unmanaged.prod_tn
+prod_tn = _cast2 Unmanaged.prod_tn
 
 prod_out_ttnbs
   :: ForeignPtr Tensor
@@ -1118,7 +1118,7 @@ prod_out_ttnbs
   -> CBool
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-prod_out_ttnbs = cast5 Unmanaged.prod_out_ttnbs
+prod_out_ttnbs = _cast5 Unmanaged.prod_out_ttnbs
 
 prod_out_ttnb
   :: ForeignPtr Tensor
@@ -1126,51 +1126,51 @@ prod_out_ttnb
   -> ForeignPtr Dimname
   -> CBool
   -> IO (ForeignPtr Tensor)
-prod_out_ttnb = cast4 Unmanaged.prod_out_ttnb
+prod_out_ttnb = _cast4 Unmanaged.prod_out_ttnb
 
 prod_out_ttn
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> IO (ForeignPtr Tensor)
-prod_out_ttn = cast3 Unmanaged.prod_out_ttn
+prod_out_ttn = _cast3 Unmanaged.prod_out_ttn
 
 t_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-t_t = cast1 Unmanaged.t_t
+t_t = _cast1 Unmanaged.t_t
 
 tan_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tan_t = cast1 Unmanaged.tan_t
+tan_t = _cast1 Unmanaged.tan_t
 
 tan__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tan__t = cast1 Unmanaged.tan__t
+tan__t = _cast1 Unmanaged.tan__t
 
 tan_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tan_out_tt = cast2 Unmanaged.tan_out_tt
+tan_out_tt = _cast2 Unmanaged.tan_out_tt
 
 tanh_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tanh_t = cast1 Unmanaged.tanh_t
+tanh_t = _cast1 Unmanaged.tanh_t
 
 tanh__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tanh__t = cast1 Unmanaged.tanh__t
+tanh__t = _cast1 Unmanaged.tanh__t
 
 tanh_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tanh_out_tt = cast2 Unmanaged.tanh_out_tt
+tanh_out_tt = _cast2 Unmanaged.tanh_out_tt
 
 tensordot_ttll
   :: ForeignPtr Tensor
@@ -1178,7 +1178,7 @@ tensordot_ttll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-tensordot_ttll = cast4 Unmanaged.tensordot_ttll
+tensordot_ttll = _cast4 Unmanaged.tensordot_ttll
 
 tensordot_out_tttll
   :: ForeignPtr Tensor
@@ -1187,21 +1187,21 @@ tensordot_out_tttll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-tensordot_out_tttll = cast5 Unmanaged.tensordot_out_tttll
+tensordot_out_tttll = _cast5 Unmanaged.tensordot_out_tttll
 
 threshold_tss
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-threshold_tss = cast3 Unmanaged.threshold_tss
+threshold_tss = _cast3 Unmanaged.threshold_tss
 
 threshold__tss
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-threshold__tss = cast3 Unmanaged.threshold__tss
+threshold__tss = _cast3 Unmanaged.threshold__tss
 
 threshold_out_ttss
   :: ForeignPtr Tensor
@@ -1209,7 +1209,7 @@ threshold_out_ttss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-threshold_out_ttss = cast4 Unmanaged.threshold_out_ttss
+threshold_out_ttss = _cast4 Unmanaged.threshold_out_ttss
 
 threshold_backward_out_ttts
   :: ForeignPtr Tensor
@@ -1217,168 +1217,168 @@ threshold_backward_out_ttts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-threshold_backward_out_ttts = cast4 Unmanaged.threshold_backward_out_ttts
+threshold_backward_out_ttts = _cast4 Unmanaged.threshold_backward_out_ttts
 
 threshold_backward_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-threshold_backward_tts = cast3 Unmanaged.threshold_backward_tts
+threshold_backward_tts = _cast3 Unmanaged.threshold_backward_tts
 
 tile_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-tile_tl = cast2 Unmanaged.tile_tl
+tile_tl = _cast2 Unmanaged.tile_tl
 
 transpose_tll
   :: ForeignPtr Tensor
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-transpose_tll = cast3 Unmanaged.transpose_tll
+transpose_tll = _cast3 Unmanaged.transpose_tll
 
 transpose_tnn
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> ForeignPtr Dimname
   -> IO (ForeignPtr Tensor)
-transpose_tnn = cast3 Unmanaged.transpose_tnn
+transpose_tnn = _cast3 Unmanaged.transpose_tnn
 
 _mkldnn_transpose_tll
   :: ForeignPtr Tensor
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-_mkldnn_transpose_tll = cast3 Unmanaged._mkldnn_transpose_tll
+_mkldnn_transpose_tll = _cast3 Unmanaged._mkldnn_transpose_tll
 
 _mkldnn_transpose__tll
   :: ForeignPtr Tensor
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-_mkldnn_transpose__tll = cast3 Unmanaged._mkldnn_transpose__tll
+_mkldnn_transpose__tll = _cast3 Unmanaged._mkldnn_transpose__tll
 
 one_hot_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-one_hot_tl = cast2 Unmanaged.one_hot_tl
+one_hot_tl = _cast2 Unmanaged.one_hot_tl
 
 one_hot_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-one_hot_t = cast1 Unmanaged.one_hot_t
+one_hot_t = _cast1 Unmanaged.one_hot_t
 
 flip_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-flip_tl = cast2 Unmanaged.flip_tl
+flip_tl = _cast2 Unmanaged.flip_tl
 
 fliplr_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fliplr_t = cast1 Unmanaged.fliplr_t
+fliplr_t = _cast1 Unmanaged.fliplr_t
 
 flipud_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-flipud_t = cast1 Unmanaged.flipud_t
+flipud_t = _cast1 Unmanaged.flipud_t
 
 roll_tll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-roll_tll = cast3 Unmanaged.roll_tll
+roll_tll = _cast3 Unmanaged.roll_tll
 
 roll_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-roll_tl = cast2 Unmanaged.roll_tl
+roll_tl = _cast2 Unmanaged.roll_tl
 
 rot90_tll
   :: ForeignPtr Tensor
   -> Int64
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-rot90_tll = cast3 Unmanaged.rot90_tll
+rot90_tll = _cast3 Unmanaged.rot90_tll
 
 rot90_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-rot90_tl = cast2 Unmanaged.rot90_tl
+rot90_tl = _cast2 Unmanaged.rot90_tl
 
 rot90_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-rot90_t = cast1 Unmanaged.rot90_t
+rot90_t = _cast1 Unmanaged.rot90_t
 
 trapezoid_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-trapezoid_ttl = cast3 Unmanaged.trapezoid_ttl
+trapezoid_ttl = _cast3 Unmanaged.trapezoid_ttl
 
 trapezoid_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-trapezoid_tt = cast2 Unmanaged.trapezoid_tt
+trapezoid_tt = _cast2 Unmanaged.trapezoid_tt
 
 trapezoid_tsl
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> Int64
   -> IO (ForeignPtr Tensor)
-trapezoid_tsl = cast3 Unmanaged.trapezoid_tsl
+trapezoid_tsl = _cast3 Unmanaged.trapezoid_tsl
 
 trapezoid_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-trapezoid_ts = cast2 Unmanaged.trapezoid_ts
+trapezoid_ts = _cast2 Unmanaged.trapezoid_ts
 
 trapezoid_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-trapezoid_t = cast1 Unmanaged.trapezoid_t
+trapezoid_t = _cast1 Unmanaged.trapezoid_t
 
 trapz_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-trapz_ttl = cast3 Unmanaged.trapz_ttl
+trapz_ttl = _cast3 Unmanaged.trapz_ttl
 
 trapz_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-trapz_tt = cast2 Unmanaged.trapz_tt
+trapz_tt = _cast2 Unmanaged.trapz_tt
 
 trapz_tdl
   :: ForeignPtr Tensor
   -> CDouble
   -> Int64
   -> IO (ForeignPtr Tensor)
-trapz_tdl = cast3 Unmanaged.trapz_tdl
+trapz_tdl = _cast3 Unmanaged.trapz_tdl
 
 trapz_td
   :: ForeignPtr Tensor
   -> CDouble
   -> IO (ForeignPtr Tensor)
-trapz_td = cast2 Unmanaged.trapz_td
+trapz_td = _cast2 Unmanaged.trapz_td
 
 trapz_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-trapz_t = cast1 Unmanaged.trapz_t
+trapz_t = _cast1 Unmanaged.trapz_t
 
 _trilinear_tttlllll
   :: ForeignPtr Tensor
@@ -1390,7 +1390,7 @@ _trilinear_tttlllll
   -> ForeignPtr IntArray
   -> Int64
   -> IO (ForeignPtr Tensor)
-_trilinear_tttlllll = cast8 Unmanaged._trilinear_tttlllll
+_trilinear_tttlllll = _cast8 Unmanaged._trilinear_tttlllll
 
 _trilinear_tttllll
   :: ForeignPtr Tensor
@@ -1401,7 +1401,7 @@ _trilinear_tttllll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-_trilinear_tttllll = cast7 Unmanaged._trilinear_tttllll
+_trilinear_tttllll = _cast7 Unmanaged._trilinear_tttllll
 
 triplet_margin_loss_tttdddbl
   :: ForeignPtr Tensor
@@ -1413,7 +1413,7 @@ triplet_margin_loss_tttdddbl
   -> CBool
   -> Int64
   -> IO (ForeignPtr Tensor)
-triplet_margin_loss_tttdddbl = cast8 Unmanaged.triplet_margin_loss_tttdddbl
+triplet_margin_loss_tttdddbl = _cast8 Unmanaged.triplet_margin_loss_tttdddbl
 
 triplet_margin_loss_tttdddb
   :: ForeignPtr Tensor
@@ -1424,7 +1424,7 @@ triplet_margin_loss_tttdddb
   -> CDouble
   -> CBool
   -> IO (ForeignPtr Tensor)
-triplet_margin_loss_tttdddb = cast7 Unmanaged.triplet_margin_loss_tttdddb
+triplet_margin_loss_tttdddb = _cast7 Unmanaged.triplet_margin_loss_tttdddb
 
 triplet_margin_loss_tttddd
   :: ForeignPtr Tensor
@@ -1434,7 +1434,7 @@ triplet_margin_loss_tttddd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-triplet_margin_loss_tttddd = cast6 Unmanaged.triplet_margin_loss_tttddd
+triplet_margin_loss_tttddd = _cast6 Unmanaged.triplet_margin_loss_tttddd
 
 triplet_margin_loss_tttdd
   :: ForeignPtr Tensor
@@ -1443,7 +1443,7 @@ triplet_margin_loss_tttdd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-triplet_margin_loss_tttdd = cast5 Unmanaged.triplet_margin_loss_tttdd
+triplet_margin_loss_tttdd = _cast5 Unmanaged.triplet_margin_loss_tttdd
 
 triplet_margin_loss_tttd
   :: ForeignPtr Tensor
@@ -1451,68 +1451,68 @@ triplet_margin_loss_tttd
   -> ForeignPtr Tensor
   -> CDouble
   -> IO (ForeignPtr Tensor)
-triplet_margin_loss_tttd = cast4 Unmanaged.triplet_margin_loss_tttd
+triplet_margin_loss_tttd = _cast4 Unmanaged.triplet_margin_loss_tttd
 
 triplet_margin_loss_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-triplet_margin_loss_ttt = cast3 Unmanaged.triplet_margin_loss_ttt
+triplet_margin_loss_ttt = _cast3 Unmanaged.triplet_margin_loss_ttt
 
 trunc_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-trunc_t = cast1 Unmanaged.trunc_t
+trunc_t = _cast1 Unmanaged.trunc_t
 
 trunc__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-trunc__t = cast1 Unmanaged.trunc__t
+trunc__t = _cast1 Unmanaged.trunc__t
 
 trunc_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-trunc_out_tt = cast2 Unmanaged.trunc_out_tt
+trunc_out_tt = _cast2 Unmanaged.trunc_out_tt
 
 fix_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fix_t = cast1 Unmanaged.fix_t
+fix_t = _cast1 Unmanaged.fix_t
 
 fix__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fix__t = cast1 Unmanaged.fix__t
+fix__t = _cast1 Unmanaged.fix__t
 
 fix_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fix_out_tt = cast2 Unmanaged.fix_out_tt
+fix_out_tt = _cast2 Unmanaged.fix_out_tt
 
 _has_compatible_shallow_copy_type_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (CBool)
-_has_compatible_shallow_copy_type_tt = cast2 Unmanaged._has_compatible_shallow_copy_type_tt
+_has_compatible_shallow_copy_type_tt = _cast2 Unmanaged._has_compatible_shallow_copy_type_tt
 
 _unique_tbb
   :: ForeignPtr Tensor
   -> CBool
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-_unique_tbb = cast3 Unmanaged._unique_tbb
+_unique_tbb = _cast3 Unmanaged._unique_tbb
 
 _unique_tb
   :: ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-_unique_tb = cast2 Unmanaged._unique_tb
+_unique_tb = _cast2 Unmanaged._unique_tb
 
 _unique_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-_unique_t = cast1 Unmanaged._unique_t
+_unique_t = _cast1 Unmanaged._unique_t
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Native/Native7.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Native/Native7.hs
@@ -28,7 +28,7 @@ unique_dim_tlbbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-unique_dim_tlbbb = cast5 Unmanaged.unique_dim_tlbbb
+unique_dim_tlbbb = _cast5 Unmanaged.unique_dim_tlbbb
 
 unique_dim_tlbb
   :: ForeignPtr Tensor
@@ -36,20 +36,20 @@ unique_dim_tlbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-unique_dim_tlbb = cast4 Unmanaged.unique_dim_tlbb
+unique_dim_tlbb = _cast4 Unmanaged.unique_dim_tlbb
 
 unique_dim_tlb
   :: ForeignPtr Tensor
   -> Int64
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-unique_dim_tlb = cast3 Unmanaged.unique_dim_tlb
+unique_dim_tlb = _cast3 Unmanaged.unique_dim_tlb
 
 unique_dim_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-unique_dim_tl = cast2 Unmanaged.unique_dim_tl
+unique_dim_tl = _cast2 Unmanaged.unique_dim_tl
 
 unique_consecutive_tbbl
   :: ForeignPtr Tensor
@@ -57,25 +57,25 @@ unique_consecutive_tbbl
   -> CBool
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-unique_consecutive_tbbl = cast4 Unmanaged.unique_consecutive_tbbl
+unique_consecutive_tbbl = _cast4 Unmanaged.unique_consecutive_tbbl
 
 unique_consecutive_tbb
   :: ForeignPtr Tensor
   -> CBool
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-unique_consecutive_tbb = cast3 Unmanaged.unique_consecutive_tbb
+unique_consecutive_tbb = _cast3 Unmanaged.unique_consecutive_tbb
 
 unique_consecutive_tb
   :: ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-unique_consecutive_tb = cast2 Unmanaged.unique_consecutive_tb
+unique_consecutive_tb = _cast2 Unmanaged.unique_consecutive_tb
 
 unique_consecutive_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-unique_consecutive_t = cast1 Unmanaged.unique_consecutive_t
+unique_consecutive_t = _cast1 Unmanaged.unique_consecutive_t
 
 unique_dim_consecutive_tlbb
   :: ForeignPtr Tensor
@@ -83,20 +83,20 @@ unique_dim_consecutive_tlbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-unique_dim_consecutive_tlbb = cast4 Unmanaged.unique_dim_consecutive_tlbb
+unique_dim_consecutive_tlbb = _cast4 Unmanaged.unique_dim_consecutive_tlbb
 
 unique_dim_consecutive_tlb
   :: ForeignPtr Tensor
   -> Int64
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-unique_dim_consecutive_tlb = cast3 Unmanaged.unique_dim_consecutive_tlb
+unique_dim_consecutive_tlb = _cast3 Unmanaged.unique_dim_consecutive_tlb
 
 unique_dim_consecutive_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-unique_dim_consecutive_tl = cast2 Unmanaged.unique_dim_consecutive_tl
+unique_dim_consecutive_tl = _cast2 Unmanaged.unique_dim_consecutive_tl
 
 _unique2_tbbb
   :: ForeignPtr Tensor
@@ -104,66 +104,66 @@ _unique2_tbbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-_unique2_tbbb = cast4 Unmanaged._unique2_tbbb
+_unique2_tbbb = _cast4 Unmanaged._unique2_tbbb
 
 _unique2_tbb
   :: ForeignPtr Tensor
   -> CBool
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-_unique2_tbb = cast3 Unmanaged._unique2_tbb
+_unique2_tbb = _cast3 Unmanaged._unique2_tbb
 
 _unique2_tb
   :: ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-_unique2_tb = cast2 Unmanaged._unique2_tb
+_unique2_tb = _cast2 Unmanaged._unique2_tb
 
 _unique2_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-_unique2_t = cast1 Unmanaged._unique2_t
+_unique2_t = _cast1 Unmanaged._unique2_t
 
 _unsafe_view_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-_unsafe_view_tl = cast2 Unmanaged._unsafe_view_tl
+_unsafe_view_tl = _cast2 Unmanaged._unsafe_view_tl
 
 unsqueeze_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-unsqueeze_tl = cast2 Unmanaged.unsqueeze_tl
+unsqueeze_tl = _cast2 Unmanaged.unsqueeze_tl
 
 vander_tlb
   :: ForeignPtr Tensor
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-vander_tlb = cast3 Unmanaged.vander_tlb
+vander_tlb = _cast3 Unmanaged.vander_tlb
 
 vander_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-vander_tl = cast2 Unmanaged.vander_tl
+vander_tl = _cast2 Unmanaged.vander_tl
 
 vander_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-vander_t = cast1 Unmanaged.vander_t
+vander_t = _cast1 Unmanaged.vander_t
 
 var_tb
   :: ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-var_tb = cast2 Unmanaged.var_tb
+var_tb = _cast2 Unmanaged.var_tb
 
 var_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-var_t = cast1 Unmanaged.var_t
+var_t = _cast1 Unmanaged.var_t
 
 var_tlbb
   :: ForeignPtr Tensor
@@ -171,20 +171,20 @@ var_tlbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-var_tlbb = cast4 Unmanaged.var_tlbb
+var_tlbb = _cast4 Unmanaged.var_tlbb
 
 var_tlb
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-var_tlb = cast3 Unmanaged.var_tlb
+var_tlb = _cast3 Unmanaged.var_tlb
 
 var_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-var_tl = cast2 Unmanaged.var_tl
+var_tl = _cast2 Unmanaged.var_tl
 
 var_tllb
   :: ForeignPtr Tensor
@@ -192,14 +192,14 @@ var_tllb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-var_tllb = cast4 Unmanaged.var_tllb
+var_tllb = _cast4 Unmanaged.var_tllb
 
 var_tll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> Int64
   -> IO (ForeignPtr Tensor)
-var_tll = cast3 Unmanaged.var_tll
+var_tll = _cast3 Unmanaged.var_tll
 
 var_out_ttlbb
   :: ForeignPtr Tensor
@@ -208,7 +208,7 @@ var_out_ttlbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-var_out_ttlbb = cast5 Unmanaged.var_out_ttlbb
+var_out_ttlbb = _cast5 Unmanaged.var_out_ttlbb
 
 var_out_ttlb
   :: ForeignPtr Tensor
@@ -216,14 +216,14 @@ var_out_ttlb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-var_out_ttlb = cast4 Unmanaged.var_out_ttlb
+var_out_ttlb = _cast4 Unmanaged.var_out_ttlb
 
 var_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-var_out_ttl = cast3 Unmanaged.var_out_ttl
+var_out_ttl = _cast3 Unmanaged.var_out_ttl
 
 var_out_ttllb
   :: ForeignPtr Tensor
@@ -232,7 +232,7 @@ var_out_ttllb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-var_out_ttllb = cast5 Unmanaged.var_out_ttllb
+var_out_ttllb = _cast5 Unmanaged.var_out_ttllb
 
 var_out_ttll
   :: ForeignPtr Tensor
@@ -240,7 +240,7 @@ var_out_ttll
   -> ForeignPtr IntArray
   -> Int64
   -> IO (ForeignPtr Tensor)
-var_out_ttll = cast4 Unmanaged.var_out_ttll
+var_out_ttll = _cast4 Unmanaged.var_out_ttll
 
 var_tNbb
   :: ForeignPtr Tensor
@@ -248,20 +248,20 @@ var_tNbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-var_tNbb = cast4 Unmanaged.var_tNbb
+var_tNbb = _cast4 Unmanaged.var_tNbb
 
 var_tNb
   :: ForeignPtr Tensor
   -> ForeignPtr DimnameList
   -> CBool
   -> IO (ForeignPtr Tensor)
-var_tNb = cast3 Unmanaged.var_tNb
+var_tNb = _cast3 Unmanaged.var_tNb
 
 var_tN
   :: ForeignPtr Tensor
   -> ForeignPtr DimnameList
   -> IO (ForeignPtr Tensor)
-var_tN = cast2 Unmanaged.var_tN
+var_tN = _cast2 Unmanaged.var_tN
 
 var_out_ttNbb
   :: ForeignPtr Tensor
@@ -270,7 +270,7 @@ var_out_ttNbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-var_out_ttNbb = cast5 Unmanaged.var_out_ttNbb
+var_out_ttNbb = _cast5 Unmanaged.var_out_ttNbb
 
 var_out_ttNb
   :: ForeignPtr Tensor
@@ -278,14 +278,14 @@ var_out_ttNb
   -> ForeignPtr DimnameList
   -> CBool
   -> IO (ForeignPtr Tensor)
-var_out_ttNb = cast4 Unmanaged.var_out_ttNb
+var_out_ttNb = _cast4 Unmanaged.var_out_ttNb
 
 var_out_ttN
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr DimnameList
   -> IO (ForeignPtr Tensor)
-var_out_ttN = cast3 Unmanaged.var_out_ttN
+var_out_ttN = _cast3 Unmanaged.var_out_ttN
 
 var_tNlb
   :: ForeignPtr Tensor
@@ -293,14 +293,14 @@ var_tNlb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-var_tNlb = cast4 Unmanaged.var_tNlb
+var_tNlb = _cast4 Unmanaged.var_tNlb
 
 var_tNl
   :: ForeignPtr Tensor
   -> ForeignPtr DimnameList
   -> Int64
   -> IO (ForeignPtr Tensor)
-var_tNl = cast3 Unmanaged.var_tNl
+var_tNl = _cast3 Unmanaged.var_tNl
 
 var_out_ttNlb
   :: ForeignPtr Tensor
@@ -309,7 +309,7 @@ var_out_ttNlb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-var_out_ttNlb = cast5 Unmanaged.var_out_ttNlb
+var_out_ttNlb = _cast5 Unmanaged.var_out_ttNlb
 
 var_out_ttNl
   :: ForeignPtr Tensor
@@ -317,18 +317,18 @@ var_out_ttNl
   -> ForeignPtr DimnameList
   -> Int64
   -> IO (ForeignPtr Tensor)
-var_out_ttNl = cast4 Unmanaged.var_out_ttNl
+var_out_ttNl = _cast4 Unmanaged.var_out_ttNl
 
 var_mean_tb
   :: ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-var_mean_tb = cast2 Unmanaged.var_mean_tb
+var_mean_tb = _cast2 Unmanaged.var_mean_tb
 
 var_mean_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-var_mean_t = cast1 Unmanaged.var_mean_t
+var_mean_t = _cast1 Unmanaged.var_mean_t
 
 var_mean_tlbb
   :: ForeignPtr Tensor
@@ -336,20 +336,20 @@ var_mean_tlbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-var_mean_tlbb = cast4 Unmanaged.var_mean_tlbb
+var_mean_tlbb = _cast4 Unmanaged.var_mean_tlbb
 
 var_mean_tlb
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-var_mean_tlb = cast3 Unmanaged.var_mean_tlb
+var_mean_tlb = _cast3 Unmanaged.var_mean_tlb
 
 var_mean_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-var_mean_tl = cast2 Unmanaged.var_mean_tl
+var_mean_tl = _cast2 Unmanaged.var_mean_tl
 
 var_mean_tllb
   :: ForeignPtr Tensor
@@ -357,14 +357,14 @@ var_mean_tllb
   -> Int64
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-var_mean_tllb = cast4 Unmanaged.var_mean_tllb
+var_mean_tllb = _cast4 Unmanaged.var_mean_tllb
 
 var_mean_tll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-var_mean_tll = cast3 Unmanaged.var_mean_tll
+var_mean_tll = _cast3 Unmanaged.var_mean_tll
 
 var_mean_tNbb
   :: ForeignPtr Tensor
@@ -372,20 +372,20 @@ var_mean_tNbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-var_mean_tNbb = cast4 Unmanaged.var_mean_tNbb
+var_mean_tNbb = _cast4 Unmanaged.var_mean_tNbb
 
 var_mean_tNb
   :: ForeignPtr Tensor
   -> ForeignPtr DimnameList
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-var_mean_tNb = cast3 Unmanaged.var_mean_tNb
+var_mean_tNb = _cast3 Unmanaged.var_mean_tNb
 
 var_mean_tN
   :: ForeignPtr Tensor
   -> ForeignPtr DimnameList
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-var_mean_tN = cast2 Unmanaged.var_mean_tN
+var_mean_tN = _cast2 Unmanaged.var_mean_tN
 
 var_mean_tNlb
   :: ForeignPtr Tensor
@@ -393,98 +393,98 @@ var_mean_tNlb
   -> Int64
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-var_mean_tNlb = cast4 Unmanaged.var_mean_tNlb
+var_mean_tNlb = _cast4 Unmanaged.var_mean_tNlb
 
 var_mean_tNl
   :: ForeignPtr Tensor
   -> ForeignPtr DimnameList
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-var_mean_tNl = cast3 Unmanaged.var_mean_tNl
+var_mean_tNl = _cast3 Unmanaged.var_mean_tNl
 
 where_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-where_ttt = cast3 Unmanaged.where_ttt
+where_ttt = _cast3 Unmanaged.where_ttt
 
 where_tst
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-where_tst = cast3 Unmanaged.where_tst
+where_tst = _cast3 Unmanaged.where_tst
 
 where_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-where_tts = cast3 Unmanaged.where_tts
+where_tts = _cast3 Unmanaged.where_tts
 
 where_tss
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-where_tss = cast3 Unmanaged.where_tss
+where_tss = _cast3 Unmanaged.where_tss
 
 where_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr TensorList)
-where_t = cast1 Unmanaged.where_t
+where_t = _cast1 Unmanaged.where_t
 
 _s_where_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_s_where_ttt = cast3 Unmanaged._s_where_ttt
+_s_where_ttt = _cast3 Unmanaged._s_where_ttt
 
 norm_except_dim_tll
   :: ForeignPtr Tensor
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-norm_except_dim_tll = cast3 Unmanaged.norm_except_dim_tll
+norm_except_dim_tll = _cast3 Unmanaged.norm_except_dim_tll
 
 norm_except_dim_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-norm_except_dim_tl = cast2 Unmanaged.norm_except_dim_tl
+norm_except_dim_tl = _cast2 Unmanaged.norm_except_dim_tl
 
 norm_except_dim_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-norm_except_dim_t = cast1 Unmanaged.norm_except_dim_t
+norm_except_dim_t = _cast1 Unmanaged.norm_except_dim_t
 
 _weight_norm_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-_weight_norm_ttl = cast3 Unmanaged._weight_norm_ttl
+_weight_norm_ttl = _cast3 Unmanaged._weight_norm_ttl
 
 _weight_norm_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_weight_norm_tt = cast2 Unmanaged._weight_norm_tt
+_weight_norm_tt = _cast2 Unmanaged._weight_norm_tt
 
 _weight_norm_cuda_interface_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-_weight_norm_cuda_interface_ttl = cast3 Unmanaged._weight_norm_cuda_interface_ttl
+_weight_norm_cuda_interface_ttl = _cast3 Unmanaged._weight_norm_cuda_interface_ttl
 
 _weight_norm_cuda_interface_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-_weight_norm_cuda_interface_tt = cast2 Unmanaged._weight_norm_cuda_interface_tt
+_weight_norm_cuda_interface_tt = _cast2 Unmanaged._weight_norm_cuda_interface_tt
 
 _weight_norm_cuda_interface_backward_ttttl
   :: ForeignPtr Tensor
@@ -493,7 +493,7 @@ _weight_norm_cuda_interface_backward_ttttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-_weight_norm_cuda_interface_backward_ttttl = cast5 Unmanaged._weight_norm_cuda_interface_backward_ttttl
+_weight_norm_cuda_interface_backward_ttttl = _cast5 Unmanaged._weight_norm_cuda_interface_backward_ttttl
 
 _weight_norm_differentiable_backward_ttttl
   :: ForeignPtr Tensor
@@ -502,136 +502,136 @@ _weight_norm_differentiable_backward_ttttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-_weight_norm_differentiable_backward_ttttl = cast5 Unmanaged._weight_norm_differentiable_backward_ttttl
+_weight_norm_differentiable_backward_ttttl = _cast5 Unmanaged._weight_norm_differentiable_backward_ttttl
 
 zeros_lNo
   :: ForeignPtr IntArray
   -> ForeignPtr DimnameList
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-zeros_lNo = cast3 Unmanaged.zeros_lNo
+zeros_lNo = _cast3 Unmanaged.zeros_lNo
 
 zeros_lN
   :: ForeignPtr IntArray
   -> ForeignPtr DimnameList
   -> IO (ForeignPtr Tensor)
-zeros_lN = cast2 Unmanaged.zeros_lN
+zeros_lN = _cast2 Unmanaged.zeros_lN
 
 _efficientzerotensor_lo
   :: ForeignPtr IntArray
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-_efficientzerotensor_lo = cast2 Unmanaged._efficientzerotensor_lo
+_efficientzerotensor_lo = _cast2 Unmanaged._efficientzerotensor_lo
 
 _efficientzerotensor_l
   :: ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-_efficientzerotensor_l = cast1 Unmanaged._efficientzerotensor_l
+_efficientzerotensor_l = _cast1 Unmanaged._efficientzerotensor_l
 
 zeros_lo
   :: ForeignPtr IntArray
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-zeros_lo = cast2 Unmanaged.zeros_lo
+zeros_lo = _cast2 Unmanaged.zeros_lo
 
 zeros_l
   :: ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-zeros_l = cast1 Unmanaged.zeros_l
+zeros_l = _cast1 Unmanaged.zeros_l
 
 zeros_out_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-zeros_out_tl = cast2 Unmanaged.zeros_out_tl
+zeros_out_tl = _cast2 Unmanaged.zeros_out_tl
 
 zeros_like_toM
   :: ForeignPtr Tensor
   -> ForeignPtr TensorOptions
   -> MemoryFormat
   -> IO (ForeignPtr Tensor)
-zeros_like_toM = cast3 Unmanaged.zeros_like_toM
+zeros_like_toM = _cast3 Unmanaged.zeros_like_toM
 
 zeros_like_to
   :: ForeignPtr Tensor
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-zeros_like_to = cast2 Unmanaged.zeros_like_to
+zeros_like_to = _cast2 Unmanaged.zeros_like_to
 
 zeros_like_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-zeros_like_t = cast1 Unmanaged.zeros_like_t
+zeros_like_t = _cast1 Unmanaged.zeros_like_t
 
 _standard_gamma_grad_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_standard_gamma_grad_tt = cast2 Unmanaged._standard_gamma_grad_tt
+_standard_gamma_grad_tt = _cast2 Unmanaged._standard_gamma_grad_tt
 
 _standard_gamma_tG
   :: ForeignPtr Tensor
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-_standard_gamma_tG = cast2 Unmanaged._standard_gamma_tG
+_standard_gamma_tG = _cast2 Unmanaged._standard_gamma_tG
 
 _standard_gamma_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_standard_gamma_t = cast1 Unmanaged._standard_gamma_t
+_standard_gamma_t = _cast1 Unmanaged._standard_gamma_t
 
 _dirichlet_grad_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_dirichlet_grad_ttt = cast3 Unmanaged._dirichlet_grad_ttt
+_dirichlet_grad_ttt = _cast3 Unmanaged._dirichlet_grad_ttt
 
 _sample_dirichlet_tG
   :: ForeignPtr Tensor
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-_sample_dirichlet_tG = cast2 Unmanaged._sample_dirichlet_tG
+_sample_dirichlet_tG = _cast2 Unmanaged._sample_dirichlet_tG
 
 _sample_dirichlet_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_sample_dirichlet_t = cast1 Unmanaged._sample_dirichlet_t
+_sample_dirichlet_t = _cast1 Unmanaged._sample_dirichlet_t
 
 poisson_tG
   :: ForeignPtr Tensor
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-poisson_tG = cast2 Unmanaged.poisson_tG
+poisson_tG = _cast2 Unmanaged.poisson_tG
 
 poisson_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-poisson_t = cast1 Unmanaged.poisson_t
+poisson_t = _cast1 Unmanaged.poisson_t
 
 binomial_ttG
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-binomial_ttG = cast3 Unmanaged.binomial_ttG
+binomial_ttG = _cast3 Unmanaged.binomial_ttG
 
 binomial_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-binomial_tt = cast2 Unmanaged.binomial_tt
+binomial_tt = _cast2 Unmanaged.binomial_tt
 
 native_norm_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-native_norm_ts = cast2 Unmanaged.native_norm_ts
+native_norm_ts = _cast2 Unmanaged.native_norm_ts
 
 native_norm_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-native_norm_t = cast1 Unmanaged.native_norm_t
+native_norm_t = _cast1 Unmanaged.native_norm_t
 
 native_norm_tslbs
   :: ForeignPtr Tensor
@@ -640,71 +640,71 @@ native_norm_tslbs
   -> CBool
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-native_norm_tslbs = cast5 Unmanaged.native_norm_tslbs
+native_norm_tslbs = _cast5 Unmanaged.native_norm_tslbs
 
 _sparse_sum_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_sparse_sum_t = cast1 Unmanaged._sparse_sum_t
+_sparse_sum_t = _cast1 Unmanaged._sparse_sum_t
 
 _sparse_sum_ts
   :: ForeignPtr Tensor
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-_sparse_sum_ts = cast2 Unmanaged._sparse_sum_ts
+_sparse_sum_ts = _cast2 Unmanaged._sparse_sum_ts
 
 _sparse_sum_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-_sparse_sum_tl = cast2 Unmanaged._sparse_sum_tl
+_sparse_sum_tl = _cast2 Unmanaged._sparse_sum_tl
 
 _sparse_sum_tls
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-_sparse_sum_tls = cast3 Unmanaged._sparse_sum_tls
+_sparse_sum_tls = _cast3 Unmanaged._sparse_sum_tls
 
 _sparse_sum_backward_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-_sparse_sum_backward_ttl = cast3 Unmanaged._sparse_sum_backward_ttl
+_sparse_sum_backward_ttl = _cast3 Unmanaged._sparse_sum_backward_ttl
 
 _sparse_softmax_tls
   :: ForeignPtr Tensor
   -> Int64
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-_sparse_softmax_tls = cast3 Unmanaged._sparse_softmax_tls
+_sparse_softmax_tls = _cast3 Unmanaged._sparse_softmax_tls
 
 _sparse_softmax_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-_sparse_softmax_tl = cast2 Unmanaged._sparse_softmax_tl
+_sparse_softmax_tl = _cast2 Unmanaged._sparse_softmax_tl
 
 _sparse_softmax_tns
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-_sparse_softmax_tns = cast3 Unmanaged._sparse_softmax_tns
+_sparse_softmax_tns = _cast3 Unmanaged._sparse_softmax_tns
 
 _sparse_softmax_tn
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> IO (ForeignPtr Tensor)
-_sparse_softmax_tn = cast2 Unmanaged._sparse_softmax_tn
+_sparse_softmax_tn = _cast2 Unmanaged._sparse_softmax_tn
 
 _sparse_softmax_tlb
   :: ForeignPtr Tensor
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-_sparse_softmax_tlb = cast3 Unmanaged._sparse_softmax_tlb
+_sparse_softmax_tlb = _cast3 Unmanaged._sparse_softmax_tlb
 
 _sparse_softmax_backward_data_ttlt
   :: ForeignPtr Tensor
@@ -712,40 +712,40 @@ _sparse_softmax_backward_data_ttlt
   -> Int64
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_sparse_softmax_backward_data_ttlt = cast4 Unmanaged._sparse_softmax_backward_data_ttlt
+_sparse_softmax_backward_data_ttlt = _cast4 Unmanaged._sparse_softmax_backward_data_ttlt
 
 _sparse_log_softmax_tls
   :: ForeignPtr Tensor
   -> Int64
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-_sparse_log_softmax_tls = cast3 Unmanaged._sparse_log_softmax_tls
+_sparse_log_softmax_tls = _cast3 Unmanaged._sparse_log_softmax_tls
 
 _sparse_log_softmax_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-_sparse_log_softmax_tl = cast2 Unmanaged._sparse_log_softmax_tl
+_sparse_log_softmax_tl = _cast2 Unmanaged._sparse_log_softmax_tl
 
 _sparse_log_softmax_tns
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-_sparse_log_softmax_tns = cast3 Unmanaged._sparse_log_softmax_tns
+_sparse_log_softmax_tns = _cast3 Unmanaged._sparse_log_softmax_tns
 
 _sparse_log_softmax_tn
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> IO (ForeignPtr Tensor)
-_sparse_log_softmax_tn = cast2 Unmanaged._sparse_log_softmax_tn
+_sparse_log_softmax_tn = _cast2 Unmanaged._sparse_log_softmax_tn
 
 _sparse_log_softmax_tlb
   :: ForeignPtr Tensor
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-_sparse_log_softmax_tlb = cast3 Unmanaged._sparse_log_softmax_tlb
+_sparse_log_softmax_tlb = _cast3 Unmanaged._sparse_log_softmax_tlb
 
 _sparse_log_softmax_backward_data_ttlt
   :: ForeignPtr Tensor
@@ -753,25 +753,25 @@ _sparse_log_softmax_backward_data_ttlt
   -> Int64
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_sparse_log_softmax_backward_data_ttlt = cast4 Unmanaged._sparse_log_softmax_backward_data_ttlt
+_sparse_log_softmax_backward_data_ttlt = _cast4 Unmanaged._sparse_log_softmax_backward_data_ttlt
 
 norm_tss
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-norm_tss = cast3 Unmanaged.norm_tss
+norm_tss = _cast3 Unmanaged.norm_tss
 
 norm_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-norm_ts = cast2 Unmanaged.norm_ts
+norm_ts = _cast2 Unmanaged.norm_ts
 
 norm_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-norm_t = cast1 Unmanaged.norm_t
+norm_t = _cast1 Unmanaged.norm_t
 
 norm_tslbs
   :: ForeignPtr Tensor
@@ -780,7 +780,7 @@ norm_tslbs
   -> CBool
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-norm_tslbs = cast5 Unmanaged.norm_tslbs
+norm_tslbs = _cast5 Unmanaged.norm_tslbs
 
 norm_tslb
   :: ForeignPtr Tensor
@@ -788,14 +788,14 @@ norm_tslb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-norm_tslb = cast4 Unmanaged.norm_tslb
+norm_tslb = _cast4 Unmanaged.norm_tslb
 
 norm_tsl
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-norm_tsl = cast3 Unmanaged.norm_tsl
+norm_tsl = _cast3 Unmanaged.norm_tsl
 
 norm_out_ttslbs
   :: ForeignPtr Tensor
@@ -805,7 +805,7 @@ norm_out_ttslbs
   -> CBool
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-norm_out_ttslbs = cast6 Unmanaged.norm_out_ttslbs
+norm_out_ttslbs = _cast6 Unmanaged.norm_out_ttslbs
 
 norm_out_ttslb
   :: ForeignPtr Tensor
@@ -814,7 +814,7 @@ norm_out_ttslb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-norm_out_ttslb = cast5 Unmanaged.norm_out_ttslb
+norm_out_ttslb = _cast5 Unmanaged.norm_out_ttslb
 
 norm_out_ttsl
   :: ForeignPtr Tensor
@@ -822,7 +822,7 @@ norm_out_ttsl
   -> ForeignPtr Scalar
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-norm_out_ttsl = cast4 Unmanaged.norm_out_ttsl
+norm_out_ttsl = _cast4 Unmanaged.norm_out_ttsl
 
 norm_tsNbs
   :: ForeignPtr Tensor
@@ -831,7 +831,7 @@ norm_tsNbs
   -> CBool
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-norm_tsNbs = cast5 Unmanaged.norm_tsNbs
+norm_tsNbs = _cast5 Unmanaged.norm_tsNbs
 
 norm_tsNb
   :: ForeignPtr Tensor
@@ -839,14 +839,14 @@ norm_tsNb
   -> ForeignPtr DimnameList
   -> CBool
   -> IO (ForeignPtr Tensor)
-norm_tsNb = cast4 Unmanaged.norm_tsNb
+norm_tsNb = _cast4 Unmanaged.norm_tsNb
 
 norm_tsN
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr DimnameList
   -> IO (ForeignPtr Tensor)
-norm_tsN = cast3 Unmanaged.norm_tsN
+norm_tsN = _cast3 Unmanaged.norm_tsN
 
 norm_out_ttsNbs
   :: ForeignPtr Tensor
@@ -856,7 +856,7 @@ norm_out_ttsNbs
   -> CBool
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-norm_out_ttsNbs = cast6 Unmanaged.norm_out_ttsNbs
+norm_out_ttsNbs = _cast6 Unmanaged.norm_out_ttsNbs
 
 norm_out_ttsNb
   :: ForeignPtr Tensor
@@ -865,7 +865,7 @@ norm_out_ttsNb
   -> ForeignPtr DimnameList
   -> CBool
   -> IO (ForeignPtr Tensor)
-norm_out_ttsNb = cast5 Unmanaged.norm_out_ttsNb
+norm_out_ttsNb = _cast5 Unmanaged.norm_out_ttsNb
 
 norm_out_ttsN
   :: ForeignPtr Tensor
@@ -873,37 +873,37 @@ norm_out_ttsN
   -> ForeignPtr Scalar
   -> ForeignPtr DimnameList
   -> IO (ForeignPtr Tensor)
-norm_out_ttsN = cast4 Unmanaged.norm_out_ttsN
+norm_out_ttsN = _cast4 Unmanaged.norm_out_ttsN
 
 frexp_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-frexp_t = cast1 Unmanaged.frexp_t
+frexp_t = _cast1 Unmanaged.frexp_t
 
 frexp_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-frexp_out_ttt = cast3 Unmanaged.frexp_out_ttt
+frexp_out_ttt = _cast3 Unmanaged.frexp_out_ttt
 
 frobenius_norm_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-frobenius_norm_t = cast1 Unmanaged.frobenius_norm_t
+frobenius_norm_t = _cast1 Unmanaged.frobenius_norm_t
 
 frobenius_norm_tlb
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-frobenius_norm_tlb = cast3 Unmanaged.frobenius_norm_tlb
+frobenius_norm_tlb = _cast3 Unmanaged.frobenius_norm_tlb
 
 frobenius_norm_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-frobenius_norm_tl = cast2 Unmanaged.frobenius_norm_tl
+frobenius_norm_tl = _cast2 Unmanaged.frobenius_norm_tl
 
 frobenius_norm_out_ttlb
   :: ForeignPtr Tensor
@@ -911,51 +911,51 @@ frobenius_norm_out_ttlb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-frobenius_norm_out_ttlb = cast4 Unmanaged.frobenius_norm_out_ttlb
+frobenius_norm_out_ttlb = _cast4 Unmanaged.frobenius_norm_out_ttlb
 
 frobenius_norm_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-frobenius_norm_out_ttl = cast3 Unmanaged.frobenius_norm_out_ttl
+frobenius_norm_out_ttl = _cast3 Unmanaged.frobenius_norm_out_ttl
 
 nuclear_norm_tb
   :: ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-nuclear_norm_tb = cast2 Unmanaged.nuclear_norm_tb
+nuclear_norm_tb = _cast2 Unmanaged.nuclear_norm_tb
 
 nuclear_norm_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-nuclear_norm_t = cast1 Unmanaged.nuclear_norm_t
+nuclear_norm_t = _cast1 Unmanaged.nuclear_norm_t
 
 nuclear_norm_out_ttb
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-nuclear_norm_out_ttb = cast3 Unmanaged.nuclear_norm_out_ttb
+nuclear_norm_out_ttb = _cast3 Unmanaged.nuclear_norm_out_ttb
 
 nuclear_norm_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-nuclear_norm_out_tt = cast2 Unmanaged.nuclear_norm_out_tt
+nuclear_norm_out_tt = _cast2 Unmanaged.nuclear_norm_out_tt
 
 nuclear_norm_tlb
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-nuclear_norm_tlb = cast3 Unmanaged.nuclear_norm_tlb
+nuclear_norm_tlb = _cast3 Unmanaged.nuclear_norm_tlb
 
 nuclear_norm_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-nuclear_norm_tl = cast2 Unmanaged.nuclear_norm_tl
+nuclear_norm_tl = _cast2 Unmanaged.nuclear_norm_tl
 
 nuclear_norm_out_ttlb
   :: ForeignPtr Tensor
@@ -963,54 +963,54 @@ nuclear_norm_out_ttlb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-nuclear_norm_out_ttlb = cast4 Unmanaged.nuclear_norm_out_ttlb
+nuclear_norm_out_ttlb = _cast4 Unmanaged.nuclear_norm_out_ttlb
 
 nuclear_norm_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-nuclear_norm_out_ttl = cast3 Unmanaged.nuclear_norm_out_ttl
+nuclear_norm_out_ttl = _cast3 Unmanaged.nuclear_norm_out_ttl
 
 clone_tM
   :: ForeignPtr Tensor
   -> MemoryFormat
   -> IO (ForeignPtr Tensor)
-clone_tM = cast2 Unmanaged.clone_tM
+clone_tM = _cast2 Unmanaged.clone_tM
 
 clone_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-clone_t = cast1 Unmanaged.clone_t
+clone_t = _cast1 Unmanaged.clone_t
 
 positive_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-positive_t = cast1 Unmanaged.positive_t
+positive_t = _cast1 Unmanaged.positive_t
 
 resize_as__ttM
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> MemoryFormat
   -> IO (ForeignPtr Tensor)
-resize_as__ttM = cast3 Unmanaged.resize_as__ttM
+resize_as__ttM = _cast3 Unmanaged.resize_as__ttM
 
 resize_as__tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-resize_as__tt = cast2 Unmanaged.resize_as__tt
+resize_as__tt = _cast2 Unmanaged.resize_as__tt
 
 resize_as_sparse__tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-resize_as_sparse__tt = cast2 Unmanaged.resize_as_sparse__tt
+resize_as_sparse__tt = _cast2 Unmanaged.resize_as_sparse__tt
 
 zero__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-zero__t = cast1 Unmanaged.zero__t
+zero__t = _cast1 Unmanaged.zero__t
 
 sub_out_ttts
   :: ForeignPtr Tensor
@@ -1018,40 +1018,40 @@ sub_out_ttts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-sub_out_ttts = cast4 Unmanaged.sub_out_ttts
+sub_out_ttts = _cast4 Unmanaged.sub_out_ttts
 
 sub_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-sub_out_ttt = cast3 Unmanaged.sub_out_ttt
+sub_out_ttt = _cast3 Unmanaged.sub_out_ttt
 
 sub_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-sub_tts = cast3 Unmanaged.sub_tts
+sub_tts = _cast3 Unmanaged.sub_tts
 
 sub_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-sub_tt = cast2 Unmanaged.sub_tt
+sub_tt = _cast2 Unmanaged.sub_tt
 
 sub_tss
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-sub_tss = cast3 Unmanaged.sub_tss
+sub_tss = _cast3 Unmanaged.sub_tss
 
 sub_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-sub_ts = cast2 Unmanaged.sub_ts
+sub_ts = _cast2 Unmanaged.sub_ts
 
 subtract_out_ttts
   :: ForeignPtr Tensor
@@ -1059,79 +1059,79 @@ subtract_out_ttts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-subtract_out_ttts = cast4 Unmanaged.subtract_out_ttts
+subtract_out_ttts = _cast4 Unmanaged.subtract_out_ttts
 
 subtract_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-subtract_out_ttt = cast3 Unmanaged.subtract_out_ttt
+subtract_out_ttt = _cast3 Unmanaged.subtract_out_ttt
 
 subtract_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-subtract_tts = cast3 Unmanaged.subtract_tts
+subtract_tts = _cast3 Unmanaged.subtract_tts
 
 subtract_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-subtract_tt = cast2 Unmanaged.subtract_tt
+subtract_tt = _cast2 Unmanaged.subtract_tt
 
 subtract_tss
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-subtract_tss = cast3 Unmanaged.subtract_tss
+subtract_tss = _cast3 Unmanaged.subtract_tss
 
 subtract_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-subtract_ts = cast2 Unmanaged.subtract_ts
+subtract_ts = _cast2 Unmanaged.subtract_ts
 
 rsub_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-rsub_tts = cast3 Unmanaged.rsub_tts
+rsub_tts = _cast3 Unmanaged.rsub_tts
 
 rsub_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-rsub_tt = cast2 Unmanaged.rsub_tt
+rsub_tt = _cast2 Unmanaged.rsub_tt
 
 heaviside_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-heaviside_out_ttt = cast3 Unmanaged.heaviside_out_ttt
+heaviside_out_ttt = _cast3 Unmanaged.heaviside_out_ttt
 
 heaviside_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-heaviside_tt = cast2 Unmanaged.heaviside_tt
+heaviside_tt = _cast2 Unmanaged.heaviside_tt
 
 rsub_tss
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-rsub_tss = cast3 Unmanaged.rsub_tss
+rsub_tss = _cast3 Unmanaged.rsub_tss
 
 rsub_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-rsub_ts = cast2 Unmanaged.rsub_ts
+rsub_ts = _cast2 Unmanaged.rsub_ts
 
 _sparse_addmm_tttss
   :: ForeignPtr Tensor
@@ -1140,7 +1140,7 @@ _sparse_addmm_tttss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-_sparse_addmm_tttss = cast5 Unmanaged._sparse_addmm_tttss
+_sparse_addmm_tttss = _cast5 Unmanaged._sparse_addmm_tttss
 
 _sparse_addmm_ttts
   :: ForeignPtr Tensor
@@ -1148,14 +1148,14 @@ _sparse_addmm_ttts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-_sparse_addmm_ttts = cast4 Unmanaged._sparse_addmm_ttts
+_sparse_addmm_ttts = _cast4 Unmanaged._sparse_addmm_ttts
 
 _sparse_addmm_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_sparse_addmm_ttt = cast3 Unmanaged._sparse_addmm_ttt
+_sparse_addmm_ttt = _cast3 Unmanaged._sparse_addmm_ttt
 
 sparse_sampled_addmm_out_ttttss
   :: ForeignPtr Tensor
@@ -1165,7 +1165,7 @@ sparse_sampled_addmm_out_ttttss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-sparse_sampled_addmm_out_ttttss = cast6 Unmanaged.sparse_sampled_addmm_out_ttttss
+sparse_sampled_addmm_out_ttttss = _cast6 Unmanaged.sparse_sampled_addmm_out_ttttss
 
 sparse_sampled_addmm_out_tttts
   :: ForeignPtr Tensor
@@ -1174,7 +1174,7 @@ sparse_sampled_addmm_out_tttts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-sparse_sampled_addmm_out_tttts = cast5 Unmanaged.sparse_sampled_addmm_out_tttts
+sparse_sampled_addmm_out_tttts = _cast5 Unmanaged.sparse_sampled_addmm_out_tttts
 
 sparse_sampled_addmm_out_tttt
   :: ForeignPtr Tensor
@@ -1182,7 +1182,7 @@ sparse_sampled_addmm_out_tttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-sparse_sampled_addmm_out_tttt = cast4 Unmanaged.sparse_sampled_addmm_out_tttt
+sparse_sampled_addmm_out_tttt = _cast4 Unmanaged.sparse_sampled_addmm_out_tttt
 
 sparse_sampled_addmm_tttss
   :: ForeignPtr Tensor
@@ -1191,7 +1191,7 @@ sparse_sampled_addmm_tttss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-sparse_sampled_addmm_tttss = cast5 Unmanaged.sparse_sampled_addmm_tttss
+sparse_sampled_addmm_tttss = _cast5 Unmanaged.sparse_sampled_addmm_tttss
 
 sparse_sampled_addmm_ttts
   :: ForeignPtr Tensor
@@ -1199,14 +1199,14 @@ sparse_sampled_addmm_ttts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-sparse_sampled_addmm_ttts = cast4 Unmanaged.sparse_sampled_addmm_ttts
+sparse_sampled_addmm_ttts = _cast4 Unmanaged.sparse_sampled_addmm_ttts
 
 sparse_sampled_addmm_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-sparse_sampled_addmm_ttt = cast3 Unmanaged.sparse_sampled_addmm_ttt
+sparse_sampled_addmm_ttt = _cast3 Unmanaged.sparse_sampled_addmm_ttt
 
 addmm_out_ttttss
   :: ForeignPtr Tensor
@@ -1216,7 +1216,7 @@ addmm_out_ttttss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-addmm_out_ttttss = cast6 Unmanaged.addmm_out_ttttss
+addmm_out_ttttss = _cast6 Unmanaged.addmm_out_ttttss
 
 addmm_out_tttts
   :: ForeignPtr Tensor
@@ -1225,7 +1225,7 @@ addmm_out_tttts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-addmm_out_tttts = cast5 Unmanaged.addmm_out_tttts
+addmm_out_tttts = _cast5 Unmanaged.addmm_out_tttts
 
 addmm_out_tttt
   :: ForeignPtr Tensor
@@ -1233,7 +1233,7 @@ addmm_out_tttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-addmm_out_tttt = cast4 Unmanaged.addmm_out_tttt
+addmm_out_tttt = _cast4 Unmanaged.addmm_out_tttt
 
 addmm_tttss
   :: ForeignPtr Tensor
@@ -1242,7 +1242,7 @@ addmm_tttss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-addmm_tttss = cast5 Unmanaged.addmm_tttss
+addmm_tttss = _cast5 Unmanaged.addmm_tttss
 
 addmm_ttts
   :: ForeignPtr Tensor
@@ -1250,14 +1250,14 @@ addmm_ttts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-addmm_ttts = cast4 Unmanaged.addmm_ttts
+addmm_ttts = _cast4 Unmanaged.addmm_ttts
 
 addmm_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-addmm_ttt = cast3 Unmanaged.addmm_ttt
+addmm_ttt = _cast3 Unmanaged.addmm_ttt
 
 sparse_csr_tensor_tttlo
   :: ForeignPtr Tensor
@@ -1266,7 +1266,7 @@ sparse_csr_tensor_tttlo
   -> ForeignPtr IntArray
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-sparse_csr_tensor_tttlo = cast5 Unmanaged.sparse_csr_tensor_tttlo
+sparse_csr_tensor_tttlo = _cast5 Unmanaged.sparse_csr_tensor_tttlo
 
 sparse_csr_tensor_ttto
   :: ForeignPtr Tensor
@@ -1274,7 +1274,7 @@ sparse_csr_tensor_ttto
   -> ForeignPtr Tensor
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-sparse_csr_tensor_ttto = cast4 Unmanaged.sparse_csr_tensor_ttto
+sparse_csr_tensor_ttto = _cast4 Unmanaged.sparse_csr_tensor_ttto
 
 _sparse_csr_tensor_unsafe_tttlo
   :: ForeignPtr Tensor
@@ -1283,7 +1283,7 @@ _sparse_csr_tensor_unsafe_tttlo
   -> ForeignPtr IntArray
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-_sparse_csr_tensor_unsafe_tttlo = cast5 Unmanaged._sparse_csr_tensor_unsafe_tttlo
+_sparse_csr_tensor_unsafe_tttlo = _cast5 Unmanaged._sparse_csr_tensor_unsafe_tttlo
 
 _sparse_csr_tensor_unsafe_tttl
   :: ForeignPtr Tensor
@@ -1291,26 +1291,26 @@ _sparse_csr_tensor_unsafe_tttl
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-_sparse_csr_tensor_unsafe_tttl = cast4 Unmanaged._sparse_csr_tensor_unsafe_tttl
+_sparse_csr_tensor_unsafe_tttl = _cast4 Unmanaged._sparse_csr_tensor_unsafe_tttl
 
 sparse_coo_tensor_lo
   :: ForeignPtr IntArray
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-sparse_coo_tensor_lo = cast2 Unmanaged.sparse_coo_tensor_lo
+sparse_coo_tensor_lo = _cast2 Unmanaged.sparse_coo_tensor_lo
 
 sparse_coo_tensor_tto
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-sparse_coo_tensor_tto = cast3 Unmanaged.sparse_coo_tensor_tto
+sparse_coo_tensor_tto = _cast3 Unmanaged.sparse_coo_tensor_tto
 
 sparse_coo_tensor_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-sparse_coo_tensor_tt = cast2 Unmanaged.sparse_coo_tensor_tt
+sparse_coo_tensor_tt = _cast2 Unmanaged.sparse_coo_tensor_tt
 
 sparse_coo_tensor_ttlo
   :: ForeignPtr Tensor
@@ -1318,14 +1318,14 @@ sparse_coo_tensor_ttlo
   -> ForeignPtr IntArray
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-sparse_coo_tensor_ttlo = cast4 Unmanaged.sparse_coo_tensor_ttlo
+sparse_coo_tensor_ttlo = _cast4 Unmanaged.sparse_coo_tensor_ttlo
 
 sparse_coo_tensor_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-sparse_coo_tensor_ttl = cast3 Unmanaged.sparse_coo_tensor_ttl
+sparse_coo_tensor_ttl = _cast3 Unmanaged.sparse_coo_tensor_ttl
 
 _sparse_coo_tensor_unsafe_ttlo
   :: ForeignPtr Tensor
@@ -1333,21 +1333,21 @@ _sparse_coo_tensor_unsafe_ttlo
   -> ForeignPtr IntArray
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-_sparse_coo_tensor_unsafe_ttlo = cast4 Unmanaged._sparse_coo_tensor_unsafe_ttlo
+_sparse_coo_tensor_unsafe_ttlo = _cast4 Unmanaged._sparse_coo_tensor_unsafe_ttlo
 
 _sparse_coo_tensor_unsafe_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-_sparse_coo_tensor_unsafe_ttl = cast3 Unmanaged._sparse_coo_tensor_unsafe_ttl
+_sparse_coo_tensor_unsafe_ttl = _cast3 Unmanaged._sparse_coo_tensor_unsafe_ttl
 
 _validate_sparse_coo_tensor_args_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (())
-_validate_sparse_coo_tensor_args_ttl = cast3 Unmanaged._validate_sparse_coo_tensor_args_ttl
+_validate_sparse_coo_tensor_args_ttl = _cast3 Unmanaged._validate_sparse_coo_tensor_args_ttl
 
 _validate_sparse_csr_tensor_args_tttl
   :: ForeignPtr Tensor
@@ -1355,7 +1355,7 @@ _validate_sparse_csr_tensor_args_tttl
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (())
-_validate_sparse_csr_tensor_args_tttl = cast4 Unmanaged._validate_sparse_csr_tensor_args_tttl
+_validate_sparse_csr_tensor_args_tttl = _cast4 Unmanaged._validate_sparse_csr_tensor_args_tttl
 
 _sparse_coo_tensor_with_dims_lllo
   :: Int64
@@ -1363,7 +1363,7 @@ _sparse_coo_tensor_with_dims_lllo
   -> ForeignPtr IntArray
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-_sparse_coo_tensor_with_dims_lllo = cast4 Unmanaged._sparse_coo_tensor_with_dims_lllo
+_sparse_coo_tensor_with_dims_lllo = _cast4 Unmanaged._sparse_coo_tensor_with_dims_lllo
 
 _sparse_coo_tensor_with_dims_and_tensors_llltto
   :: Int64
@@ -1373,66 +1373,66 @@ _sparse_coo_tensor_with_dims_and_tensors_llltto
   -> ForeignPtr Tensor
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-_sparse_coo_tensor_with_dims_and_tensors_llltto = cast6 Unmanaged._sparse_coo_tensor_with_dims_and_tensors_llltto
+_sparse_coo_tensor_with_dims_and_tensors_llltto = _cast6 Unmanaged._sparse_coo_tensor_with_dims_and_tensors_llltto
 
 _to_cpu_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr TensorList)
-_to_cpu_l = cast1 Unmanaged._to_cpu_l
+_to_cpu_l = _cast1 Unmanaged._to_cpu_l
 
 to_dense_backward_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-to_dense_backward_tt = cast2 Unmanaged.to_dense_backward_tt
+to_dense_backward_tt = _cast2 Unmanaged.to_dense_backward_tt
 
 _coalesce_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_coalesce_t = cast1 Unmanaged._coalesce_t
+_coalesce_t = _cast1 Unmanaged._coalesce_t
 
 hspmm_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-hspmm_out_ttt = cast3 Unmanaged.hspmm_out_ttt
+hspmm_out_ttt = _cast3 Unmanaged.hspmm_out_ttt
 
 hspmm_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-hspmm_tt = cast2 Unmanaged.hspmm_tt
+hspmm_tt = _cast2 Unmanaged.hspmm_tt
 
 copy_sparse_to_sparse__ttb
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-copy_sparse_to_sparse__ttb = cast3 Unmanaged.copy_sparse_to_sparse__ttb
+copy_sparse_to_sparse__ttb = _cast3 Unmanaged.copy_sparse_to_sparse__ttb
 
 copy_sparse_to_sparse__tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-copy_sparse_to_sparse__tt = cast2 Unmanaged.copy_sparse_to_sparse__tt
+copy_sparse_to_sparse__tt = _cast2 Unmanaged.copy_sparse_to_sparse__tt
 
 unbind_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr TensorList)
-unbind_tl = cast2 Unmanaged.unbind_tl
+unbind_tl = _cast2 Unmanaged.unbind_tl
 
 unbind_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr TensorList)
-unbind_t = cast1 Unmanaged.unbind_t
+unbind_t = _cast1 Unmanaged.unbind_t
 
 unbind_tn
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> IO (ForeignPtr TensorList)
-unbind_tn = cast2 Unmanaged.unbind_tn
+unbind_tn = _cast2 Unmanaged.unbind_tn
 
 mkldnn_reorder_conv2d_weight_tllll
   :: ForeignPtr Tensor
@@ -1441,7 +1441,7 @@ mkldnn_reorder_conv2d_weight_tllll
   -> ForeignPtr IntArray
   -> Int64
   -> IO (ForeignPtr Tensor)
-mkldnn_reorder_conv2d_weight_tllll = cast5 Unmanaged.mkldnn_reorder_conv2d_weight_tllll
+mkldnn_reorder_conv2d_weight_tllll = _cast5 Unmanaged.mkldnn_reorder_conv2d_weight_tllll
 
 mkldnn_reorder_conv2d_weight_tlll
   :: ForeignPtr Tensor
@@ -1449,25 +1449,25 @@ mkldnn_reorder_conv2d_weight_tlll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-mkldnn_reorder_conv2d_weight_tlll = cast4 Unmanaged.mkldnn_reorder_conv2d_weight_tlll
+mkldnn_reorder_conv2d_weight_tlll = _cast4 Unmanaged.mkldnn_reorder_conv2d_weight_tlll
 
 mkldnn_reorder_conv2d_weight_tll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-mkldnn_reorder_conv2d_weight_tll = cast3 Unmanaged.mkldnn_reorder_conv2d_weight_tll
+mkldnn_reorder_conv2d_weight_tll = _cast3 Unmanaged.mkldnn_reorder_conv2d_weight_tll
 
 mkldnn_reorder_conv2d_weight_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-mkldnn_reorder_conv2d_weight_tl = cast2 Unmanaged.mkldnn_reorder_conv2d_weight_tl
+mkldnn_reorder_conv2d_weight_tl = _cast2 Unmanaged.mkldnn_reorder_conv2d_weight_tl
 
 mkldnn_reorder_conv2d_weight_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-mkldnn_reorder_conv2d_weight_t = cast1 Unmanaged.mkldnn_reorder_conv2d_weight_t
+mkldnn_reorder_conv2d_weight_t = _cast1 Unmanaged.mkldnn_reorder_conv2d_weight_t
 
 mkldnn_reorder_conv3d_weight_tllll
   :: ForeignPtr Tensor
@@ -1476,7 +1476,7 @@ mkldnn_reorder_conv3d_weight_tllll
   -> ForeignPtr IntArray
   -> Int64
   -> IO (ForeignPtr Tensor)
-mkldnn_reorder_conv3d_weight_tllll = cast5 Unmanaged.mkldnn_reorder_conv3d_weight_tllll
+mkldnn_reorder_conv3d_weight_tllll = _cast5 Unmanaged.mkldnn_reorder_conv3d_weight_tllll
 
 mkldnn_reorder_conv3d_weight_tlll
   :: ForeignPtr Tensor
@@ -1484,23 +1484,23 @@ mkldnn_reorder_conv3d_weight_tlll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-mkldnn_reorder_conv3d_weight_tlll = cast4 Unmanaged.mkldnn_reorder_conv3d_weight_tlll
+mkldnn_reorder_conv3d_weight_tlll = _cast4 Unmanaged.mkldnn_reorder_conv3d_weight_tlll
 
 mkldnn_reorder_conv3d_weight_tll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-mkldnn_reorder_conv3d_weight_tll = cast3 Unmanaged.mkldnn_reorder_conv3d_weight_tll
+mkldnn_reorder_conv3d_weight_tll = _cast3 Unmanaged.mkldnn_reorder_conv3d_weight_tll
 
 mkldnn_reorder_conv3d_weight_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-mkldnn_reorder_conv3d_weight_tl = cast2 Unmanaged.mkldnn_reorder_conv3d_weight_tl
+mkldnn_reorder_conv3d_weight_tl = _cast2 Unmanaged.mkldnn_reorder_conv3d_weight_tl
 
 mkldnn_reorder_conv3d_weight_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-mkldnn_reorder_conv3d_weight_t = cast1 Unmanaged.mkldnn_reorder_conv3d_weight_t
+mkldnn_reorder_conv3d_weight_t = _cast1 Unmanaged.mkldnn_reorder_conv3d_weight_t
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Native/Native8.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Native/Native8.hs
@@ -25,14 +25,14 @@ to_mkldnn_backward_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-to_mkldnn_backward_tt = cast2 Unmanaged.to_mkldnn_backward_tt
+to_mkldnn_backward_tt = _cast2 Unmanaged.to_mkldnn_backward_tt
 
 quantize_per_tensor_dynamic_tsb
   :: ForeignPtr Tensor
   -> ScalarType
   -> CBool
   -> IO (ForeignPtr Tensor)
-quantize_per_tensor_dynamic_tsb = cast3 Unmanaged.quantize_per_tensor_dynamic_tsb
+quantize_per_tensor_dynamic_tsb = _cast3 Unmanaged.quantize_per_tensor_dynamic_tsb
 
 quantize_per_tensor_tdls
   :: ForeignPtr Tensor
@@ -40,7 +40,7 @@ quantize_per_tensor_tdls
   -> Int64
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-quantize_per_tensor_tdls = cast4 Unmanaged.quantize_per_tensor_tdls
+quantize_per_tensor_tdls = _cast4 Unmanaged.quantize_per_tensor_tdls
 
 quantize_per_tensor_ttts
   :: ForeignPtr Tensor
@@ -48,7 +48,7 @@ quantize_per_tensor_ttts
   -> ForeignPtr Tensor
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-quantize_per_tensor_ttts = cast4 Unmanaged.quantize_per_tensor_ttts
+quantize_per_tensor_ttts = _cast4 Unmanaged.quantize_per_tensor_ttts
 
 quantize_per_tensor_ltts
   :: ForeignPtr TensorList
@@ -56,7 +56,7 @@ quantize_per_tensor_ltts
   -> ForeignPtr Tensor
   -> ScalarType
   -> IO (ForeignPtr TensorList)
-quantize_per_tensor_ltts = cast4 Unmanaged.quantize_per_tensor_ltts
+quantize_per_tensor_ltts = _cast4 Unmanaged.quantize_per_tensor_ltts
 
 quantize_per_channel_tttls
   :: ForeignPtr Tensor
@@ -65,54 +65,54 @@ quantize_per_channel_tttls
   -> Int64
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-quantize_per_channel_tttls = cast5 Unmanaged.quantize_per_channel_tttls
+quantize_per_channel_tttls = _cast5 Unmanaged.quantize_per_channel_tttls
 
 dequantize_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-dequantize_t = cast1 Unmanaged.dequantize_t
+dequantize_t = _cast1 Unmanaged.dequantize_t
 
 dequantize_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr TensorList)
-dequantize_l = cast1 Unmanaged.dequantize_l
+dequantize_l = _cast1 Unmanaged.dequantize_l
 
 q_scale_t
   :: ForeignPtr Tensor
   -> IO (CDouble)
-q_scale_t = cast1 Unmanaged.q_scale_t
+q_scale_t = _cast1 Unmanaged.q_scale_t
 
 q_zero_point_t
   :: ForeignPtr Tensor
   -> IO (Int64)
-q_zero_point_t = cast1 Unmanaged.q_zero_point_t
+q_zero_point_t = _cast1 Unmanaged.q_zero_point_t
 
 q_per_channel_scales_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-q_per_channel_scales_t = cast1 Unmanaged.q_per_channel_scales_t
+q_per_channel_scales_t = _cast1 Unmanaged.q_per_channel_scales_t
 
 q_per_channel_zero_points_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-q_per_channel_zero_points_t = cast1 Unmanaged.q_per_channel_zero_points_t
+q_per_channel_zero_points_t = _cast1 Unmanaged.q_per_channel_zero_points_t
 
 q_per_channel_axis_t
   :: ForeignPtr Tensor
   -> IO (Int64)
-q_per_channel_axis_t = cast1 Unmanaged.q_per_channel_axis_t
+q_per_channel_axis_t = _cast1 Unmanaged.q_per_channel_axis_t
 
 int_repr_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-int_repr_t = cast1 Unmanaged.int_repr_t
+int_repr_t = _cast1 Unmanaged.int_repr_t
 
 _make_per_tensor_quantized_tensor_tdl
   :: ForeignPtr Tensor
   -> CDouble
   -> Int64
   -> IO (ForeignPtr Tensor)
-_make_per_tensor_quantized_tensor_tdl = cast3 Unmanaged._make_per_tensor_quantized_tensor_tdl
+_make_per_tensor_quantized_tensor_tdl = _cast3 Unmanaged._make_per_tensor_quantized_tensor_tdl
 
 _make_per_channel_quantized_tensor_tttl
   :: ForeignPtr Tensor
@@ -120,7 +120,7 @@ _make_per_channel_quantized_tensor_tttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-_make_per_channel_quantized_tensor_tttl = cast4 Unmanaged._make_per_channel_quantized_tensor_tttl
+_make_per_channel_quantized_tensor_tttl = _cast4 Unmanaged._make_per_channel_quantized_tensor_tttl
 
 fake_quantize_per_tensor_affine_tdlll
   :: ForeignPtr Tensor
@@ -129,7 +129,7 @@ fake_quantize_per_tensor_affine_tdlll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-fake_quantize_per_tensor_affine_tdlll = cast5 Unmanaged.fake_quantize_per_tensor_affine_tdlll
+fake_quantize_per_tensor_affine_tdlll = _cast5 Unmanaged.fake_quantize_per_tensor_affine_tdlll
 
 fake_quantize_per_tensor_affine_tttll
   :: ForeignPtr Tensor
@@ -138,7 +138,7 @@ fake_quantize_per_tensor_affine_tttll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-fake_quantize_per_tensor_affine_tttll = cast5 Unmanaged.fake_quantize_per_tensor_affine_tttll
+fake_quantize_per_tensor_affine_tttll = _cast5 Unmanaged.fake_quantize_per_tensor_affine_tttll
 
 fake_quantize_per_tensor_affine_cachemask_tdlll
   :: ForeignPtr Tensor
@@ -147,7 +147,7 @@ fake_quantize_per_tensor_affine_cachemask_tdlll
   -> Int64
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-fake_quantize_per_tensor_affine_cachemask_tdlll = cast5 Unmanaged.fake_quantize_per_tensor_affine_cachemask_tdlll
+fake_quantize_per_tensor_affine_cachemask_tdlll = _cast5 Unmanaged.fake_quantize_per_tensor_affine_cachemask_tdlll
 
 _fake_quantize_per_tensor_affine_cachemask_tensor_qparams_ttttll
   :: ForeignPtr Tensor
@@ -157,13 +157,13 @@ _fake_quantize_per_tensor_affine_cachemask_tensor_qparams_ttttll
   -> Int64
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-_fake_quantize_per_tensor_affine_cachemask_tensor_qparams_ttttll = cast6 Unmanaged._fake_quantize_per_tensor_affine_cachemask_tensor_qparams_ttttll
+_fake_quantize_per_tensor_affine_cachemask_tensor_qparams_ttttll = _cast6 Unmanaged._fake_quantize_per_tensor_affine_cachemask_tensor_qparams_ttttll
 
 fake_quantize_per_tensor_affine_cachemask_backward_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fake_quantize_per_tensor_affine_cachemask_backward_tt = cast2 Unmanaged.fake_quantize_per_tensor_affine_cachemask_backward_tt
+fake_quantize_per_tensor_affine_cachemask_backward_tt = _cast2 Unmanaged.fake_quantize_per_tensor_affine_cachemask_backward_tt
 
 _fake_quantize_learnable_per_tensor_affine_tttlld
   :: ForeignPtr Tensor
@@ -173,7 +173,7 @@ _fake_quantize_learnable_per_tensor_affine_tttlld
   -> Int64
   -> CDouble
   -> IO (ForeignPtr Tensor)
-_fake_quantize_learnable_per_tensor_affine_tttlld = cast6 Unmanaged._fake_quantize_learnable_per_tensor_affine_tttlld
+_fake_quantize_learnable_per_tensor_affine_tttlld = _cast6 Unmanaged._fake_quantize_learnable_per_tensor_affine_tttlld
 
 _fake_quantize_learnable_per_tensor_affine_tttll
   :: ForeignPtr Tensor
@@ -182,7 +182,7 @@ _fake_quantize_learnable_per_tensor_affine_tttll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-_fake_quantize_learnable_per_tensor_affine_tttll = cast5 Unmanaged._fake_quantize_learnable_per_tensor_affine_tttll
+_fake_quantize_learnable_per_tensor_affine_tttll = _cast5 Unmanaged._fake_quantize_learnable_per_tensor_affine_tttll
 
 _fake_quantize_learnable_per_tensor_affine_backward_ttttlld
   :: ForeignPtr Tensor
@@ -193,7 +193,7 @@ _fake_quantize_learnable_per_tensor_affine_backward_ttttlld
   -> Int64
   -> CDouble
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-_fake_quantize_learnable_per_tensor_affine_backward_ttttlld = cast7 Unmanaged._fake_quantize_learnable_per_tensor_affine_backward_ttttlld
+_fake_quantize_learnable_per_tensor_affine_backward_ttttlld = _cast7 Unmanaged._fake_quantize_learnable_per_tensor_affine_backward_ttttlld
 
 _fake_quantize_learnable_per_tensor_affine_backward_ttttll
   :: ForeignPtr Tensor
@@ -203,7 +203,7 @@ _fake_quantize_learnable_per_tensor_affine_backward_ttttll
   -> Int64
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-_fake_quantize_learnable_per_tensor_affine_backward_ttttll = cast6 Unmanaged._fake_quantize_learnable_per_tensor_affine_backward_ttttll
+_fake_quantize_learnable_per_tensor_affine_backward_ttttll = _cast6 Unmanaged._fake_quantize_learnable_per_tensor_affine_backward_ttttll
 
 fake_quantize_per_channel_affine_tttlll
   :: ForeignPtr Tensor
@@ -213,7 +213,7 @@ fake_quantize_per_channel_affine_tttlll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-fake_quantize_per_channel_affine_tttlll = cast6 Unmanaged.fake_quantize_per_channel_affine_tttlll
+fake_quantize_per_channel_affine_tttlll = _cast6 Unmanaged.fake_quantize_per_channel_affine_tttlll
 
 fake_quantize_per_channel_affine_cachemask_tttlll
   :: ForeignPtr Tensor
@@ -223,13 +223,13 @@ fake_quantize_per_channel_affine_cachemask_tttlll
   -> Int64
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-fake_quantize_per_channel_affine_cachemask_tttlll = cast6 Unmanaged.fake_quantize_per_channel_affine_cachemask_tttlll
+fake_quantize_per_channel_affine_cachemask_tttlll = _cast6 Unmanaged.fake_quantize_per_channel_affine_cachemask_tttlll
 
 fake_quantize_per_channel_affine_cachemask_backward_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fake_quantize_per_channel_affine_cachemask_backward_tt = cast2 Unmanaged.fake_quantize_per_channel_affine_cachemask_backward_tt
+fake_quantize_per_channel_affine_cachemask_backward_tt = _cast2 Unmanaged.fake_quantize_per_channel_affine_cachemask_backward_tt
 
 _fake_quantize_learnable_per_channel_affine_tttllld
   :: ForeignPtr Tensor
@@ -240,7 +240,7 @@ _fake_quantize_learnable_per_channel_affine_tttllld
   -> Int64
   -> CDouble
   -> IO (ForeignPtr Tensor)
-_fake_quantize_learnable_per_channel_affine_tttllld = cast7 Unmanaged._fake_quantize_learnable_per_channel_affine_tttllld
+_fake_quantize_learnable_per_channel_affine_tttllld = _cast7 Unmanaged._fake_quantize_learnable_per_channel_affine_tttllld
 
 _fake_quantize_learnable_per_channel_affine_tttlll
   :: ForeignPtr Tensor
@@ -250,7 +250,7 @@ _fake_quantize_learnable_per_channel_affine_tttlll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-_fake_quantize_learnable_per_channel_affine_tttlll = cast6 Unmanaged._fake_quantize_learnable_per_channel_affine_tttlll
+_fake_quantize_learnable_per_channel_affine_tttlll = _cast6 Unmanaged._fake_quantize_learnable_per_channel_affine_tttlll
 
 _fake_quantize_learnable_per_channel_affine_backward_ttttllld
   :: ForeignPtr Tensor
@@ -262,7 +262,7 @@ _fake_quantize_learnable_per_channel_affine_backward_ttttllld
   -> Int64
   -> CDouble
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-_fake_quantize_learnable_per_channel_affine_backward_ttttllld = cast8 Unmanaged._fake_quantize_learnable_per_channel_affine_backward_ttttllld
+_fake_quantize_learnable_per_channel_affine_backward_ttttllld = _cast8 Unmanaged._fake_quantize_learnable_per_channel_affine_backward_ttttllld
 
 _fake_quantize_learnable_per_channel_affine_backward_ttttlll
   :: ForeignPtr Tensor
@@ -273,7 +273,7 @@ _fake_quantize_learnable_per_channel_affine_backward_ttttlll
   -> Int64
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-_fake_quantize_learnable_per_channel_affine_backward_ttttlll = cast7 Unmanaged._fake_quantize_learnable_per_channel_affine_backward_ttttlll
+_fake_quantize_learnable_per_channel_affine_backward_ttttlll = _cast7 Unmanaged._fake_quantize_learnable_per_channel_affine_backward_ttttlll
 
 fused_moving_avg_obs_fake_quant_tttttttdlllbb
   :: ForeignPtr Tensor
@@ -290,7 +290,7 @@ fused_moving_avg_obs_fake_quant_tttttttdlllbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-fused_moving_avg_obs_fake_quant_tttttttdlllbb = cast13 Unmanaged.fused_moving_avg_obs_fake_quant_tttttttdlllbb
+fused_moving_avg_obs_fake_quant_tttttttdlllbb = _cast13 Unmanaged.fused_moving_avg_obs_fake_quant_tttttttdlllbb
 
 fused_moving_avg_obs_fake_quant_tttttttdlllb
   :: ForeignPtr Tensor
@@ -306,7 +306,7 @@ fused_moving_avg_obs_fake_quant_tttttttdlllb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-fused_moving_avg_obs_fake_quant_tttttttdlllb = cast12 Unmanaged.fused_moving_avg_obs_fake_quant_tttttttdlllb
+fused_moving_avg_obs_fake_quant_tttttttdlllb = _cast12 Unmanaged.fused_moving_avg_obs_fake_quant_tttttttdlllb
 
 fused_moving_avg_obs_fake_quant_tttttttdlll
   :: ForeignPtr Tensor
@@ -321,7 +321,7 @@ fused_moving_avg_obs_fake_quant_tttttttdlll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-fused_moving_avg_obs_fake_quant_tttttttdlll = cast11 Unmanaged.fused_moving_avg_obs_fake_quant_tttttttdlll
+fused_moving_avg_obs_fake_quant_tttttttdlll = _cast11 Unmanaged.fused_moving_avg_obs_fake_quant_tttttttdlll
 
 _fused_moving_avg_obs_fq_helper_tttttttdlllbb
   :: ForeignPtr Tensor
@@ -338,7 +338,7 @@ _fused_moving_avg_obs_fq_helper_tttttttdlllbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-_fused_moving_avg_obs_fq_helper_tttttttdlllbb = cast13 Unmanaged._fused_moving_avg_obs_fq_helper_tttttttdlllbb
+_fused_moving_avg_obs_fq_helper_tttttttdlllbb = _cast13 Unmanaged._fused_moving_avg_obs_fq_helper_tttttttdlllbb
 
 _fused_moving_avg_obs_fq_helper_tttttttdlllb
   :: ForeignPtr Tensor
@@ -354,7 +354,7 @@ _fused_moving_avg_obs_fq_helper_tttttttdlllb
   -> Int64
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-_fused_moving_avg_obs_fq_helper_tttttttdlllb = cast12 Unmanaged._fused_moving_avg_obs_fq_helper_tttttttdlllb
+_fused_moving_avg_obs_fq_helper_tttttttdlllb = _cast12 Unmanaged._fused_moving_avg_obs_fq_helper_tttttttdlllb
 
 _fused_moving_avg_obs_fq_helper_tttttttdlll
   :: ForeignPtr Tensor
@@ -369,23 +369,23 @@ _fused_moving_avg_obs_fq_helper_tttttttdlll
   -> Int64
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-_fused_moving_avg_obs_fq_helper_tttttttdlll = cast11 Unmanaged._fused_moving_avg_obs_fq_helper_tttttttdlll
+_fused_moving_avg_obs_fq_helper_tttttttdlll = _cast11 Unmanaged._fused_moving_avg_obs_fq_helper_tttttttdlll
 
 _choose_qparams_per_tensor_tb
   :: ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(CDouble,Int64)))
-_choose_qparams_per_tensor_tb = cast2 Unmanaged._choose_qparams_per_tensor_tb
+_choose_qparams_per_tensor_tb = _cast2 Unmanaged._choose_qparams_per_tensor_tb
 
 _choose_qparams_per_tensor_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(CDouble,Int64)))
-_choose_qparams_per_tensor_t = cast1 Unmanaged._choose_qparams_per_tensor_t
+_choose_qparams_per_tensor_t = _cast1 Unmanaged._choose_qparams_per_tensor_t
 
 _saturate_weight_to_fp16_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_saturate_weight_to_fp16_t = cast1 Unmanaged._saturate_weight_to_fp16_t
+_saturate_weight_to_fp16_t = _cast1 Unmanaged._saturate_weight_to_fp16_t
 
 choose_qparams_optimized_tlldl
   :: ForeignPtr Tensor
@@ -394,7 +394,7 @@ choose_qparams_optimized_tlldl
   -> CDouble
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-choose_qparams_optimized_tlldl = cast5 Unmanaged.choose_qparams_optimized_tlldl
+choose_qparams_optimized_tlldl = _cast5 Unmanaged.choose_qparams_optimized_tlldl
 
 _to_copy_tobM
   :: ForeignPtr Tensor
@@ -402,100 +402,100 @@ _to_copy_tobM
   -> CBool
   -> MemoryFormat
   -> IO (ForeignPtr Tensor)
-_to_copy_tobM = cast4 Unmanaged._to_copy_tobM
+_to_copy_tobM = _cast4 Unmanaged._to_copy_tobM
 
 _to_copy_tob
   :: ForeignPtr Tensor
   -> ForeignPtr TensorOptions
   -> CBool
   -> IO (ForeignPtr Tensor)
-_to_copy_tob = cast3 Unmanaged._to_copy_tob
+_to_copy_tob = _cast3 Unmanaged._to_copy_tob
 
 _to_copy_to
   :: ForeignPtr Tensor
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-_to_copy_to = cast2 Unmanaged._to_copy_to
+_to_copy_to = _cast2 Unmanaged._to_copy_to
 
 _to_copy_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_to_copy_t = cast1 Unmanaged._to_copy_t
+_to_copy_t = _cast1 Unmanaged._to_copy_t
 
 meshgrid_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr TensorList)
-meshgrid_l = cast1 Unmanaged.meshgrid_l
+meshgrid_l = _cast1 Unmanaged.meshgrid_l
 
 meshgrid_ls
   :: ForeignPtr TensorList
   -> ForeignPtr StdString
   -> IO (ForeignPtr TensorList)
-meshgrid_ls = cast2 Unmanaged.meshgrid_ls
+meshgrid_ls = _cast2 Unmanaged.meshgrid_ls
 
 cartesian_prod_l
   :: ForeignPtr TensorList
   -> IO (ForeignPtr Tensor)
-cartesian_prod_l = cast1 Unmanaged.cartesian_prod_l
+cartesian_prod_l = _cast1 Unmanaged.cartesian_prod_l
 
 combinations_tlb
   :: ForeignPtr Tensor
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-combinations_tlb = cast3 Unmanaged.combinations_tlb
+combinations_tlb = _cast3 Unmanaged.combinations_tlb
 
 combinations_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-combinations_tl = cast2 Unmanaged.combinations_tl
+combinations_tl = _cast2 Unmanaged.combinations_tl
 
 combinations_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-combinations_t = cast1 Unmanaged.combinations_t
+combinations_t = _cast1 Unmanaged.combinations_t
 
 result_type_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ScalarType)
-result_type_tt = cast2 Unmanaged.result_type_tt
+result_type_tt = _cast2 Unmanaged.result_type_tt
 
 result_type_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ScalarType)
-result_type_ts = cast2 Unmanaged.result_type_ts
+result_type_ts = _cast2 Unmanaged.result_type_ts
 
 result_type_st
   :: ForeignPtr Scalar
   -> ForeignPtr Tensor
   -> IO (ScalarType)
-result_type_st = cast2 Unmanaged.result_type_st
+result_type_st = _cast2 Unmanaged.result_type_st
 
 result_type_ss
   :: ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ScalarType)
-result_type_ss = cast2 Unmanaged.result_type_ss
+result_type_ss = _cast2 Unmanaged.result_type_ss
 
 can_cast_ss
   :: ScalarType
   -> ScalarType
   -> IO (CBool)
-can_cast_ss = cast2 Unmanaged.can_cast_ss
+can_cast_ss = _cast2 Unmanaged.can_cast_ss
 
 promote_types_ss
   :: ScalarType
   -> ScalarType
   -> IO (ScalarType)
-promote_types_ss = cast2 Unmanaged.promote_types_ss
+promote_types_ss = _cast2 Unmanaged.promote_types_ss
 
 _local_scalar_dense_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Scalar)
-_local_scalar_dense_t = cast1 Unmanaged._local_scalar_dense_t
+_local_scalar_dense_t = _cast1 Unmanaged._local_scalar_dense_t
 
 _thnn_fused_lstm_cell_ttttt
   :: ForeignPtr Tensor
@@ -504,7 +504,7 @@ _thnn_fused_lstm_cell_ttttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-_thnn_fused_lstm_cell_ttttt = cast5 Unmanaged._thnn_fused_lstm_cell_ttttt
+_thnn_fused_lstm_cell_ttttt = _cast5 Unmanaged._thnn_fused_lstm_cell_ttttt
 
 _thnn_fused_lstm_cell_tttt
   :: ForeignPtr Tensor
@@ -512,14 +512,14 @@ _thnn_fused_lstm_cell_tttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-_thnn_fused_lstm_cell_tttt = cast4 Unmanaged._thnn_fused_lstm_cell_tttt
+_thnn_fused_lstm_cell_tttt = _cast4 Unmanaged._thnn_fused_lstm_cell_tttt
 
 _thnn_fused_lstm_cell_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-_thnn_fused_lstm_cell_ttt = cast3 Unmanaged._thnn_fused_lstm_cell_ttt
+_thnn_fused_lstm_cell_ttt = _cast3 Unmanaged._thnn_fused_lstm_cell_ttt
 
 _thnn_fused_lstm_cell_backward_tttttb
   :: ForeignPtr Tensor
@@ -529,7 +529,7 @@ _thnn_fused_lstm_cell_backward_tttttb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Tensor)))
-_thnn_fused_lstm_cell_backward_tttttb = cast6 Unmanaged._thnn_fused_lstm_cell_backward_tttttb
+_thnn_fused_lstm_cell_backward_tttttb = _cast6 Unmanaged._thnn_fused_lstm_cell_backward_tttttb
 
 _thnn_differentiable_lstm_cell_backward_tttttttt
   :: ForeignPtr Tensor
@@ -541,7 +541,7 @@ _thnn_differentiable_lstm_cell_backward_tttttttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Tensor)))
-_thnn_differentiable_lstm_cell_backward_tttttttt = cast8 Unmanaged._thnn_differentiable_lstm_cell_backward_tttttttt
+_thnn_differentiable_lstm_cell_backward_tttttttt = _cast8 Unmanaged._thnn_differentiable_lstm_cell_backward_tttttttt
 
 _thnn_fused_gru_cell_ttttt
   :: ForeignPtr Tensor
@@ -550,7 +550,7 @@ _thnn_fused_gru_cell_ttttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-_thnn_fused_gru_cell_ttttt = cast5 Unmanaged._thnn_fused_gru_cell_ttttt
+_thnn_fused_gru_cell_ttttt = _cast5 Unmanaged._thnn_fused_gru_cell_ttttt
 
 _thnn_fused_gru_cell_tttt
   :: ForeignPtr Tensor
@@ -558,21 +558,21 @@ _thnn_fused_gru_cell_tttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-_thnn_fused_gru_cell_tttt = cast4 Unmanaged._thnn_fused_gru_cell_tttt
+_thnn_fused_gru_cell_tttt = _cast4 Unmanaged._thnn_fused_gru_cell_tttt
 
 _thnn_fused_gru_cell_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-_thnn_fused_gru_cell_ttt = cast3 Unmanaged._thnn_fused_gru_cell_ttt
+_thnn_fused_gru_cell_ttt = _cast3 Unmanaged._thnn_fused_gru_cell_ttt
 
 _thnn_fused_gru_cell_backward_ttb
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Tensor)))
-_thnn_fused_gru_cell_backward_ttb = cast3 Unmanaged._thnn_fused_gru_cell_backward_ttb
+_thnn_fused_gru_cell_backward_ttb = _cast3 Unmanaged._thnn_fused_gru_cell_backward_ttb
 
 _thnn_differentiable_gru_cell_backward_tttttt
   :: ForeignPtr Tensor
@@ -582,7 +582,7 @@ _thnn_differentiable_gru_cell_backward_tttttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Tensor)))
-_thnn_differentiable_gru_cell_backward_tttttt = cast6 Unmanaged._thnn_differentiable_gru_cell_backward_tttttt
+_thnn_differentiable_gru_cell_backward_tttttt = _cast6 Unmanaged._thnn_differentiable_gru_cell_backward_tttttt
 
 lstm_tllbldbbb
   :: ForeignPtr Tensor
@@ -595,7 +595,7 @@ lstm_tllbldbbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-lstm_tllbldbbb = cast9 Unmanaged.lstm_tllbldbbb
+lstm_tllbldbbb = _cast9 Unmanaged.lstm_tllbldbbb
 
 lstm_ttllbldbb
   :: ForeignPtr Tensor
@@ -608,7 +608,7 @@ lstm_ttllbldbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-lstm_ttllbldbb = cast9 Unmanaged.lstm_ttllbldbb
+lstm_ttllbldbb = _cast9 Unmanaged.lstm_ttllbldbb
 
 gru_ttlbldbbb
   :: ForeignPtr Tensor
@@ -621,7 +621,7 @@ gru_ttlbldbbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-gru_ttlbldbbb = cast9 Unmanaged.gru_ttlbldbbb
+gru_ttlbldbbb = _cast9 Unmanaged.gru_ttlbldbbb
 
 gru_tttlbldbb
   :: ForeignPtr Tensor
@@ -634,7 +634,7 @@ gru_tttlbldbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-gru_tttlbldbb = cast9 Unmanaged.gru_tttlbldbb
+gru_tttlbldbb = _cast9 Unmanaged.gru_tttlbldbb
 
 rnn_tanh_ttlbldbbb
   :: ForeignPtr Tensor
@@ -647,7 +647,7 @@ rnn_tanh_ttlbldbbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-rnn_tanh_ttlbldbbb = cast9 Unmanaged.rnn_tanh_ttlbldbbb
+rnn_tanh_ttlbldbbb = _cast9 Unmanaged.rnn_tanh_ttlbldbbb
 
 rnn_tanh_tttlbldbb
   :: ForeignPtr Tensor
@@ -660,7 +660,7 @@ rnn_tanh_tttlbldbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-rnn_tanh_tttlbldbb = cast9 Unmanaged.rnn_tanh_tttlbldbb
+rnn_tanh_tttlbldbb = _cast9 Unmanaged.rnn_tanh_tttlbldbb
 
 rnn_relu_ttlbldbbb
   :: ForeignPtr Tensor
@@ -673,7 +673,7 @@ rnn_relu_ttlbldbbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-rnn_relu_ttlbldbbb = cast9 Unmanaged.rnn_relu_ttlbldbbb
+rnn_relu_ttlbldbbb = _cast9 Unmanaged.rnn_relu_ttlbldbbb
 
 rnn_relu_tttlbldbb
   :: ForeignPtr Tensor
@@ -686,7 +686,7 @@ rnn_relu_tttlbldbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-rnn_relu_tttlbldbb = cast9 Unmanaged.rnn_relu_tttlbldbb
+rnn_relu_tttlbldbb = _cast9 Unmanaged.rnn_relu_tttlbldbb
 
 lstm_cell_tltttt
   :: ForeignPtr Tensor
@@ -696,7 +696,7 @@ lstm_cell_tltttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-lstm_cell_tltttt = cast6 Unmanaged.lstm_cell_tltttt
+lstm_cell_tltttt = _cast6 Unmanaged.lstm_cell_tltttt
 
 lstm_cell_tlttt
   :: ForeignPtr Tensor
@@ -705,7 +705,7 @@ lstm_cell_tlttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-lstm_cell_tlttt = cast5 Unmanaged.lstm_cell_tlttt
+lstm_cell_tlttt = _cast5 Unmanaged.lstm_cell_tlttt
 
 lstm_cell_tltt
   :: ForeignPtr Tensor
@@ -713,7 +713,7 @@ lstm_cell_tltt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-lstm_cell_tltt = cast4 Unmanaged.lstm_cell_tltt
+lstm_cell_tltt = _cast4 Unmanaged.lstm_cell_tltt
 
 gru_cell_tttttt
   :: ForeignPtr Tensor
@@ -723,7 +723,7 @@ gru_cell_tttttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-gru_cell_tttttt = cast6 Unmanaged.gru_cell_tttttt
+gru_cell_tttttt = _cast6 Unmanaged.gru_cell_tttttt
 
 gru_cell_ttttt
   :: ForeignPtr Tensor
@@ -732,7 +732,7 @@ gru_cell_ttttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-gru_cell_ttttt = cast5 Unmanaged.gru_cell_ttttt
+gru_cell_ttttt = _cast5 Unmanaged.gru_cell_ttttt
 
 gru_cell_tttt
   :: ForeignPtr Tensor
@@ -740,7 +740,7 @@ gru_cell_tttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-gru_cell_tttt = cast4 Unmanaged.gru_cell_tttt
+gru_cell_tttt = _cast4 Unmanaged.gru_cell_tttt
 
 rnn_tanh_cell_tttttt
   :: ForeignPtr Tensor
@@ -750,7 +750,7 @@ rnn_tanh_cell_tttttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-rnn_tanh_cell_tttttt = cast6 Unmanaged.rnn_tanh_cell_tttttt
+rnn_tanh_cell_tttttt = _cast6 Unmanaged.rnn_tanh_cell_tttttt
 
 rnn_tanh_cell_ttttt
   :: ForeignPtr Tensor
@@ -759,7 +759,7 @@ rnn_tanh_cell_ttttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-rnn_tanh_cell_ttttt = cast5 Unmanaged.rnn_tanh_cell_ttttt
+rnn_tanh_cell_ttttt = _cast5 Unmanaged.rnn_tanh_cell_ttttt
 
 rnn_tanh_cell_tttt
   :: ForeignPtr Tensor
@@ -767,7 +767,7 @@ rnn_tanh_cell_tttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-rnn_tanh_cell_tttt = cast4 Unmanaged.rnn_tanh_cell_tttt
+rnn_tanh_cell_tttt = _cast4 Unmanaged.rnn_tanh_cell_tttt
 
 rnn_relu_cell_tttttt
   :: ForeignPtr Tensor
@@ -777,7 +777,7 @@ rnn_relu_cell_tttttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-rnn_relu_cell_tttttt = cast6 Unmanaged.rnn_relu_cell_tttttt
+rnn_relu_cell_tttttt = _cast6 Unmanaged.rnn_relu_cell_tttttt
 
 rnn_relu_cell_ttttt
   :: ForeignPtr Tensor
@@ -786,7 +786,7 @@ rnn_relu_cell_ttttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-rnn_relu_cell_ttttt = cast5 Unmanaged.rnn_relu_cell_ttttt
+rnn_relu_cell_ttttt = _cast5 Unmanaged.rnn_relu_cell_ttttt
 
 rnn_relu_cell_tttt
   :: ForeignPtr Tensor
@@ -794,7 +794,7 @@ rnn_relu_cell_tttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-rnn_relu_cell_tttt = cast4 Unmanaged.rnn_relu_cell_tttt
+rnn_relu_cell_tttt = _cast4 Unmanaged.rnn_relu_cell_tttt
 
 quantized_lstm_cell_tlttttttttssss
   :: ForeignPtr Tensor
@@ -812,7 +812,7 @@ quantized_lstm_cell_tlttttttttssss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-quantized_lstm_cell_tlttttttttssss = cast14 Unmanaged.quantized_lstm_cell_tlttttttttssss
+quantized_lstm_cell_tlttttttttssss = _cast14 Unmanaged.quantized_lstm_cell_tlttttttttssss
 
 quantized_gru_cell_ttttttttttssss
   :: ForeignPtr Tensor
@@ -830,7 +830,7 @@ quantized_gru_cell_ttttttttttssss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-quantized_gru_cell_ttttttttttssss = cast14 Unmanaged.quantized_gru_cell_ttttttttttssss
+quantized_gru_cell_ttttttttttssss = _cast14 Unmanaged.quantized_gru_cell_ttttttttttssss
 
 quantized_rnn_relu_cell_ttttttttttssss
   :: ForeignPtr Tensor
@@ -848,7 +848,7 @@ quantized_rnn_relu_cell_ttttttttttssss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-quantized_rnn_relu_cell_ttttttttttssss = cast14 Unmanaged.quantized_rnn_relu_cell_ttttttttttssss
+quantized_rnn_relu_cell_ttttttttttssss = _cast14 Unmanaged.quantized_rnn_relu_cell_ttttttttttssss
 
 quantized_rnn_tanh_cell_ttttttttttssss
   :: ForeignPtr Tensor
@@ -866,14 +866,14 @@ quantized_rnn_tanh_cell_ttttttttttssss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-quantized_rnn_tanh_cell_ttttttttttssss = cast14 Unmanaged.quantized_rnn_tanh_cell_ttttttttttssss
+quantized_rnn_tanh_cell_ttttttttttssss = _cast14 Unmanaged.quantized_rnn_tanh_cell_ttttttttttssss
 
 _pack_padded_sequence_ttb
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-_pack_padded_sequence_ttb = cast3 Unmanaged._pack_padded_sequence_ttb
+_pack_padded_sequence_ttb = _cast3 Unmanaged._pack_padded_sequence_ttb
 
 _pack_padded_sequence_backward_tltb
   :: ForeignPtr Tensor
@@ -881,7 +881,7 @@ _pack_padded_sequence_backward_tltb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-_pack_padded_sequence_backward_tltb = cast4 Unmanaged._pack_padded_sequence_backward_tltb
+_pack_padded_sequence_backward_tltb = _cast4 Unmanaged._pack_padded_sequence_backward_tltb
 
 _pad_packed_sequence_ttbsl
   :: ForeignPtr Tensor
@@ -890,34 +890,34 @@ _pad_packed_sequence_ttbsl
   -> ForeignPtr Scalar
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-_pad_packed_sequence_ttbsl = cast5 Unmanaged._pad_packed_sequence_ttbsl
+_pad_packed_sequence_ttbsl = _cast5 Unmanaged._pad_packed_sequence_ttbsl
 
 masked_fill_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-masked_fill_tts = cast3 Unmanaged.masked_fill_tts
+masked_fill_tts = _cast3 Unmanaged.masked_fill_tts
 
 masked_fill_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-masked_fill_ttt = cast3 Unmanaged.masked_fill_ttt
+masked_fill_ttt = _cast3 Unmanaged.masked_fill_ttt
 
 masked_scatter_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-masked_scatter_ttt = cast3 Unmanaged.masked_scatter_ttt
+masked_scatter_ttt = _cast3 Unmanaged.masked_scatter_ttt
 
 _masked_softmax_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_masked_softmax_tt = cast2 Unmanaged._masked_softmax_tt
+_masked_softmax_tt = _cast2 Unmanaged._masked_softmax_tt
 
 put_tttb
   :: ForeignPtr Tensor
@@ -925,14 +925,14 @@ put_tttb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-put_tttb = cast4 Unmanaged.put_tttb
+put_tttb = _cast4 Unmanaged.put_tttb
 
 put_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-put_ttt = cast3 Unmanaged.put_ttt
+put_ttt = _cast3 Unmanaged.put_ttt
 
 index_add_out_ttltts
   :: ForeignPtr Tensor
@@ -942,7 +942,7 @@ index_add_out_ttltts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-index_add_out_ttltts = cast6 Unmanaged.index_add_out_ttltts
+index_add_out_ttltts = _cast6 Unmanaged.index_add_out_ttltts
 
 index_add_out_ttltt
   :: ForeignPtr Tensor
@@ -951,7 +951,7 @@ index_add_out_ttltt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-index_add_out_ttltt = cast5 Unmanaged.index_add_out_ttltt
+index_add_out_ttltt = _cast5 Unmanaged.index_add_out_ttltt
 
 index_add_tltts
   :: ForeignPtr Tensor
@@ -960,7 +960,7 @@ index_add_tltts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-index_add_tltts = cast5 Unmanaged.index_add_tltts
+index_add_tltts = _cast5 Unmanaged.index_add_tltts
 
 index_add_tltt
   :: ForeignPtr Tensor
@@ -968,7 +968,7 @@ index_add_tltt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-index_add_tltt = cast4 Unmanaged.index_add_tltt
+index_add_tltt = _cast4 Unmanaged.index_add_tltt
 
 index_add_tntts
   :: ForeignPtr Tensor
@@ -977,7 +977,7 @@ index_add_tntts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-index_add_tntts = cast5 Unmanaged.index_add_tntts
+index_add_tntts = _cast5 Unmanaged.index_add_tntts
 
 index_add_tntt
   :: ForeignPtr Tensor
@@ -985,7 +985,7 @@ index_add_tntt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-index_add_tntt = cast4 Unmanaged.index_add_tntt
+index_add_tntt = _cast4 Unmanaged.index_add_tntt
 
 index_fill_tlts
   :: ForeignPtr Tensor
@@ -993,7 +993,7 @@ index_fill_tlts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-index_fill_tlts = cast4 Unmanaged.index_fill_tlts
+index_fill_tlts = _cast4 Unmanaged.index_fill_tlts
 
 index_fill_tltt
   :: ForeignPtr Tensor
@@ -1001,7 +1001,7 @@ index_fill_tltt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-index_fill_tltt = cast4 Unmanaged.index_fill_tltt
+index_fill_tltt = _cast4 Unmanaged.index_fill_tltt
 
 index_fill_tnts
   :: ForeignPtr Tensor
@@ -1009,7 +1009,7 @@ index_fill_tnts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-index_fill_tnts = cast4 Unmanaged.index_fill_tnts
+index_fill_tnts = _cast4 Unmanaged.index_fill_tnts
 
 index_fill_tntt
   :: ForeignPtr Tensor
@@ -1017,7 +1017,7 @@ index_fill_tntt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-index_fill_tntt = cast4 Unmanaged.index_fill_tntt
+index_fill_tntt = _cast4 Unmanaged.index_fill_tntt
 
 scatter_tltt
   :: ForeignPtr Tensor
@@ -1025,7 +1025,7 @@ scatter_tltt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-scatter_tltt = cast4 Unmanaged.scatter_tltt
+scatter_tltt = _cast4 Unmanaged.scatter_tltt
 
 scatter_out_ttltt
   :: ForeignPtr Tensor
@@ -1034,7 +1034,7 @@ scatter_out_ttltt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-scatter_out_ttltt = cast5 Unmanaged.scatter_out_ttltt
+scatter_out_ttltt = _cast5 Unmanaged.scatter_out_ttltt
 
 scatter_tlts
   :: ForeignPtr Tensor
@@ -1042,7 +1042,7 @@ scatter_tlts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-scatter_tlts = cast4 Unmanaged.scatter_tlts
+scatter_tlts = _cast4 Unmanaged.scatter_tlts
 
 scatter_out_ttlts
   :: ForeignPtr Tensor
@@ -1051,7 +1051,7 @@ scatter_out_ttlts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-scatter_out_ttlts = cast5 Unmanaged.scatter_out_ttlts
+scatter_out_ttlts = _cast5 Unmanaged.scatter_out_ttlts
 
 scatter_tltts
   :: ForeignPtr Tensor
@@ -1060,7 +1060,7 @@ scatter_tltts
   -> ForeignPtr Tensor
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-scatter_tltts = cast5 Unmanaged.scatter_tltts
+scatter_tltts = _cast5 Unmanaged.scatter_tltts
 
 scatter_out_ttltts
   :: ForeignPtr Tensor
@@ -1070,7 +1070,7 @@ scatter_out_ttltts
   -> ForeignPtr Tensor
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-scatter_out_ttltts = cast6 Unmanaged.scatter_out_ttltts
+scatter_out_ttltts = _cast6 Unmanaged.scatter_out_ttltts
 
 scatter_tltss
   :: ForeignPtr Tensor
@@ -1079,7 +1079,7 @@ scatter_tltss
   -> ForeignPtr Scalar
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-scatter_tltss = cast5 Unmanaged.scatter_tltss
+scatter_tltss = _cast5 Unmanaged.scatter_tltss
 
 scatter_out_ttltss
   :: ForeignPtr Tensor
@@ -1089,7 +1089,7 @@ scatter_out_ttltss
   -> ForeignPtr Scalar
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-scatter_out_ttltss = cast6 Unmanaged.scatter_out_ttltss
+scatter_out_ttltss = _cast6 Unmanaged.scatter_out_ttltss
 
 scatter_tntt
   :: ForeignPtr Tensor
@@ -1097,7 +1097,7 @@ scatter_tntt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-scatter_tntt = cast4 Unmanaged.scatter_tntt
+scatter_tntt = _cast4 Unmanaged.scatter_tntt
 
 scatter_tnts
   :: ForeignPtr Tensor
@@ -1105,7 +1105,7 @@ scatter_tnts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-scatter_tnts = cast4 Unmanaged.scatter_tnts
+scatter_tnts = _cast4 Unmanaged.scatter_tnts
 
 scatter_add_tltt
   :: ForeignPtr Tensor
@@ -1113,7 +1113,7 @@ scatter_add_tltt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-scatter_add_tltt = cast4 Unmanaged.scatter_add_tltt
+scatter_add_tltt = _cast4 Unmanaged.scatter_add_tltt
 
 scatter_add_out_ttltt
   :: ForeignPtr Tensor
@@ -1122,7 +1122,7 @@ scatter_add_out_ttltt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-scatter_add_out_ttltt = cast5 Unmanaged.scatter_add_out_ttltt
+scatter_add_out_ttltt = _cast5 Unmanaged.scatter_add_out_ttltt
 
 scatter_add_tntt
   :: ForeignPtr Tensor
@@ -1130,7 +1130,7 @@ scatter_add_tntt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-scatter_add_tntt = cast4 Unmanaged.scatter_add_tntt
+scatter_add_tntt = _cast4 Unmanaged.scatter_add_tntt
 
 scatter_reduce_tltsl
   :: ForeignPtr Tensor
@@ -1139,7 +1139,7 @@ scatter_reduce_tltsl
   -> ForeignPtr StdString
   -> Int64
   -> IO (ForeignPtr Tensor)
-scatter_reduce_tltsl = cast5 Unmanaged.scatter_reduce_tltsl
+scatter_reduce_tltsl = _cast5 Unmanaged.scatter_reduce_tltsl
 
 scatter_reduce_tlts
   :: ForeignPtr Tensor
@@ -1147,209 +1147,209 @@ scatter_reduce_tlts
   -> ForeignPtr Tensor
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-scatter_reduce_tlts = cast4 Unmanaged.scatter_reduce_tlts
+scatter_reduce_tlts = _cast4 Unmanaged.scatter_reduce_tlts
 
 bitwise_and_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-bitwise_and_out_ttt = cast3 Unmanaged.bitwise_and_out_ttt
+bitwise_and_out_ttt = _cast3 Unmanaged.bitwise_and_out_ttt
 
 bitwise_and_out_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-bitwise_and_out_tts = cast3 Unmanaged.bitwise_and_out_tts
+bitwise_and_out_tts = _cast3 Unmanaged.bitwise_and_out_tts
 
 bitwise_and_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-bitwise_and_ts = cast2 Unmanaged.bitwise_and_ts
+bitwise_and_ts = _cast2 Unmanaged.bitwise_and_ts
 
 bitwise_and_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-bitwise_and_tt = cast2 Unmanaged.bitwise_and_tt
+bitwise_and_tt = _cast2 Unmanaged.bitwise_and_tt
 
 __and___ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-__and___ts = cast2 Unmanaged.__and___ts
+__and___ts = _cast2 Unmanaged.__and___ts
 
 __and___tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-__and___tt = cast2 Unmanaged.__and___tt
+__and___tt = _cast2 Unmanaged.__and___tt
 
 bitwise_or_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-bitwise_or_out_ttt = cast3 Unmanaged.bitwise_or_out_ttt
+bitwise_or_out_ttt = _cast3 Unmanaged.bitwise_or_out_ttt
 
 bitwise_or_out_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-bitwise_or_out_tts = cast3 Unmanaged.bitwise_or_out_tts
+bitwise_or_out_tts = _cast3 Unmanaged.bitwise_or_out_tts
 
 bitwise_or_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-bitwise_or_ts = cast2 Unmanaged.bitwise_or_ts
+bitwise_or_ts = _cast2 Unmanaged.bitwise_or_ts
 
 bitwise_or_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-bitwise_or_tt = cast2 Unmanaged.bitwise_or_tt
+bitwise_or_tt = _cast2 Unmanaged.bitwise_or_tt
 
 __or___ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-__or___ts = cast2 Unmanaged.__or___ts
+__or___ts = _cast2 Unmanaged.__or___ts
 
 __or___tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-__or___tt = cast2 Unmanaged.__or___tt
+__or___tt = _cast2 Unmanaged.__or___tt
 
 bitwise_xor_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-bitwise_xor_out_ttt = cast3 Unmanaged.bitwise_xor_out_ttt
+bitwise_xor_out_ttt = _cast3 Unmanaged.bitwise_xor_out_ttt
 
 bitwise_xor_out_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-bitwise_xor_out_tts = cast3 Unmanaged.bitwise_xor_out_tts
+bitwise_xor_out_tts = _cast3 Unmanaged.bitwise_xor_out_tts
 
 bitwise_xor_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-bitwise_xor_ts = cast2 Unmanaged.bitwise_xor_ts
+bitwise_xor_ts = _cast2 Unmanaged.bitwise_xor_ts
 
 bitwise_xor_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-bitwise_xor_tt = cast2 Unmanaged.bitwise_xor_tt
+bitwise_xor_tt = _cast2 Unmanaged.bitwise_xor_tt
 
 __xor___ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-__xor___ts = cast2 Unmanaged.__xor___ts
+__xor___ts = _cast2 Unmanaged.__xor___ts
 
 __xor___tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-__xor___tt = cast2 Unmanaged.__xor___tt
+__xor___tt = _cast2 Unmanaged.__xor___tt
 
 __lshift___ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-__lshift___ts = cast2 Unmanaged.__lshift___ts
+__lshift___ts = _cast2 Unmanaged.__lshift___ts
 
 __lshift___tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-__lshift___tt = cast2 Unmanaged.__lshift___tt
+__lshift___tt = _cast2 Unmanaged.__lshift___tt
 
 bitwise_left_shift_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-bitwise_left_shift_tt = cast2 Unmanaged.bitwise_left_shift_tt
+bitwise_left_shift_tt = _cast2 Unmanaged.bitwise_left_shift_tt
 
 bitwise_left_shift_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-bitwise_left_shift_out_ttt = cast3 Unmanaged.bitwise_left_shift_out_ttt
+bitwise_left_shift_out_ttt = _cast3 Unmanaged.bitwise_left_shift_out_ttt
 
 bitwise_left_shift_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-bitwise_left_shift_ts = cast2 Unmanaged.bitwise_left_shift_ts
+bitwise_left_shift_ts = _cast2 Unmanaged.bitwise_left_shift_ts
 
 bitwise_left_shift_out_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-bitwise_left_shift_out_tts = cast3 Unmanaged.bitwise_left_shift_out_tts
+bitwise_left_shift_out_tts = _cast3 Unmanaged.bitwise_left_shift_out_tts
 
 bitwise_left_shift_st
   :: ForeignPtr Scalar
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-bitwise_left_shift_st = cast2 Unmanaged.bitwise_left_shift_st
+bitwise_left_shift_st = _cast2 Unmanaged.bitwise_left_shift_st
 
 __rshift___ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-__rshift___ts = cast2 Unmanaged.__rshift___ts
+__rshift___ts = _cast2 Unmanaged.__rshift___ts
 
 __rshift___tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-__rshift___tt = cast2 Unmanaged.__rshift___tt
+__rshift___tt = _cast2 Unmanaged.__rshift___tt
 
 bitwise_right_shift_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-bitwise_right_shift_tt = cast2 Unmanaged.bitwise_right_shift_tt
+bitwise_right_shift_tt = _cast2 Unmanaged.bitwise_right_shift_tt
 
 bitwise_right_shift_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-bitwise_right_shift_out_ttt = cast3 Unmanaged.bitwise_right_shift_out_ttt
+bitwise_right_shift_out_ttt = _cast3 Unmanaged.bitwise_right_shift_out_ttt
 
 bitwise_right_shift_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-bitwise_right_shift_ts = cast2 Unmanaged.bitwise_right_shift_ts
+bitwise_right_shift_ts = _cast2 Unmanaged.bitwise_right_shift_ts
 
 bitwise_right_shift_out_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-bitwise_right_shift_out_tts = cast3 Unmanaged.bitwise_right_shift_out_tts
+bitwise_right_shift_out_tts = _cast3 Unmanaged.bitwise_right_shift_out_tts
 
 bitwise_right_shift_st
   :: ForeignPtr Scalar
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-bitwise_right_shift_st = cast2 Unmanaged.bitwise_right_shift_st
+bitwise_right_shift_st = _cast2 Unmanaged.bitwise_right_shift_st
 
 addbmm_out_ttttss
   :: ForeignPtr Tensor
@@ -1359,7 +1359,7 @@ addbmm_out_ttttss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-addbmm_out_ttttss = cast6 Unmanaged.addbmm_out_ttttss
+addbmm_out_ttttss = _cast6 Unmanaged.addbmm_out_ttttss
 
 addbmm_out_tttts
   :: ForeignPtr Tensor
@@ -1368,7 +1368,7 @@ addbmm_out_tttts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-addbmm_out_tttts = cast5 Unmanaged.addbmm_out_tttts
+addbmm_out_tttts = _cast5 Unmanaged.addbmm_out_tttts
 
 addbmm_out_tttt
   :: ForeignPtr Tensor
@@ -1376,7 +1376,7 @@ addbmm_out_tttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-addbmm_out_tttt = cast4 Unmanaged.addbmm_out_tttt
+addbmm_out_tttt = _cast4 Unmanaged.addbmm_out_tttt
 
 addbmm_tttss
   :: ForeignPtr Tensor
@@ -1385,7 +1385,7 @@ addbmm_tttss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-addbmm_tttss = cast5 Unmanaged.addbmm_tttss
+addbmm_tttss = _cast5 Unmanaged.addbmm_tttss
 
 addbmm_ttts
   :: ForeignPtr Tensor
@@ -1393,45 +1393,45 @@ addbmm_ttts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-addbmm_ttts = cast4 Unmanaged.addbmm_ttts
+addbmm_ttts = _cast4 Unmanaged.addbmm_ttts
 
 addbmm_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-addbmm_ttt = cast3 Unmanaged.addbmm_ttt
+addbmm_ttt = _cast3 Unmanaged.addbmm_ttt
 
 diag_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-diag_out_ttl = cast3 Unmanaged.diag_out_ttl
+diag_out_ttl = _cast3 Unmanaged.diag_out_ttl
 
 diag_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-diag_out_tt = cast2 Unmanaged.diag_out_tt
+diag_out_tt = _cast2 Unmanaged.diag_out_tt
 
 diag_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-diag_tl = cast2 Unmanaged.diag_tl
+diag_tl = _cast2 Unmanaged.diag_tl
 
 diag_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-diag_t = cast1 Unmanaged.diag_t
+diag_t = _cast1 Unmanaged.diag_t
 
 diag_backward_tll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> Int64
   -> IO (ForeignPtr Tensor)
-diag_backward_tll = cast3 Unmanaged.diag_backward_tll
+diag_backward_tll = _cast3 Unmanaged.diag_backward_tll
 
 cross_out_tttl
   :: ForeignPtr Tensor
@@ -1439,75 +1439,75 @@ cross_out_tttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-cross_out_tttl = cast4 Unmanaged.cross_out_tttl
+cross_out_tttl = _cast4 Unmanaged.cross_out_tttl
 
 cross_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-cross_out_ttt = cast3 Unmanaged.cross_out_ttt
+cross_out_ttt = _cast3 Unmanaged.cross_out_ttt
 
 cross_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-cross_ttl = cast3 Unmanaged.cross_ttl
+cross_ttl = _cast3 Unmanaged.cross_ttl
 
 cross_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-cross_tt = cast2 Unmanaged.cross_tt
+cross_tt = _cast2 Unmanaged.cross_tt
 
 triu_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-triu_out_ttl = cast3 Unmanaged.triu_out_ttl
+triu_out_ttl = _cast3 Unmanaged.triu_out_ttl
 
 triu_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-triu_out_tt = cast2 Unmanaged.triu_out_tt
+triu_out_tt = _cast2 Unmanaged.triu_out_tt
 
 triu_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-triu_tl = cast2 Unmanaged.triu_tl
+triu_tl = _cast2 Unmanaged.triu_tl
 
 triu_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-triu_t = cast1 Unmanaged.triu_t
+triu_t = _cast1 Unmanaged.triu_t
 
 tril_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-tril_out_ttl = cast3 Unmanaged.tril_out_ttl
+tril_out_ttl = _cast3 Unmanaged.tril_out_ttl
 
 tril_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tril_out_tt = cast2 Unmanaged.tril_out_tt
+tril_out_tt = _cast2 Unmanaged.tril_out_tt
 
 tril_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-tril_tl = cast2 Unmanaged.tril_tl
+tril_tl = _cast2 Unmanaged.tril_tl
 
 tril_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tril_t = cast1 Unmanaged.tril_t
+tril_t = _cast1 Unmanaged.tril_t
 
 tril_indices_lllo
   :: Int64
@@ -1515,20 +1515,20 @@ tril_indices_lllo
   -> Int64
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-tril_indices_lllo = cast4 Unmanaged.tril_indices_lllo
+tril_indices_lllo = _cast4 Unmanaged.tril_indices_lllo
 
 tril_indices_lll
   :: Int64
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-tril_indices_lll = cast3 Unmanaged.tril_indices_lll
+tril_indices_lll = _cast3 Unmanaged.tril_indices_lll
 
 tril_indices_ll
   :: Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-tril_indices_ll = cast2 Unmanaged.tril_indices_ll
+tril_indices_ll = _cast2 Unmanaged.tril_indices_ll
 
 triu_indices_lllo
   :: Int64
@@ -1536,185 +1536,185 @@ triu_indices_lllo
   -> Int64
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-triu_indices_lllo = cast4 Unmanaged.triu_indices_lllo
+triu_indices_lllo = _cast4 Unmanaged.triu_indices_lllo
 
 triu_indices_lll
   :: Int64
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-triu_indices_lll = cast3 Unmanaged.triu_indices_lll
+triu_indices_lll = _cast3 Unmanaged.triu_indices_lll
 
 triu_indices_ll
   :: Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-triu_indices_ll = cast2 Unmanaged.triu_indices_ll
+triu_indices_ll = _cast2 Unmanaged.triu_indices_ll
 
 trace_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-trace_t = cast1 Unmanaged.trace_t
+trace_t = _cast1 Unmanaged.trace_t
 
 trace_backward_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-trace_backward_tl = cast2 Unmanaged.trace_backward_tl
+trace_backward_tl = _cast2 Unmanaged.trace_backward_tl
 
 ne_out_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-ne_out_tts = cast3 Unmanaged.ne_out_tts
+ne_out_tts = _cast3 Unmanaged.ne_out_tts
 
 ne_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-ne_ts = cast2 Unmanaged.ne_ts
+ne_ts = _cast2 Unmanaged.ne_ts
 
 ne_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-ne_out_ttt = cast3 Unmanaged.ne_out_ttt
+ne_out_ttt = _cast3 Unmanaged.ne_out_ttt
 
 ne_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-ne_tt = cast2 Unmanaged.ne_tt
+ne_tt = _cast2 Unmanaged.ne_tt
 
 not_equal_out_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-not_equal_out_tts = cast3 Unmanaged.not_equal_out_tts
+not_equal_out_tts = _cast3 Unmanaged.not_equal_out_tts
 
 not_equal_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-not_equal_ts = cast2 Unmanaged.not_equal_ts
+not_equal_ts = _cast2 Unmanaged.not_equal_ts
 
 not_equal_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-not_equal_out_ttt = cast3 Unmanaged.not_equal_out_ttt
+not_equal_out_ttt = _cast3 Unmanaged.not_equal_out_ttt
 
 not_equal_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-not_equal_tt = cast2 Unmanaged.not_equal_tt
+not_equal_tt = _cast2 Unmanaged.not_equal_tt
 
 eq_out_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-eq_out_tts = cast3 Unmanaged.eq_out_tts
+eq_out_tts = _cast3 Unmanaged.eq_out_tts
 
 eq_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-eq_ts = cast2 Unmanaged.eq_ts
+eq_ts = _cast2 Unmanaged.eq_ts
 
 eq_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-eq_out_ttt = cast3 Unmanaged.eq_out_ttt
+eq_out_ttt = _cast3 Unmanaged.eq_out_ttt
 
 eq_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-eq_tt = cast2 Unmanaged.eq_tt
+eq_tt = _cast2 Unmanaged.eq_tt
 
 ge_out_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-ge_out_tts = cast3 Unmanaged.ge_out_tts
+ge_out_tts = _cast3 Unmanaged.ge_out_tts
 
 ge_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-ge_ts = cast2 Unmanaged.ge_ts
+ge_ts = _cast2 Unmanaged.ge_ts
 
 ge_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-ge_out_ttt = cast3 Unmanaged.ge_out_ttt
+ge_out_ttt = _cast3 Unmanaged.ge_out_ttt
 
 ge_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-ge_tt = cast2 Unmanaged.ge_tt
+ge_tt = _cast2 Unmanaged.ge_tt
 
 greater_equal_out_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-greater_equal_out_tts = cast3 Unmanaged.greater_equal_out_tts
+greater_equal_out_tts = _cast3 Unmanaged.greater_equal_out_tts
 
 greater_equal_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-greater_equal_ts = cast2 Unmanaged.greater_equal_ts
+greater_equal_ts = _cast2 Unmanaged.greater_equal_ts
 
 greater_equal_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-greater_equal_out_ttt = cast3 Unmanaged.greater_equal_out_ttt
+greater_equal_out_ttt = _cast3 Unmanaged.greater_equal_out_ttt
 
 greater_equal_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-greater_equal_tt = cast2 Unmanaged.greater_equal_tt
+greater_equal_tt = _cast2 Unmanaged.greater_equal_tt
 
 le_out_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-le_out_tts = cast3 Unmanaged.le_out_tts
+le_out_tts = _cast3 Unmanaged.le_out_tts
 
 le_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-le_ts = cast2 Unmanaged.le_ts
+le_ts = _cast2 Unmanaged.le_ts
 
 le_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-le_out_ttt = cast3 Unmanaged.le_out_ttt
+le_out_ttt = _cast3 Unmanaged.le_out_ttt
 
 le_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-le_tt = cast2 Unmanaged.le_tt
+le_tt = _cast2 Unmanaged.le_tt
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Native/Native9.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Native/Native9.hs
@@ -26,143 +26,143 @@ less_equal_out_tts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-less_equal_out_tts = cast3 Unmanaged.less_equal_out_tts
+less_equal_out_tts = _cast3 Unmanaged.less_equal_out_tts
 
 less_equal_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-less_equal_ts = cast2 Unmanaged.less_equal_ts
+less_equal_ts = _cast2 Unmanaged.less_equal_ts
 
 less_equal_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-less_equal_out_ttt = cast3 Unmanaged.less_equal_out_ttt
+less_equal_out_ttt = _cast3 Unmanaged.less_equal_out_ttt
 
 less_equal_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-less_equal_tt = cast2 Unmanaged.less_equal_tt
+less_equal_tt = _cast2 Unmanaged.less_equal_tt
 
 gt_out_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-gt_out_tts = cast3 Unmanaged.gt_out_tts
+gt_out_tts = _cast3 Unmanaged.gt_out_tts
 
 gt_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-gt_ts = cast2 Unmanaged.gt_ts
+gt_ts = _cast2 Unmanaged.gt_ts
 
 gt_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-gt_out_ttt = cast3 Unmanaged.gt_out_ttt
+gt_out_ttt = _cast3 Unmanaged.gt_out_ttt
 
 gt_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-gt_tt = cast2 Unmanaged.gt_tt
+gt_tt = _cast2 Unmanaged.gt_tt
 
 greater_out_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-greater_out_tts = cast3 Unmanaged.greater_out_tts
+greater_out_tts = _cast3 Unmanaged.greater_out_tts
 
 greater_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-greater_ts = cast2 Unmanaged.greater_ts
+greater_ts = _cast2 Unmanaged.greater_ts
 
 greater_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-greater_out_ttt = cast3 Unmanaged.greater_out_ttt
+greater_out_ttt = _cast3 Unmanaged.greater_out_ttt
 
 greater_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-greater_tt = cast2 Unmanaged.greater_tt
+greater_tt = _cast2 Unmanaged.greater_tt
 
 lt_out_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-lt_out_tts = cast3 Unmanaged.lt_out_tts
+lt_out_tts = _cast3 Unmanaged.lt_out_tts
 
 lt_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-lt_ts = cast2 Unmanaged.lt_ts
+lt_ts = _cast2 Unmanaged.lt_ts
 
 lt_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-lt_out_ttt = cast3 Unmanaged.lt_out_ttt
+lt_out_ttt = _cast3 Unmanaged.lt_out_ttt
 
 lt_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-lt_tt = cast2 Unmanaged.lt_tt
+lt_tt = _cast2 Unmanaged.lt_tt
 
 less_out_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-less_out_tts = cast3 Unmanaged.less_out_tts
+less_out_tts = _cast3 Unmanaged.less_out_tts
 
 less_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-less_ts = cast2 Unmanaged.less_ts
+less_ts = _cast2 Unmanaged.less_ts
 
 less_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-less_out_ttt = cast3 Unmanaged.less_out_ttt
+less_out_ttt = _cast3 Unmanaged.less_out_ttt
 
 less_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-less_tt = cast2 Unmanaged.less_tt
+less_tt = _cast2 Unmanaged.less_tt
 
 take_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-take_out_ttt = cast3 Unmanaged.take_out_ttt
+take_out_ttt = _cast3 Unmanaged.take_out_ttt
 
 take_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-take_tt = cast2 Unmanaged.take_tt
+take_tt = _cast2 Unmanaged.take_tt
 
 take_along_dim_out_tttl
   :: ForeignPtr Tensor
@@ -170,27 +170,27 @@ take_along_dim_out_tttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-take_along_dim_out_tttl = cast4 Unmanaged.take_along_dim_out_tttl
+take_along_dim_out_tttl = _cast4 Unmanaged.take_along_dim_out_tttl
 
 take_along_dim_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-take_along_dim_out_ttt = cast3 Unmanaged.take_along_dim_out_ttt
+take_along_dim_out_ttt = _cast3 Unmanaged.take_along_dim_out_ttt
 
 take_along_dim_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-take_along_dim_ttl = cast3 Unmanaged.take_along_dim_ttl
+take_along_dim_ttl = _cast3 Unmanaged.take_along_dim_ttl
 
 take_along_dim_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-take_along_dim_tt = cast2 Unmanaged.take_along_dim_tt
+take_along_dim_tt = _cast2 Unmanaged.take_along_dim_tt
 
 index_select_out_ttlt
   :: ForeignPtr Tensor
@@ -198,14 +198,14 @@ index_select_out_ttlt
   -> Int64
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-index_select_out_ttlt = cast4 Unmanaged.index_select_out_ttlt
+index_select_out_ttlt = _cast4 Unmanaged.index_select_out_ttlt
 
 index_select_tlt
   :: ForeignPtr Tensor
   -> Int64
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-index_select_tlt = cast3 Unmanaged.index_select_tlt
+index_select_tlt = _cast3 Unmanaged.index_select_tlt
 
 index_select_out_ttnt
   :: ForeignPtr Tensor
@@ -213,14 +213,14 @@ index_select_out_ttnt
   -> ForeignPtr Dimname
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-index_select_out_ttnt = cast4 Unmanaged.index_select_out_ttnt
+index_select_out_ttnt = _cast4 Unmanaged.index_select_out_ttnt
 
 index_select_tnt
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-index_select_tnt = cast3 Unmanaged.index_select_tnt
+index_select_tnt = _cast3 Unmanaged.index_select_tnt
 
 index_select_backward_tllt
   :: ForeignPtr Tensor
@@ -228,48 +228,48 @@ index_select_backward_tllt
   -> Int64
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-index_select_backward_tllt = cast4 Unmanaged.index_select_backward_tllt
+index_select_backward_tllt = _cast4 Unmanaged.index_select_backward_tllt
 
 masked_select_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-masked_select_out_ttt = cast3 Unmanaged.masked_select_out_ttt
+masked_select_out_ttt = _cast3 Unmanaged.masked_select_out_ttt
 
 masked_select_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-masked_select_tt = cast2 Unmanaged.masked_select_tt
+masked_select_tt = _cast2 Unmanaged.masked_select_tt
 
 masked_select_backward_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-masked_select_backward_ttt = cast3 Unmanaged.masked_select_backward_ttt
+masked_select_backward_ttt = _cast3 Unmanaged.masked_select_backward_ttt
 
 nonzero_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-nonzero_out_tt = cast2 Unmanaged.nonzero_out_tt
+nonzero_out_tt = _cast2 Unmanaged.nonzero_out_tt
 
 nonzero_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-nonzero_t = cast1 Unmanaged.nonzero_t
+nonzero_t = _cast1 Unmanaged.nonzero_t
 
 nonzero_numpy_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr TensorList)
-nonzero_numpy_t = cast1 Unmanaged.nonzero_numpy_t
+nonzero_numpy_t = _cast1 Unmanaged.nonzero_numpy_t
 
 argwhere_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-argwhere_t = cast1 Unmanaged.argwhere_t
+argwhere_t = _cast1 Unmanaged.argwhere_t
 
 gather_out_ttltb
   :: ForeignPtr Tensor
@@ -278,7 +278,7 @@ gather_out_ttltb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-gather_out_ttltb = cast5 Unmanaged.gather_out_ttltb
+gather_out_ttltb = _cast5 Unmanaged.gather_out_ttltb
 
 gather_out_ttlt
   :: ForeignPtr Tensor
@@ -286,7 +286,7 @@ gather_out_ttlt
   -> Int64
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-gather_out_ttlt = cast4 Unmanaged.gather_out_ttlt
+gather_out_ttlt = _cast4 Unmanaged.gather_out_ttlt
 
 gather_tltb
   :: ForeignPtr Tensor
@@ -294,14 +294,14 @@ gather_tltb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-gather_tltb = cast4 Unmanaged.gather_tltb
+gather_tltb = _cast4 Unmanaged.gather_tltb
 
 gather_tlt
   :: ForeignPtr Tensor
   -> Int64
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-gather_tlt = cast3 Unmanaged.gather_tlt
+gather_tlt = _cast3 Unmanaged.gather_tlt
 
 gather_backward_ttltb
   :: ForeignPtr Tensor
@@ -310,7 +310,7 @@ gather_backward_ttltb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-gather_backward_ttltb = cast5 Unmanaged.gather_backward_ttltb
+gather_backward_ttltb = _cast5 Unmanaged.gather_backward_ttltb
 
 gather_out_ttntb
   :: ForeignPtr Tensor
@@ -319,7 +319,7 @@ gather_out_ttntb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-gather_out_ttntb = cast5 Unmanaged.gather_out_ttntb
+gather_out_ttntb = _cast5 Unmanaged.gather_out_ttntb
 
 gather_out_ttnt
   :: ForeignPtr Tensor
@@ -327,7 +327,7 @@ gather_out_ttnt
   -> ForeignPtr Dimname
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-gather_out_ttnt = cast4 Unmanaged.gather_out_ttnt
+gather_out_ttnt = _cast4 Unmanaged.gather_out_ttnt
 
 gather_tntb
   :: ForeignPtr Tensor
@@ -335,14 +335,14 @@ gather_tntb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-gather_tntb = cast4 Unmanaged.gather_tntb
+gather_tntb = _cast4 Unmanaged.gather_tntb
 
 gather_tnt
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-gather_tnt = cast3 Unmanaged.gather_tnt
+gather_tnt = _cast3 Unmanaged.gather_tnt
 
 _gather_sparse_backward_tltt
   :: ForeignPtr Tensor
@@ -350,7 +350,7 @@ _gather_sparse_backward_tltt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_gather_sparse_backward_tltt = cast4 Unmanaged._gather_sparse_backward_tltt
+_gather_sparse_backward_tltt = _cast4 Unmanaged._gather_sparse_backward_tltt
 
 addcmul_out_tttts
   :: ForeignPtr Tensor
@@ -359,7 +359,7 @@ addcmul_out_tttts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-addcmul_out_tttts = cast5 Unmanaged.addcmul_out_tttts
+addcmul_out_tttts = _cast5 Unmanaged.addcmul_out_tttts
 
 addcmul_out_tttt
   :: ForeignPtr Tensor
@@ -367,7 +367,7 @@ addcmul_out_tttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-addcmul_out_tttt = cast4 Unmanaged.addcmul_out_tttt
+addcmul_out_tttt = _cast4 Unmanaged.addcmul_out_tttt
 
 addcmul_ttts
   :: ForeignPtr Tensor
@@ -375,14 +375,14 @@ addcmul_ttts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-addcmul_ttts = cast4 Unmanaged.addcmul_ttts
+addcmul_ttts = _cast4 Unmanaged.addcmul_ttts
 
 addcmul_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-addcmul_ttt = cast3 Unmanaged.addcmul_ttt
+addcmul_ttt = _cast3 Unmanaged.addcmul_ttt
 
 addcdiv_out_tttts
   :: ForeignPtr Tensor
@@ -391,7 +391,7 @@ addcdiv_out_tttts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-addcdiv_out_tttts = cast5 Unmanaged.addcdiv_out_tttts
+addcdiv_out_tttts = _cast5 Unmanaged.addcdiv_out_tttts
 
 addcdiv_out_tttt
   :: ForeignPtr Tensor
@@ -399,7 +399,7 @@ addcdiv_out_tttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-addcdiv_out_tttt = cast4 Unmanaged.addcdiv_out_tttt
+addcdiv_out_tttt = _cast4 Unmanaged.addcdiv_out_tttt
 
 addcdiv_ttts
   :: ForeignPtr Tensor
@@ -407,14 +407,14 @@ addcdiv_ttts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-addcdiv_ttts = cast4 Unmanaged.addcdiv_ttts
+addcdiv_ttts = _cast4 Unmanaged.addcdiv_ttts
 
 addcdiv_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-addcdiv_ttt = cast3 Unmanaged.addcdiv_ttt
+addcdiv_ttt = _cast3 Unmanaged.addcdiv_ttt
 
 cross_entropy_loss_tttlld
   :: ForeignPtr Tensor
@@ -424,7 +424,7 @@ cross_entropy_loss_tttlld
   -> Int64
   -> CDouble
   -> IO (ForeignPtr Tensor)
-cross_entropy_loss_tttlld = cast6 Unmanaged.cross_entropy_loss_tttlld
+cross_entropy_loss_tttlld = _cast6 Unmanaged.cross_entropy_loss_tttlld
 
 cross_entropy_loss_tttll
   :: ForeignPtr Tensor
@@ -433,7 +433,7 @@ cross_entropy_loss_tttll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-cross_entropy_loss_tttll = cast5 Unmanaged.cross_entropy_loss_tttll
+cross_entropy_loss_tttll = _cast5 Unmanaged.cross_entropy_loss_tttll
 
 cross_entropy_loss_tttl
   :: ForeignPtr Tensor
@@ -441,20 +441,20 @@ cross_entropy_loss_tttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-cross_entropy_loss_tttl = cast4 Unmanaged.cross_entropy_loss_tttl
+cross_entropy_loss_tttl = _cast4 Unmanaged.cross_entropy_loss_tttl
 
 cross_entropy_loss_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-cross_entropy_loss_ttt = cast3 Unmanaged.cross_entropy_loss_ttt
+cross_entropy_loss_ttt = _cast3 Unmanaged.cross_entropy_loss_ttt
 
 cross_entropy_loss_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-cross_entropy_loss_tt = cast2 Unmanaged.cross_entropy_loss_tt
+cross_entropy_loss_tt = _cast2 Unmanaged.cross_entropy_loss_tt
 
 lstsq_out_tttt
   :: ForeignPtr Tensor
@@ -462,13 +462,13 @@ lstsq_out_tttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-lstsq_out_tttt = cast4 Unmanaged.lstsq_out_tttt
+lstsq_out_tttt = _cast4 Unmanaged.lstsq_out_tttt
 
 lstsq_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-lstsq_tt = cast2 Unmanaged.lstsq_tt
+lstsq_tt = _cast2 Unmanaged.lstsq_tt
 
 triangular_solve_out_ttttbbb
   :: ForeignPtr Tensor
@@ -479,7 +479,7 @@ triangular_solve_out_ttttbbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-triangular_solve_out_ttttbbb = cast7 Unmanaged.triangular_solve_out_ttttbbb
+triangular_solve_out_ttttbbb = _cast7 Unmanaged.triangular_solve_out_ttttbbb
 
 triangular_solve_out_ttttbb
   :: ForeignPtr Tensor
@@ -489,7 +489,7 @@ triangular_solve_out_ttttbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-triangular_solve_out_ttttbb = cast6 Unmanaged.triangular_solve_out_ttttbb
+triangular_solve_out_ttttbb = _cast6 Unmanaged.triangular_solve_out_ttttbb
 
 triangular_solve_out_ttttb
   :: ForeignPtr Tensor
@@ -498,7 +498,7 @@ triangular_solve_out_ttttb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-triangular_solve_out_ttttb = cast5 Unmanaged.triangular_solve_out_ttttb
+triangular_solve_out_ttttb = _cast5 Unmanaged.triangular_solve_out_ttttb
 
 triangular_solve_out_tttt
   :: ForeignPtr Tensor
@@ -506,7 +506,7 @@ triangular_solve_out_tttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-triangular_solve_out_tttt = cast4 Unmanaged.triangular_solve_out_tttt
+triangular_solve_out_tttt = _cast4 Unmanaged.triangular_solve_out_tttt
 
 triangular_solve_ttbbb
   :: ForeignPtr Tensor
@@ -515,7 +515,7 @@ triangular_solve_ttbbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-triangular_solve_ttbbb = cast5 Unmanaged.triangular_solve_ttbbb
+triangular_solve_ttbbb = _cast5 Unmanaged.triangular_solve_ttbbb
 
 triangular_solve_ttbb
   :: ForeignPtr Tensor
@@ -523,27 +523,27 @@ triangular_solve_ttbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-triangular_solve_ttbb = cast4 Unmanaged.triangular_solve_ttbb
+triangular_solve_ttbb = _cast4 Unmanaged.triangular_solve_ttbb
 
 triangular_solve_ttb
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-triangular_solve_ttb = cast3 Unmanaged.triangular_solve_ttb
+triangular_solve_ttb = _cast3 Unmanaged.triangular_solve_ttb
 
 triangular_solve_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-triangular_solve_tt = cast2 Unmanaged.triangular_solve_tt
+triangular_solve_tt = _cast2 Unmanaged.triangular_solve_tt
 
 _linalg_check_errors_tsb
   :: ForeignPtr Tensor
   -> ForeignPtr StdString
   -> CBool
   -> IO (())
-_linalg_check_errors_tsb = cast3 Unmanaged._linalg_check_errors_tsb
+_linalg_check_errors_tsb = _cast3 Unmanaged._linalg_check_errors_tsb
 
 linalg_solve_triangular_out_tttbbb
   :: ForeignPtr Tensor
@@ -553,7 +553,7 @@ linalg_solve_triangular_out_tttbbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-linalg_solve_triangular_out_tttbbb = cast6 Unmanaged.linalg_solve_triangular_out_tttbbb
+linalg_solve_triangular_out_tttbbb = _cast6 Unmanaged.linalg_solve_triangular_out_tttbbb
 
 linalg_solve_triangular_out_tttbb
   :: ForeignPtr Tensor
@@ -562,7 +562,7 @@ linalg_solve_triangular_out_tttbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-linalg_solve_triangular_out_tttbb = cast5 Unmanaged.linalg_solve_triangular_out_tttbb
+linalg_solve_triangular_out_tttbb = _cast5 Unmanaged.linalg_solve_triangular_out_tttbb
 
 linalg_solve_triangular_out_tttb
   :: ForeignPtr Tensor
@@ -570,7 +570,7 @@ linalg_solve_triangular_out_tttb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-linalg_solve_triangular_out_tttb = cast4 Unmanaged.linalg_solve_triangular_out_tttb
+linalg_solve_triangular_out_tttb = _cast4 Unmanaged.linalg_solve_triangular_out_tttb
 
 linalg_solve_triangular_ttbbb
   :: ForeignPtr Tensor
@@ -579,7 +579,7 @@ linalg_solve_triangular_ttbbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-linalg_solve_triangular_ttbbb = cast5 Unmanaged.linalg_solve_triangular_ttbbb
+linalg_solve_triangular_ttbbb = _cast5 Unmanaged.linalg_solve_triangular_ttbbb
 
 linalg_solve_triangular_ttbb
   :: ForeignPtr Tensor
@@ -587,14 +587,14 @@ linalg_solve_triangular_ttbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-linalg_solve_triangular_ttbb = cast4 Unmanaged.linalg_solve_triangular_ttbb
+linalg_solve_triangular_ttbb = _cast4 Unmanaged.linalg_solve_triangular_ttbb
 
 linalg_solve_triangular_ttb
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-linalg_solve_triangular_ttb = cast3 Unmanaged.linalg_solve_triangular_ttb
+linalg_solve_triangular_ttb = _cast3 Unmanaged.linalg_solve_triangular_ttb
 
 symeig_out_tttbb
   :: ForeignPtr Tensor
@@ -603,7 +603,7 @@ symeig_out_tttbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-symeig_out_tttbb = cast5 Unmanaged.symeig_out_tttbb
+symeig_out_tttbb = _cast5 Unmanaged.symeig_out_tttbb
 
 symeig_out_tttb
   :: ForeignPtr Tensor
@@ -611,39 +611,39 @@ symeig_out_tttb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-symeig_out_tttb = cast4 Unmanaged.symeig_out_tttb
+symeig_out_tttb = _cast4 Unmanaged.symeig_out_tttb
 
 symeig_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-symeig_out_ttt = cast3 Unmanaged.symeig_out_ttt
+symeig_out_ttt = _cast3 Unmanaged.symeig_out_ttt
 
 symeig_tbb
   :: ForeignPtr Tensor
   -> CBool
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-symeig_tbb = cast3 Unmanaged.symeig_tbb
+symeig_tbb = _cast3 Unmanaged.symeig_tbb
 
 symeig_tb
   :: ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-symeig_tb = cast2 Unmanaged.symeig_tb
+symeig_tb = _cast2 Unmanaged.symeig_tb
 
 symeig_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-symeig_t = cast1 Unmanaged.symeig_t
+symeig_t = _cast1 Unmanaged.symeig_t
 
 _symeig_helper_tbb
   :: ForeignPtr Tensor
   -> CBool
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-_symeig_helper_tbb = cast3 Unmanaged._symeig_helper_tbb
+_symeig_helper_tbb = _cast3 Unmanaged._symeig_helper_tbb
 
 eig_out_tttb
   :: ForeignPtr Tensor
@@ -651,25 +651,25 @@ eig_out_tttb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-eig_out_tttb = cast4 Unmanaged.eig_out_tttb
+eig_out_tttb = _cast4 Unmanaged.eig_out_tttb
 
 eig_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-eig_out_ttt = cast3 Unmanaged.eig_out_ttt
+eig_out_ttt = _cast3 Unmanaged.eig_out_ttt
 
 eig_tb
   :: ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-eig_tb = cast2 Unmanaged.eig_tb
+eig_tb = _cast2 Unmanaged.eig_tb
 
 eig_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-eig_t = cast1 Unmanaged.eig_t
+eig_t = _cast1 Unmanaged.eig_t
 
 svd_out_ttttbb
   :: ForeignPtr Tensor
@@ -679,7 +679,7 @@ svd_out_ttttbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-svd_out_ttttbb = cast6 Unmanaged.svd_out_ttttbb
+svd_out_ttttbb = _cast6 Unmanaged.svd_out_ttttbb
 
 svd_out_ttttb
   :: ForeignPtr Tensor
@@ -688,7 +688,7 @@ svd_out_ttttb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-svd_out_ttttb = cast5 Unmanaged.svd_out_ttttb
+svd_out_ttttb = _cast5 Unmanaged.svd_out_ttttb
 
 svd_out_tttt
   :: ForeignPtr Tensor
@@ -696,63 +696,63 @@ svd_out_tttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-svd_out_tttt = cast4 Unmanaged.svd_out_tttt
+svd_out_tttt = _cast4 Unmanaged.svd_out_tttt
 
 svd_tbb
   :: ForeignPtr Tensor
   -> CBool
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-svd_tbb = cast3 Unmanaged.svd_tbb
+svd_tbb = _cast3 Unmanaged.svd_tbb
 
 svd_tb
   :: ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-svd_tb = cast2 Unmanaged.svd_tb
+svd_tb = _cast2 Unmanaged.svd_tb
 
 svd_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-svd_t = cast1 Unmanaged.svd_t
+svd_t = _cast1 Unmanaged.svd_t
 
 swapaxes_tll
   :: ForeignPtr Tensor
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-swapaxes_tll = cast3 Unmanaged.swapaxes_tll
+swapaxes_tll = _cast3 Unmanaged.swapaxes_tll
 
 swapdims_tll
   :: ForeignPtr Tensor
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-swapdims_tll = cast3 Unmanaged.swapdims_tll
+swapdims_tll = _cast3 Unmanaged.swapdims_tll
 
 cholesky_out_ttb
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-cholesky_out_ttb = cast3 Unmanaged.cholesky_out_ttb
+cholesky_out_ttb = _cast3 Unmanaged.cholesky_out_ttb
 
 cholesky_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-cholesky_out_tt = cast2 Unmanaged.cholesky_out_tt
+cholesky_out_tt = _cast2 Unmanaged.cholesky_out_tt
 
 cholesky_tb
   :: ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-cholesky_tb = cast2 Unmanaged.cholesky_tb
+cholesky_tb = _cast2 Unmanaged.cholesky_tb
 
 cholesky_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-cholesky_t = cast1 Unmanaged.cholesky_t
+cholesky_t = _cast1 Unmanaged.cholesky_t
 
 cholesky_solve_out_tttb
   :: ForeignPtr Tensor
@@ -760,40 +760,40 @@ cholesky_solve_out_tttb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-cholesky_solve_out_tttb = cast4 Unmanaged.cholesky_solve_out_tttb
+cholesky_solve_out_tttb = _cast4 Unmanaged.cholesky_solve_out_tttb
 
 cholesky_solve_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-cholesky_solve_out_ttt = cast3 Unmanaged.cholesky_solve_out_ttt
+cholesky_solve_out_ttt = _cast3 Unmanaged.cholesky_solve_out_ttt
 
 cholesky_solve_ttb
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-cholesky_solve_ttb = cast3 Unmanaged.cholesky_solve_ttb
+cholesky_solve_ttb = _cast3 Unmanaged.cholesky_solve_ttb
 
 cholesky_solve_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-cholesky_solve_tt = cast2 Unmanaged.cholesky_solve_tt
+cholesky_solve_tt = _cast2 Unmanaged.cholesky_solve_tt
 
 _cholesky_solve_helper_ttb
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-_cholesky_solve_helper_ttb = cast3 Unmanaged._cholesky_solve_helper_ttb
+_cholesky_solve_helper_ttb = _cast3 Unmanaged._cholesky_solve_helper_ttb
 
 solve_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-solve_tt = cast2 Unmanaged.solve_tt
+solve_tt = _cast2 Unmanaged.solve_tt
 
 solve_out_tttt
   :: ForeignPtr Tensor
@@ -801,37 +801,37 @@ solve_out_tttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-solve_out_tttt = cast4 Unmanaged.solve_out_tttt
+solve_out_tttt = _cast4 Unmanaged.solve_out_tttt
 
 _solve_helper_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-_solve_helper_tt = cast2 Unmanaged._solve_helper_tt
+_solve_helper_tt = _cast2 Unmanaged._solve_helper_tt
 
 cholesky_inverse_tb
   :: ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-cholesky_inverse_tb = cast2 Unmanaged.cholesky_inverse_tb
+cholesky_inverse_tb = _cast2 Unmanaged.cholesky_inverse_tb
 
 cholesky_inverse_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-cholesky_inverse_t = cast1 Unmanaged.cholesky_inverse_t
+cholesky_inverse_t = _cast1 Unmanaged.cholesky_inverse_t
 
 cholesky_inverse_out_ttb
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-cholesky_inverse_out_ttb = cast3 Unmanaged.cholesky_inverse_out_ttb
+cholesky_inverse_out_ttb = _cast3 Unmanaged.cholesky_inverse_out_ttb
 
 cholesky_inverse_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-cholesky_inverse_out_tt = cast2 Unmanaged.cholesky_inverse_out_tt
+cholesky_inverse_out_tt = _cast2 Unmanaged.cholesky_inverse_out_tt
 
 qr_out_tttb
   :: ForeignPtr Tensor
@@ -839,50 +839,50 @@ qr_out_tttb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-qr_out_tttb = cast4 Unmanaged.qr_out_tttb
+qr_out_tttb = _cast4 Unmanaged.qr_out_tttb
 
 qr_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-qr_out_ttt = cast3 Unmanaged.qr_out_ttt
+qr_out_ttt = _cast3 Unmanaged.qr_out_ttt
 
 qr_tb
   :: ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-qr_tb = cast2 Unmanaged.qr_tb
+qr_tb = _cast2 Unmanaged.qr_tb
 
 qr_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-qr_t = cast1 Unmanaged.qr_t
+qr_t = _cast1 Unmanaged.qr_t
 
 geqrf_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-geqrf_out_ttt = cast3 Unmanaged.geqrf_out_ttt
+geqrf_out_ttt = _cast3 Unmanaged.geqrf_out_ttt
 
 geqrf_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-geqrf_t = cast1 Unmanaged.geqrf_t
+geqrf_t = _cast1 Unmanaged.geqrf_t
 
 orgqr_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-orgqr_tt = cast2 Unmanaged.orgqr_tt
+orgqr_tt = _cast2 Unmanaged.orgqr_tt
 
 orgqr_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-orgqr_out_ttt = cast3 Unmanaged.orgqr_out_ttt
+orgqr_out_ttt = _cast3 Unmanaged.orgqr_out_ttt
 
 ormqr_out_ttttbb
   :: ForeignPtr Tensor
@@ -892,7 +892,7 @@ ormqr_out_ttttbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-ormqr_out_ttttbb = cast6 Unmanaged.ormqr_out_ttttbb
+ormqr_out_ttttbb = _cast6 Unmanaged.ormqr_out_ttttbb
 
 ormqr_out_ttttb
   :: ForeignPtr Tensor
@@ -901,7 +901,7 @@ ormqr_out_ttttb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-ormqr_out_ttttb = cast5 Unmanaged.ormqr_out_ttttb
+ormqr_out_ttttb = _cast5 Unmanaged.ormqr_out_ttttb
 
 ormqr_out_tttt
   :: ForeignPtr Tensor
@@ -909,7 +909,7 @@ ormqr_out_tttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-ormqr_out_tttt = cast4 Unmanaged.ormqr_out_tttt
+ormqr_out_tttt = _cast4 Unmanaged.ormqr_out_tttt
 
 ormqr_tttbb
   :: ForeignPtr Tensor
@@ -918,7 +918,7 @@ ormqr_tttbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-ormqr_tttbb = cast5 Unmanaged.ormqr_tttbb
+ormqr_tttbb = _cast5 Unmanaged.ormqr_tttbb
 
 ormqr_tttb
   :: ForeignPtr Tensor
@@ -926,32 +926,32 @@ ormqr_tttb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-ormqr_tttb = cast4 Unmanaged.ormqr_tttb
+ormqr_tttb = _cast4 Unmanaged.ormqr_tttb
 
 ormqr_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-ormqr_ttt = cast3 Unmanaged.ormqr_ttt
+ormqr_ttt = _cast3 Unmanaged.ormqr_ttt
 
 _lu_with_info_tbb
   :: ForeignPtr Tensor
   -> CBool
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-_lu_with_info_tbb = cast3 Unmanaged._lu_with_info_tbb
+_lu_with_info_tbb = _cast3 Unmanaged._lu_with_info_tbb
 
 _lu_with_info_tb
   :: ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-_lu_with_info_tb = cast2 Unmanaged._lu_with_info_tb
+_lu_with_info_tb = _cast2 Unmanaged._lu_with_info_tb
 
 _lu_with_info_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-_lu_with_info_t = cast1 Unmanaged._lu_with_info_t
+_lu_with_info_t = _cast1 Unmanaged._lu_with_info_t
 
 lu_solve_out_tttt
   :: ForeignPtr Tensor
@@ -959,14 +959,14 @@ lu_solve_out_tttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-lu_solve_out_tttt = cast4 Unmanaged.lu_solve_out_tttt
+lu_solve_out_tttt = _cast4 Unmanaged.lu_solve_out_tttt
 
 lu_solve_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-lu_solve_ttt = cast3 Unmanaged.lu_solve_ttt
+lu_solve_ttt = _cast3 Unmanaged.lu_solve_ttt
 
 lu_unpack_ttbb
   :: ForeignPtr Tensor
@@ -974,20 +974,20 @@ lu_unpack_ttbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-lu_unpack_ttbb = cast4 Unmanaged.lu_unpack_ttbb
+lu_unpack_ttbb = _cast4 Unmanaged.lu_unpack_ttbb
 
 lu_unpack_ttb
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-lu_unpack_ttb = cast3 Unmanaged.lu_unpack_ttb
+lu_unpack_ttb = _cast3 Unmanaged.lu_unpack_ttb
 
 lu_unpack_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-lu_unpack_tt = cast2 Unmanaged.lu_unpack_tt
+lu_unpack_tt = _cast2 Unmanaged.lu_unpack_tt
 
 lu_unpack_out_tttttbb
   :: ForeignPtr Tensor
@@ -998,7 +998,7 @@ lu_unpack_out_tttttbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-lu_unpack_out_tttttbb = cast7 Unmanaged.lu_unpack_out_tttttbb
+lu_unpack_out_tttttbb = _cast7 Unmanaged.lu_unpack_out_tttttbb
 
 lu_unpack_out_tttttb
   :: ForeignPtr Tensor
@@ -1008,7 +1008,7 @@ lu_unpack_out_tttttb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-lu_unpack_out_tttttb = cast6 Unmanaged.lu_unpack_out_tttttb
+lu_unpack_out_tttttb = _cast6 Unmanaged.lu_unpack_out_tttttb
 
 lu_unpack_out_ttttt
   :: ForeignPtr Tensor
@@ -1017,7 +1017,7 @@ lu_unpack_out_ttttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-lu_unpack_out_ttttt = cast5 Unmanaged.lu_unpack_out_ttttt
+lu_unpack_out_ttttt = _cast5 Unmanaged.lu_unpack_out_ttttt
 
 multinomial_out_ttlbG
   :: ForeignPtr Tensor
@@ -1026,7 +1026,7 @@ multinomial_out_ttlbG
   -> CBool
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-multinomial_out_ttlbG = cast5 Unmanaged.multinomial_out_ttlbG
+multinomial_out_ttlbG = _cast5 Unmanaged.multinomial_out_ttlbG
 
 multinomial_out_ttlb
   :: ForeignPtr Tensor
@@ -1034,14 +1034,14 @@ multinomial_out_ttlb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-multinomial_out_ttlb = cast4 Unmanaged.multinomial_out_ttlb
+multinomial_out_ttlb = _cast4 Unmanaged.multinomial_out_ttlb
 
 multinomial_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-multinomial_out_ttl = cast3 Unmanaged.multinomial_out_ttl
+multinomial_out_ttl = _cast3 Unmanaged.multinomial_out_ttl
 
 multinomial_tlbG
   :: ForeignPtr Tensor
@@ -1049,143 +1049,143 @@ multinomial_tlbG
   -> CBool
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-multinomial_tlbG = cast4 Unmanaged.multinomial_tlbG
+multinomial_tlbG = _cast4 Unmanaged.multinomial_tlbG
 
 multinomial_tlb
   :: ForeignPtr Tensor
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-multinomial_tlb = cast3 Unmanaged.multinomial_tlb
+multinomial_tlb = _cast3 Unmanaged.multinomial_tlb
 
 multinomial_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-multinomial_tl = cast2 Unmanaged.multinomial_tl
+multinomial_tl = _cast2 Unmanaged.multinomial_tl
 
 lgamma_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-lgamma_out_tt = cast2 Unmanaged.lgamma_out_tt
+lgamma_out_tt = _cast2 Unmanaged.lgamma_out_tt
 
 lgamma_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-lgamma_t = cast1 Unmanaged.lgamma_t
+lgamma_t = _cast1 Unmanaged.lgamma_t
 
 digamma_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-digamma_out_tt = cast2 Unmanaged.digamma_out_tt
+digamma_out_tt = _cast2 Unmanaged.digamma_out_tt
 
 digamma_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-digamma_t = cast1 Unmanaged.digamma_t
+digamma_t = _cast1 Unmanaged.digamma_t
 
 polygamma_out_tlt
   :: ForeignPtr Tensor
   -> Int64
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-polygamma_out_tlt = cast3 Unmanaged.polygamma_out_tlt
+polygamma_out_tlt = _cast3 Unmanaged.polygamma_out_tlt
 
 polygamma_lt
   :: Int64
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-polygamma_lt = cast2 Unmanaged.polygamma_lt
+polygamma_lt = _cast2 Unmanaged.polygamma_lt
 
 erfinv_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-erfinv_t = cast1 Unmanaged.erfinv_t
+erfinv_t = _cast1 Unmanaged.erfinv_t
 
 erfinv_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-erfinv_out_tt = cast2 Unmanaged.erfinv_out_tt
+erfinv_out_tt = _cast2 Unmanaged.erfinv_out_tt
 
 i0_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-i0_t = cast1 Unmanaged.i0_t
+i0_t = _cast1 Unmanaged.i0_t
 
 i0__t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-i0__t = cast1 Unmanaged.i0__t
+i0__t = _cast1 Unmanaged.i0__t
 
 i0_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-i0_out_tt = cast2 Unmanaged.i0_out_tt
+i0_out_tt = _cast2 Unmanaged.i0_out_tt
 
 sign_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-sign_t = cast1 Unmanaged.sign_t
+sign_t = _cast1 Unmanaged.sign_t
 
 sign_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-sign_out_tt = cast2 Unmanaged.sign_out_tt
+sign_out_tt = _cast2 Unmanaged.sign_out_tt
 
 signbit_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-signbit_t = cast1 Unmanaged.signbit_t
+signbit_t = _cast1 Unmanaged.signbit_t
 
 signbit_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-signbit_out_tt = cast2 Unmanaged.signbit_out_tt
+signbit_out_tt = _cast2 Unmanaged.signbit_out_tt
 
 dist_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-dist_tts = cast3 Unmanaged.dist_tts
+dist_tts = _cast3 Unmanaged.dist_tts
 
 dist_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-dist_tt = cast2 Unmanaged.dist_tt
+dist_tt = _cast2 Unmanaged.dist_tt
 
 atan2_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-atan2_out_ttt = cast3 Unmanaged.atan2_out_ttt
+atan2_out_ttt = _cast3 Unmanaged.atan2_out_ttt
 
 atan2_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-atan2_tt = cast2 Unmanaged.atan2_tt
+atan2_tt = _cast2 Unmanaged.atan2_tt
 
 arctan2_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-arctan2_tt = cast2 Unmanaged.arctan2_tt
+arctan2_tt = _cast2 Unmanaged.arctan2_tt
 
 arctan2_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-arctan2_out_ttt = cast3 Unmanaged.arctan2_out_ttt
+arctan2_out_ttt = _cast3 Unmanaged.arctan2_out_ttt
 
 lerp_out_ttts
   :: ForeignPtr Tensor
@@ -1193,7 +1193,7 @@ lerp_out_ttts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-lerp_out_ttts = cast4 Unmanaged.lerp_out_ttts
+lerp_out_ttts = _cast4 Unmanaged.lerp_out_ttts
 
 lerp_out_tttt
   :: ForeignPtr Tensor
@@ -1201,21 +1201,21 @@ lerp_out_tttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-lerp_out_tttt = cast4 Unmanaged.lerp_out_tttt
+lerp_out_tttt = _cast4 Unmanaged.lerp_out_tttt
 
 lerp_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-lerp_tts = cast3 Unmanaged.lerp_tts
+lerp_tts = _cast3 Unmanaged.lerp_tts
 
 lerp_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-lerp_ttt = cast3 Unmanaged.lerp_ttt
+lerp_ttt = _cast3 Unmanaged.lerp_ttt
 
 histc_out_ttlss
   :: ForeignPtr Tensor
@@ -1224,7 +1224,7 @@ histc_out_ttlss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-histc_out_ttlss = cast5 Unmanaged.histc_out_ttlss
+histc_out_ttlss = _cast5 Unmanaged.histc_out_ttlss
 
 histc_out_ttls
   :: ForeignPtr Tensor
@@ -1232,20 +1232,20 @@ histc_out_ttls
   -> Int64
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-histc_out_ttls = cast4 Unmanaged.histc_out_ttls
+histc_out_ttls = _cast4 Unmanaged.histc_out_ttls
 
 histc_out_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-histc_out_ttl = cast3 Unmanaged.histc_out_ttl
+histc_out_ttl = _cast3 Unmanaged.histc_out_ttl
 
 histc_out_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-histc_out_tt = cast2 Unmanaged.histc_out_tt
+histc_out_tt = _cast2 Unmanaged.histc_out_tt
 
 histc_tlss
   :: ForeignPtr Tensor
@@ -1253,25 +1253,25 @@ histc_tlss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-histc_tlss = cast4 Unmanaged.histc_tlss
+histc_tlss = _cast4 Unmanaged.histc_tlss
 
 histc_tls
   :: ForeignPtr Tensor
   -> Int64
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-histc_tls = cast3 Unmanaged.histc_tls
+histc_tls = _cast3 Unmanaged.histc_tls
 
 histc_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-histc_tl = cast2 Unmanaged.histc_tl
+histc_tl = _cast2 Unmanaged.histc_tl
 
 histc_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-histc_t = cast1 Unmanaged.histc_t
+histc_t = _cast1 Unmanaged.histc_t
 
 histogram_out_tttttb
   :: ForeignPtr Tensor
@@ -1281,7 +1281,7 @@ histogram_out_tttttb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-histogram_out_tttttb = cast6 Unmanaged.histogram_out_tttttb
+histogram_out_tttttb = _cast6 Unmanaged.histogram_out_tttttb
 
 histogram_out_ttttt
   :: ForeignPtr Tensor
@@ -1290,7 +1290,7 @@ histogram_out_ttttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-histogram_out_ttttt = cast5 Unmanaged.histogram_out_ttttt
+histogram_out_ttttt = _cast5 Unmanaged.histogram_out_ttttt
 
 histogram_out_tttt
   :: ForeignPtr Tensor
@@ -1298,7 +1298,7 @@ histogram_out_tttt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-histogram_out_tttt = cast4 Unmanaged.histogram_out_tttt
+histogram_out_tttt = _cast4 Unmanaged.histogram_out_tttt
 
 histogram_tttb
   :: ForeignPtr Tensor
@@ -1306,20 +1306,20 @@ histogram_tttb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-histogram_tttb = cast4 Unmanaged.histogram_tttb
+histogram_tttb = _cast4 Unmanaged.histogram_tttb
 
 histogram_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-histogram_ttt = cast3 Unmanaged.histogram_ttt
+histogram_ttt = _cast3 Unmanaged.histogram_ttt
 
 histogram_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-histogram_tt = cast2 Unmanaged.histogram_tt
+histogram_tt = _cast2 Unmanaged.histogram_tt
 
 histogram_out_tttlatb
   :: ForeignPtr Tensor
@@ -1330,7 +1330,7 @@ histogram_out_tttlatb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-histogram_out_tttlatb = cast7 Unmanaged.histogram_out_tttlatb
+histogram_out_tttlatb = _cast7 Unmanaged.histogram_out_tttlatb
 
 histogram_out_tttlat
   :: ForeignPtr Tensor
@@ -1340,7 +1340,7 @@ histogram_out_tttlat
   -> ForeignPtr (StdVector CDouble)
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-histogram_out_tttlat = cast6 Unmanaged.histogram_out_tttlat
+histogram_out_tttlat = _cast6 Unmanaged.histogram_out_tttlat
 
 histogram_out_tttla
   :: ForeignPtr Tensor
@@ -1349,7 +1349,7 @@ histogram_out_tttla
   -> Int64
   -> ForeignPtr (StdVector CDouble)
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-histogram_out_tttla = cast5 Unmanaged.histogram_out_tttla
+histogram_out_tttla = _cast5 Unmanaged.histogram_out_tttla
 
 histogram_out_tttl
   :: ForeignPtr Tensor
@@ -1357,14 +1357,14 @@ histogram_out_tttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-histogram_out_tttl = cast4 Unmanaged.histogram_out_tttl
+histogram_out_tttl = _cast4 Unmanaged.histogram_out_tttl
 
 histogram_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-histogram_out_ttt = cast3 Unmanaged.histogram_out_ttt
+histogram_out_ttt = _cast3 Unmanaged.histogram_out_ttt
 
 histogram_tlatb
   :: ForeignPtr Tensor
@@ -1373,7 +1373,7 @@ histogram_tlatb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-histogram_tlatb = cast5 Unmanaged.histogram_tlatb
+histogram_tlatb = _cast5 Unmanaged.histogram_tlatb
 
 histogram_tlat
   :: ForeignPtr Tensor
@@ -1381,25 +1381,25 @@ histogram_tlat
   -> ForeignPtr (StdVector CDouble)
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-histogram_tlat = cast4 Unmanaged.histogram_tlat
+histogram_tlat = _cast4 Unmanaged.histogram_tlat
 
 histogram_tla
   :: ForeignPtr Tensor
   -> Int64
   -> ForeignPtr (StdVector CDouble)
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-histogram_tla = cast3 Unmanaged.histogram_tla
+histogram_tla = _cast3 Unmanaged.histogram_tla
 
 histogram_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-histogram_tl = cast2 Unmanaged.histogram_tl
+histogram_tl = _cast2 Unmanaged.histogram_tl
 
 histogram_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-histogram_t = cast1 Unmanaged.histogram_t
+histogram_t = _cast1 Unmanaged.histogram_t
 
 _histogramdd_bin_edges_tlatb
   :: ForeignPtr Tensor
@@ -1408,7 +1408,7 @@ _histogramdd_bin_edges_tlatb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr TensorList)
-_histogramdd_bin_edges_tlatb = cast5 Unmanaged._histogramdd_bin_edges_tlatb
+_histogramdd_bin_edges_tlatb = _cast5 Unmanaged._histogramdd_bin_edges_tlatb
 
 _histogramdd_bin_edges_tlat
   :: ForeignPtr Tensor
@@ -1416,20 +1416,20 @@ _histogramdd_bin_edges_tlat
   -> ForeignPtr (StdVector CDouble)
   -> ForeignPtr Tensor
   -> IO (ForeignPtr TensorList)
-_histogramdd_bin_edges_tlat = cast4 Unmanaged._histogramdd_bin_edges_tlat
+_histogramdd_bin_edges_tlat = _cast4 Unmanaged._histogramdd_bin_edges_tlat
 
 _histogramdd_bin_edges_tla
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr (StdVector CDouble)
   -> IO (ForeignPtr TensorList)
-_histogramdd_bin_edges_tla = cast3 Unmanaged._histogramdd_bin_edges_tla
+_histogramdd_bin_edges_tla = _cast3 Unmanaged._histogramdd_bin_edges_tla
 
 _histogramdd_bin_edges_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr TensorList)
-_histogramdd_bin_edges_tl = cast2 Unmanaged._histogramdd_bin_edges_tl
+_histogramdd_bin_edges_tl = _cast2 Unmanaged._histogramdd_bin_edges_tl
 
 _histogramdd_from_bin_cts_tlatb
   :: ForeignPtr Tensor
@@ -1438,7 +1438,7 @@ _histogramdd_from_bin_cts_tlatb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-_histogramdd_from_bin_cts_tlatb = cast5 Unmanaged._histogramdd_from_bin_cts_tlatb
+_histogramdd_from_bin_cts_tlatb = _cast5 Unmanaged._histogramdd_from_bin_cts_tlatb
 
 _histogramdd_from_bin_cts_tlat
   :: ForeignPtr Tensor
@@ -1446,20 +1446,20 @@ _histogramdd_from_bin_cts_tlat
   -> ForeignPtr (StdVector CDouble)
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_histogramdd_from_bin_cts_tlat = cast4 Unmanaged._histogramdd_from_bin_cts_tlat
+_histogramdd_from_bin_cts_tlat = _cast4 Unmanaged._histogramdd_from_bin_cts_tlat
 
 _histogramdd_from_bin_cts_tla
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr (StdVector CDouble)
   -> IO (ForeignPtr Tensor)
-_histogramdd_from_bin_cts_tla = cast3 Unmanaged._histogramdd_from_bin_cts_tla
+_histogramdd_from_bin_cts_tla = _cast3 Unmanaged._histogramdd_from_bin_cts_tla
 
 _histogramdd_from_bin_cts_tl
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-_histogramdd_from_bin_cts_tl = cast2 Unmanaged._histogramdd_from_bin_cts_tl
+_histogramdd_from_bin_cts_tl = _cast2 Unmanaged._histogramdd_from_bin_cts_tl
 
 _histogramdd_from_bin_tensors_tltb
   :: ForeignPtr Tensor
@@ -1467,83 +1467,83 @@ _histogramdd_from_bin_tensors_tltb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-_histogramdd_from_bin_tensors_tltb = cast4 Unmanaged._histogramdd_from_bin_tensors_tltb
+_histogramdd_from_bin_tensors_tltb = _cast4 Unmanaged._histogramdd_from_bin_tensors_tltb
 
 _histogramdd_from_bin_tensors_tlt
   :: ForeignPtr Tensor
   -> ForeignPtr TensorList
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-_histogramdd_from_bin_tensors_tlt = cast3 Unmanaged._histogramdd_from_bin_tensors_tlt
+_histogramdd_from_bin_tensors_tlt = _cast3 Unmanaged._histogramdd_from_bin_tensors_tlt
 
 _histogramdd_from_bin_tensors_tl
   :: ForeignPtr Tensor
   -> ForeignPtr TensorList
   -> IO (ForeignPtr Tensor)
-_histogramdd_from_bin_tensors_tl = cast2 Unmanaged._histogramdd_from_bin_tensors_tl
+_histogramdd_from_bin_tensors_tl = _cast2 Unmanaged._histogramdd_from_bin_tensors_tl
 
 fmod_out_tts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-fmod_out_tts = cast3 Unmanaged.fmod_out_tts
+fmod_out_tts = _cast3 Unmanaged.fmod_out_tts
 
 fmod_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-fmod_ts = cast2 Unmanaged.fmod_ts
+fmod_ts = _cast2 Unmanaged.fmod_ts
 
 fmod_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fmod_out_ttt = cast3 Unmanaged.fmod_out_ttt
+fmod_out_ttt = _cast3 Unmanaged.fmod_out_ttt
 
 fmod_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-fmod_tt = cast2 Unmanaged.fmod_tt
+fmod_tt = _cast2 Unmanaged.fmod_tt
 
 hypot_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-hypot_out_ttt = cast3 Unmanaged.hypot_out_ttt
+hypot_out_ttt = _cast3 Unmanaged.hypot_out_ttt
 
 hypot_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-hypot_tt = cast2 Unmanaged.hypot_tt
+hypot_tt = _cast2 Unmanaged.hypot_tt
 
 igamma_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-igamma_out_ttt = cast3 Unmanaged.igamma_out_ttt
+igamma_out_ttt = _cast3 Unmanaged.igamma_out_ttt
 
 igamma_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-igamma_tt = cast2 Unmanaged.igamma_tt
+igamma_tt = _cast2 Unmanaged.igamma_tt
 
 igammac_out_ttt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-igammac_out_ttt = cast3 Unmanaged.igammac_out_ttt
+igammac_out_ttt = _cast3 Unmanaged.igammac_out_ttt
 
 igammac_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-igammac_tt = cast2 Unmanaged.igammac_tt
+igammac_tt = _cast2 Unmanaged.igammac_tt
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Optim.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Optim.hs
@@ -23,7 +23,7 @@ import Control.Concurrent.MVar (MVar(..), newEmptyMVar, putMVar, takeMVar)
 --   -> (ForeignPtr TensorList -> IO (ForeignPtr Tensor))
 --   -> Int
 --   -> IO (ForeignPtr TensorList)
--- optimizerWithAdam adamLr adamBetas0 adamBetas1 adamEps adamWeightDecay adamAmsgrad initParams loss numIter = cast2 (\i n -> Unmanaged.optimizerWithAdam adamLr adamBetas0 adamBetas1 adamEps adamWeightDecay adamAmsgrad i (trans loss) n) initParams numIter
+-- optimizerWithAdam adamLr adamBetas0 adamBetas1 adamEps adamWeightDecay adamAmsgrad initParams loss numIter = _cast2 (\i n -> Unmanaged.optimizerWithAdam adamLr adamBetas0 adamBetas1 adamEps adamWeightDecay adamAmsgrad i (trans loss) n) initParams numIter
 --   where
 --     trans :: (ForeignPtr TensorList -> IO (ForeignPtr Tensor)) -> Ptr TensorList -> IO (Ptr Tensor)
 --     trans func inputs = do
@@ -39,7 +39,7 @@ adagrad
   -> CDouble
   -> ForeignPtr TensorList
   -> IO (ForeignPtr Optimizer)
-adagrad = cast6 Unmanaged.adagrad
+adagrad = _cast6 Unmanaged.adagrad
 
 rmsprop
   :: CDouble
@@ -50,7 +50,7 @@ rmsprop
   -> CBool
   -> ForeignPtr TensorList
   -> IO (ForeignPtr Optimizer)
-rmsprop = cast7 Unmanaged.rmsprop
+rmsprop = _cast7 Unmanaged.rmsprop
 
 sgd
   :: CDouble
@@ -60,7 +60,7 @@ sgd
   -> CBool
   -> ForeignPtr TensorList
   -> IO (ForeignPtr Optimizer)
-sgd = cast6 Unmanaged.sgd
+sgd = _cast6 Unmanaged.sgd
 
 adam
   :: CDouble
@@ -71,7 +71,7 @@ adam
   -> CBool
   -> ForeignPtr TensorList
   -> IO (ForeignPtr Optimizer)
-adam = cast7 Unmanaged.adam
+adam = _cast7 Unmanaged.adam
 
 adamw
   :: CDouble
@@ -82,7 +82,7 @@ adamw
   -> CBool
   -> ForeignPtr TensorList
   -> IO (ForeignPtr Optimizer)
-adamw = cast7 Unmanaged.adamw
+adamw = _cast7 Unmanaged.adamw
 
 lbfgs
   :: CDouble
@@ -94,10 +94,10 @@ lbfgs
   -> Maybe (ForeignPtr StdString)
   -> ForeignPtr TensorList
   -> IO (ForeignPtr Optimizer)
-lbfgs = cast8 Unmanaged.lbfgs
+lbfgs = _cast8 Unmanaged.lbfgs
 
 getParams :: ForeignPtr Optimizer -> IO (ForeignPtr TensorList) 
-getParams = cast1 Unmanaged.getParams
+getParams = _cast1 Unmanaged.getParams
 
 step :: ForeignPtr Optimizer -> (ForeignPtr TensorList -> IO (ForeignPtr Tensor)) -> IO (ForeignPtr Tensor)
 step optimizer loss = do
@@ -141,10 +141,10 @@ stepWithGenerator optimizer generator loss = do
 
 
 unsafeStep :: ForeignPtr Optimizer -> ForeignPtr Tensor -> IO (ForeignPtr TensorList)
-unsafeStep = cast2 Unmanaged.unsafeStep
+unsafeStep = _cast2 Unmanaged.unsafeStep
 
 save :: ForeignPtr Optimizer -> ForeignPtr StdString -> IO ()
-save = cast2 Unmanaged.save
+save = _cast2 Unmanaged.save
 
 load :: ForeignPtr Optimizer -> ForeignPtr StdString -> IO ()
-load = cast2 Unmanaged.load
+load = _cast2 Unmanaged.load

--- a/libtorch-ffi/src/Torch/Internal/Managed/Serialize.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Serialize.hs
@@ -11,13 +11,13 @@ import Torch.Internal.Objects
 
 
 save :: ForeignPtr TensorList -> FilePath -> IO ()
-save = cast2 Unmanaged.save
+save = _cast2 Unmanaged.save
 
 load :: FilePath -> IO (ForeignPtr TensorList)
-load = cast1 Unmanaged.load
+load = _cast1 Unmanaged.load
 
 pickleSave :: ForeignPtr IValue -> FilePath -> IO ()
-pickleSave = cast2 Unmanaged.pickleSave
+pickleSave = _cast2 Unmanaged.pickleSave
 
 pickleLoad :: FilePath -> IO (ForeignPtr IValue)
-pickleLoad = cast1 Unmanaged.pickleLoad
+pickleLoad = _cast1 Unmanaged.pickleLoad

--- a/libtorch-ffi/src/Torch/Internal/Managed/TensorFactories.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/TensorFactories.hs
@@ -27,31 +27,31 @@ _cudnn_init_dropout_state_dblo
   -> Int64
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-_cudnn_init_dropout_state_dblo = cast4 Unmanaged._cudnn_init_dropout_state_dblo
+_cudnn_init_dropout_state_dblo = _cast4 Unmanaged._cudnn_init_dropout_state_dblo
 
 arange_so
   :: ForeignPtr Scalar
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-arange_so = cast2 Unmanaged.arange_so
+arange_so = _cast2 Unmanaged.arange_so
 
 arange_s
   :: ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-arange_s = cast1 Unmanaged.arange_s
+arange_s = _cast1 Unmanaged.arange_s
 
 arange_sso
   :: ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-arange_sso = cast3 Unmanaged.arange_sso
+arange_sso = _cast3 Unmanaged.arange_sso
 
 arange_ss
   :: ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-arange_ss = cast2 Unmanaged.arange_ss
+arange_ss = _cast2 Unmanaged.arange_ss
 
 arange_ssso
   :: ForeignPtr Scalar
@@ -59,62 +59,62 @@ arange_ssso
   -> ForeignPtr Scalar
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-arange_ssso = cast4 Unmanaged.arange_ssso
+arange_ssso = _cast4 Unmanaged.arange_ssso
 
 arange_sss
   :: ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-arange_sss = cast3 Unmanaged.arange_sss
+arange_sss = _cast3 Unmanaged.arange_sss
 
 bartlett_window_lo
   :: Int64
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-bartlett_window_lo = cast2 Unmanaged.bartlett_window_lo
+bartlett_window_lo = _cast2 Unmanaged.bartlett_window_lo
 
 bartlett_window_l
   :: Int64
   -> IO (ForeignPtr Tensor)
-bartlett_window_l = cast1 Unmanaged.bartlett_window_l
+bartlett_window_l = _cast1 Unmanaged.bartlett_window_l
 
 bartlett_window_lbo
   :: Int64
   -> CBool
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-bartlett_window_lbo = cast3 Unmanaged.bartlett_window_lbo
+bartlett_window_lbo = _cast3 Unmanaged.bartlett_window_lbo
 
 bartlett_window_lb
   :: Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-bartlett_window_lb = cast2 Unmanaged.bartlett_window_lb
+bartlett_window_lb = _cast2 Unmanaged.bartlett_window_lb
 
 blackman_window_lo
   :: Int64
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-blackman_window_lo = cast2 Unmanaged.blackman_window_lo
+blackman_window_lo = _cast2 Unmanaged.blackman_window_lo
 
 blackman_window_l
   :: Int64
   -> IO (ForeignPtr Tensor)
-blackman_window_l = cast1 Unmanaged.blackman_window_l
+blackman_window_l = _cast1 Unmanaged.blackman_window_l
 
 blackman_window_lbo
   :: Int64
   -> CBool
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-blackman_window_lbo = cast3 Unmanaged.blackman_window_lbo
+blackman_window_lbo = _cast3 Unmanaged.blackman_window_lbo
 
 blackman_window_lb
   :: Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-blackman_window_lb = cast2 Unmanaged.blackman_window_lb
+blackman_window_lb = _cast2 Unmanaged.blackman_window_lb
 
 empty_lNoM
   :: ForeignPtr IntArray
@@ -122,38 +122,38 @@ empty_lNoM
   -> ForeignPtr TensorOptions
   -> MemoryFormat
   -> IO (ForeignPtr Tensor)
-empty_lNoM = cast4 Unmanaged.empty_lNoM
+empty_lNoM = _cast4 Unmanaged.empty_lNoM
 
 empty_lNo
   :: ForeignPtr IntArray
   -> ForeignPtr DimnameList
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-empty_lNo = cast3 Unmanaged.empty_lNo
+empty_lNo = _cast3 Unmanaged.empty_lNo
 
 empty_lN
   :: ForeignPtr IntArray
   -> ForeignPtr DimnameList
   -> IO (ForeignPtr Tensor)
-empty_lN = cast2 Unmanaged.empty_lN
+empty_lN = _cast2 Unmanaged.empty_lN
 
 empty_loM
   :: ForeignPtr IntArray
   -> ForeignPtr TensorOptions
   -> MemoryFormat
   -> IO (ForeignPtr Tensor)
-empty_loM = cast3 Unmanaged.empty_loM
+empty_loM = _cast3 Unmanaged.empty_loM
 
 empty_lo
   :: ForeignPtr IntArray
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-empty_lo = cast2 Unmanaged.empty_lo
+empty_lo = _cast2 Unmanaged.empty_lo
 
 empty_l
   :: ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-empty_l = cast1 Unmanaged.empty_l
+empty_l = _cast1 Unmanaged.empty_l
 
 _empty_affine_quantized_lodlM
   :: ForeignPtr IntArray
@@ -162,7 +162,7 @@ _empty_affine_quantized_lodlM
   -> Int64
   -> MemoryFormat
   -> IO (ForeignPtr Tensor)
-_empty_affine_quantized_lodlM = cast5 Unmanaged._empty_affine_quantized_lodlM
+_empty_affine_quantized_lodlM = _cast5 Unmanaged._empty_affine_quantized_lodlM
 
 _empty_affine_quantized_lodl
   :: ForeignPtr IntArray
@@ -170,25 +170,25 @@ _empty_affine_quantized_lodl
   -> CDouble
   -> Int64
   -> IO (ForeignPtr Tensor)
-_empty_affine_quantized_lodl = cast4 Unmanaged._empty_affine_quantized_lodl
+_empty_affine_quantized_lodl = _cast4 Unmanaged._empty_affine_quantized_lodl
 
 _empty_affine_quantized_lod
   :: ForeignPtr IntArray
   -> ForeignPtr TensorOptions
   -> CDouble
   -> IO (ForeignPtr Tensor)
-_empty_affine_quantized_lod = cast3 Unmanaged._empty_affine_quantized_lod
+_empty_affine_quantized_lod = _cast3 Unmanaged._empty_affine_quantized_lod
 
 _empty_affine_quantized_lo
   :: ForeignPtr IntArray
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-_empty_affine_quantized_lo = cast2 Unmanaged._empty_affine_quantized_lo
+_empty_affine_quantized_lo = _cast2 Unmanaged._empty_affine_quantized_lo
 
 _empty_affine_quantized_l
   :: ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-_empty_affine_quantized_l = cast1 Unmanaged._empty_affine_quantized_l
+_empty_affine_quantized_l = _cast1 Unmanaged._empty_affine_quantized_l
 
 _empty_per_channel_affine_quantized_lttloM
   :: ForeignPtr IntArray
@@ -198,7 +198,7 @@ _empty_per_channel_affine_quantized_lttloM
   -> ForeignPtr TensorOptions
   -> MemoryFormat
   -> IO (ForeignPtr Tensor)
-_empty_per_channel_affine_quantized_lttloM = cast6 Unmanaged._empty_per_channel_affine_quantized_lttloM
+_empty_per_channel_affine_quantized_lttloM = _cast6 Unmanaged._empty_per_channel_affine_quantized_lttloM
 
 _empty_per_channel_affine_quantized_lttlo
   :: ForeignPtr IntArray
@@ -207,7 +207,7 @@ _empty_per_channel_affine_quantized_lttlo
   -> Int64
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-_empty_per_channel_affine_quantized_lttlo = cast5 Unmanaged._empty_per_channel_affine_quantized_lttlo
+_empty_per_channel_affine_quantized_lttlo = _cast5 Unmanaged._empty_per_channel_affine_quantized_lttlo
 
 _empty_per_channel_affine_quantized_lttl
   :: ForeignPtr IntArray
@@ -215,62 +215,62 @@ _empty_per_channel_affine_quantized_lttl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-_empty_per_channel_affine_quantized_lttl = cast4 Unmanaged._empty_per_channel_affine_quantized_lttl
+_empty_per_channel_affine_quantized_lttl = _cast4 Unmanaged._empty_per_channel_affine_quantized_lttl
 
 empty_like_toM
   :: ForeignPtr Tensor
   -> ForeignPtr TensorOptions
   -> MemoryFormat
   -> IO (ForeignPtr Tensor)
-empty_like_toM = cast3 Unmanaged.empty_like_toM
+empty_like_toM = _cast3 Unmanaged.empty_like_toM
 
 empty_like_to
   :: ForeignPtr Tensor
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-empty_like_to = cast2 Unmanaged.empty_like_to
+empty_like_to = _cast2 Unmanaged.empty_like_to
 
 empty_like_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-empty_like_t = cast1 Unmanaged.empty_like_t
+empty_like_t = _cast1 Unmanaged.empty_like_t
 
 empty_strided_llo
   :: ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-empty_strided_llo = cast3 Unmanaged.empty_strided_llo
+empty_strided_llo = _cast3 Unmanaged.empty_strided_llo
 
 empty_strided_ll
   :: ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-empty_strided_ll = cast2 Unmanaged.empty_strided_ll
+empty_strided_ll = _cast2 Unmanaged.empty_strided_ll
 
 eye_lo
   :: Int64
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-eye_lo = cast2 Unmanaged.eye_lo
+eye_lo = _cast2 Unmanaged.eye_lo
 
 eye_l
   :: Int64
   -> IO (ForeignPtr Tensor)
-eye_l = cast1 Unmanaged.eye_l
+eye_l = _cast1 Unmanaged.eye_l
 
 eye_llo
   :: Int64
   -> Int64
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-eye_llo = cast3 Unmanaged.eye_llo
+eye_llo = _cast3 Unmanaged.eye_llo
 
 eye_ll
   :: Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-eye_ll = cast2 Unmanaged.eye_ll
+eye_ll = _cast2 Unmanaged.eye_ll
 
 full_lsNo
   :: ForeignPtr IntArray
@@ -278,27 +278,27 @@ full_lsNo
   -> ForeignPtr DimnameList
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-full_lsNo = cast4 Unmanaged.full_lsNo
+full_lsNo = _cast4 Unmanaged.full_lsNo
 
 full_lsN
   :: ForeignPtr IntArray
   -> ForeignPtr Scalar
   -> ForeignPtr DimnameList
   -> IO (ForeignPtr Tensor)
-full_lsN = cast3 Unmanaged.full_lsN
+full_lsN = _cast3 Unmanaged.full_lsN
 
 full_lso
   :: ForeignPtr IntArray
   -> ForeignPtr Scalar
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-full_lso = cast3 Unmanaged.full_lso
+full_lso = _cast3 Unmanaged.full_lso
 
 full_ls
   :: ForeignPtr IntArray
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-full_ls = cast2 Unmanaged.full_ls
+full_ls = _cast2 Unmanaged.full_ls
 
 full_like_tsoM
   :: ForeignPtr Tensor
@@ -306,20 +306,20 @@ full_like_tsoM
   -> ForeignPtr TensorOptions
   -> MemoryFormat
   -> IO (ForeignPtr Tensor)
-full_like_tsoM = cast4 Unmanaged.full_like_tsoM
+full_like_tsoM = _cast4 Unmanaged.full_like_tsoM
 
 full_like_tso
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-full_like_tso = cast3 Unmanaged.full_like_tso
+full_like_tso = _cast3 Unmanaged.full_like_tso
 
 full_like_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-full_like_ts = cast2 Unmanaged.full_like_ts
+full_like_ts = _cast2 Unmanaged.full_like_ts
 
 from_file_sblo
   :: ForeignPtr StdString
@@ -327,73 +327,73 @@ from_file_sblo
   -> Int64
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-from_file_sblo = cast4 Unmanaged.from_file_sblo
+from_file_sblo = _cast4 Unmanaged.from_file_sblo
 
 from_file_sbl
   :: ForeignPtr StdString
   -> CBool
   -> Int64
   -> IO (ForeignPtr Tensor)
-from_file_sbl = cast3 Unmanaged.from_file_sbl
+from_file_sbl = _cast3 Unmanaged.from_file_sbl
 
 from_file_sb
   :: ForeignPtr StdString
   -> CBool
   -> IO (ForeignPtr Tensor)
-from_file_sb = cast2 Unmanaged.from_file_sb
+from_file_sb = _cast2 Unmanaged.from_file_sb
 
 from_file_s
   :: ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-from_file_s = cast1 Unmanaged.from_file_s
+from_file_s = _cast1 Unmanaged.from_file_s
 
 hann_window_lo
   :: Int64
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-hann_window_lo = cast2 Unmanaged.hann_window_lo
+hann_window_lo = _cast2 Unmanaged.hann_window_lo
 
 hann_window_l
   :: Int64
   -> IO (ForeignPtr Tensor)
-hann_window_l = cast1 Unmanaged.hann_window_l
+hann_window_l = _cast1 Unmanaged.hann_window_l
 
 hann_window_lbo
   :: Int64
   -> CBool
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-hann_window_lbo = cast3 Unmanaged.hann_window_lbo
+hann_window_lbo = _cast3 Unmanaged.hann_window_lbo
 
 hann_window_lb
   :: Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-hann_window_lb = cast2 Unmanaged.hann_window_lb
+hann_window_lb = _cast2 Unmanaged.hann_window_lb
 
 hamming_window_lo
   :: Int64
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-hamming_window_lo = cast2 Unmanaged.hamming_window_lo
+hamming_window_lo = _cast2 Unmanaged.hamming_window_lo
 
 hamming_window_l
   :: Int64
   -> IO (ForeignPtr Tensor)
-hamming_window_l = cast1 Unmanaged.hamming_window_l
+hamming_window_l = _cast1 Unmanaged.hamming_window_l
 
 hamming_window_lbo
   :: Int64
   -> CBool
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-hamming_window_lbo = cast3 Unmanaged.hamming_window_lbo
+hamming_window_lbo = _cast3 Unmanaged.hamming_window_lbo
 
 hamming_window_lb
   :: Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-hamming_window_lb = cast2 Unmanaged.hamming_window_lb
+hamming_window_lb = _cast2 Unmanaged.hamming_window_lb
 
 hamming_window_lbdo
   :: Int64
@@ -401,14 +401,14 @@ hamming_window_lbdo
   -> CDouble
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-hamming_window_lbdo = cast4 Unmanaged.hamming_window_lbdo
+hamming_window_lbdo = _cast4 Unmanaged.hamming_window_lbdo
 
 hamming_window_lbd
   :: Int64
   -> CBool
   -> CDouble
   -> IO (ForeignPtr Tensor)
-hamming_window_lbd = cast3 Unmanaged.hamming_window_lbd
+hamming_window_lbd = _cast3 Unmanaged.hamming_window_lbd
 
 hamming_window_lbddo
   :: Int64
@@ -417,7 +417,7 @@ hamming_window_lbddo
   -> CDouble
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-hamming_window_lbddo = cast5 Unmanaged.hamming_window_lbddo
+hamming_window_lbddo = _cast5 Unmanaged.hamming_window_lbddo
 
 hamming_window_lbdd
   :: Int64
@@ -425,31 +425,31 @@ hamming_window_lbdd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-hamming_window_lbdd = cast4 Unmanaged.hamming_window_lbdd
+hamming_window_lbdd = _cast4 Unmanaged.hamming_window_lbdd
 
 kaiser_window_lo
   :: Int64
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-kaiser_window_lo = cast2 Unmanaged.kaiser_window_lo
+kaiser_window_lo = _cast2 Unmanaged.kaiser_window_lo
 
 kaiser_window_l
   :: Int64
   -> IO (ForeignPtr Tensor)
-kaiser_window_l = cast1 Unmanaged.kaiser_window_l
+kaiser_window_l = _cast1 Unmanaged.kaiser_window_l
 
 kaiser_window_lbo
   :: Int64
   -> CBool
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-kaiser_window_lbo = cast3 Unmanaged.kaiser_window_lbo
+kaiser_window_lbo = _cast3 Unmanaged.kaiser_window_lbo
 
 kaiser_window_lb
   :: Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-kaiser_window_lb = cast2 Unmanaged.kaiser_window_lb
+kaiser_window_lb = _cast2 Unmanaged.kaiser_window_lb
 
 kaiser_window_lbdo
   :: Int64
@@ -457,14 +457,14 @@ kaiser_window_lbdo
   -> CDouble
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-kaiser_window_lbdo = cast4 Unmanaged.kaiser_window_lbdo
+kaiser_window_lbdo = _cast4 Unmanaged.kaiser_window_lbdo
 
 kaiser_window_lbd
   :: Int64
   -> CBool
   -> CDouble
   -> IO (ForeignPtr Tensor)
-kaiser_window_lbd = cast3 Unmanaged.kaiser_window_lbd
+kaiser_window_lbd = _cast3 Unmanaged.kaiser_window_lbd
 
 linspace_sslo
   :: ForeignPtr Scalar
@@ -472,20 +472,20 @@ linspace_sslo
   -> Int64
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-linspace_sslo = cast4 Unmanaged.linspace_sslo
+linspace_sslo = _cast4 Unmanaged.linspace_sslo
 
 linspace_ssl
   :: ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> Int64
   -> IO (ForeignPtr Tensor)
-linspace_ssl = cast3 Unmanaged.linspace_ssl
+linspace_ssl = _cast3 Unmanaged.linspace_ssl
 
 -- linspace_ss
 --   :: ForeignPtr Scalar
 --   -> ForeignPtr Scalar
 --   -> IO (ForeignPtr Tensor)
--- linspace_ss = cast2 Unmanaged.linspace_ss
+-- linspace_ss = _cast2 Unmanaged.linspace_ss
 
 logspace_ssldo
   :: ForeignPtr Scalar
@@ -494,7 +494,7 @@ logspace_ssldo
   -> CDouble
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-logspace_ssldo = cast5 Unmanaged.logspace_ssldo
+logspace_ssldo = _cast5 Unmanaged.logspace_ssldo
 
 logspace_ssld
   :: ForeignPtr Scalar
@@ -502,86 +502,86 @@ logspace_ssld
   -> Int64
   -> CDouble
   -> IO (ForeignPtr Tensor)
-logspace_ssld = cast4 Unmanaged.logspace_ssld
+logspace_ssld = _cast4 Unmanaged.logspace_ssld
 
 logspace_ssl
   :: ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> Int64
   -> IO (ForeignPtr Tensor)
-logspace_ssl = cast3 Unmanaged.logspace_ssl
+logspace_ssl = _cast3 Unmanaged.logspace_ssl
 
 -- logspace_ss
 --   :: ForeignPtr Scalar
 --   -> ForeignPtr Scalar
 --   -> IO (ForeignPtr Tensor)
--- logspace_ss = cast2 Unmanaged.logspace_ss
+-- logspace_ss = _cast2 Unmanaged.logspace_ss
 
 ones_lNo
   :: ForeignPtr IntArray
   -> ForeignPtr DimnameList
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-ones_lNo = cast3 Unmanaged.ones_lNo
+ones_lNo = _cast3 Unmanaged.ones_lNo
 
 ones_lN
   :: ForeignPtr IntArray
   -> ForeignPtr DimnameList
   -> IO (ForeignPtr Tensor)
-ones_lN = cast2 Unmanaged.ones_lN
+ones_lN = _cast2 Unmanaged.ones_lN
 
 ones_lo
   :: ForeignPtr IntArray
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-ones_lo = cast2 Unmanaged.ones_lo
+ones_lo = _cast2 Unmanaged.ones_lo
 
 ones_l
   :: ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-ones_l = cast1 Unmanaged.ones_l
+ones_l = _cast1 Unmanaged.ones_l
 
 ones_like_toM
   :: ForeignPtr Tensor
   -> ForeignPtr TensorOptions
   -> MemoryFormat
   -> IO (ForeignPtr Tensor)
-ones_like_toM = cast3 Unmanaged.ones_like_toM
+ones_like_toM = _cast3 Unmanaged.ones_like_toM
 
 ones_like_to
   :: ForeignPtr Tensor
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-ones_like_to = cast2 Unmanaged.ones_like_to
+ones_like_to = _cast2 Unmanaged.ones_like_to
 
 ones_like_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-ones_like_t = cast1 Unmanaged.ones_like_t
+ones_like_t = _cast1 Unmanaged.ones_like_t
 
 scalar_tensor_so
   :: ForeignPtr Scalar
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-scalar_tensor_so = cast2 Unmanaged.scalar_tensor_so
+scalar_tensor_so = _cast2 Unmanaged.scalar_tensor_so
 
 scalar_tensor_s
   :: ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-scalar_tensor_s = cast1 Unmanaged.scalar_tensor_s
+scalar_tensor_s = _cast1 Unmanaged.scalar_tensor_s
 
 rand_lNo
   :: ForeignPtr IntArray
   -> ForeignPtr DimnameList
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-rand_lNo = cast3 Unmanaged.rand_lNo
+rand_lNo = _cast3 Unmanaged.rand_lNo
 
 rand_lN
   :: ForeignPtr IntArray
   -> ForeignPtr DimnameList
   -> IO (ForeignPtr Tensor)
-rand_lN = cast2 Unmanaged.rand_lN
+rand_lN = _cast2 Unmanaged.rand_lN
 
 rand_lGNo
   :: ForeignPtr IntArray
@@ -589,69 +589,69 @@ rand_lGNo
   -> ForeignPtr DimnameList
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-rand_lGNo = cast4 Unmanaged.rand_lGNo
+rand_lGNo = _cast4 Unmanaged.rand_lGNo
 
 rand_lGN
   :: ForeignPtr IntArray
   -> ForeignPtr Generator
   -> ForeignPtr DimnameList
   -> IO (ForeignPtr Tensor)
-rand_lGN = cast3 Unmanaged.rand_lGN
+rand_lGN = _cast3 Unmanaged.rand_lGN
 
 rand_lo
   :: ForeignPtr IntArray
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-rand_lo = cast2 Unmanaged.rand_lo
+rand_lo = _cast2 Unmanaged.rand_lo
 
 rand_l
   :: ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-rand_l = cast1 Unmanaged.rand_l
+rand_l = _cast1 Unmanaged.rand_l
 
 rand_lGo
   :: ForeignPtr IntArray
   -> ForeignPtr Generator
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-rand_lGo = cast3 Unmanaged.rand_lGo
+rand_lGo = _cast3 Unmanaged.rand_lGo
 
 rand_lG
   :: ForeignPtr IntArray
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-rand_lG = cast2 Unmanaged.rand_lG
+rand_lG = _cast2 Unmanaged.rand_lG
 
 rand_like_toM
   :: ForeignPtr Tensor
   -> ForeignPtr TensorOptions
   -> MemoryFormat
   -> IO (ForeignPtr Tensor)
-rand_like_toM = cast3 Unmanaged.rand_like_toM
+rand_like_toM = _cast3 Unmanaged.rand_like_toM
 
 rand_like_to
   :: ForeignPtr Tensor
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-rand_like_to = cast2 Unmanaged.rand_like_to
+rand_like_to = _cast2 Unmanaged.rand_like_to
 
 rand_like_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-rand_like_t = cast1 Unmanaged.rand_like_t
+rand_like_t = _cast1 Unmanaged.rand_like_t
 
 randint_llo
   :: Int64
   -> ForeignPtr IntArray
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-randint_llo = cast3 Unmanaged.randint_llo
+randint_llo = _cast3 Unmanaged.randint_llo
 
 randint_ll
   :: Int64
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-randint_ll = cast2 Unmanaged.randint_ll
+randint_ll = _cast2 Unmanaged.randint_ll
 
 randint_llGo
   :: Int64
@@ -659,14 +659,14 @@ randint_llGo
   -> ForeignPtr Generator
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-randint_llGo = cast4 Unmanaged.randint_llGo
+randint_llGo = _cast4 Unmanaged.randint_llGo
 
 randint_llG
   :: Int64
   -> ForeignPtr IntArray
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-randint_llG = cast3 Unmanaged.randint_llG
+randint_llG = _cast3 Unmanaged.randint_llG
 
 randint_lllo
   :: Int64
@@ -674,14 +674,14 @@ randint_lllo
   -> ForeignPtr IntArray
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-randint_lllo = cast4 Unmanaged.randint_lllo
+randint_lllo = _cast4 Unmanaged.randint_lllo
 
 randint_lll
   :: Int64
   -> Int64
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-randint_lll = cast3 Unmanaged.randint_lll
+randint_lll = _cast3 Unmanaged.randint_lll
 
 randint_lllGo
   :: Int64
@@ -690,7 +690,7 @@ randint_lllGo
   -> ForeignPtr Generator
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-randint_lllGo = cast5 Unmanaged.randint_lllGo
+randint_lllGo = _cast5 Unmanaged.randint_lllGo
 
 randint_lllG
   :: Int64
@@ -698,7 +698,7 @@ randint_lllG
   -> ForeignPtr IntArray
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-randint_lllG = cast4 Unmanaged.randint_lllG
+randint_lllG = _cast4 Unmanaged.randint_lllG
 
 randint_like_tloM
   :: ForeignPtr Tensor
@@ -706,20 +706,20 @@ randint_like_tloM
   -> ForeignPtr TensorOptions
   -> MemoryFormat
   -> IO (ForeignPtr Tensor)
-randint_like_tloM = cast4 Unmanaged.randint_like_tloM
+randint_like_tloM = _cast4 Unmanaged.randint_like_tloM
 
 randint_like_tlo
   :: ForeignPtr Tensor
   -> Int64
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-randint_like_tlo = cast3 Unmanaged.randint_like_tlo
+randint_like_tlo = _cast3 Unmanaged.randint_like_tlo
 
 randint_like_tl
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-randint_like_tl = cast2 Unmanaged.randint_like_tl
+randint_like_tl = _cast2 Unmanaged.randint_like_tl
 
 randint_like_tlloM
   :: ForeignPtr Tensor
@@ -728,7 +728,7 @@ randint_like_tlloM
   -> ForeignPtr TensorOptions
   -> MemoryFormat
   -> IO (ForeignPtr Tensor)
-randint_like_tlloM = cast5 Unmanaged.randint_like_tlloM
+randint_like_tlloM = _cast5 Unmanaged.randint_like_tlloM
 
 randint_like_tllo
   :: ForeignPtr Tensor
@@ -736,51 +736,51 @@ randint_like_tllo
   -> Int64
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-randint_like_tllo = cast4 Unmanaged.randint_like_tllo
+randint_like_tllo = _cast4 Unmanaged.randint_like_tllo
 
 randint_like_tll
   :: ForeignPtr Tensor
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-randint_like_tll = cast3 Unmanaged.randint_like_tll
+randint_like_tll = _cast3 Unmanaged.randint_like_tll
 
 randn_lo
   :: ForeignPtr IntArray
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-randn_lo = cast2 Unmanaged.randn_lo
+randn_lo = _cast2 Unmanaged.randn_lo
 
 randn_l
   :: ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-randn_l = cast1 Unmanaged.randn_l
+randn_l = _cast1 Unmanaged.randn_l
 
 randn_lGo
   :: ForeignPtr IntArray
   -> ForeignPtr Generator
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-randn_lGo = cast3 Unmanaged.randn_lGo
+randn_lGo = _cast3 Unmanaged.randn_lGo
 
 randn_lG
   :: ForeignPtr IntArray
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-randn_lG = cast2 Unmanaged.randn_lG
+randn_lG = _cast2 Unmanaged.randn_lG
 
 randn_lNo
   :: ForeignPtr IntArray
   -> ForeignPtr DimnameList
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-randn_lNo = cast3 Unmanaged.randn_lNo
+randn_lNo = _cast3 Unmanaged.randn_lNo
 
 randn_lN
   :: ForeignPtr IntArray
   -> ForeignPtr DimnameList
   -> IO (ForeignPtr Tensor)
-randn_lN = cast2 Unmanaged.randn_lN
+randn_lN = _cast2 Unmanaged.randn_lN
 
 randn_lGNo
   :: ForeignPtr IntArray
@@ -788,56 +788,56 @@ randn_lGNo
   -> ForeignPtr DimnameList
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-randn_lGNo = cast4 Unmanaged.randn_lGNo
+randn_lGNo = _cast4 Unmanaged.randn_lGNo
 
 randn_lGN
   :: ForeignPtr IntArray
   -> ForeignPtr Generator
   -> ForeignPtr DimnameList
   -> IO (ForeignPtr Tensor)
-randn_lGN = cast3 Unmanaged.randn_lGN
+randn_lGN = _cast3 Unmanaged.randn_lGN
 
 randn_like_toM
   :: ForeignPtr Tensor
   -> ForeignPtr TensorOptions
   -> MemoryFormat
   -> IO (ForeignPtr Tensor)
-randn_like_toM = cast3 Unmanaged.randn_like_toM
+randn_like_toM = _cast3 Unmanaged.randn_like_toM
 
 randn_like_to
   :: ForeignPtr Tensor
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-randn_like_to = cast2 Unmanaged.randn_like_to
+randn_like_to = _cast2 Unmanaged.randn_like_to
 
 randn_like_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-randn_like_t = cast1 Unmanaged.randn_like_t
+randn_like_t = _cast1 Unmanaged.randn_like_t
 
 randperm_lo
   :: Int64
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-randperm_lo = cast2 Unmanaged.randperm_lo
+randperm_lo = _cast2 Unmanaged.randperm_lo
 
 randperm_l
   :: Int64
   -> IO (ForeignPtr Tensor)
-randperm_l = cast1 Unmanaged.randperm_l
+randperm_l = _cast1 Unmanaged.randperm_l
 
 randperm_lGo
   :: Int64
   -> ForeignPtr Generator
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-randperm_lGo = cast3 Unmanaged.randperm_lGo
+randperm_lGo = _cast3 Unmanaged.randperm_lGo
 
 randperm_lG
   :: Int64
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-randperm_lG = cast2 Unmanaged.randperm_lG
+randperm_lG = _cast2 Unmanaged.randperm_lG
 
 range_ssso
   :: ForeignPtr Scalar
@@ -845,56 +845,56 @@ range_ssso
   -> ForeignPtr Scalar
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-range_ssso = cast4 Unmanaged.range_ssso
+range_ssso = _cast4 Unmanaged.range_ssso
 
 range_sss
   :: ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-range_sss = cast3 Unmanaged.range_sss
+range_sss = _cast3 Unmanaged.range_sss
 
 zeros_lNo
   :: ForeignPtr IntArray
   -> ForeignPtr DimnameList
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-zeros_lNo = cast3 Unmanaged.zeros_lNo
+zeros_lNo = _cast3 Unmanaged.zeros_lNo
 
 zeros_lN
   :: ForeignPtr IntArray
   -> ForeignPtr DimnameList
   -> IO (ForeignPtr Tensor)
-zeros_lN = cast2 Unmanaged.zeros_lN
+zeros_lN = _cast2 Unmanaged.zeros_lN
 
 zeros_lo
   :: ForeignPtr IntArray
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-zeros_lo = cast2 Unmanaged.zeros_lo
+zeros_lo = _cast2 Unmanaged.zeros_lo
 
 zeros_l
   :: ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-zeros_l = cast1 Unmanaged.zeros_l
+zeros_l = _cast1 Unmanaged.zeros_l
 
 zeros_like_toM
   :: ForeignPtr Tensor
   -> ForeignPtr TensorOptions
   -> MemoryFormat
   -> IO (ForeignPtr Tensor)
-zeros_like_toM = cast3 Unmanaged.zeros_like_toM
+zeros_like_toM = _cast3 Unmanaged.zeros_like_toM
 
 zeros_like_to
   :: ForeignPtr Tensor
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-zeros_like_to = cast2 Unmanaged.zeros_like_to
+zeros_like_to = _cast2 Unmanaged.zeros_like_to
 
 zeros_like_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-zeros_like_t = cast1 Unmanaged.zeros_like_t
+zeros_like_t = _cast1 Unmanaged.zeros_like_t
 
 -- _sparse_csr_tensor_tttlo
 --   :: ForeignPtr Tensor
@@ -903,7 +903,7 @@ zeros_like_t = cast1 Unmanaged.zeros_like_t
 --   -> ForeignPtr IntArray
 --   -> ForeignPtr TensorOptions
 --   -> IO (ForeignPtr Tensor)
--- _sparse_csr_tensor_tttlo = cast5 Unmanaged._sparse_csr_tensor_tttlo
+-- _sparse_csr_tensor_tttlo = _cast5 Unmanaged._sparse_csr_tensor_tttlo
 
 -- _sparse_csr_tensor_ttto
 --   :: ForeignPtr Tensor
@@ -911,26 +911,26 @@ zeros_like_t = cast1 Unmanaged.zeros_like_t
 --   -> ForeignPtr Tensor
 --   -> ForeignPtr TensorOptions
 --   -> IO (ForeignPtr Tensor)
--- _sparse_csr_tensor_ttto = cast4 Unmanaged._sparse_csr_tensor_ttto
+-- _sparse_csr_tensor_ttto = _cast4 Unmanaged._sparse_csr_tensor_ttto
 
 sparse_coo_tensor_lo
   :: ForeignPtr IntArray
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-sparse_coo_tensor_lo = cast2 Unmanaged.sparse_coo_tensor_lo
+sparse_coo_tensor_lo = _cast2 Unmanaged.sparse_coo_tensor_lo
 
 sparse_coo_tensor_tto
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-sparse_coo_tensor_tto = cast3 Unmanaged.sparse_coo_tensor_tto
+sparse_coo_tensor_tto = _cast3 Unmanaged.sparse_coo_tensor_tto
 
 sparse_coo_tensor_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-sparse_coo_tensor_tt = cast2 Unmanaged.sparse_coo_tensor_tt
+sparse_coo_tensor_tt = _cast2 Unmanaged.sparse_coo_tensor_tt
 
 sparse_coo_tensor_ttlo
   :: ForeignPtr Tensor
@@ -938,14 +938,14 @@ sparse_coo_tensor_ttlo
   -> ForeignPtr IntArray
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-sparse_coo_tensor_ttlo = cast4 Unmanaged.sparse_coo_tensor_ttlo
+sparse_coo_tensor_ttlo = _cast4 Unmanaged.sparse_coo_tensor_ttlo
 
 sparse_coo_tensor_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-sparse_coo_tensor_ttl = cast3 Unmanaged.sparse_coo_tensor_ttl
+sparse_coo_tensor_ttl = _cast3 Unmanaged.sparse_coo_tensor_ttl
 
 _sparse_coo_tensor_unsafe_ttlo
   :: ForeignPtr Tensor
@@ -953,14 +953,14 @@ _sparse_coo_tensor_unsafe_ttlo
   -> ForeignPtr IntArray
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-_sparse_coo_tensor_unsafe_ttlo = cast4 Unmanaged._sparse_coo_tensor_unsafe_ttlo
+_sparse_coo_tensor_unsafe_ttlo = _cast4 Unmanaged._sparse_coo_tensor_unsafe_ttlo
 
 _sparse_coo_tensor_unsafe_ttl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-_sparse_coo_tensor_unsafe_ttl = cast3 Unmanaged._sparse_coo_tensor_unsafe_ttl
+_sparse_coo_tensor_unsafe_ttl = _cast3 Unmanaged._sparse_coo_tensor_unsafe_ttl
 
 _sparse_coo_tensor_with_dims_lllo
   :: Int64
@@ -968,7 +968,7 @@ _sparse_coo_tensor_with_dims_lllo
   -> ForeignPtr IntArray
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-_sparse_coo_tensor_with_dims_lllo = cast4 Unmanaged._sparse_coo_tensor_with_dims_lllo
+_sparse_coo_tensor_with_dims_lllo = _cast4 Unmanaged._sparse_coo_tensor_with_dims_lllo
 
 _sparse_coo_tensor_with_dims_and_tensors_llltto
   :: Int64
@@ -978,7 +978,7 @@ _sparse_coo_tensor_with_dims_and_tensors_llltto
   -> ForeignPtr Tensor
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-_sparse_coo_tensor_with_dims_and_tensors_llltto = cast6 Unmanaged._sparse_coo_tensor_with_dims_and_tensors_llltto
+_sparse_coo_tensor_with_dims_and_tensors_llltto = _cast6 Unmanaged._sparse_coo_tensor_with_dims_and_tensors_llltto
 
 tril_indices_lllo
   :: Int64
@@ -986,20 +986,20 @@ tril_indices_lllo
   -> Int64
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-tril_indices_lllo = cast4 Unmanaged.tril_indices_lllo
+tril_indices_lllo = _cast4 Unmanaged.tril_indices_lllo
 
 tril_indices_lll
   :: Int64
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-tril_indices_lll = cast3 Unmanaged.tril_indices_lll
+tril_indices_lll = _cast3 Unmanaged.tril_indices_lll
 
 tril_indices_ll
   :: Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-tril_indices_ll = cast2 Unmanaged.tril_indices_ll
+tril_indices_ll = _cast2 Unmanaged.tril_indices_ll
 
 triu_indices_lllo
   :: Int64
@@ -1007,20 +1007,20 @@ triu_indices_lllo
   -> Int64
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-triu_indices_lllo = cast4 Unmanaged.triu_indices_lllo
+triu_indices_lllo = _cast4 Unmanaged.triu_indices_lllo
 
 triu_indices_lll
   :: Int64
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-triu_indices_lll = cast3 Unmanaged.triu_indices_lll
+triu_indices_lll = _cast3 Unmanaged.triu_indices_lll
 
 triu_indices_ll
   :: Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-triu_indices_ll = cast2 Unmanaged.triu_indices_ll
+triu_indices_ll = _cast2 Unmanaged.triu_indices_ll
 
 normal_ddlGo
   :: CDouble
@@ -1029,7 +1029,7 @@ normal_ddlGo
   -> ForeignPtr Generator
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-normal_ddlGo = cast5 Unmanaged.normal_ddlGo
+normal_ddlGo = _cast5 Unmanaged.normal_ddlGo
 
 normal_ddlG
   :: CDouble
@@ -1037,48 +1037,48 @@ normal_ddlG
   -> ForeignPtr IntArray
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-normal_ddlG = cast4 Unmanaged.normal_ddlG
+normal_ddlG = _cast4 Unmanaged.normal_ddlG
 
 normal_ddl
   :: CDouble
   -> CDouble
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-normal_ddl = cast3 Unmanaged.normal_ddl
+normal_ddl = _cast3 Unmanaged.normal_ddl
 
 fft_fftfreq_ldo
   :: Int64
   -> CDouble
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-fft_fftfreq_ldo = cast3 Unmanaged.fft_fftfreq_ldo
+fft_fftfreq_ldo = _cast3 Unmanaged.fft_fftfreq_ldo
 
 fft_fftfreq_ld
   :: Int64
   -> CDouble
   -> IO (ForeignPtr Tensor)
-fft_fftfreq_ld = cast2 Unmanaged.fft_fftfreq_ld
+fft_fftfreq_ld = _cast2 Unmanaged.fft_fftfreq_ld
 
 fft_fftfreq_l
   :: Int64
   -> IO (ForeignPtr Tensor)
-fft_fftfreq_l = cast1 Unmanaged.fft_fftfreq_l
+fft_fftfreq_l = _cast1 Unmanaged.fft_fftfreq_l
 
 fft_rfftfreq_ldo
   :: Int64
   -> CDouble
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-fft_rfftfreq_ldo = cast3 Unmanaged.fft_rfftfreq_ldo
+fft_rfftfreq_ldo = _cast3 Unmanaged.fft_rfftfreq_ldo
 
 fft_rfftfreq_ld
   :: Int64
   -> CDouble
   -> IO (ForeignPtr Tensor)
-fft_rfftfreq_ld = cast2 Unmanaged.fft_rfftfreq_ld
+fft_rfftfreq_ld = _cast2 Unmanaged.fft_rfftfreq_ld
 
 fft_rfftfreq_l
   :: Int64
   -> IO (ForeignPtr Tensor)
-fft_rfftfreq_l = cast1 Unmanaged.fft_rfftfreq_l
+fft_rfftfreq_l = _cast1 Unmanaged.fft_rfftfreq_l
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Type/C10Dict.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Type/C10Dict.hs
@@ -25,19 +25,19 @@ import Control.Monad (forM)
 
 
 newC10Dict :: ForeignPtr IValue -> ForeignPtr IValue -> IO (ForeignPtr (C10Dict '(IValue,IValue)))
-newC10Dict = cast2 Unmanaged.newC10Dict
+newC10Dict = _cast2 Unmanaged.newC10Dict
 
 c10Dict_empty :: ForeignPtr (C10Dict '(IValue,IValue)) -> IO (CBool)
-c10Dict_empty = cast1 Unmanaged.c10Dict_empty
+c10Dict_empty = _cast1 Unmanaged.c10Dict_empty
 
 c10Dict_size :: ForeignPtr (C10Dict '(IValue,IValue)) -> IO (CSize)
-c10Dict_size = cast1 Unmanaged.c10Dict_size
+c10Dict_size = _cast1 Unmanaged.c10Dict_size
 
 c10Dict_at :: ForeignPtr (C10Dict '(IValue,IValue)) -> ForeignPtr IValue -> IO (ForeignPtr IValue)
-c10Dict_at = cast2 Unmanaged.c10Dict_at
+c10Dict_at = _cast2 Unmanaged.c10Dict_at
 
 c10Dict_insert :: ForeignPtr (C10Dict '(IValue,IValue)) -> ForeignPtr IValue -> ForeignPtr IValue -> IO ()
-c10Dict_insert = cast3 Unmanaged.c10Dict_insert
+c10Dict_insert = _cast3 Unmanaged.c10Dict_insert
 
 c10Dict_toList :: ForeignPtr (C10Dict '(IValue,IValue)) -> IO [(ForeignPtr IValue,ForeignPtr IValue)]
 c10Dict_toList obj = withForeignPtr obj $ \obj' -> do

--- a/libtorch-ffi/src/Torch/Internal/Managed/Type/C10List.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Type/C10List.hs
@@ -24,95 +24,95 @@ import qualified Torch.Internal.Unmanaged.Type.C10List as Unmanaged
 
 
 newC10ListIValue :: ForeignPtr IValue -> IO (ForeignPtr (C10List IValue))
-newC10ListIValue elem = cast1 Unmanaged.newC10ListIValue elem
+newC10ListIValue elem = _cast1 Unmanaged.newC10ListIValue elem
 
 newC10ListTensor :: IO (ForeignPtr (C10List Tensor))
-newC10ListTensor = cast0 Unmanaged.newC10ListTensor
+newC10ListTensor = _cast0 Unmanaged.newC10ListTensor
 
 newC10ListOptionalTensor :: IO (ForeignPtr (C10List (C10Optional Tensor)))
-newC10ListOptionalTensor = cast0 Unmanaged.newC10ListOptionalTensor
+newC10ListOptionalTensor = _cast0 Unmanaged.newC10ListOptionalTensor
 
 newC10ListDouble :: IO (ForeignPtr (C10List CDouble))
-newC10ListDouble = cast0 Unmanaged.newC10ListDouble
+newC10ListDouble = _cast0 Unmanaged.newC10ListDouble
 
 newC10ListInt :: IO (ForeignPtr (C10List Int64))
-newC10ListInt = cast0 Unmanaged.newC10ListInt
+newC10ListInt = _cast0 Unmanaged.newC10ListInt
 
 newC10ListBool :: IO (ForeignPtr (C10List CBool))
-newC10ListBool = cast0 Unmanaged.newC10ListBool
+newC10ListBool = _cast0 Unmanaged.newC10ListBool
 
 
 
 
 
 c10ListIValue_empty :: ForeignPtr (C10List IValue) -> IO (CBool)
-c10ListIValue_empty = cast1 Unmanaged.c10ListIValue_empty
+c10ListIValue_empty = _cast1 Unmanaged.c10ListIValue_empty
 
 c10ListTensor_empty :: ForeignPtr (C10List Tensor) -> IO (CBool)
-c10ListTensor_empty = cast1 Unmanaged.c10ListTensor_empty
+c10ListTensor_empty = _cast1 Unmanaged.c10ListTensor_empty
 
 c10ListOptionalTensor_empty :: ForeignPtr (C10List (C10Optional Tensor)) -> IO (CBool)
-c10ListOptionalTensor_empty = cast1 Unmanaged.c10ListOptionalTensor_empty
+c10ListOptionalTensor_empty = _cast1 Unmanaged.c10ListOptionalTensor_empty
 
 c10ListDouble_empty :: ForeignPtr (C10List CDouble) -> IO (CBool)
-c10ListDouble_empty = cast1 Unmanaged.c10ListDouble_empty
+c10ListDouble_empty = _cast1 Unmanaged.c10ListDouble_empty
 
 c10ListInt_empty :: ForeignPtr (C10List Int64) -> IO (CBool)
-c10ListInt_empty = cast1 Unmanaged.c10ListInt_empty
+c10ListInt_empty = _cast1 Unmanaged.c10ListInt_empty
 
 c10ListBool_empty :: ForeignPtr (C10List CBool) -> IO (CBool)
-c10ListBool_empty = cast1 Unmanaged.c10ListBool_empty
+c10ListBool_empty = _cast1 Unmanaged.c10ListBool_empty
 
 c10ListIValue_size :: ForeignPtr (C10List IValue) -> IO (CSize)
-c10ListIValue_size = cast1 Unmanaged.c10ListIValue_size
+c10ListIValue_size = _cast1 Unmanaged.c10ListIValue_size
 
 c10ListTensor_size :: ForeignPtr (C10List Tensor) -> IO (CSize)
-c10ListTensor_size = cast1 Unmanaged.c10ListTensor_size
+c10ListTensor_size = _cast1 Unmanaged.c10ListTensor_size
 
 c10ListOptionalTensor_size :: ForeignPtr (C10List (C10Optional Tensor)) -> IO (CSize)
-c10ListOptionalTensor_size = cast1 Unmanaged.c10ListOptionalTensor_size
+c10ListOptionalTensor_size = _cast1 Unmanaged.c10ListOptionalTensor_size
 
 c10ListDouble_size :: ForeignPtr (C10List CDouble) -> IO (CSize)
-c10ListDouble_size = cast1 Unmanaged.c10ListDouble_size
+c10ListDouble_size = _cast1 Unmanaged.c10ListDouble_size
 
 c10ListInt_size :: ForeignPtr (C10List Int64) -> IO (CSize)
-c10ListInt_size = cast1 Unmanaged.c10ListInt_size
+c10ListInt_size = _cast1 Unmanaged.c10ListInt_size
 
 c10ListBool_size :: ForeignPtr (C10List CBool) -> IO (CSize)
-c10ListBool_size = cast1 Unmanaged.c10ListBool_size
+c10ListBool_size = _cast1 Unmanaged.c10ListBool_size
 
 c10ListIValue_at :: ForeignPtr (C10List IValue) -> CSize -> IO (ForeignPtr IValue)
-c10ListIValue_at = cast2 Unmanaged.c10ListIValue_at
+c10ListIValue_at = _cast2 Unmanaged.c10ListIValue_at
 
 c10ListTensor_at :: ForeignPtr (C10List Tensor) -> CSize -> IO (ForeignPtr Tensor)
-c10ListTensor_at = cast2 Unmanaged.c10ListTensor_at
+c10ListTensor_at = _cast2 Unmanaged.c10ListTensor_at
 
 c10ListOptionalTensor_at :: ForeignPtr (C10List (C10Optional Tensor)) -> CSize -> IO (ForeignPtr Tensor)
-c10ListOptionalTensor_at = cast2 Unmanaged.c10ListOptionalTensor_at
+c10ListOptionalTensor_at = _cast2 Unmanaged.c10ListOptionalTensor_at
 
 c10ListDouble_at :: ForeignPtr (C10List CDouble) -> CSize -> IO CDouble
-c10ListDouble_at = cast2 Unmanaged.c10ListDouble_at
+c10ListDouble_at = _cast2 Unmanaged.c10ListDouble_at
 
 c10ListInt_at :: ForeignPtr (C10List Int64) -> CSize -> IO Int64
-c10ListInt_at = cast2 Unmanaged.c10ListInt_at
+c10ListInt_at = _cast2 Unmanaged.c10ListInt_at
 
 c10ListBool_at :: ForeignPtr (C10List CBool) -> CSize -> IO CBool
-c10ListBool_at = cast2 Unmanaged.c10ListBool_at
+c10ListBool_at = _cast2 Unmanaged.c10ListBool_at
 
 c10ListIValue_push_back :: ForeignPtr (C10List IValue) -> ForeignPtr IValue -> IO ()
-c10ListIValue_push_back = cast2 Unmanaged.c10ListIValue_push_back
+c10ListIValue_push_back = _cast2 Unmanaged.c10ListIValue_push_back
 
 c10ListTensor_push_back :: ForeignPtr (C10List Tensor) -> ForeignPtr Tensor -> IO ()
-c10ListTensor_push_back = cast2 Unmanaged.c10ListTensor_push_back
+c10ListTensor_push_back = _cast2 Unmanaged.c10ListTensor_push_back
 
 c10ListOptionalTensor_push_back :: ForeignPtr (C10List (C10Optional Tensor)) -> ForeignPtr Tensor -> IO ()
-c10ListOptionalTensor_push_back = cast2 Unmanaged.c10ListOptionalTensor_push_back
+c10ListOptionalTensor_push_back = _cast2 Unmanaged.c10ListOptionalTensor_push_back
 
 c10ListDouble_push_back :: ForeignPtr (C10List CDouble) -> CDouble -> IO ()
-c10ListDouble_push_back = cast2 Unmanaged.c10ListDouble_push_back
+c10ListDouble_push_back = _cast2 Unmanaged.c10ListDouble_push_back
 
 c10ListInt_push_back :: ForeignPtr (C10List Int64) -> Int64 -> IO ()
-c10ListInt_push_back = cast2 Unmanaged.c10ListInt_push_back
+c10ListInt_push_back = _cast2 Unmanaged.c10ListInt_push_back
 
 c10ListBool_push_back :: ForeignPtr (C10List CBool) -> CBool -> IO ()
-c10ListBool_push_back = cast2 Unmanaged.c10ListBool_push_back
+c10ListBool_push_back = _cast2 Unmanaged.c10ListBool_push_back

--- a/libtorch-ffi/src/Torch/Internal/Managed/Type/C10Tuple.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Type/C10Tuple.hs
@@ -25,25 +25,25 @@ import qualified Torch.Internal.Unmanaged.Type.C10Tuple as Unmanaged
 
 newC10Tuple
   :: IO (ForeignPtr (C10Ptr IVTuple))
-newC10Tuple = cast0 Unmanaged.newC10Tuple
+newC10Tuple = _cast0 Unmanaged.newC10Tuple
 
 newC10Tuple_tuple
   :: ForeignPtr IValueList
   -> IO (ForeignPtr (C10Ptr IVTuple))
-newC10Tuple_tuple  = cast1 Unmanaged.newC10Tuple_tuple
+newC10Tuple_tuple  = _cast1 Unmanaged.newC10Tuple_tuple
 
 c10Tuple_empty
   :: ForeignPtr (C10Ptr IVTuple)
   -> IO (CBool)
-c10Tuple_empty = cast1 Unmanaged.c10Tuple_empty
+c10Tuple_empty = _cast1 Unmanaged.c10Tuple_empty
 
 c10Tuple_size
   :: ForeignPtr (C10Ptr IVTuple)
   -> IO (CSize)
-c10Tuple_size = cast1 Unmanaged.c10Tuple_size
+c10Tuple_size = _cast1 Unmanaged.c10Tuple_size
 
 c10Tuple_at
   :: ForeignPtr (C10Ptr IVTuple)
   -> CSize
   -> IO (ForeignPtr IValue)
-c10Tuple_at = cast2 Unmanaged.c10Tuple_at
+c10Tuple_at = _cast2 Unmanaged.c10Tuple_at

--- a/libtorch-ffi/src/Torch/Internal/Managed/Type/Context.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Type/Context.hs
@@ -32,48 +32,48 @@ import qualified Torch.Internal.Unmanaged.Type.Context as Unmanaged
 
 init
   :: IO (())
-init = cast0 Unmanaged.init
+init = _cast0 Unmanaged.init
 
 hasCUDA
   :: IO (CBool)
-hasCUDA = cast0 Unmanaged.hasCUDA
+hasCUDA = _cast0 Unmanaged.hasCUDA
 
 hasHIP
   :: IO (CBool)
-hasHIP = cast0 Unmanaged.hasHIP
+hasHIP = _cast0 Unmanaged.hasHIP
 
 hasXLA
   :: IO (CBool)
-hasXLA = cast0 Unmanaged.hasXLA
+hasXLA = _cast0 Unmanaged.hasXLA
 
 getNumGPUs
   :: IO (CSize)
-getNumGPUs = cast0 Unmanaged.getNumGPUs
+getNumGPUs = _cast0 Unmanaged.getNumGPUs
 
 hasOpenMP
   :: IO (CBool)
-hasOpenMP = cast0 Unmanaged.hasOpenMP
+hasOpenMP = _cast0 Unmanaged.hasOpenMP
 
 hasMKL
   :: IO (CBool)
-hasMKL = cast0 Unmanaged.hasMKL
+hasMKL = _cast0 Unmanaged.hasMKL
 
 hasLAPACK
   :: IO (CBool)
-hasLAPACK = cast0 Unmanaged.hasLAPACK
+hasLAPACK = _cast0 Unmanaged.hasLAPACK
 
 hasMAGMA
   :: IO (CBool)
-hasMAGMA = cast0 Unmanaged.hasMAGMA
+hasMAGMA = _cast0 Unmanaged.hasMAGMA
 
 hasMKLDNN
   :: IO (CBool)
-hasMKLDNN = cast0 Unmanaged.hasMKLDNN
+hasMKLDNN = _cast0 Unmanaged.hasMKLDNN
 
 manual_seed_L
   :: Word64
   -> IO (())
-manual_seed_L = cast1 Unmanaged.manual_seed_L
+manual_seed_L = _cast1 Unmanaged.manual_seed_L
 
 get_manual_seed
   :: IO (Word64)

--- a/libtorch-ffi/src/Torch/Internal/Managed/Type/Dimname.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Type/Dimname.hs
@@ -27,40 +27,40 @@ import qualified Torch.Internal.Unmanaged.Type.Dimname as Unmanaged
 newDimname_n
   :: ForeignPtr Dimname
   -> IO (ForeignPtr Dimname)
-newDimname_n = cast1 Unmanaged.newDimname_n
+newDimname_n = _cast1 Unmanaged.newDimname_n
 
 dimname_symbol
   :: ForeignPtr Dimname
   -> IO (ForeignPtr Symbol)
-dimname_symbol = cast1 Unmanaged.dimname_symbol
+dimname_symbol = _cast1 Unmanaged.dimname_symbol
 
 dimname_isBasic
   :: ForeignPtr Dimname
   -> IO (CBool)
-dimname_isBasic = cast1 Unmanaged.dimname_isBasic
+dimname_isBasic = _cast1 Unmanaged.dimname_isBasic
 
 dimname_isWildcard
   :: ForeignPtr Dimname
   -> IO (CBool)
-dimname_isWildcard = cast1 Unmanaged.dimname_isWildcard
+dimname_isWildcard = _cast1 Unmanaged.dimname_isWildcard
 
 dimname_matches_n
   :: ForeignPtr Dimname
   -> ForeignPtr Dimname
   -> IO (CBool)
-dimname_matches_n = cast2 Unmanaged.dimname_matches_n
+dimname_matches_n = _cast2 Unmanaged.dimname_matches_n
 
 fromSymbol_s
   :: ForeignPtr Symbol
   -> IO (ForeignPtr Dimname)
-fromSymbol_s = cast1 Unmanaged.fromSymbol_s
+fromSymbol_s = _cast1 Unmanaged.fromSymbol_s
 
 wildcard
   :: IO (ForeignPtr Dimname)
-wildcard = cast0 Unmanaged.wildcard
+wildcard = _cast0 Unmanaged.wildcard
 
 isValidName_s
   :: ForeignPtr StdString
   -> IO (CBool)
-isValidName_s = cast1 Unmanaged.isValidName_s
+isValidName_s = _cast1 Unmanaged.isValidName_s
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Type/DimnameList.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Type/DimnameList.hs
@@ -26,27 +26,27 @@ import qualified Torch.Internal.Unmanaged.Type.DimnameList as Unmanaged
 
 newDimnameList
   :: IO (ForeignPtr DimnameList)
-newDimnameList = cast0 Unmanaged.newDimnameList
+newDimnameList = _cast0 Unmanaged.newDimnameList
 
 dimnameList_empty
   :: ForeignPtr DimnameList
   -> IO (CBool)
-dimnameList_empty = cast1 Unmanaged.dimnameList_empty
+dimnameList_empty = _cast1 Unmanaged.dimnameList_empty
 
 dimnameList_size
   :: ForeignPtr DimnameList
   -> IO (CSize)
-dimnameList_size = cast1 Unmanaged.dimnameList_size
+dimnameList_size = _cast1 Unmanaged.dimnameList_size
 
 dimnameList_at_s
   :: ForeignPtr DimnameList
   -> CSize
   -> IO (ForeignPtr Dimname)
-dimnameList_at_s = cast2 Unmanaged.dimnameList_at_s
+dimnameList_at_s = _cast2 Unmanaged.dimnameList_at_s
 
 dimnameList_push_back_n
   :: ForeignPtr DimnameList
   -> ForeignPtr Dimname
   -> IO (())
-dimnameList_push_back_n = cast2 Unmanaged.dimnameList_push_back_n
+dimnameList_push_back_n = _cast2 Unmanaged.dimnameList_push_back_n
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Type/Extra.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Type/Extra.hs
@@ -26,7 +26,7 @@ tensor_assign1_l
   -> Int64
   -> Int64
   -> IO ()
-tensor_assign1_l  = cast3 Unmanaged.tensor_assign1_l
+tensor_assign1_l  = _cast3 Unmanaged.tensor_assign1_l
 
 tensor_assign2_l
   :: ForeignPtr Tensor
@@ -34,14 +34,14 @@ tensor_assign2_l
   -> Int64
   -> Int64
   -> IO ()
-tensor_assign2_l = cast4 Unmanaged.tensor_assign2_l
+tensor_assign2_l = _cast4 Unmanaged.tensor_assign2_l
 
 tensor_assign1_d
   :: ForeignPtr Tensor
   -> Int64
   -> CDouble
   -> IO ()
-tensor_assign1_d = cast3 Unmanaged.tensor_assign1_d
+tensor_assign1_d = _cast3 Unmanaged.tensor_assign1_d
 
 tensor_assign2_d
   :: ForeignPtr Tensor
@@ -49,14 +49,14 @@ tensor_assign2_d
   -> Int64
   -> CDouble
   -> IO ()
-tensor_assign2_d = cast4 Unmanaged.tensor_assign2_d
+tensor_assign2_d = _cast4 Unmanaged.tensor_assign2_d
 
 tensor_assign1_t
   :: ForeignPtr Tensor
   -> Int64
   -> ForeignPtr Tensor
   -> IO ()
-tensor_assign1_t  = cast3 Unmanaged.tensor_assign1_t
+tensor_assign1_t  = _cast3 Unmanaged.tensor_assign1_t
 
 tensor_assign2_t
   :: ForeignPtr Tensor
@@ -64,10 +64,10 @@ tensor_assign2_t
   -> Int64
   -> ForeignPtr Tensor
   -> IO ()
-tensor_assign2_t = cast4 Unmanaged.tensor_assign2_t
+tensor_assign2_t = _cast4 Unmanaged.tensor_assign2_t
 
 tensor_names
   :: ForeignPtr Tensor
   -> IO (ForeignPtr DimnameList)
-tensor_names = cast1 Unmanaged.tensor_names
+tensor_names = _cast1 Unmanaged.tensor_names
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Type/Extra.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Type/Extra.hs
@@ -71,3 +71,14 @@ tensor_names
   -> IO (ForeignPtr DimnameList)
 tensor_names = _cast1 Unmanaged.tensor_names
 
+tensor_to_device
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_to_device = _cast2 Unmanaged.tensor_to_device
+
+new_empty_tensor
+  :: [Int]
+  -> ForeignPtr TensorOptions
+  -> IO (ForeignPtr Tensor)
+new_empty_tensor = _cast2 Unmanaged.new_empty_tensor

--- a/libtorch-ffi/src/Torch/Internal/Managed/Type/Generator.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Type/Generator.hs
@@ -26,12 +26,12 @@ import qualified Torch.Internal.Unmanaged.Type.Generator as Unmanaged
 newCUDAGenerator
   :: Word16
   -> IO (ForeignPtr Generator)
-newCUDAGenerator _device_index = cast1 Unmanaged.newCUDAGenerator _device_index
+newCUDAGenerator _device_index = _cast1 Unmanaged.newCUDAGenerator _device_index
 
 newCPUGenerator
   :: Word64
   -> IO (ForeignPtr Generator)
-newCPUGenerator _seed_in = cast1 Unmanaged.newCPUGenerator _seed_in
+newCPUGenerator _seed_in = _cast1 Unmanaged.newCPUGenerator _seed_in
 
 
 
@@ -41,39 +41,39 @@ generator_set_current_seed
   :: ForeignPtr Generator
   -> Word64
   -> IO ()
-generator_set_current_seed = cast2 Unmanaged.generator_set_current_seed
+generator_set_current_seed = _cast2 Unmanaged.generator_set_current_seed
 
 generator_current_seed
   :: ForeignPtr Generator
   -> IO (Word64)
-generator_current_seed = cast1 Unmanaged.generator_current_seed
+generator_current_seed = _cast1 Unmanaged.generator_current_seed
 
 generator_seed
   :: ForeignPtr Generator
   -> IO (Word64)
-generator_seed = cast1 Unmanaged.generator_seed
+generator_seed = _cast1 Unmanaged.generator_seed
 
 generator_clone
   :: ForeignPtr Generator
   -> IO (ForeignPtr Generator)
-generator_clone _obj = cast1 Unmanaged.generator_clone _obj
+generator_clone _obj = _cast1 Unmanaged.generator_clone _obj
 
 generator_get_device
   :: ForeignPtr Generator
   -> IO Int64
-generator_get_device _obj = cast1 Unmanaged.generator_get_device _obj
+generator_get_device _obj = _cast1 Unmanaged.generator_get_device _obj
 
 generator_is_cpu
   :: ForeignPtr Generator
   -> IO CBool
-generator_is_cpu _obj = cast1 Unmanaged.generator_is_cpu _obj
+generator_is_cpu _obj = _cast1 Unmanaged.generator_is_cpu _obj
 
 generator_is_cuda
   :: ForeignPtr Generator
   -> IO CBool
-generator_is_cuda _obj = cast1 Unmanaged.generator_is_cuda _obj
+generator_is_cuda _obj = _cast1 Unmanaged.generator_is_cuda _obj
 
 generator_is_hip
   :: ForeignPtr Generator
   -> IO CBool
-generator_is_hip _obj = cast1 Unmanaged.generator_is_hip _obj
+generator_is_hip _obj = _cast1 Unmanaged.generator_is_hip _obj

--- a/libtorch-ffi/src/Torch/Internal/Managed/Type/IValue.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Type/IValue.hs
@@ -28,187 +28,187 @@ import qualified Torch.Internal.Unmanaged.Type.IValue as Unmanaged
 import Torch.Internal.Unmanaged.Type.IValue (IValueLike)
 
 instance IValueLike Double (ForeignPtr IValue) where
-  toIValue x = cast1 (Unmanaged.toIValue :: CDouble -> IO (Ptr IValue)) x
-  fromIValue x = cast1 (Unmanaged.fromIValue :: Ptr IValue -> IO CDouble) x
+  toIValue x = _cast1 (Unmanaged.toIValue :: CDouble -> IO (Ptr IValue)) x
+  fromIValue x = _cast1 (Unmanaged.fromIValue :: Ptr IValue -> IO CDouble) x
 
 instance IValueLike Int64 (ForeignPtr IValue) where
-  toIValue x = cast1 (Unmanaged.toIValue :: Int64 -> IO (Ptr IValue)) x
-  fromIValue x = cast1 (Unmanaged.fromIValue :: Ptr IValue -> IO Int64) x
+  toIValue x = _cast1 (Unmanaged.toIValue :: Int64 -> IO (Ptr IValue)) x
+  fromIValue x = _cast1 (Unmanaged.fromIValue :: Ptr IValue -> IO Int64) x
 
 instance IValueLike Bool (ForeignPtr IValue) where
-  toIValue x = cast1 (Unmanaged.toIValue :: CBool -> IO (Ptr IValue)) x
-  fromIValue x = cast1 (Unmanaged.fromIValue :: Ptr IValue -> IO CBool) x
+  toIValue x = _cast1 (Unmanaged.toIValue :: CBool -> IO (Ptr IValue)) x
+  fromIValue x = _cast1 (Unmanaged.fromIValue :: Ptr IValue -> IO CBool) x
 
 --instance IValueLike (ForeignPtr StdString) (ForeignPtr IValue) where
---  toIValue x = cast1 (Unmanaged.toIValue :: Ptr StdString -> IO (Ptr IValue)) x
---  fromIValue x = cast1 (Unmanaged.fromIValue :: Ptr IValue -> IO (Ptr StdString)) x
+--  toIValue x = _cast1 (Unmanaged.toIValue :: Ptr StdString -> IO (Ptr IValue)) x
+--  fromIValue x = _cast1 (Unmanaged.fromIValue :: Ptr IValue -> IO (Ptr StdString)) x
 --instance IValueLike String (ForeignPtr IValue) where
---  toIValue x = cast1 (Unmanaged.toIValue :: CBool -> IO (Ptr IValue)) x
---  fromIValue x = cast1 (Unmanaged.fromIValue :: Ptr IValue -> IO CBool) x
+--  toIValue x = _cast1 (Unmanaged.toIValue :: CBool -> IO (Ptr IValue)) x
+--  fromIValue x = _cast1 (Unmanaged.fromIValue :: Ptr IValue -> IO CBool) x
 
 instance (CppObject a, IValueLike (Ptr a) (Ptr IValue)) => IValueLike (ForeignPtr a) (ForeignPtr IValue) where
-  toIValue x = cast1 (Unmanaged.toIValue :: Ptr a -> IO (Ptr IValue)) x
-  fromIValue x = cast1 (Unmanaged.fromIValue :: Ptr IValue -> IO (Ptr a)) x
+  toIValue x = _cast1 (Unmanaged.toIValue :: Ptr a -> IO (Ptr IValue)) x
+  fromIValue x = _cast1 (Unmanaged.fromIValue :: Ptr IValue -> IO (Ptr a)) x
 
 newIValue
   :: IO (ForeignPtr IValue)
-newIValue  = cast0 Unmanaged.newIValue
+newIValue  = _cast0 Unmanaged.newIValue
 
 iValue_isAliasOf_V
   :: ForeignPtr IValue
   -> ForeignPtr IValue
   -> IO (CBool)
-iValue_isAliasOf_V = cast2 Unmanaged.iValue_isAliasOf_V
+iValue_isAliasOf_V = _cast2 Unmanaged.iValue_isAliasOf_V
 
 iValue_use_count
   :: ForeignPtr IValue
   -> IO (CSize)
-iValue_use_count = cast1 Unmanaged.iValue_use_count
+iValue_use_count = _cast1 Unmanaged.iValue_use_count
 
 iValue_swap_V
   :: ForeignPtr IValue
   -> ForeignPtr IValue
   -> IO (())
-iValue_swap_V = cast2 Unmanaged.iValue_swap_V
+iValue_swap_V = _cast2 Unmanaged.iValue_swap_V
 
 iValue_isTensor
   :: ForeignPtr IValue
   -> IO (CBool)
-iValue_isTensor = cast1 Unmanaged.iValue_isTensor
+iValue_isTensor = _cast1 Unmanaged.iValue_isTensor
 
 iValue_isBlob
   :: ForeignPtr IValue
   -> IO (CBool)
-iValue_isBlob = cast1 Unmanaged.iValue_isBlob
+iValue_isBlob = _cast1 Unmanaged.iValue_isBlob
 
 iValue_isCapsule
   :: ForeignPtr IValue
   -> IO (CBool)
-iValue_isCapsule = cast1 Unmanaged.iValue_isCapsule
+iValue_isCapsule = _cast1 Unmanaged.iValue_isCapsule
 
 iValue_isTuple
   :: ForeignPtr IValue
   -> IO (CBool)
-iValue_isTuple = cast1 Unmanaged.iValue_isTuple
+iValue_isTuple = _cast1 Unmanaged.iValue_isTuple
 
 iValue_isDouble
   :: ForeignPtr IValue
   -> IO (CBool)
-iValue_isDouble = cast1 Unmanaged.iValue_isDouble
+iValue_isDouble = _cast1 Unmanaged.iValue_isDouble
 
 iValue_isFuture
   :: ForeignPtr IValue
   -> IO (CBool)
-iValue_isFuture = cast1 Unmanaged.iValue_isFuture
+iValue_isFuture = _cast1 Unmanaged.iValue_isFuture
 
 iValue_isInt
   :: ForeignPtr IValue
   -> IO (CBool)
-iValue_isInt = cast1 Unmanaged.iValue_isInt
+iValue_isInt = _cast1 Unmanaged.iValue_isInt
 
 iValue_isIntList
   :: ForeignPtr IValue
   -> IO (CBool)
-iValue_isIntList = cast1 Unmanaged.iValue_isIntList
+iValue_isIntList = _cast1 Unmanaged.iValue_isIntList
 
 iValue_isString
   :: ForeignPtr IValue
   -> IO (CBool)
-iValue_isString = cast1 Unmanaged.iValue_isString
+iValue_isString = _cast1 Unmanaged.iValue_isString
 
 iValue_toStringRef
   :: ForeignPtr IValue
   -> IO (ForeignPtr StdString)
-iValue_toStringRef = cast1 Unmanaged.iValue_toStringRef
+iValue_toStringRef = _cast1 Unmanaged.iValue_toStringRef
 
 iValue_isDoubleList
   :: ForeignPtr IValue
   -> IO (CBool)
-iValue_isDoubleList = cast1 Unmanaged.iValue_isDoubleList
+iValue_isDoubleList = _cast1 Unmanaged.iValue_isDoubleList
 
 iValue_isBool
   :: ForeignPtr IValue
   -> IO (CBool)
-iValue_isBool = cast1 Unmanaged.iValue_isBool
+iValue_isBool = _cast1 Unmanaged.iValue_isBool
 
 iValue_isObject
   :: ForeignPtr IValue
   -> IO (CBool)
-iValue_isObject = cast1 Unmanaged.iValue_isObject
+iValue_isObject = _cast1 Unmanaged.iValue_isObject
 
 iValue_isBoolList
   :: ForeignPtr IValue
   -> IO (CBool)
-iValue_isBoolList = cast1 Unmanaged.iValue_isBoolList
+iValue_isBoolList = _cast1 Unmanaged.iValue_isBoolList
 
 iValue_isTensorList
   :: ForeignPtr IValue
   -> IO (CBool)
-iValue_isTensorList = cast1 Unmanaged.iValue_isTensorList
+iValue_isTensorList = _cast1 Unmanaged.iValue_isTensorList
 
 iValue_isList
   :: ForeignPtr IValue
   -> IO (CBool)
-iValue_isList = cast1 Unmanaged.iValue_isList
+iValue_isList = _cast1 Unmanaged.iValue_isList
 
 iValue_isGenericDict
   :: ForeignPtr IValue
   -> IO (CBool)
-iValue_isGenericDict = cast1 Unmanaged.iValue_isGenericDict
+iValue_isGenericDict = _cast1 Unmanaged.iValue_isGenericDict
 
 iValue_isNone
   :: ForeignPtr IValue
   -> IO (CBool)
-iValue_isNone = cast1 Unmanaged.iValue_isNone
+iValue_isNone = _cast1 Unmanaged.iValue_isNone
 
 iValue_toNone
   :: ForeignPtr IValue
   -> IO (ForeignPtr StdString)
-iValue_toNone = cast1 Unmanaged.iValue_toNone
+iValue_toNone = _cast1 Unmanaged.iValue_toNone
 
 iValue_isScalar
   :: ForeignPtr IValue
   -> IO (CBool)
-iValue_isScalar = cast1 Unmanaged.iValue_isScalar
+iValue_isScalar = _cast1 Unmanaged.iValue_isScalar
 
 iValue_isDevice
   :: ForeignPtr IValue
   -> IO (CBool)
-iValue_isDevice = cast1 Unmanaged.iValue_isDevice
+iValue_isDevice = _cast1 Unmanaged.iValue_isDevice
 
 iValue_toScalarType
   :: ForeignPtr IValue
   -> IO (ScalarType)
-iValue_toScalarType = cast1 Unmanaged.iValue_toScalarType
+iValue_toScalarType = _cast1 Unmanaged.iValue_toScalarType
 
 iValue_toLayout
   :: ForeignPtr IValue
   -> IO (Layout)
-iValue_toLayout = cast1 Unmanaged.iValue_toLayout
+iValue_toLayout = _cast1 Unmanaged.iValue_toLayout
 
 iValue_toMemoryFormat
   :: ForeignPtr IValue
   -> IO (MemoryFormat)
-iValue_toMemoryFormat = cast1 Unmanaged.iValue_toMemoryFormat
+iValue_toMemoryFormat = _cast1 Unmanaged.iValue_toMemoryFormat
 
 iValue_toQScheme
   :: ForeignPtr IValue
   -> IO (QScheme)
-iValue_toQScheme = cast1 Unmanaged.iValue_toQScheme
+iValue_toQScheme = _cast1 Unmanaged.iValue_toQScheme
 
 iValue_tagKind
   :: ForeignPtr IValue
   -> IO (ForeignPtr StdString)
-iValue_tagKind = cast1 Unmanaged.iValue_tagKind
+iValue_tagKind = _cast1 Unmanaged.iValue_tagKind
 
 iValue_isSameIdentity_V
   :: ForeignPtr IValue
   -> ForeignPtr IValue
   -> IO (CBool)
-iValue_isSameIdentity_V = cast2 Unmanaged.iValue_isSameIdentity_V
+iValue_isSameIdentity_V = _cast2 Unmanaged.iValue_isSameIdentity_V
 
 iValue_isPtrType
   :: ForeignPtr IValue
   -> IO (CBool)
-iValue_isPtrType = cast1 Unmanaged.iValue_isPtrType
+iValue_isPtrType = _cast1 Unmanaged.iValue_isPtrType
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Type/IValueList.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Type/IValueList.hs
@@ -25,7 +25,7 @@ import qualified Torch.Internal.Unmanaged.Type.IValueList as Unmanaged
 
 newIValueList
   :: IO (ForeignPtr IValueList)
-newIValueList = cast0 Unmanaged.newIValueList
+newIValueList = _cast0 Unmanaged.newIValueList
 
 
 
@@ -34,24 +34,24 @@ newIValueList = cast0 Unmanaged.newIValueList
 ivalueList_empty
   :: ForeignPtr IValueList
   -> IO (CBool)
-ivalueList_empty = cast1 Unmanaged.ivalueList_empty
+ivalueList_empty = _cast1 Unmanaged.ivalueList_empty
 
 ivalueList_size
   :: ForeignPtr IValueList
   -> IO (CSize)
-ivalueList_size = cast1 Unmanaged.ivalueList_size
+ivalueList_size = _cast1 Unmanaged.ivalueList_size
 
 ivalueList_at
   :: ForeignPtr IValueList
   -> CSize
   -> IO (ForeignPtr IValue)
-ivalueList_at = cast2 Unmanaged.ivalueList_at
+ivalueList_at = _cast2 Unmanaged.ivalueList_at
 
 ivalueList_push_back
   :: ForeignPtr IValueList
   -> ForeignPtr IValue
   -> IO (())
-ivalueList_push_back = cast2 Unmanaged.ivalueList_push_back
+ivalueList_push_back = _cast2 Unmanaged.ivalueList_push_back
 
 
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Type/IntArray.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Type/IntArray.hs
@@ -26,27 +26,27 @@ import qualified Torch.Internal.Unmanaged.Type.IntArray as Unmanaged
 
 newIntArray
   :: IO (ForeignPtr IntArray)
-newIntArray = cast0 Unmanaged.newIntArray
+newIntArray = _cast0 Unmanaged.newIntArray
 
 intArray_empty
   :: ForeignPtr IntArray
   -> IO (CBool)
-intArray_empty = cast1 Unmanaged.intArray_empty
+intArray_empty = _cast1 Unmanaged.intArray_empty
 
 intArray_size
   :: ForeignPtr IntArray
   -> IO (CSize)
-intArray_size = cast1 Unmanaged.intArray_size
+intArray_size = _cast1 Unmanaged.intArray_size
 
 intArray_at_s
   :: ForeignPtr IntArray
   -> CSize
   -> IO (Int64)
-intArray_at_s = cast2 Unmanaged.intArray_at_s
+intArray_at_s = _cast2 Unmanaged.intArray_at_s
 
 intArray_push_back_l
   :: ForeignPtr IntArray
   -> Int64
   -> IO (())
-intArray_push_back_l = cast2 Unmanaged.intArray_push_back_l
+intArray_push_back_l = _cast2 Unmanaged.intArray_push_back_l
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Type/IntArray.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Type/IntArray.hs
@@ -50,3 +50,12 @@ intArray_push_back_l
   -> IO (())
 intArray_push_back_l = _cast2 Unmanaged.intArray_push_back_l
 
+intArray_fromList
+  :: ForeignPtr IntArray
+  -> [Int64]
+  -> IO (())
+intArray_fromList = _cast2 Unmanaged.intArray_fromList
+
+intArray_toList
+  :: ForeignPtr IntArray -> IO [Int64]
+intArray_toList = _cast1 Unmanaged.intArray_toList

--- a/libtorch-ffi/src/Torch/Internal/Managed/Type/Module.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Type/Module.hs
@@ -30,37 +30,37 @@ import Control.Concurrent.MVar (MVar(..), newEmptyMVar, putMVar, takeMVar)
 import qualified Torch.Internal.Unmanaged.Type.Module as Unmanaged
 
 newModule :: ForeignPtr StdString -> IO (ForeignPtr Module)
-newModule = cast1 Unmanaged.newModule
+newModule = _cast1 Unmanaged.newModule
 
 save :: ForeignPtr Module -> FilePath -> IO ()
-save = cast2 Unmanaged.save
+save = _cast2 Unmanaged.save
 
 load :: FilePath -> IO (ForeignPtr Module)
-load = cast1 Unmanaged.load
+load = _cast1 Unmanaged.load
 
 forward :: ForeignPtr Module -> (ForeignPtr (StdVector IValue)) -> IO (ForeignPtr IValue)
-forward = cast2 Unmanaged.forward
+forward = _cast2 Unmanaged.forward
 
 registerParameter :: ForeignPtr Module -> ForeignPtr StdString -> ForeignPtr Tensor -> CBool -> IO ()
-registerParameter = cast4 Unmanaged.registerParameter
+registerParameter = _cast4 Unmanaged.registerParameter
 
 registerModule :: ForeignPtr Module -> ForeignPtr StdString -> ForeignPtr Module -> IO ()
-registerModule = cast3 Unmanaged.registerModule
+registerModule = _cast3 Unmanaged.registerModule
 
 train :: ForeignPtr Module -> CBool -> IO ()
-train = cast2 Unmanaged.train
+train = _cast2 Unmanaged.train
 
 runMethod :: ForeignPtr Module -> ForeignPtr StdString -> ForeignPtr (C10List IValue) -> IO (Ptr IValue)
-runMethod = cast3 Unmanaged.runMethod
+runMethod = _cast3 Unmanaged.runMethod
 
 runMethod1 :: ForeignPtr Module -> ForeignPtr StdString -> ForeignPtr IValue -> IO (Ptr IValue)
-runMethod1 = cast3 Unmanaged.runMethod1
+runMethod1 = _cast3 Unmanaged.runMethod1
 
 getParameters :: ForeignPtr Module -> IO (ForeignPtr TensorList)
-getParameters = cast1 Unmanaged.getParameters
+getParameters = _cast1 Unmanaged.getParameters
 
 setParameters :: ForeignPtr Module -> ForeignPtr TensorList -> IO ()
-setParameters = cast2 Unmanaged.setParameters
+setParameters = _cast2 Unmanaged.setParameters
 
 getNamedParameters :: ForeignPtr Module -> IO [(ForeignPtr StdString,ForeignPtr Tensor)]
 getNamedParameters obj = withForeignPtr obj $ \obj' -> do
@@ -103,13 +103,13 @@ getNamedChildren obj = withForeignPtr obj $ \obj' -> do
     return (a',b')
 
 toDevice :: ForeignPtr Module -> DeviceType -> Int16 -> IO ()
-toDevice = cast3 Unmanaged.toDevice
+toDevice = _cast3 Unmanaged.toDevice
 
 clone :: ForeignPtr Module -> IO (ForeignPtr Module)
-clone = cast1 Unmanaged.clone
+clone = _cast1 Unmanaged.clone
 
 define :: ForeignPtr Module -> ForeignPtr StdString -> IO ()
-define = cast2 Unmanaged.define
+define = _cast2 Unmanaged.define
 
 
 -- Note: Not to release "ForeignPtr TensorList" before calling trace, put the pointer to MVar, and touch the reference.
@@ -145,10 +145,10 @@ traceAsGraph func inputs = do
       return $ unsafeForeignPtrToPtr ret
 
 printGraph :: ForeignPtr (SharedPtr JitGraph) -> IO (ForeignPtr StdString)
-printGraph graph = cast1 Unmanaged.printGraph graph
+printGraph graph = _cast1 Unmanaged.printGraph graph
 
 printOnnx :: ForeignPtr (SharedPtr JitGraph) -> IO (ForeignPtr StdString)
-printOnnx graph = cast1 Unmanaged.printOnnx graph
+printOnnx graph = _cast1 Unmanaged.printOnnx graph
 
 dumpToStr
   :: ForeignPtr Module
@@ -156,4 +156,4 @@ dumpToStr
   -> CBool
   -> CBool
   -> IO (ForeignPtr StdString)
-dumpToStr = cast4 Unmanaged.dumpToStr
+dumpToStr = _cast4 Unmanaged.dumpToStr

--- a/libtorch-ffi/src/Torch/Internal/Managed/Type/Scalar.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Type/Scalar.hs
@@ -26,25 +26,25 @@ import qualified Torch.Internal.Unmanaged.Type.Scalar as Unmanaged
 
 newScalar
   :: IO (ForeignPtr Scalar)
-newScalar = cast0 Unmanaged.newScalar
+newScalar = _cast0 Unmanaged.newScalar
 
 newScalar_i
   :: CInt
   -> IO (ForeignPtr Scalar)
-newScalar_i = cast1 Unmanaged.newScalar_i
+newScalar_i = _cast1 Unmanaged.newScalar_i
 
 newScalar_d
   :: CDouble
   -> IO (ForeignPtr Scalar)
-newScalar_d = cast1 Unmanaged.newScalar_d
+newScalar_d = _cast1 Unmanaged.newScalar_d
 
 newScalar_b
   :: CBool
   -> IO (ForeignPtr Scalar)
-newScalar_b = cast1 Unmanaged.newScalar_b
+newScalar_b = _cast1 Unmanaged.newScalar_b
 
 newScalar_f
   :: CFloat
   -> IO (ForeignPtr Scalar)
-newScalar_f = cast1 Unmanaged.newScalar_f
+newScalar_f = _cast1 Unmanaged.newScalar_f
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Type/StdArray.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Type/StdArray.hs
@@ -24,44 +24,44 @@ import qualified Torch.Internal.Unmanaged.Type.StdArray as Unmanaged
 
 newStdArrayBool2
   :: IO (ForeignPtr (StdArray '(CBool,2)))
-newStdArrayBool2 = cast0 Unmanaged.newStdArrayBool2
+newStdArrayBool2 = _cast0 Unmanaged.newStdArrayBool2
 
 newStdArrayBool2_bb
   :: CBool
   -> CBool
   -> IO (ForeignPtr (StdArray '(CBool,2)))
-newStdArrayBool2_bb = cast2 Unmanaged.newStdArrayBool2_bb
+newStdArrayBool2_bb = _cast2 Unmanaged.newStdArrayBool2_bb
 
 instance CppTuple2 (ForeignPtr (StdArray '(CBool,2))) where
   type A (ForeignPtr (StdArray '(CBool,2))) = CBool
   type B (ForeignPtr (StdArray '(CBool,2))) = CBool
-  get0 v = cast1 (get0 :: Ptr (StdArray '(CBool,2)) -> IO CBool) v
-  get1 v = cast1 (get1 :: Ptr (StdArray '(CBool,2)) -> IO CBool) v
+  get0 v = _cast1 (get0 :: Ptr (StdArray '(CBool,2)) -> IO CBool) v
+  get1 v = _cast1 (get1 :: Ptr (StdArray '(CBool,2)) -> IO CBool) v
 
 newStdArrayBool3
   :: IO (ForeignPtr (StdArray '(CBool,3)))
-newStdArrayBool3 = cast0 Unmanaged.newStdArrayBool3
+newStdArrayBool3 = _cast0 Unmanaged.newStdArrayBool3
 
 newStdArrayBool3_bbb
   :: CBool
   -> CBool
   -> CBool
   -> IO (ForeignPtr (StdArray '(CBool,3)))
-newStdArrayBool3_bbb = cast3 Unmanaged.newStdArrayBool3_bbb
+newStdArrayBool3_bbb = _cast3 Unmanaged.newStdArrayBool3_bbb
 
 instance CppTuple2 (ForeignPtr (StdArray '(CBool,3))) where
   type A (ForeignPtr (StdArray '(CBool,3))) = CBool
   type B (ForeignPtr (StdArray '(CBool,3))) = CBool
-  get0 v = cast1 (get0 :: Ptr (StdArray '(CBool,3)) -> IO CBool) v
-  get1 v = cast1 (get1 :: Ptr (StdArray '(CBool,3)) -> IO CBool) v
+  get0 v = _cast1 (get0 :: Ptr (StdArray '(CBool,3)) -> IO CBool) v
+  get1 v = _cast1 (get1 :: Ptr (StdArray '(CBool,3)) -> IO CBool) v
 
 instance CppTuple3 (ForeignPtr (StdArray '(CBool,3))) where
   type C (ForeignPtr (StdArray '(CBool,3))) = CBool
-  get2 v = cast1 (get2 :: Ptr (StdArray '(CBool,3)) -> IO CBool) v
+  get2 v = _cast1 (get2 :: Ptr (StdArray '(CBool,3)) -> IO CBool) v
 
 newStdArrayBool4
   :: IO (ForeignPtr (StdArray '(CBool,4)))
-newStdArrayBool4 = cast0 Unmanaged.newStdArrayBool4
+newStdArrayBool4 = _cast0 Unmanaged.newStdArrayBool4
 
 newStdArrayBool4_bbbb
   :: CBool
@@ -69,18 +69,18 @@ newStdArrayBool4_bbbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr (StdArray '(CBool,4)))
-newStdArrayBool4_bbbb = cast4 Unmanaged.newStdArrayBool4_bbbb
+newStdArrayBool4_bbbb = _cast4 Unmanaged.newStdArrayBool4_bbbb
 
 instance CppTuple2 (ForeignPtr (StdArray '(CBool,4))) where
   type A (ForeignPtr (StdArray '(CBool,4))) = CBool
   type B (ForeignPtr (StdArray '(CBool,4))) = CBool
-  get0 v = cast1 (get0 :: Ptr (StdArray '(CBool,4)) -> IO CBool) v
-  get1 v = cast1 (get1 :: Ptr (StdArray '(CBool,4)) -> IO CBool) v
+  get0 v = _cast1 (get0 :: Ptr (StdArray '(CBool,4)) -> IO CBool) v
+  get1 v = _cast1 (get1 :: Ptr (StdArray '(CBool,4)) -> IO CBool) v
 
 instance CppTuple3 (ForeignPtr (StdArray '(CBool,4))) where
   type C (ForeignPtr (StdArray '(CBool,4))) = CBool
-  get2 v = cast1 (get2 :: Ptr (StdArray '(CBool,4)) -> IO CBool) v
+  get2 v = _cast1 (get2 :: Ptr (StdArray '(CBool,4)) -> IO CBool) v
 
 instance CppTuple4 (ForeignPtr (StdArray '(CBool,4))) where
   type D (ForeignPtr (StdArray '(CBool,4))) = CBool
-  get3 v = cast1 (get3 :: Ptr (StdArray '(CBool,4)) -> IO CBool) v
+  get3 v = _cast1 (get3 :: Ptr (StdArray '(CBool,4)) -> IO CBool) v

--- a/libtorch-ffi/src/Torch/Internal/Managed/Type/StdString.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Type/StdString.hs
@@ -24,17 +24,17 @@ import qualified Torch.Internal.Unmanaged.Type.StdString as Unmanaged
 
 newStdString
   :: IO (ForeignPtr StdString)
-newStdString = cast0 Unmanaged.newStdString
+newStdString = _cast0 Unmanaged.newStdString
 
 newStdString_s
   :: String
   -> IO (ForeignPtr StdString)
-newStdString_s str = cast1 Unmanaged.newStdString_s str
+newStdString_s str = _cast1 Unmanaged.newStdString_s str
 
 string_c_str
   :: ForeignPtr StdString
   -> IO String
-string_c_str str = cast1 Unmanaged.string_c_str str
+string_c_str str = _cast1 Unmanaged.string_c_str str
 
 instance Castable String (ForeignPtr StdString) where
   cast str f = newStdString_s str >>= f

--- a/libtorch-ffi/src/Torch/Internal/Managed/Type/StdVector.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Type/StdVector.hs
@@ -24,50 +24,50 @@ import qualified Torch.Internal.Unmanaged.Type.StdVector as Unmanaged
 
 
 newStdVectorDouble :: IO (ForeignPtr (StdVector CDouble))
-newStdVectorDouble = cast0 Unmanaged.newStdVectorDouble
+newStdVectorDouble = _cast0 Unmanaged.newStdVectorDouble
 
 newStdVectorInt :: IO (ForeignPtr (StdVector Int64))
-newStdVectorInt = cast0 Unmanaged.newStdVectorInt
+newStdVectorInt = _cast0 Unmanaged.newStdVectorInt
 
 newStdVectorBool :: IO (ForeignPtr (StdVector CBool))
-newStdVectorBool = cast0 Unmanaged.newStdVectorBool
+newStdVectorBool = _cast0 Unmanaged.newStdVectorBool
 
 
 
 
 
 stdVectorDouble_empty :: ForeignPtr (StdVector CDouble) -> IO (CBool)
-stdVectorDouble_empty = cast1 Unmanaged.stdVectorDouble_empty
+stdVectorDouble_empty = _cast1 Unmanaged.stdVectorDouble_empty
 
 stdVectorInt_empty :: ForeignPtr (StdVector Int64) -> IO (CBool)
-stdVectorInt_empty = cast1 Unmanaged.stdVectorInt_empty
+stdVectorInt_empty = _cast1 Unmanaged.stdVectorInt_empty
 
 stdVectorBool_empty :: ForeignPtr (StdVector CBool) -> IO (CBool)
-stdVectorBool_empty = cast1 Unmanaged.stdVectorBool_empty
+stdVectorBool_empty = _cast1 Unmanaged.stdVectorBool_empty
 
 stdVectorDouble_size :: ForeignPtr (StdVector CDouble) -> IO (CSize)
-stdVectorDouble_size = cast1 Unmanaged.stdVectorDouble_size
+stdVectorDouble_size = _cast1 Unmanaged.stdVectorDouble_size
 
 stdVectorInt_size :: ForeignPtr (StdVector Int64) -> IO (CSize)
-stdVectorInt_size = cast1 Unmanaged.stdVectorInt_size
+stdVectorInt_size = _cast1 Unmanaged.stdVectorInt_size
 
 stdVectorBool_size :: ForeignPtr (StdVector CBool) -> IO (CSize)
-stdVectorBool_size = cast1 Unmanaged.stdVectorBool_size
+stdVectorBool_size = _cast1 Unmanaged.stdVectorBool_size
 
 stdVectorDouble_at :: ForeignPtr (StdVector CDouble) -> CSize -> IO CDouble
-stdVectorDouble_at = cast2 Unmanaged.stdVectorDouble_at
+stdVectorDouble_at = _cast2 Unmanaged.stdVectorDouble_at
 
 stdVectorInt_at :: ForeignPtr (StdVector Int64) -> CSize -> IO Int64
-stdVectorInt_at = cast2 Unmanaged.stdVectorInt_at
+stdVectorInt_at = _cast2 Unmanaged.stdVectorInt_at
 
 stdVectorBool_at :: ForeignPtr (StdVector CBool) -> CSize -> IO CBool
-stdVectorBool_at = cast2 Unmanaged.stdVectorBool_at
+stdVectorBool_at = _cast2 Unmanaged.stdVectorBool_at
 
 stdVectorDouble_push_back :: ForeignPtr (StdVector CDouble) -> CDouble -> IO ()
-stdVectorDouble_push_back = cast2 Unmanaged.stdVectorDouble_push_back
+stdVectorDouble_push_back = _cast2 Unmanaged.stdVectorDouble_push_back
 
 stdVectorInt_push_back :: ForeignPtr (StdVector Int64) -> Int64 -> IO ()
-stdVectorInt_push_back = cast2 Unmanaged.stdVectorInt_push_back
+stdVectorInt_push_back = _cast2 Unmanaged.stdVectorInt_push_back
 
 stdVectorBool_push_back :: ForeignPtr (StdVector CBool) -> CBool -> IO ()
-stdVectorBool_push_back = cast2 Unmanaged.stdVectorBool_push_back
+stdVectorBool_push_back = _cast2 Unmanaged.stdVectorBool_push_back

--- a/libtorch-ffi/src/Torch/Internal/Managed/Type/Storage.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Type/Storage.hs
@@ -26,5 +26,5 @@ import qualified Torch.Internal.Unmanaged.Type.Storage as Unmanaged
 
 newStorage
   :: IO (ForeignPtr Storage)
-newStorage = cast0 Unmanaged.newStorage
+newStorage = _cast0 Unmanaged.newStorage
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Type/Symbol.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Type/Symbol.hs
@@ -26,90 +26,90 @@ import qualified Torch.Internal.Unmanaged.Type.Symbol as Unmanaged
 
 newSymbol
   :: IO (ForeignPtr Symbol)
-newSymbol = cast0 Unmanaged.newSymbol
+newSymbol = _cast0 Unmanaged.newSymbol
 
 symbol_is_attr
   :: ForeignPtr Symbol
   -> IO (CBool)
-symbol_is_attr = cast1 Unmanaged.symbol_is_attr
+symbol_is_attr = _cast1 Unmanaged.symbol_is_attr
 
 symbol_is_aten
   :: ForeignPtr Symbol
   -> IO (CBool)
-symbol_is_aten = cast1 Unmanaged.symbol_is_aten
+symbol_is_aten = _cast1 Unmanaged.symbol_is_aten
 
 symbol_is_prim
   :: ForeignPtr Symbol
   -> IO (CBool)
-symbol_is_prim = cast1 Unmanaged.symbol_is_prim
+symbol_is_prim = _cast1 Unmanaged.symbol_is_prim
 
 symbol_is_onnx
   :: ForeignPtr Symbol
   -> IO (CBool)
-symbol_is_onnx = cast1 Unmanaged.symbol_is_onnx
+symbol_is_onnx = _cast1 Unmanaged.symbol_is_onnx
 
 symbol_is_user
   :: ForeignPtr Symbol
   -> IO (CBool)
-symbol_is_user = cast1 Unmanaged.symbol_is_user
+symbol_is_user = _cast1 Unmanaged.symbol_is_user
 
 symbol_is_caffe2
   :: ForeignPtr Symbol
   -> IO (CBool)
-symbol_is_caffe2 = cast1 Unmanaged.symbol_is_caffe2
+symbol_is_caffe2 = _cast1 Unmanaged.symbol_is_caffe2
 
 symbol_is_dimname
   :: ForeignPtr Symbol
   -> IO (CBool)
-symbol_is_dimname = cast1 Unmanaged.symbol_is_dimname
+symbol_is_dimname = _cast1 Unmanaged.symbol_is_dimname
 
 symbol_toUnqualString
   :: ForeignPtr Symbol
   -> IO (ForeignPtr StdString)
-symbol_toUnqualString = cast1 Unmanaged.symbol_toUnqualString
+symbol_toUnqualString = _cast1 Unmanaged.symbol_toUnqualString
 
 symbol_toQualString
   :: ForeignPtr Symbol
   -> IO (ForeignPtr StdString)
-symbol_toQualString = cast1 Unmanaged.symbol_toQualString
+symbol_toQualString = _cast1 Unmanaged.symbol_toQualString
 
 symbol_toDisplayString
   :: ForeignPtr Symbol
   -> IO (ForeignPtr StdString)
-symbol_toDisplayString = cast1 Unmanaged.symbol_toDisplayString
+symbol_toDisplayString = _cast1 Unmanaged.symbol_toDisplayString
 
 attr_s
   :: ForeignPtr StdString
   -> IO (ForeignPtr Symbol)
-attr_s = cast1 Unmanaged.attr_s
+attr_s = _cast1 Unmanaged.attr_s
 
 aten_s
   :: ForeignPtr StdString
   -> IO (ForeignPtr Symbol)
-aten_s = cast1 Unmanaged.aten_s
+aten_s = _cast1 Unmanaged.aten_s
 
 onnx_s
   :: ForeignPtr StdString
   -> IO (ForeignPtr Symbol)
-onnx_s = cast1 Unmanaged.onnx_s
+onnx_s = _cast1 Unmanaged.onnx_s
 
 prim_s
   :: ForeignPtr StdString
   -> IO (ForeignPtr Symbol)
-prim_s = cast1 Unmanaged.prim_s
+prim_s = _cast1 Unmanaged.prim_s
 
 user_s
   :: ForeignPtr StdString
   -> IO (ForeignPtr Symbol)
-user_s = cast1 Unmanaged.user_s
+user_s = _cast1 Unmanaged.user_s
 
 caffe2_s
   :: ForeignPtr StdString
   -> IO (ForeignPtr Symbol)
-caffe2_s = cast1 Unmanaged.caffe2_s
+caffe2_s = _cast1 Unmanaged.caffe2_s
 
 dimname_s
   :: ForeignPtr StdString
   -> IO (ForeignPtr Symbol)
-dimname_s = cast1 Unmanaged.dimname_s
+dimname_s = _cast1 Unmanaged.dimname_s
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Type/Tensor/Tensor0.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Type/Tensor/Tensor0.hs
@@ -26,17 +26,17 @@ import qualified Torch.Internal.Unmanaged.Type.Tensor.Tensor0 as Unmanaged
 
 newTensor
   :: IO (ForeignPtr Tensor)
-newTensor = cast0 Unmanaged.newTensor
+newTensor = _cast0 Unmanaged.newTensor
 
 newTensor_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-newTensor_t = cast1 Unmanaged.newTensor_t
+newTensor_t = _cast1 Unmanaged.newTensor_t
 
 tensor___dispatch_contiguous
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor___dispatch_contiguous = cast1 Unmanaged.tensor___dispatch_contiguous
+tensor___dispatch_contiguous = _cast1 Unmanaged.tensor___dispatch_contiguous
 
 tensor_backward_tbb
   :: ForeignPtr Tensor
@@ -75,6 +75,16 @@ tensor_dim
   :: ForeignPtr Tensor
   -> IO (Int64)
 tensor_dim = cast1 Unmanaged.tensor_dim
+
+tensor_dim_unsafe
+  :: ForeignPtr Tensor
+  -> IO (Int64)
+tensor_dim_unsafe = cast1 Unmanaged.tensor_dim_unsafe
+
+tensor_dim_c_unsafe
+  :: ForeignPtr Tensor
+  -> IO (Int64)
+tensor_dim_c_unsafe = cast1 Unmanaged.tensor_dim_c_unsafe
 
 tensor_element_size
   :: ForeignPtr Tensor
@@ -366,7 +376,7 @@ tensor_to_Dsbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-tensor_to_Dsbb = cast5 Unmanaged.tensor_to_Dsbb
+tensor_to_Dsbb = _cast5 Unmanaged.tensor_to_Dsbb
 
 tensor_to_sbb
   :: ForeignPtr Tensor
@@ -374,7 +384,7 @@ tensor_to_sbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-tensor_to_sbb = cast4 Unmanaged.tensor_to_sbb
+tensor_to_sbb = _cast4 Unmanaged.tensor_to_sbb
 
 tensor_to_tbb
   :: ForeignPtr Tensor
@@ -382,7 +392,7 @@ tensor_to_tbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-tensor_to_tbb = cast4 Unmanaged.tensor_to_tbb
+tensor_to_tbb = _cast4 Unmanaged.tensor_to_tbb
 
 tensor_to_obb
   :: ForeignPtr Tensor
@@ -390,49 +400,49 @@ tensor_to_obb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-tensor_to_obb = cast4 Unmanaged.tensor_to_obb
+tensor_to_obb = _cast4 Unmanaged.tensor_to_obb
 
 tensor_toBackend_B
   :: ForeignPtr Tensor
   -> Backend
   -> IO (ForeignPtr Tensor)
-tensor_toBackend_B = cast2 Unmanaged.tensor_toBackend_B
+tensor_toBackend_B = _cast2 Unmanaged.tensor_toBackend_B
 
 tensor_toString
   :: ForeignPtr Tensor
   -> IO (ForeignPtr StdString)
-tensor_toString = cast1 Unmanaged.tensor_toString
+tensor_toString = _cast1 Unmanaged.tensor_toString
 
 tensor_toType_s
   :: ForeignPtr Tensor
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-tensor_toType_s = cast2 Unmanaged.tensor_toType_s
+tensor_toType_s = _cast2 Unmanaged.tensor_toType_s
 
 tensor_to_dense
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_to_dense = cast1 Unmanaged.tensor_to_dense
+tensor_to_dense = _cast1 Unmanaged.tensor_to_dense
 
 tensor_to_mkldnn
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_to_mkldnn = cast1 Unmanaged.tensor_to_mkldnn
+tensor_to_mkldnn = _cast1 Unmanaged.tensor_to_mkldnn
 
 tensor_use_count
   :: ForeignPtr Tensor
   -> IO (CSize)
-tensor_use_count = cast1 Unmanaged.tensor_use_count
+tensor_use_count = _cast1 Unmanaged.tensor_use_count
 
 tensor_vulkan
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_vulkan = cast1 Unmanaged.tensor_vulkan
+tensor_vulkan = _cast1 Unmanaged.tensor_vulkan
 
 tensor_weak_use_count
   :: ForeignPtr Tensor
   -> IO (CSize)
-tensor_weak_use_count = cast1 Unmanaged.tensor_weak_use_count
+tensor_weak_use_count = _cast1 Unmanaged.tensor_weak_use_count
 
 tensor__backward_ltbb
   :: ForeignPtr Tensor
@@ -441,215 +451,215 @@ tensor__backward_ltbb
   -> CBool
   -> CBool
   -> IO (())
-tensor__backward_ltbb = cast5 Unmanaged.tensor__backward_ltbb
+tensor__backward_ltbb = _cast5 Unmanaged.tensor__backward_ltbb
 
 tensor_set_data_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (())
-tensor_set_data_t = cast2 Unmanaged.tensor_set_data_t
+tensor_set_data_t = _cast2 Unmanaged.tensor_set_data_t
 
 tensor_data
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_data = cast1 Unmanaged.tensor_data
+tensor_data = _cast1 Unmanaged.tensor_data
 
 tensor_is_leaf
   :: ForeignPtr Tensor
   -> IO (CBool)
-tensor_is_leaf = cast1 Unmanaged.tensor_is_leaf
+tensor_is_leaf = _cast1 Unmanaged.tensor_is_leaf
 
 tensor_output_nr
   :: ForeignPtr Tensor
   -> IO (Int64)
-tensor_output_nr = cast1 Unmanaged.tensor_output_nr
+tensor_output_nr = _cast1 Unmanaged.tensor_output_nr
 
 tensor__version
   :: ForeignPtr Tensor
   -> IO (Int64)
-tensor__version = cast1 Unmanaged.tensor__version
+tensor__version = _cast1 Unmanaged.tensor__version
 
 tensor_requires_grad__b
   :: ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-tensor_requires_grad__b = cast2 Unmanaged.tensor_requires_grad__b
+tensor_requires_grad__b = _cast2 Unmanaged.tensor_requires_grad__b
 
 tensor_retain_grad
   :: ForeignPtr Tensor
   -> IO (())
-tensor_retain_grad = cast1 Unmanaged.tensor_retain_grad
+tensor_retain_grad = _cast1 Unmanaged.tensor_retain_grad
 
 tensor_retains_grad
   :: ForeignPtr Tensor
   -> IO (CBool)
-tensor_retains_grad = cast1 Unmanaged.tensor_retains_grad
+tensor_retains_grad = _cast1 Unmanaged.tensor_retains_grad
 
 tensor__fw_primal_l
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor__fw_primal_l = cast2 Unmanaged.tensor__fw_primal_l
+tensor__fw_primal_l = _cast2 Unmanaged.tensor__fw_primal_l
 
 tensor_rename__N
   :: ForeignPtr Tensor
   -> ForeignPtr DimnameList
   -> IO (ForeignPtr Tensor)
-tensor_rename__N = cast2 Unmanaged.tensor_rename__N
+tensor_rename__N = _cast2 Unmanaged.tensor_rename__N
 
 tensor_rename_N
   :: ForeignPtr Tensor
   -> ForeignPtr DimnameList
   -> IO (ForeignPtr Tensor)
-tensor_rename_N = cast2 Unmanaged.tensor_rename_N
+tensor_rename_N = _cast2 Unmanaged.tensor_rename_N
 
 tensor_align_to_N
   :: ForeignPtr Tensor
   -> ForeignPtr DimnameList
   -> IO (ForeignPtr Tensor)
-tensor_align_to_N = cast2 Unmanaged.tensor_align_to_N
+tensor_align_to_N = _cast2 Unmanaged.tensor_align_to_N
 
 tensor_align_to_Nl
   :: ForeignPtr Tensor
   -> ForeignPtr DimnameList
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor_align_to_Nl = cast3 Unmanaged.tensor_align_to_Nl
+tensor_align_to_Nl = _cast3 Unmanaged.tensor_align_to_Nl
 
 tensor_align_as_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_align_as_t = cast2 Unmanaged.tensor_align_as_t
+tensor_align_as_t = _cast2 Unmanaged.tensor_align_as_t
 
 tensor_refine_names_N
   :: ForeignPtr Tensor
   -> ForeignPtr DimnameList
   -> IO (ForeignPtr Tensor)
-tensor_refine_names_N = cast2 Unmanaged.tensor_refine_names_N
+tensor_refine_names_N = _cast2 Unmanaged.tensor_refine_names_N
 
 tensor_abs
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_abs = cast1 Unmanaged.tensor_abs
+tensor_abs = _cast1 Unmanaged.tensor_abs
 
 tensor_abs_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_abs_ = cast1 Unmanaged.tensor_abs_
+tensor_abs_ = _cast1 Unmanaged.tensor_abs_
 
 tensor_absolute
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_absolute = cast1 Unmanaged.tensor_absolute
+tensor_absolute = _cast1 Unmanaged.tensor_absolute
 
 tensor_absolute_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_absolute_ = cast1 Unmanaged.tensor_absolute_
+tensor_absolute_ = _cast1 Unmanaged.tensor_absolute_
 
 tensor_angle
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_angle = cast1 Unmanaged.tensor_angle
+tensor_angle = _cast1 Unmanaged.tensor_angle
 
 tensor_sgn
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_sgn = cast1 Unmanaged.tensor_sgn
+tensor_sgn = _cast1 Unmanaged.tensor_sgn
 
 tensor_sgn_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_sgn_ = cast1 Unmanaged.tensor_sgn_
+tensor_sgn_ = _cast1 Unmanaged.tensor_sgn_
 
 tensor__conj
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor__conj = cast1 Unmanaged.tensor__conj
+tensor__conj = _cast1 Unmanaged.tensor__conj
 
 tensor_conj
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_conj = cast1 Unmanaged.tensor_conj
+tensor_conj = _cast1 Unmanaged.tensor_conj
 
 tensor__conj_physical
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor__conj_physical = cast1 Unmanaged.tensor__conj_physical
+tensor__conj_physical = _cast1 Unmanaged.tensor__conj_physical
 
 tensor_conj_physical
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_conj_physical = cast1 Unmanaged.tensor_conj_physical
+tensor_conj_physical = _cast1 Unmanaged.tensor_conj_physical
 
 tensor_conj_physical_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_conj_physical_ = cast1 Unmanaged.tensor_conj_physical_
+tensor_conj_physical_ = _cast1 Unmanaged.tensor_conj_physical_
 
 tensor_resolve_conj
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_resolve_conj = cast1 Unmanaged.tensor_resolve_conj
+tensor_resolve_conj = _cast1 Unmanaged.tensor_resolve_conj
 
 tensor_resolve_neg
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_resolve_neg = cast1 Unmanaged.tensor_resolve_neg
+tensor_resolve_neg = _cast1 Unmanaged.tensor_resolve_neg
 
 tensor__neg_view
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor__neg_view = cast1 Unmanaged.tensor__neg_view
+tensor__neg_view = _cast1 Unmanaged.tensor__neg_view
 
 tensor_acos
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_acos = cast1 Unmanaged.tensor_acos
+tensor_acos = _cast1 Unmanaged.tensor_acos
 
 tensor_acos_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_acos_ = cast1 Unmanaged.tensor_acos_
+tensor_acos_ = _cast1 Unmanaged.tensor_acos_
 
 tensor_arccos
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_arccos = cast1 Unmanaged.tensor_arccos
+tensor_arccos = _cast1 Unmanaged.tensor_arccos
 
 tensor_arccos_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_arccos_ = cast1 Unmanaged.tensor_arccos_
+tensor_arccos_ = _cast1 Unmanaged.tensor_arccos_
 
 tensor_add_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_add_ts = cast3 Unmanaged.tensor_add_ts
+tensor_add_ts = _cast3 Unmanaged.tensor_add_ts
 
 tensor_add__ts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_add__ts = cast3 Unmanaged.tensor_add__ts
+tensor_add__ts = _cast3 Unmanaged.tensor_add__ts
 
 tensor_add_ss
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_add_ss = cast3 Unmanaged.tensor_add_ss
+tensor_add_ss = _cast3 Unmanaged.tensor_add_ss
 
 tensor_add__ss
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_add__ss = cast3 Unmanaged.tensor_add__ss
+tensor_add__ss = _cast3 Unmanaged.tensor_add__ss
 
 tensor_addmv_ttss
   :: ForeignPtr Tensor
@@ -658,7 +668,7 @@ tensor_addmv_ttss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_addmv_ttss = cast5 Unmanaged.tensor_addmv_ttss
+tensor_addmv_ttss = _cast5 Unmanaged.tensor_addmv_ttss
 
 tensor_addmv__ttss
   :: ForeignPtr Tensor
@@ -667,7 +677,7 @@ tensor_addmv__ttss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_addmv__ttss = cast5 Unmanaged.tensor_addmv__ttss
+tensor_addmv__ttss = _cast5 Unmanaged.tensor_addmv__ttss
 
 tensor_addr_ttss
   :: ForeignPtr Tensor
@@ -676,7 +686,7 @@ tensor_addr_ttss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_addr_ttss = cast5 Unmanaged.tensor_addr_ttss
+tensor_addr_ttss = _cast5 Unmanaged.tensor_addr_ttss
 
 tensor_addr__ttss
   :: ForeignPtr Tensor
@@ -685,21 +695,21 @@ tensor_addr__ttss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_addr__ttss = cast5 Unmanaged.tensor_addr__ttss
+tensor_addr__ttss = _cast5 Unmanaged.tensor_addr__ttss
 
 tensor_all_lb
   :: ForeignPtr Tensor
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-tensor_all_lb = cast3 Unmanaged.tensor_all_lb
+tensor_all_lb = _cast3 Unmanaged.tensor_all_lb
 
 tensor_all_nb
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> CBool
   -> IO (ForeignPtr Tensor)
-tensor_all_nb = cast3 Unmanaged.tensor_all_nb
+tensor_all_nb = _cast3 Unmanaged.tensor_all_nb
 
 tensor_allclose_tddb
   :: ForeignPtr Tensor
@@ -708,95 +718,95 @@ tensor_allclose_tddb
   -> CDouble
   -> CBool
   -> IO (CBool)
-tensor_allclose_tddb = cast5 Unmanaged.tensor_allclose_tddb
+tensor_allclose_tddb = _cast5 Unmanaged.tensor_allclose_tddb
 
 tensor_any_lb
   :: ForeignPtr Tensor
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-tensor_any_lb = cast3 Unmanaged.tensor_any_lb
+tensor_any_lb = _cast3 Unmanaged.tensor_any_lb
 
 tensor_any_nb
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> CBool
   -> IO (ForeignPtr Tensor)
-tensor_any_nb = cast3 Unmanaged.tensor_any_nb
+tensor_any_nb = _cast3 Unmanaged.tensor_any_nb
 
 tensor_argmax_lb
   :: ForeignPtr Tensor
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-tensor_argmax_lb = cast3 Unmanaged.tensor_argmax_lb
+tensor_argmax_lb = _cast3 Unmanaged.tensor_argmax_lb
 
 tensor_argmin_lb
   :: ForeignPtr Tensor
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-tensor_argmin_lb = cast3 Unmanaged.tensor_argmin_lb
+tensor_argmin_lb = _cast3 Unmanaged.tensor_argmin_lb
 
 tensor_acosh
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_acosh = cast1 Unmanaged.tensor_acosh
+tensor_acosh = _cast1 Unmanaged.tensor_acosh
 
 tensor_acosh_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_acosh_ = cast1 Unmanaged.tensor_acosh_
+tensor_acosh_ = _cast1 Unmanaged.tensor_acosh_
 
 tensor_arccosh
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_arccosh = cast1 Unmanaged.tensor_arccosh
+tensor_arccosh = _cast1 Unmanaged.tensor_arccosh
 
 tensor_arccosh_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_arccosh_ = cast1 Unmanaged.tensor_arccosh_
+tensor_arccosh_ = _cast1 Unmanaged.tensor_arccosh_
 
 tensor_asinh
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_asinh = cast1 Unmanaged.tensor_asinh
+tensor_asinh = _cast1 Unmanaged.tensor_asinh
 
 tensor_asinh_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_asinh_ = cast1 Unmanaged.tensor_asinh_
+tensor_asinh_ = _cast1 Unmanaged.tensor_asinh_
 
 tensor_arcsinh
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_arcsinh = cast1 Unmanaged.tensor_arcsinh
+tensor_arcsinh = _cast1 Unmanaged.tensor_arcsinh
 
 tensor_arcsinh_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_arcsinh_ = cast1 Unmanaged.tensor_arcsinh_
+tensor_arcsinh_ = _cast1 Unmanaged.tensor_arcsinh_
 
 tensor_atanh
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_atanh = cast1 Unmanaged.tensor_atanh
+tensor_atanh = _cast1 Unmanaged.tensor_atanh
 
 tensor_atanh_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_atanh_ = cast1 Unmanaged.tensor_atanh_
+tensor_atanh_ = _cast1 Unmanaged.tensor_atanh_
 
 tensor_arctanh
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_arctanh = cast1 Unmanaged.tensor_arctanh
+tensor_arctanh = _cast1 Unmanaged.tensor_arctanh
 
 tensor_arctanh_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_arctanh_ = cast1 Unmanaged.tensor_arctanh_
+tensor_arctanh_ = _cast1 Unmanaged.tensor_arctanh_
 
 tensor_as_strided_lll
   :: ForeignPtr Tensor
@@ -804,7 +814,7 @@ tensor_as_strided_lll
   -> ForeignPtr IntArray
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor_as_strided_lll = cast4 Unmanaged.tensor_as_strided_lll
+tensor_as_strided_lll = _cast4 Unmanaged.tensor_as_strided_lll
 
 tensor_as_strided__lll
   :: ForeignPtr Tensor
@@ -812,47 +822,47 @@ tensor_as_strided__lll
   -> ForeignPtr IntArray
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor_as_strided__lll = cast4 Unmanaged.tensor_as_strided__lll
+tensor_as_strided__lll = _cast4 Unmanaged.tensor_as_strided__lll
 
 tensor_asin
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_asin = cast1 Unmanaged.tensor_asin
+tensor_asin = _cast1 Unmanaged.tensor_asin
 
 tensor_asin_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_asin_ = cast1 Unmanaged.tensor_asin_
+tensor_asin_ = _cast1 Unmanaged.tensor_asin_
 
 tensor_arcsin
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_arcsin = cast1 Unmanaged.tensor_arcsin
+tensor_arcsin = _cast1 Unmanaged.tensor_arcsin
 
 tensor_arcsin_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_arcsin_ = cast1 Unmanaged.tensor_arcsin_
+tensor_arcsin_ = _cast1 Unmanaged.tensor_arcsin_
 
 tensor_atan
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_atan = cast1 Unmanaged.tensor_atan
+tensor_atan = _cast1 Unmanaged.tensor_atan
 
 tensor_atan_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_atan_ = cast1 Unmanaged.tensor_atan_
+tensor_atan_ = _cast1 Unmanaged.tensor_atan_
 
 tensor_arctan
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_arctan = cast1 Unmanaged.tensor_arctan
+tensor_arctan = _cast1 Unmanaged.tensor_arctan
 
 tensor_arctan_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_arctan_ = cast1 Unmanaged.tensor_arctan_
+tensor_arctan_ = _cast1 Unmanaged.tensor_arctan_
 
 tensor_baddbmm_ttss
   :: ForeignPtr Tensor
@@ -861,7 +871,7 @@ tensor_baddbmm_ttss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_baddbmm_ttss = cast5 Unmanaged.tensor_baddbmm_ttss
+tensor_baddbmm_ttss = _cast5 Unmanaged.tensor_baddbmm_ttss
 
 tensor_baddbmm__ttss
   :: ForeignPtr Tensor
@@ -870,301 +880,301 @@ tensor_baddbmm__ttss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_baddbmm__ttss = cast5 Unmanaged.tensor_baddbmm__ttss
+tensor_baddbmm__ttss = _cast5 Unmanaged.tensor_baddbmm__ttss
 
 tensor_bernoulli_G
   :: ForeignPtr Tensor
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-tensor_bernoulli_G = cast2 Unmanaged.tensor_bernoulli_G
+tensor_bernoulli_G = _cast2 Unmanaged.tensor_bernoulli_G
 
 tensor_bernoulli__tG
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-tensor_bernoulli__tG = cast3 Unmanaged.tensor_bernoulli__tG
+tensor_bernoulli__tG = _cast3 Unmanaged.tensor_bernoulli__tG
 
 tensor_bernoulli__dG
   :: ForeignPtr Tensor
   -> CDouble
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-tensor_bernoulli__dG = cast3 Unmanaged.tensor_bernoulli__dG
+tensor_bernoulli__dG = _cast3 Unmanaged.tensor_bernoulli__dG
 
 tensor_bernoulli_dG
   :: ForeignPtr Tensor
   -> CDouble
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-tensor_bernoulli_dG = cast3 Unmanaged.tensor_bernoulli_dG
+tensor_bernoulli_dG = _cast3 Unmanaged.tensor_bernoulli_dG
 
 tensor_bincount_tl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor_bincount_tl = cast3 Unmanaged.tensor_bincount_tl
+tensor_bincount_tl = _cast3 Unmanaged.tensor_bincount_tl
 
 tensor_bitwise_not
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_bitwise_not = cast1 Unmanaged.tensor_bitwise_not
+tensor_bitwise_not = _cast1 Unmanaged.tensor_bitwise_not
 
 tensor_bitwise_not_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_bitwise_not_ = cast1 Unmanaged.tensor_bitwise_not_
+tensor_bitwise_not_ = _cast1 Unmanaged.tensor_bitwise_not_
 
 tensor_copysign_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_copysign_t = cast2 Unmanaged.tensor_copysign_t
+tensor_copysign_t = _cast2 Unmanaged.tensor_copysign_t
 
 tensor_copysign__t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_copysign__t = cast2 Unmanaged.tensor_copysign__t
+tensor_copysign__t = _cast2 Unmanaged.tensor_copysign__t
 
 tensor_copysign_s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_copysign_s = cast2 Unmanaged.tensor_copysign_s
+tensor_copysign_s = _cast2 Unmanaged.tensor_copysign_s
 
 tensor_copysign__s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_copysign__s = cast2 Unmanaged.tensor_copysign__s
+tensor_copysign__s = _cast2 Unmanaged.tensor_copysign__s
 
 tensor_logical_not
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_logical_not = cast1 Unmanaged.tensor_logical_not
+tensor_logical_not = _cast1 Unmanaged.tensor_logical_not
 
 tensor_logical_not_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_logical_not_ = cast1 Unmanaged.tensor_logical_not_
+tensor_logical_not_ = _cast1 Unmanaged.tensor_logical_not_
 
 tensor_logical_xor_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_logical_xor_t = cast2 Unmanaged.tensor_logical_xor_t
+tensor_logical_xor_t = _cast2 Unmanaged.tensor_logical_xor_t
 
 tensor_logical_xor__t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_logical_xor__t = cast2 Unmanaged.tensor_logical_xor__t
+tensor_logical_xor__t = _cast2 Unmanaged.tensor_logical_xor__t
 
 tensor_logical_and_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_logical_and_t = cast2 Unmanaged.tensor_logical_and_t
+tensor_logical_and_t = _cast2 Unmanaged.tensor_logical_and_t
 
 tensor_logical_and__t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_logical_and__t = cast2 Unmanaged.tensor_logical_and__t
+tensor_logical_and__t = _cast2 Unmanaged.tensor_logical_and__t
 
 tensor_logical_or_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_logical_or_t = cast2 Unmanaged.tensor_logical_or_t
+tensor_logical_or_t = _cast2 Unmanaged.tensor_logical_or_t
 
 tensor_logical_or__t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_logical_or__t = cast2 Unmanaged.tensor_logical_or__t
+tensor_logical_or__t = _cast2 Unmanaged.tensor_logical_or__t
 
 tensor_bmm_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_bmm_t = cast2 Unmanaged.tensor_bmm_t
+tensor_bmm_t = _cast2 Unmanaged.tensor_bmm_t
 
 tensor_broadcast_to_l
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-tensor_broadcast_to_l = cast2 Unmanaged.tensor_broadcast_to_l
+tensor_broadcast_to_l = _cast2 Unmanaged.tensor_broadcast_to_l
 
 tensor_ceil
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_ceil = cast1 Unmanaged.tensor_ceil
+tensor_ceil = _cast1 Unmanaged.tensor_ceil
 
 tensor_ceil_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_ceil_ = cast1 Unmanaged.tensor_ceil_
+tensor_ceil_ = _cast1 Unmanaged.tensor_ceil_
 
 tensor_unsafe_chunk_ll
   :: ForeignPtr Tensor
   -> Int64
   -> Int64
   -> IO (ForeignPtr TensorList)
-tensor_unsafe_chunk_ll = cast3 Unmanaged.tensor_unsafe_chunk_ll
+tensor_unsafe_chunk_ll = _cast3 Unmanaged.tensor_unsafe_chunk_ll
 
 tensor_chunk_ll
   :: ForeignPtr Tensor
   -> Int64
   -> Int64
   -> IO (ForeignPtr TensorList)
-tensor_chunk_ll = cast3 Unmanaged.tensor_chunk_ll
+tensor_chunk_ll = _cast3 Unmanaged.tensor_chunk_ll
 
 tensor_tensor_split_tl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr TensorList)
-tensor_tensor_split_tl = cast3 Unmanaged.tensor_tensor_split_tl
+tensor_tensor_split_tl = _cast3 Unmanaged.tensor_tensor_split_tl
 
 tensor_clamp_ss
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_clamp_ss = cast3 Unmanaged.tensor_clamp_ss
+tensor_clamp_ss = _cast3 Unmanaged.tensor_clamp_ss
 
 tensor_clamp_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_clamp_tt = cast3 Unmanaged.tensor_clamp_tt
+tensor_clamp_tt = _cast3 Unmanaged.tensor_clamp_tt
 
 tensor_clamp__ss
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_clamp__ss = cast3 Unmanaged.tensor_clamp__ss
+tensor_clamp__ss = _cast3 Unmanaged.tensor_clamp__ss
 
 tensor_clamp__tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_clamp__tt = cast3 Unmanaged.tensor_clamp__tt
+tensor_clamp__tt = _cast3 Unmanaged.tensor_clamp__tt
 
 tensor_clamp_max_s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_clamp_max_s = cast2 Unmanaged.tensor_clamp_max_s
+tensor_clamp_max_s = _cast2 Unmanaged.tensor_clamp_max_s
 
 tensor_clamp_max_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_clamp_max_t = cast2 Unmanaged.tensor_clamp_max_t
+tensor_clamp_max_t = _cast2 Unmanaged.tensor_clamp_max_t
 
 tensor_clamp_max__s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_clamp_max__s = cast2 Unmanaged.tensor_clamp_max__s
+tensor_clamp_max__s = _cast2 Unmanaged.tensor_clamp_max__s
 
 tensor_clamp_max__t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_clamp_max__t = cast2 Unmanaged.tensor_clamp_max__t
+tensor_clamp_max__t = _cast2 Unmanaged.tensor_clamp_max__t
 
 tensor_clamp_min_s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_clamp_min_s = cast2 Unmanaged.tensor_clamp_min_s
+tensor_clamp_min_s = _cast2 Unmanaged.tensor_clamp_min_s
 
 tensor_clamp_min_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_clamp_min_t = cast2 Unmanaged.tensor_clamp_min_t
+tensor_clamp_min_t = _cast2 Unmanaged.tensor_clamp_min_t
 
 tensor_clamp_min__s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_clamp_min__s = cast2 Unmanaged.tensor_clamp_min__s
+tensor_clamp_min__s = _cast2 Unmanaged.tensor_clamp_min__s
 
 tensor_clamp_min__t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_clamp_min__t = cast2 Unmanaged.tensor_clamp_min__t
+tensor_clamp_min__t = _cast2 Unmanaged.tensor_clamp_min__t
 
 tensor_clip_ss
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_clip_ss = cast3 Unmanaged.tensor_clip_ss
+tensor_clip_ss = _cast3 Unmanaged.tensor_clip_ss
 
 tensor_clip_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_clip_tt = cast3 Unmanaged.tensor_clip_tt
+tensor_clip_tt = _cast3 Unmanaged.tensor_clip_tt
 
 tensor_clip__ss
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_clip__ss = cast3 Unmanaged.tensor_clip__ss
+tensor_clip__ss = _cast3 Unmanaged.tensor_clip__ss
 
 tensor_clip__tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_clip__tt = cast3 Unmanaged.tensor_clip__tt
+tensor_clip__tt = _cast3 Unmanaged.tensor_clip__tt
 
 tensor_contiguous_M
   :: ForeignPtr Tensor
   -> MemoryFormat
   -> IO (ForeignPtr Tensor)
-tensor_contiguous_M = cast2 Unmanaged.tensor_contiguous_M
+tensor_contiguous_M = _cast2 Unmanaged.tensor_contiguous_M
 
 tensor_copy__tb
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-tensor_copy__tb = cast3 Unmanaged.tensor_copy__tb
+tensor_copy__tb = _cast3 Unmanaged.tensor_copy__tb
 
 tensor_cos
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_cos = cast1 Unmanaged.tensor_cos
+tensor_cos = _cast1 Unmanaged.tensor_cos
 
 tensor_cos_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_cos_ = cast1 Unmanaged.tensor_cos_
+tensor_cos_ = _cast1 Unmanaged.tensor_cos_
 
 tensor_cosh
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_cosh = cast1 Unmanaged.tensor_cosh
+tensor_cosh = _cast1 Unmanaged.tensor_cosh
 
 tensor_cosh_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_cosh_ = cast1 Unmanaged.tensor_cosh_
+tensor_cosh_ = _cast1 Unmanaged.tensor_cosh_
 
 tensor_cov_ltt
   :: ForeignPtr Tensor
@@ -1172,16 +1182,16 @@ tensor_cov_ltt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_cov_ltt = cast4 Unmanaged.tensor_cov_ltt
+tensor_cov_ltt = _cast4 Unmanaged.tensor_cov_ltt
 
 tensor_corrcoef
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_corrcoef = cast1 Unmanaged.tensor_corrcoef
+tensor_corrcoef = _cast1 Unmanaged.tensor_corrcoef
 
 tensor_cummax_l
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-tensor_cummax_l = cast2 Unmanaged.tensor_cummax_l
+tensor_cummax_l = _cast2 Unmanaged.tensor_cummax_l
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Type/Tensor/Tensor1.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Type/Tensor/Tensor1.hs
@@ -28,75 +28,75 @@ tensor_cummax_n
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-tensor_cummax_n = cast2 Unmanaged.tensor_cummax_n
+tensor_cummax_n = _cast2 Unmanaged.tensor_cummax_n
 
 tensor_cummin_l
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-tensor_cummin_l = cast2 Unmanaged.tensor_cummin_l
+tensor_cummin_l = _cast2 Unmanaged.tensor_cummin_l
 
 tensor_cummin_n
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-tensor_cummin_n = cast2 Unmanaged.tensor_cummin_n
+tensor_cummin_n = _cast2 Unmanaged.tensor_cummin_n
 
 tensor_cumprod_ls
   :: ForeignPtr Tensor
   -> Int64
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-tensor_cumprod_ls = cast3 Unmanaged.tensor_cumprod_ls
+tensor_cumprod_ls = _cast3 Unmanaged.tensor_cumprod_ls
 
 tensor_cumprod__ls
   :: ForeignPtr Tensor
   -> Int64
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-tensor_cumprod__ls = cast3 Unmanaged.tensor_cumprod__ls
+tensor_cumprod__ls = _cast3 Unmanaged.tensor_cumprod__ls
 
 tensor_cumprod_ns
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-tensor_cumprod_ns = cast3 Unmanaged.tensor_cumprod_ns
+tensor_cumprod_ns = _cast3 Unmanaged.tensor_cumprod_ns
 
 tensor_cumprod__ns
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-tensor_cumprod__ns = cast3 Unmanaged.tensor_cumprod__ns
+tensor_cumprod__ns = _cast3 Unmanaged.tensor_cumprod__ns
 
 tensor_cumsum_ls
   :: ForeignPtr Tensor
   -> Int64
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-tensor_cumsum_ls = cast3 Unmanaged.tensor_cumsum_ls
+tensor_cumsum_ls = _cast3 Unmanaged.tensor_cumsum_ls
 
 tensor_cumsum__ls
   :: ForeignPtr Tensor
   -> Int64
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-tensor_cumsum__ls = cast3 Unmanaged.tensor_cumsum__ls
+tensor_cumsum__ls = _cast3 Unmanaged.tensor_cumsum__ls
 
 tensor_cumsum_ns
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-tensor_cumsum_ns = cast3 Unmanaged.tensor_cumsum_ns
+tensor_cumsum_ns = _cast3 Unmanaged.tensor_cumsum_ns
 
 tensor_cumsum__ns
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-tensor_cumsum__ns = cast3 Unmanaged.tensor_cumsum__ns
+tensor_cumsum__ns = _cast3 Unmanaged.tensor_cumsum__ns
 
 tensor_diag_embed_lll
   :: ForeignPtr Tensor
@@ -104,13 +104,13 @@ tensor_diag_embed_lll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor_diag_embed_lll = cast4 Unmanaged.tensor_diag_embed_lll
+tensor_diag_embed_lll = _cast4 Unmanaged.tensor_diag_embed_lll
 
 tensor_diagflat_l
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor_diagflat_l = cast2 Unmanaged.tensor_diagflat_l
+tensor_diagflat_l = _cast2 Unmanaged.tensor_diagflat_l
 
 tensor_diagonal_lll
   :: ForeignPtr Tensor
@@ -118,7 +118,7 @@ tensor_diagonal_lll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor_diagonal_lll = cast4 Unmanaged.tensor_diagonal_lll
+tensor_diagonal_lll = _cast4 Unmanaged.tensor_diagonal_lll
 
 tensor_diagonal_nnnl
   :: ForeignPtr Tensor
@@ -127,14 +127,14 @@ tensor_diagonal_nnnl
   -> ForeignPtr Dimname
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor_diagonal_nnnl = cast5 Unmanaged.tensor_diagonal_nnnl
+tensor_diagonal_nnnl = _cast5 Unmanaged.tensor_diagonal_nnnl
 
 tensor_fill_diagonal__sb
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> CBool
   -> IO (ForeignPtr Tensor)
-tensor_fill_diagonal__sb = cast3 Unmanaged.tensor_fill_diagonal__sb
+tensor_fill_diagonal__sb = _cast3 Unmanaged.tensor_fill_diagonal__sb
 
 tensor_diff_lltt
   :: ForeignPtr Tensor
@@ -143,154 +143,154 @@ tensor_diff_lltt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_diff_lltt = cast5 Unmanaged.tensor_diff_lltt
+tensor_diff_lltt = _cast5 Unmanaged.tensor_diff_lltt
 
 tensor_div_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_div_t = cast2 Unmanaged.tensor_div_t
+tensor_div_t = _cast2 Unmanaged.tensor_div_t
 
 tensor_div__t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_div__t = cast2 Unmanaged.tensor_div__t
+tensor_div__t = _cast2 Unmanaged.tensor_div__t
 
 tensor_div_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-tensor_div_ts = cast3 Unmanaged.tensor_div_ts
+tensor_div_ts = _cast3 Unmanaged.tensor_div_ts
 
 tensor_div__ts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-tensor_div__ts = cast3 Unmanaged.tensor_div__ts
+tensor_div__ts = _cast3 Unmanaged.tensor_div__ts
 
 tensor_div_s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_div_s = cast2 Unmanaged.tensor_div_s
+tensor_div_s = _cast2 Unmanaged.tensor_div_s
 
 tensor_div__s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_div__s = cast2 Unmanaged.tensor_div__s
+tensor_div__s = _cast2 Unmanaged.tensor_div__s
 
 tensor_div_ss
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-tensor_div_ss = cast3 Unmanaged.tensor_div_ss
+tensor_div_ss = _cast3 Unmanaged.tensor_div_ss
 
 tensor_div__ss
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-tensor_div__ss = cast3 Unmanaged.tensor_div__ss
+tensor_div__ss = _cast3 Unmanaged.tensor_div__ss
 
 tensor_divide_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_divide_t = cast2 Unmanaged.tensor_divide_t
+tensor_divide_t = _cast2 Unmanaged.tensor_divide_t
 
 tensor_divide__t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_divide__t = cast2 Unmanaged.tensor_divide__t
+tensor_divide__t = _cast2 Unmanaged.tensor_divide__t
 
 tensor_divide_s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_divide_s = cast2 Unmanaged.tensor_divide_s
+tensor_divide_s = _cast2 Unmanaged.tensor_divide_s
 
 tensor_divide__s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_divide__s = cast2 Unmanaged.tensor_divide__s
+tensor_divide__s = _cast2 Unmanaged.tensor_divide__s
 
 tensor_divide_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-tensor_divide_ts = cast3 Unmanaged.tensor_divide_ts
+tensor_divide_ts = _cast3 Unmanaged.tensor_divide_ts
 
 tensor_divide__ts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-tensor_divide__ts = cast3 Unmanaged.tensor_divide__ts
+tensor_divide__ts = _cast3 Unmanaged.tensor_divide__ts
 
 tensor_divide_ss
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-tensor_divide_ss = cast3 Unmanaged.tensor_divide_ss
+tensor_divide_ss = _cast3 Unmanaged.tensor_divide_ss
 
 tensor_divide__ss
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-tensor_divide__ss = cast3 Unmanaged.tensor_divide__ss
+tensor_divide__ss = _cast3 Unmanaged.tensor_divide__ss
 
 tensor_true_divide_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_true_divide_t = cast2 Unmanaged.tensor_true_divide_t
+tensor_true_divide_t = _cast2 Unmanaged.tensor_true_divide_t
 
 tensor_true_divide__t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_true_divide__t = cast2 Unmanaged.tensor_true_divide__t
+tensor_true_divide__t = _cast2 Unmanaged.tensor_true_divide__t
 
 tensor_true_divide_s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_true_divide_s = cast2 Unmanaged.tensor_true_divide_s
+tensor_true_divide_s = _cast2 Unmanaged.tensor_true_divide_s
 
 tensor_true_divide__s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_true_divide__s = cast2 Unmanaged.tensor_true_divide__s
+tensor_true_divide__s = _cast2 Unmanaged.tensor_true_divide__s
 
 tensor_dot_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_dot_t = cast2 Unmanaged.tensor_dot_t
+tensor_dot_t = _cast2 Unmanaged.tensor_dot_t
 
 tensor_vdot_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_vdot_t = cast2 Unmanaged.tensor_vdot_t
+tensor_vdot_t = _cast2 Unmanaged.tensor_vdot_t
 
 tensor_new_empty_lo
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-tensor_new_empty_lo = cast3 Unmanaged.tensor_new_empty_lo
+tensor_new_empty_lo = _cast3 Unmanaged.tensor_new_empty_lo
 
 tensor_new_empty_strided_llo
   :: ForeignPtr Tensor
@@ -298,7 +298,7 @@ tensor_new_empty_strided_llo
   -> ForeignPtr IntArray
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-tensor_new_empty_strided_llo = cast4 Unmanaged.tensor_new_empty_strided_llo
+tensor_new_empty_strided_llo = _cast4 Unmanaged.tensor_new_empty_strided_llo
 
 tensor_new_full_lso
   :: ForeignPtr Tensor
@@ -306,98 +306,98 @@ tensor_new_full_lso
   -> ForeignPtr Scalar
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-tensor_new_full_lso = cast4 Unmanaged.tensor_new_full_lso
+tensor_new_full_lso = _cast4 Unmanaged.tensor_new_full_lso
 
 tensor_new_zeros_lo
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-tensor_new_zeros_lo = cast3 Unmanaged.tensor_new_zeros_lo
+tensor_new_zeros_lo = _cast3 Unmanaged.tensor_new_zeros_lo
 
 tensor_new_ones_lo
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr TensorOptions
   -> IO (ForeignPtr Tensor)
-tensor_new_ones_lo = cast3 Unmanaged.tensor_new_ones_lo
+tensor_new_ones_lo = _cast3 Unmanaged.tensor_new_ones_lo
 
 tensor_resize__lM
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> MemoryFormat
   -> IO (ForeignPtr Tensor)
-tensor_resize__lM = cast3 Unmanaged.tensor_resize__lM
+tensor_resize__lM = _cast3 Unmanaged.tensor_resize__lM
 
 tensor_erf
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_erf = cast1 Unmanaged.tensor_erf
+tensor_erf = _cast1 Unmanaged.tensor_erf
 
 tensor_erf_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_erf_ = cast1 Unmanaged.tensor_erf_
+tensor_erf_ = _cast1 Unmanaged.tensor_erf_
 
 tensor_erfc
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_erfc = cast1 Unmanaged.tensor_erfc
+tensor_erfc = _cast1 Unmanaged.tensor_erfc
 
 tensor_erfc_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_erfc_ = cast1 Unmanaged.tensor_erfc_
+tensor_erfc_ = _cast1 Unmanaged.tensor_erfc_
 
 tensor_exp
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_exp = cast1 Unmanaged.tensor_exp
+tensor_exp = _cast1 Unmanaged.tensor_exp
 
 tensor_exp_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_exp_ = cast1 Unmanaged.tensor_exp_
+tensor_exp_ = _cast1 Unmanaged.tensor_exp_
 
 tensor_exp2
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_exp2 = cast1 Unmanaged.tensor_exp2
+tensor_exp2 = _cast1 Unmanaged.tensor_exp2
 
 tensor_exp2_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_exp2_ = cast1 Unmanaged.tensor_exp2_
+tensor_exp2_ = _cast1 Unmanaged.tensor_exp2_
 
 tensor_expm1
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_expm1 = cast1 Unmanaged.tensor_expm1
+tensor_expm1 = _cast1 Unmanaged.tensor_expm1
 
 tensor_expm1_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_expm1_ = cast1 Unmanaged.tensor_expm1_
+tensor_expm1_ = _cast1 Unmanaged.tensor_expm1_
 
 tensor_expand_lb
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-tensor_expand_lb = cast3 Unmanaged.tensor_expand_lb
+tensor_expand_lb = _cast3 Unmanaged.tensor_expand_lb
 
 tensor_expand_as_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_expand_as_t = cast2 Unmanaged.tensor_expand_as_t
+tensor_expand_as_t = _cast2 Unmanaged.tensor_expand_as_t
 
 tensor_flatten_ll
   :: ForeignPtr Tensor
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor_flatten_ll = cast3 Unmanaged.tensor_flatten_ll
+tensor_flatten_ll = _cast3 Unmanaged.tensor_flatten_ll
 
 tensor_flatten_lln
   :: ForeignPtr Tensor
@@ -405,7 +405,7 @@ tensor_flatten_lln
   -> Int64
   -> ForeignPtr Dimname
   -> IO (ForeignPtr Tensor)
-tensor_flatten_lln = cast4 Unmanaged.tensor_flatten_lln
+tensor_flatten_lln = _cast4 Unmanaged.tensor_flatten_lln
 
 tensor_flatten_nnn
   :: ForeignPtr Tensor
@@ -413,14 +413,14 @@ tensor_flatten_nnn
   -> ForeignPtr Dimname
   -> ForeignPtr Dimname
   -> IO (ForeignPtr Tensor)
-tensor_flatten_nnn = cast4 Unmanaged.tensor_flatten_nnn
+tensor_flatten_nnn = _cast4 Unmanaged.tensor_flatten_nnn
 
 tensor_flatten_Nn
   :: ForeignPtr Tensor
   -> ForeignPtr DimnameList
   -> ForeignPtr Dimname
   -> IO (ForeignPtr Tensor)
-tensor_flatten_Nn = cast3 Unmanaged.tensor_flatten_Nn
+tensor_flatten_Nn = _cast3 Unmanaged.tensor_flatten_Nn
 
 tensor_unflatten_llN
   :: ForeignPtr Tensor
@@ -428,7 +428,7 @@ tensor_unflatten_llN
   -> ForeignPtr IntArray
   -> ForeignPtr DimnameList
   -> IO (ForeignPtr Tensor)
-tensor_unflatten_llN = cast4 Unmanaged.tensor_unflatten_llN
+tensor_unflatten_llN = _cast4 Unmanaged.tensor_unflatten_llN
 
 tensor_unflatten_nlN
   :: ForeignPtr Tensor
@@ -436,93 +436,93 @@ tensor_unflatten_nlN
   -> ForeignPtr IntArray
   -> ForeignPtr DimnameList
   -> IO (ForeignPtr Tensor)
-tensor_unflatten_nlN = cast4 Unmanaged.tensor_unflatten_nlN
+tensor_unflatten_nlN = _cast4 Unmanaged.tensor_unflatten_nlN
 
 tensor_fill__s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_fill__s = cast2 Unmanaged.tensor_fill__s
+tensor_fill__s = _cast2 Unmanaged.tensor_fill__s
 
 tensor_fill__t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_fill__t = cast2 Unmanaged.tensor_fill__t
+tensor_fill__t = _cast2 Unmanaged.tensor_fill__t
 
 tensor_floor
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_floor = cast1 Unmanaged.tensor_floor
+tensor_floor = _cast1 Unmanaged.tensor_floor
 
 tensor_floor_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_floor_ = cast1 Unmanaged.tensor_floor_
+tensor_floor_ = _cast1 Unmanaged.tensor_floor_
 
 tensor_floor_divide_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_floor_divide_t = cast2 Unmanaged.tensor_floor_divide_t
+tensor_floor_divide_t = _cast2 Unmanaged.tensor_floor_divide_t
 
 tensor_floor_divide__t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_floor_divide__t = cast2 Unmanaged.tensor_floor_divide__t
+tensor_floor_divide__t = _cast2 Unmanaged.tensor_floor_divide__t
 
 tensor_floor_divide_s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_floor_divide_s = cast2 Unmanaged.tensor_floor_divide_s
+tensor_floor_divide_s = _cast2 Unmanaged.tensor_floor_divide_s
 
 tensor_floor_divide__s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_floor_divide__s = cast2 Unmanaged.tensor_floor_divide__s
+tensor_floor_divide__s = _cast2 Unmanaged.tensor_floor_divide__s
 
 tensor_frac
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_frac = cast1 Unmanaged.tensor_frac
+tensor_frac = _cast1 Unmanaged.tensor_frac
 
 tensor_frac_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_frac_ = cast1 Unmanaged.tensor_frac_
+tensor_frac_ = _cast1 Unmanaged.tensor_frac_
 
 tensor_gcd_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_gcd_t = cast2 Unmanaged.tensor_gcd_t
+tensor_gcd_t = _cast2 Unmanaged.tensor_gcd_t
 
 tensor_gcd__t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_gcd__t = cast2 Unmanaged.tensor_gcd__t
+tensor_gcd__t = _cast2 Unmanaged.tensor_gcd__t
 
 tensor_lcm_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_lcm_t = cast2 Unmanaged.tensor_lcm_t
+tensor_lcm_t = _cast2 Unmanaged.tensor_lcm_t
 
 tensor_lcm__t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_lcm__t = cast2 Unmanaged.tensor_lcm__t
+tensor_lcm__t = _cast2 Unmanaged.tensor_lcm__t
 
 tensor_index_l
   :: ForeignPtr Tensor
   -> ForeignPtr (C10List (C10Optional Tensor))
   -> IO (ForeignPtr Tensor)
-tensor_index_l = cast2 Unmanaged.tensor_index_l
+tensor_index_l = _cast2 Unmanaged.tensor_index_l
 
 tensor_index_copy__ltt
   :: ForeignPtr Tensor
@@ -530,7 +530,7 @@ tensor_index_copy__ltt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_index_copy__ltt = cast4 Unmanaged.tensor_index_copy__ltt
+tensor_index_copy__ltt = _cast4 Unmanaged.tensor_index_copy__ltt
 
 tensor_index_copy_ltt
   :: ForeignPtr Tensor
@@ -538,7 +538,7 @@ tensor_index_copy_ltt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_index_copy_ltt = cast4 Unmanaged.tensor_index_copy_ltt
+tensor_index_copy_ltt = _cast4 Unmanaged.tensor_index_copy_ltt
 
 tensor_index_copy__ntt
   :: ForeignPtr Tensor
@@ -546,7 +546,7 @@ tensor_index_copy__ntt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_index_copy__ntt = cast4 Unmanaged.tensor_index_copy__ntt
+tensor_index_copy__ntt = _cast4 Unmanaged.tensor_index_copy__ntt
 
 tensor_index_copy_ntt
   :: ForeignPtr Tensor
@@ -554,7 +554,7 @@ tensor_index_copy_ntt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_index_copy_ntt = cast4 Unmanaged.tensor_index_copy_ntt
+tensor_index_copy_ntt = _cast4 Unmanaged.tensor_index_copy_ntt
 
 tensor_index_put__ltb
   :: ForeignPtr Tensor
@@ -562,7 +562,7 @@ tensor_index_put__ltb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-tensor_index_put__ltb = cast4 Unmanaged.tensor_index_put__ltb
+tensor_index_put__ltb = _cast4 Unmanaged.tensor_index_put__ltb
 
 tensor_index_put_ltb
   :: ForeignPtr Tensor
@@ -570,12 +570,12 @@ tensor_index_put_ltb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-tensor_index_put_ltb = cast4 Unmanaged.tensor_index_put_ltb
+tensor_index_put_ltb = _cast4 Unmanaged.tensor_index_put_ltb
 
 tensor_inverse
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_inverse = cast1 Unmanaged.tensor_inverse
+tensor_inverse = _cast1 Unmanaged.tensor_inverse
 
 tensor_isclose_tddb
   :: ForeignPtr Tensor
@@ -584,74 +584,74 @@ tensor_isclose_tddb
   -> CDouble
   -> CBool
   -> IO (ForeignPtr Tensor)
-tensor_isclose_tddb = cast5 Unmanaged.tensor_isclose_tddb
+tensor_isclose_tddb = _cast5 Unmanaged.tensor_isclose_tddb
 
 tensor_isnan
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_isnan = cast1 Unmanaged.tensor_isnan
+tensor_isnan = _cast1 Unmanaged.tensor_isnan
 
 tensor_is_distributed
   :: ForeignPtr Tensor
   -> IO (CBool)
-tensor_is_distributed = cast1 Unmanaged.tensor_is_distributed
+tensor_is_distributed = _cast1 Unmanaged.tensor_is_distributed
 
 tensor_is_floating_point
   :: ForeignPtr Tensor
   -> IO (CBool)
-tensor_is_floating_point = cast1 Unmanaged.tensor_is_floating_point
+tensor_is_floating_point = _cast1 Unmanaged.tensor_is_floating_point
 
 tensor_is_complex
   :: ForeignPtr Tensor
   -> IO (CBool)
-tensor_is_complex = cast1 Unmanaged.tensor_is_complex
+tensor_is_complex = _cast1 Unmanaged.tensor_is_complex
 
 tensor_is_conj
   :: ForeignPtr Tensor
   -> IO (CBool)
-tensor_is_conj = cast1 Unmanaged.tensor_is_conj
+tensor_is_conj = _cast1 Unmanaged.tensor_is_conj
 
 tensor__is_zerotensor
   :: ForeignPtr Tensor
   -> IO (CBool)
-tensor__is_zerotensor = cast1 Unmanaged.tensor__is_zerotensor
+tensor__is_zerotensor = _cast1 Unmanaged.tensor__is_zerotensor
 
 tensor_is_neg
   :: ForeignPtr Tensor
   -> IO (CBool)
-tensor_is_neg = cast1 Unmanaged.tensor_is_neg
+tensor_is_neg = _cast1 Unmanaged.tensor_is_neg
 
 tensor_isreal
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_isreal = cast1 Unmanaged.tensor_isreal
+tensor_isreal = _cast1 Unmanaged.tensor_isreal
 
 tensor_is_nonzero
   :: ForeignPtr Tensor
   -> IO (CBool)
-tensor_is_nonzero = cast1 Unmanaged.tensor_is_nonzero
+tensor_is_nonzero = _cast1 Unmanaged.tensor_is_nonzero
 
 tensor_is_same_size_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (CBool)
-tensor_is_same_size_t = cast2 Unmanaged.tensor_is_same_size_t
+tensor_is_same_size_t = _cast2 Unmanaged.tensor_is_same_size_t
 
 tensor_is_signed
   :: ForeignPtr Tensor
   -> IO (CBool)
-tensor_is_signed = cast1 Unmanaged.tensor_is_signed
+tensor_is_signed = _cast1 Unmanaged.tensor_is_signed
 
 tensor_is_inference
   :: ForeignPtr Tensor
   -> IO (CBool)
-tensor_is_inference = cast1 Unmanaged.tensor_is_inference
+tensor_is_inference = _cast1 Unmanaged.tensor_is_inference
 
 tensor_kron_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_kron_t = cast2 Unmanaged.tensor_kron_t
+tensor_kron_t = _cast2 Unmanaged.tensor_kron_t
 
 tensor_kthvalue_llb
   :: ForeignPtr Tensor
@@ -659,7 +659,7 @@ tensor_kthvalue_llb
   -> Int64
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-tensor_kthvalue_llb = cast4 Unmanaged.tensor_kthvalue_llb
+tensor_kthvalue_llb = _cast4 Unmanaged.tensor_kthvalue_llb
 
 tensor_kthvalue_lnb
   :: ForeignPtr Tensor
@@ -667,7 +667,7 @@ tensor_kthvalue_lnb
   -> ForeignPtr Dimname
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-tensor_kthvalue_lnb = cast4 Unmanaged.tensor_kthvalue_lnb
+tensor_kthvalue_lnb = _cast4 Unmanaged.tensor_kthvalue_lnb
 
 tensor_nan_to_num_ddd
   :: ForeignPtr Tensor
@@ -675,7 +675,7 @@ tensor_nan_to_num_ddd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-tensor_nan_to_num_ddd = cast4 Unmanaged.tensor_nan_to_num_ddd
+tensor_nan_to_num_ddd = _cast4 Unmanaged.tensor_nan_to_num_ddd
 
 tensor_nan_to_num__ddd
   :: ForeignPtr Tensor
@@ -683,191 +683,191 @@ tensor_nan_to_num__ddd
   -> CDouble
   -> CDouble
   -> IO (ForeignPtr Tensor)
-tensor_nan_to_num__ddd = cast4 Unmanaged.tensor_nan_to_num__ddd
+tensor_nan_to_num__ddd = _cast4 Unmanaged.tensor_nan_to_num__ddd
 
 tensor_ldexp_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_ldexp_t = cast2 Unmanaged.tensor_ldexp_t
+tensor_ldexp_t = _cast2 Unmanaged.tensor_ldexp_t
 
 tensor_ldexp__t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_ldexp__t = cast2 Unmanaged.tensor_ldexp__t
+tensor_ldexp__t = _cast2 Unmanaged.tensor_ldexp__t
 
 tensor_log
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_log = cast1 Unmanaged.tensor_log
+tensor_log = _cast1 Unmanaged.tensor_log
 
 tensor_log_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_log_ = cast1 Unmanaged.tensor_log_
+tensor_log_ = _cast1 Unmanaged.tensor_log_
 
 tensor_log10
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_log10 = cast1 Unmanaged.tensor_log10
+tensor_log10 = _cast1 Unmanaged.tensor_log10
 
 tensor_log10_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_log10_ = cast1 Unmanaged.tensor_log10_
+tensor_log10_ = _cast1 Unmanaged.tensor_log10_
 
 tensor_log1p
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_log1p = cast1 Unmanaged.tensor_log1p
+tensor_log1p = _cast1 Unmanaged.tensor_log1p
 
 tensor_log1p_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_log1p_ = cast1 Unmanaged.tensor_log1p_
+tensor_log1p_ = _cast1 Unmanaged.tensor_log1p_
 
 tensor_log2
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_log2 = cast1 Unmanaged.tensor_log2
+tensor_log2 = _cast1 Unmanaged.tensor_log2
 
 tensor_log2_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_log2_ = cast1 Unmanaged.tensor_log2_
+tensor_log2_ = _cast1 Unmanaged.tensor_log2_
 
 tensor_logaddexp_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_logaddexp_t = cast2 Unmanaged.tensor_logaddexp_t
+tensor_logaddexp_t = _cast2 Unmanaged.tensor_logaddexp_t
 
 tensor_logaddexp2_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_logaddexp2_t = cast2 Unmanaged.tensor_logaddexp2_t
+tensor_logaddexp2_t = _cast2 Unmanaged.tensor_logaddexp2_t
 
 tensor_xlogy_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_xlogy_t = cast2 Unmanaged.tensor_xlogy_t
+tensor_xlogy_t = _cast2 Unmanaged.tensor_xlogy_t
 
 tensor_xlogy_s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_xlogy_s = cast2 Unmanaged.tensor_xlogy_s
+tensor_xlogy_s = _cast2 Unmanaged.tensor_xlogy_s
 
 tensor_xlogy__t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_xlogy__t = cast2 Unmanaged.tensor_xlogy__t
+tensor_xlogy__t = _cast2 Unmanaged.tensor_xlogy__t
 
 tensor_xlogy__s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_xlogy__s = cast2 Unmanaged.tensor_xlogy__s
+tensor_xlogy__s = _cast2 Unmanaged.tensor_xlogy__s
 
 tensor_logdet
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_logdet = cast1 Unmanaged.tensor_logdet
+tensor_logdet = _cast1 Unmanaged.tensor_logdet
 
 tensor_log_softmax_ls
   :: ForeignPtr Tensor
   -> Int64
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-tensor_log_softmax_ls = cast3 Unmanaged.tensor_log_softmax_ls
+tensor_log_softmax_ls = _cast3 Unmanaged.tensor_log_softmax_ls
 
 tensor_log_softmax_ns
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-tensor_log_softmax_ns = cast3 Unmanaged.tensor_log_softmax_ns
+tensor_log_softmax_ns = _cast3 Unmanaged.tensor_log_softmax_ns
 
 tensor_logcumsumexp_l
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor_logcumsumexp_l = cast2 Unmanaged.tensor_logcumsumexp_l
+tensor_logcumsumexp_l = _cast2 Unmanaged.tensor_logcumsumexp_l
 
 tensor_logcumsumexp_n
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> IO (ForeignPtr Tensor)
-tensor_logcumsumexp_n = cast2 Unmanaged.tensor_logcumsumexp_n
+tensor_logcumsumexp_n = _cast2 Unmanaged.tensor_logcumsumexp_n
 
 tensor_logsumexp_lb
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-tensor_logsumexp_lb = cast3 Unmanaged.tensor_logsumexp_lb
+tensor_logsumexp_lb = _cast3 Unmanaged.tensor_logsumexp_lb
 
 tensor_logsumexp_Nb
   :: ForeignPtr Tensor
   -> ForeignPtr DimnameList
   -> CBool
   -> IO (ForeignPtr Tensor)
-tensor_logsumexp_Nb = cast3 Unmanaged.tensor_logsumexp_Nb
+tensor_logsumexp_Nb = _cast3 Unmanaged.tensor_logsumexp_Nb
 
 tensor_matmul_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_matmul_t = cast2 Unmanaged.tensor_matmul_t
+tensor_matmul_t = _cast2 Unmanaged.tensor_matmul_t
 
 tensor_matrix_power_l
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor_matrix_power_l = cast2 Unmanaged.tensor_matrix_power_l
+tensor_matrix_power_l = _cast2 Unmanaged.tensor_matrix_power_l
 
 tensor_matrix_exp
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_matrix_exp = cast1 Unmanaged.tensor_matrix_exp
+tensor_matrix_exp = _cast1 Unmanaged.tensor_matrix_exp
 
 tensor_aminmax_lb
   :: ForeignPtr Tensor
   -> Int64
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-tensor_aminmax_lb = cast3 Unmanaged.tensor_aminmax_lb
+tensor_aminmax_lb = _cast3 Unmanaged.tensor_aminmax_lb
 
 tensor_max_lb
   :: ForeignPtr Tensor
   -> Int64
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-tensor_max_lb = cast3 Unmanaged.tensor_max_lb
+tensor_max_lb = _cast3 Unmanaged.tensor_max_lb
 
 tensor_max_nb
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-tensor_max_nb = cast3 Unmanaged.tensor_max_nb
+tensor_max_nb = _cast3 Unmanaged.tensor_max_nb
 
 tensor_amax_lb
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-tensor_amax_lb = cast3 Unmanaged.tensor_amax_lb
+tensor_amax_lb = _cast3 Unmanaged.tensor_amax_lb
 
 tensor_mean_s
   :: ForeignPtr Tensor
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-tensor_mean_s = cast2 Unmanaged.tensor_mean_s
+tensor_mean_s = _cast2 Unmanaged.tensor_mean_s
 
 tensor_mean_lbs
   :: ForeignPtr Tensor
@@ -875,7 +875,7 @@ tensor_mean_lbs
   -> CBool
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-tensor_mean_lbs = cast4 Unmanaged.tensor_mean_lbs
+tensor_mean_lbs = _cast4 Unmanaged.tensor_mean_lbs
 
 tensor_mean_Nbs
   :: ForeignPtr Tensor
@@ -883,7 +883,7 @@ tensor_mean_Nbs
   -> CBool
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-tensor_mean_Nbs = cast4 Unmanaged.tensor_mean_Nbs
+tensor_mean_Nbs = _cast4 Unmanaged.tensor_mean_Nbs
 
 tensor_nanmean_lbs
   :: ForeignPtr Tensor
@@ -891,152 +891,152 @@ tensor_nanmean_lbs
   -> CBool
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-tensor_nanmean_lbs = cast4 Unmanaged.tensor_nanmean_lbs
+tensor_nanmean_lbs = _cast4 Unmanaged.tensor_nanmean_lbs
 
 tensor_median
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_median = cast1 Unmanaged.tensor_median
+tensor_median = _cast1 Unmanaged.tensor_median
 
 tensor_median_lb
   :: ForeignPtr Tensor
   -> Int64
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-tensor_median_lb = cast3 Unmanaged.tensor_median_lb
+tensor_median_lb = _cast3 Unmanaged.tensor_median_lb
 
 tensor_median_nb
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-tensor_median_nb = cast3 Unmanaged.tensor_median_nb
+tensor_median_nb = _cast3 Unmanaged.tensor_median_nb
 
 tensor_nanmedian
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_nanmedian = cast1 Unmanaged.tensor_nanmedian
+tensor_nanmedian = _cast1 Unmanaged.tensor_nanmedian
 
 tensor_nanmedian_lb
   :: ForeignPtr Tensor
   -> Int64
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-tensor_nanmedian_lb = cast3 Unmanaged.tensor_nanmedian_lb
+tensor_nanmedian_lb = _cast3 Unmanaged.tensor_nanmedian_lb
 
 tensor_nanmedian_nb
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-tensor_nanmedian_nb = cast3 Unmanaged.tensor_nanmedian_nb
+tensor_nanmedian_nb = _cast3 Unmanaged.tensor_nanmedian_nb
 
 tensor_min_lb
   :: ForeignPtr Tensor
   -> Int64
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-tensor_min_lb = cast3 Unmanaged.tensor_min_lb
+tensor_min_lb = _cast3 Unmanaged.tensor_min_lb
 
 tensor_min_nb
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-tensor_min_nb = cast3 Unmanaged.tensor_min_nb
+tensor_min_nb = _cast3 Unmanaged.tensor_min_nb
 
 tensor_amin_lb
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-tensor_amin_lb = cast3 Unmanaged.tensor_amin_lb
+tensor_amin_lb = _cast3 Unmanaged.tensor_amin_lb
 
 tensor_mm_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_mm_t = cast2 Unmanaged.tensor_mm_t
+tensor_mm_t = _cast2 Unmanaged.tensor_mm_t
 
 tensor_mode_lb
   :: ForeignPtr Tensor
   -> Int64
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-tensor_mode_lb = cast3 Unmanaged.tensor_mode_lb
+tensor_mode_lb = _cast3 Unmanaged.tensor_mode_lb
 
 tensor_mode_nb
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-tensor_mode_nb = cast3 Unmanaged.tensor_mode_nb
+tensor_mode_nb = _cast3 Unmanaged.tensor_mode_nb
 
 tensor_mul_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_mul_t = cast2 Unmanaged.tensor_mul_t
+tensor_mul_t = _cast2 Unmanaged.tensor_mul_t
 
 tensor_mul__t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_mul__t = cast2 Unmanaged.tensor_mul__t
+tensor_mul__t = _cast2 Unmanaged.tensor_mul__t
 
 tensor_mul_s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_mul_s = cast2 Unmanaged.tensor_mul_s
+tensor_mul_s = _cast2 Unmanaged.tensor_mul_s
 
 tensor_mul__s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_mul__s = cast2 Unmanaged.tensor_mul__s
+tensor_mul__s = _cast2 Unmanaged.tensor_mul__s
 
 tensor_multiply_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_multiply_t = cast2 Unmanaged.tensor_multiply_t
+tensor_multiply_t = _cast2 Unmanaged.tensor_multiply_t
 
 tensor_multiply__t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_multiply__t = cast2 Unmanaged.tensor_multiply__t
+tensor_multiply__t = _cast2 Unmanaged.tensor_multiply__t
 
 tensor_multiply_s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_multiply_s = cast2 Unmanaged.tensor_multiply_s
+tensor_multiply_s = _cast2 Unmanaged.tensor_multiply_s
 
 tensor_multiply__s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_multiply__s = cast2 Unmanaged.tensor_multiply__s
+tensor_multiply__s = _cast2 Unmanaged.tensor_multiply__s
 
 tensor_mv_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_mv_t = cast2 Unmanaged.tensor_mv_t
+tensor_mv_t = _cast2 Unmanaged.tensor_mv_t
 
 tensor_mvlgamma_l
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor_mvlgamma_l = cast2 Unmanaged.tensor_mvlgamma_l
+tensor_mvlgamma_l = _cast2 Unmanaged.tensor_mvlgamma_l
 
 tensor_mvlgamma__l
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor_mvlgamma__l = cast2 Unmanaged.tensor_mvlgamma__l
+tensor_mvlgamma__l = _cast2 Unmanaged.tensor_mvlgamma__l
 
 tensor_narrow_copy_lll
   :: ForeignPtr Tensor
@@ -1044,7 +1044,7 @@ tensor_narrow_copy_lll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor_narrow_copy_lll = cast4 Unmanaged.tensor_narrow_copy_lll
+tensor_narrow_copy_lll = _cast4 Unmanaged.tensor_narrow_copy_lll
 
 tensor_narrow_lll
   :: ForeignPtr Tensor
@@ -1052,7 +1052,7 @@ tensor_narrow_lll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor_narrow_lll = cast4 Unmanaged.tensor_narrow_lll
+tensor_narrow_lll = _cast4 Unmanaged.tensor_narrow_lll
 
 tensor_narrow_ltl
   :: ForeignPtr Tensor
@@ -1060,117 +1060,117 @@ tensor_narrow_ltl
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor_narrow_ltl = cast4 Unmanaged.tensor_narrow_ltl
+tensor_narrow_ltl = _cast4 Unmanaged.tensor_narrow_ltl
 
 tensor_permute_l
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-tensor_permute_l = cast2 Unmanaged.tensor_permute_l
+tensor_permute_l = _cast2 Unmanaged.tensor_permute_l
 
 tensor_numpy_T
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_numpy_T = cast1 Unmanaged.tensor_numpy_T
+tensor_numpy_T = _cast1 Unmanaged.tensor_numpy_T
 
 tensor_matrix_H
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_matrix_H = cast1 Unmanaged.tensor_matrix_H
+tensor_matrix_H = _cast1 Unmanaged.tensor_matrix_H
 
 tensor_mT
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_mT = cast1 Unmanaged.tensor_mT
+tensor_mT = _cast1 Unmanaged.tensor_mT
 
 tensor_mH
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_mH = cast1 Unmanaged.tensor_mH
+tensor_mH = _cast1 Unmanaged.tensor_mH
 
 tensor_adjoint
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_adjoint = cast1 Unmanaged.tensor_adjoint
+tensor_adjoint = _cast1 Unmanaged.tensor_adjoint
 
 tensor_is_pinned_D
   :: ForeignPtr Tensor
   -> DeviceType
   -> IO (CBool)
-tensor_is_pinned_D = cast2 Unmanaged.tensor_is_pinned_D
+tensor_is_pinned_D = _cast2 Unmanaged.tensor_is_pinned_D
 
 tensor_pin_memory_D
   :: ForeignPtr Tensor
   -> DeviceType
   -> IO (ForeignPtr Tensor)
-tensor_pin_memory_D = cast2 Unmanaged.tensor_pin_memory_D
+tensor_pin_memory_D = _cast2 Unmanaged.tensor_pin_memory_D
 
 tensor_pinverse_d
   :: ForeignPtr Tensor
   -> CDouble
   -> IO (ForeignPtr Tensor)
-tensor_pinverse_d = cast2 Unmanaged.tensor_pinverse_d
+tensor_pinverse_d = _cast2 Unmanaged.tensor_pinverse_d
 
 tensor_rad2deg
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_rad2deg = cast1 Unmanaged.tensor_rad2deg
+tensor_rad2deg = _cast1 Unmanaged.tensor_rad2deg
 
 tensor_rad2deg_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_rad2deg_ = cast1 Unmanaged.tensor_rad2deg_
+tensor_rad2deg_ = _cast1 Unmanaged.tensor_rad2deg_
 
 tensor_deg2rad
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_deg2rad = cast1 Unmanaged.tensor_deg2rad
+tensor_deg2rad = _cast1 Unmanaged.tensor_deg2rad
 
 tensor_deg2rad_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_deg2rad_ = cast1 Unmanaged.tensor_deg2rad_
+tensor_deg2rad_ = _cast1 Unmanaged.tensor_deg2rad_
 
 tensor_ravel
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_ravel = cast1 Unmanaged.tensor_ravel
+tensor_ravel = _cast1 Unmanaged.tensor_ravel
 
 tensor_reciprocal
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_reciprocal = cast1 Unmanaged.tensor_reciprocal
+tensor_reciprocal = _cast1 Unmanaged.tensor_reciprocal
 
 tensor_reciprocal_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_reciprocal_ = cast1 Unmanaged.tensor_reciprocal_
+tensor_reciprocal_ = _cast1 Unmanaged.tensor_reciprocal_
 
 tensor_neg
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_neg = cast1 Unmanaged.tensor_neg
+tensor_neg = _cast1 Unmanaged.tensor_neg
 
 tensor_neg_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_neg_ = cast1 Unmanaged.tensor_neg_
+tensor_neg_ = _cast1 Unmanaged.tensor_neg_
 
 tensor_negative
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_negative = cast1 Unmanaged.tensor_negative
+tensor_negative = _cast1 Unmanaged.tensor_negative
 
 tensor_negative_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_negative_ = cast1 Unmanaged.tensor_negative_
+tensor_negative_ = _cast1 Unmanaged.tensor_negative_
 
 tensor_repeat_l
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-tensor_repeat_l = cast2 Unmanaged.tensor_repeat_l
+tensor_repeat_l = _cast2 Unmanaged.tensor_repeat_l
 
 tensor_repeat_interleave_tll
   :: ForeignPtr Tensor
@@ -1178,7 +1178,7 @@ tensor_repeat_interleave_tll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor_repeat_interleave_tll = cast4 Unmanaged.tensor_repeat_interleave_tll
+tensor_repeat_interleave_tll = _cast4 Unmanaged.tensor_repeat_interleave_tll
 
 tensor_repeat_interleave_lll
   :: ForeignPtr Tensor
@@ -1186,99 +1186,99 @@ tensor_repeat_interleave_lll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor_repeat_interleave_lll = cast4 Unmanaged.tensor_repeat_interleave_lll
+tensor_repeat_interleave_lll = _cast4 Unmanaged.tensor_repeat_interleave_lll
 
 tensor_reshape_l
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-tensor_reshape_l = cast2 Unmanaged.tensor_reshape_l
+tensor_reshape_l = _cast2 Unmanaged.tensor_reshape_l
 
 tensor__reshape_alias_ll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-tensor__reshape_alias_ll = cast3 Unmanaged.tensor__reshape_alias_ll
+tensor__reshape_alias_ll = _cast3 Unmanaged.tensor__reshape_alias_ll
 
 tensor_reshape_as_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_reshape_as_t = cast2 Unmanaged.tensor_reshape_as_t
+tensor_reshape_as_t = _cast2 Unmanaged.tensor_reshape_as_t
 
 tensor_round
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_round = cast1 Unmanaged.tensor_round
+tensor_round = _cast1 Unmanaged.tensor_round
 
 tensor_round_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_round_ = cast1 Unmanaged.tensor_round_
+tensor_round_ = _cast1 Unmanaged.tensor_round_
 
 tensor_round_l
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor_round_l = cast2 Unmanaged.tensor_round_l
+tensor_round_l = _cast2 Unmanaged.tensor_round_l
 
 tensor_round__l
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor_round__l = cast2 Unmanaged.tensor_round__l
+tensor_round__l = _cast2 Unmanaged.tensor_round__l
 
 tensor_relu
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_relu = cast1 Unmanaged.tensor_relu
+tensor_relu = _cast1 Unmanaged.tensor_relu
 
 tensor_relu_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_relu_ = cast1 Unmanaged.tensor_relu_
+tensor_relu_ = _cast1 Unmanaged.tensor_relu_
 
 tensor_prelu_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_prelu_t = cast2 Unmanaged.tensor_prelu_t
+tensor_prelu_t = _cast2 Unmanaged.tensor_prelu_t
 
 tensor_prelu_backward_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-tensor_prelu_backward_tt = cast3 Unmanaged.tensor_prelu_backward_tt
+tensor_prelu_backward_tt = _cast3 Unmanaged.tensor_prelu_backward_tt
 
 tensor_hardshrink_s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_hardshrink_s = cast2 Unmanaged.tensor_hardshrink_s
+tensor_hardshrink_s = _cast2 Unmanaged.tensor_hardshrink_s
 
 tensor_hardshrink_backward_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_hardshrink_backward_ts = cast3 Unmanaged.tensor_hardshrink_backward_ts
+tensor_hardshrink_backward_ts = _cast3 Unmanaged.tensor_hardshrink_backward_ts
 
 tensor_rsqrt
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_rsqrt = cast1 Unmanaged.tensor_rsqrt
+tensor_rsqrt = _cast1 Unmanaged.tensor_rsqrt
 
 tensor_rsqrt_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_rsqrt_ = cast1 Unmanaged.tensor_rsqrt_
+tensor_rsqrt_ = _cast1 Unmanaged.tensor_rsqrt_
 
 tensor_select_nl
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor_select_nl = cast3 Unmanaged.tensor_select_nl
+tensor_select_nl = _cast3 Unmanaged.tensor_select_nl
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Type/Tensor/Tensor2.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Type/Tensor/Tensor2.hs
@@ -29,75 +29,75 @@ tensor_select_ll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor_select_ll = cast3 Unmanaged.tensor_select_ll
+tensor_select_ll = _cast3 Unmanaged.tensor_select_ll
 
 tensor_sigmoid
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_sigmoid = cast1 Unmanaged.tensor_sigmoid
+tensor_sigmoid = _cast1 Unmanaged.tensor_sigmoid
 
 tensor_sigmoid_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_sigmoid_ = cast1 Unmanaged.tensor_sigmoid_
+tensor_sigmoid_ = _cast1 Unmanaged.tensor_sigmoid_
 
 tensor_logit_d
   :: ForeignPtr Tensor
   -> CDouble
   -> IO (ForeignPtr Tensor)
-tensor_logit_d = cast2 Unmanaged.tensor_logit_d
+tensor_logit_d = _cast2 Unmanaged.tensor_logit_d
 
 tensor_logit__d
   :: ForeignPtr Tensor
   -> CDouble
   -> IO (ForeignPtr Tensor)
-tensor_logit__d = cast2 Unmanaged.tensor_logit__d
+tensor_logit__d = _cast2 Unmanaged.tensor_logit__d
 
 tensor_sin
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_sin = cast1 Unmanaged.tensor_sin
+tensor_sin = _cast1 Unmanaged.tensor_sin
 
 tensor_sin_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_sin_ = cast1 Unmanaged.tensor_sin_
+tensor_sin_ = _cast1 Unmanaged.tensor_sin_
 
 tensor_sinc
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_sinc = cast1 Unmanaged.tensor_sinc
+tensor_sinc = _cast1 Unmanaged.tensor_sinc
 
 tensor_sinc_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_sinc_ = cast1 Unmanaged.tensor_sinc_
+tensor_sinc_ = _cast1 Unmanaged.tensor_sinc_
 
 tensor_sinh
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_sinh = cast1 Unmanaged.tensor_sinh
+tensor_sinh = _cast1 Unmanaged.tensor_sinh
 
 tensor_sinh_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_sinh_ = cast1 Unmanaged.tensor_sinh_
+tensor_sinh_ = _cast1 Unmanaged.tensor_sinh_
 
 tensor_detach
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_detach = cast1 Unmanaged.tensor_detach
+tensor_detach = _cast1 Unmanaged.tensor_detach
 
 tensor_detach_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_detach_ = cast1 Unmanaged.tensor_detach_
+tensor_detach_ = _cast1 Unmanaged.tensor_detach_
 
 tensor_size_n
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> IO (Int64)
-tensor_size_n = cast2 Unmanaged.tensor_size_n
+tensor_size_n = _cast2 Unmanaged.tensor_size_n
 
 tensor_slice_llll
   :: ForeignPtr Tensor
@@ -106,7 +106,7 @@ tensor_slice_llll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor_slice_llll = cast5 Unmanaged.tensor_slice_llll
+tensor_slice_llll = _cast5 Unmanaged.tensor_slice_llll
 
 tensor_slice_scatter_tllll
   :: ForeignPtr Tensor
@@ -116,7 +116,7 @@ tensor_slice_scatter_tllll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor_slice_scatter_tllll = cast6 Unmanaged.tensor_slice_scatter_tllll
+tensor_slice_scatter_tllll = _cast6 Unmanaged.tensor_slice_scatter_tllll
 
 tensor_select_scatter_tll
   :: ForeignPtr Tensor
@@ -124,7 +124,7 @@ tensor_select_scatter_tll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor_select_scatter_tll = cast4 Unmanaged.tensor_select_scatter_tll
+tensor_select_scatter_tll = _cast4 Unmanaged.tensor_select_scatter_tll
 
 tensor_diagonal_scatter_tlll
   :: ForeignPtr Tensor
@@ -133,94 +133,94 @@ tensor_diagonal_scatter_tlll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor_diagonal_scatter_tlll = cast5 Unmanaged.tensor_diagonal_scatter_tlll
+tensor_diagonal_scatter_tlll = _cast5 Unmanaged.tensor_diagonal_scatter_tlll
 
 tensor_slogdet
   :: ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-tensor_slogdet = cast1 Unmanaged.tensor_slogdet
+tensor_slogdet = _cast1 Unmanaged.tensor_slogdet
 
 tensor_smm_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_smm_t = cast2 Unmanaged.tensor_smm_t
+tensor_smm_t = _cast2 Unmanaged.tensor_smm_t
 
 tensor_softmax_ls
   :: ForeignPtr Tensor
   -> Int64
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-tensor_softmax_ls = cast3 Unmanaged.tensor_softmax_ls
+tensor_softmax_ls = _cast3 Unmanaged.tensor_softmax_ls
 
 tensor_softmax_ns
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-tensor_softmax_ns = cast3 Unmanaged.tensor_softmax_ns
+tensor_softmax_ns = _cast3 Unmanaged.tensor_softmax_ns
 
 tensor_unsafe_split_ll
   :: ForeignPtr Tensor
   -> Int64
   -> Int64
   -> IO (ForeignPtr TensorList)
-tensor_unsafe_split_ll = cast3 Unmanaged.tensor_unsafe_split_ll
+tensor_unsafe_split_ll = _cast3 Unmanaged.tensor_unsafe_split_ll
 
 tensor_split_ll
   :: ForeignPtr Tensor
   -> Int64
   -> Int64
   -> IO (ForeignPtr TensorList)
-tensor_split_ll = cast3 Unmanaged.tensor_split_ll
+tensor_split_ll = _cast3 Unmanaged.tensor_split_ll
 
 tensor_unsafe_split_with_sizes_ll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> Int64
   -> IO (ForeignPtr TensorList)
-tensor_unsafe_split_with_sizes_ll = cast3 Unmanaged.tensor_unsafe_split_with_sizes_ll
+tensor_unsafe_split_with_sizes_ll = _cast3 Unmanaged.tensor_unsafe_split_with_sizes_ll
 
 tensor_split_with_sizes_ll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> Int64
   -> IO (ForeignPtr TensorList)
-tensor_split_with_sizes_ll = cast3 Unmanaged.tensor_split_with_sizes_ll
+tensor_split_with_sizes_ll = _cast3 Unmanaged.tensor_split_with_sizes_ll
 
 tensor_squeeze
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_squeeze = cast1 Unmanaged.tensor_squeeze
+tensor_squeeze = _cast1 Unmanaged.tensor_squeeze
 
 tensor_squeeze_l
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor_squeeze_l = cast2 Unmanaged.tensor_squeeze_l
+tensor_squeeze_l = _cast2 Unmanaged.tensor_squeeze_l
 
 tensor_squeeze_n
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> IO (ForeignPtr Tensor)
-tensor_squeeze_n = cast2 Unmanaged.tensor_squeeze_n
+tensor_squeeze_n = _cast2 Unmanaged.tensor_squeeze_n
 
 tensor_squeeze_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_squeeze_ = cast1 Unmanaged.tensor_squeeze_
+tensor_squeeze_ = _cast1 Unmanaged.tensor_squeeze_
 
 tensor_squeeze__l
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor_squeeze__l = cast2 Unmanaged.tensor_squeeze__l
+tensor_squeeze__l = _cast2 Unmanaged.tensor_squeeze__l
 
 tensor_squeeze__n
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> IO (ForeignPtr Tensor)
-tensor_squeeze__n = cast2 Unmanaged.tensor_squeeze__n
+tensor_squeeze__n = _cast2 Unmanaged.tensor_squeeze__n
 
 tensor_sspaddmm_ttss
   :: ForeignPtr Tensor
@@ -229,7 +229,7 @@ tensor_sspaddmm_ttss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_sspaddmm_ttss = cast5 Unmanaged.tensor_sspaddmm_ttss
+tensor_sspaddmm_ttss = _cast5 Unmanaged.tensor_sspaddmm_ttss
 
 tensor_stft_llltbbb
   :: ForeignPtr Tensor
@@ -241,7 +241,7 @@ tensor_stft_llltbbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-tensor_stft_llltbbb = cast8 Unmanaged.tensor_stft_llltbbb
+tensor_stft_llltbbb = _cast8 Unmanaged.tensor_stft_llltbbb
 
 tensor_istft_llltbbblb
   :: ForeignPtr Tensor
@@ -255,19 +255,19 @@ tensor_istft_llltbbblb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-tensor_istft_llltbbblb = cast10 Unmanaged.tensor_istft_llltbbblb
+tensor_istft_llltbbblb = _cast10 Unmanaged.tensor_istft_llltbbblb
 
 tensor_stride_n
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> IO (Int64)
-tensor_stride_n = cast2 Unmanaged.tensor_stride_n
+tensor_stride_n = _cast2 Unmanaged.tensor_stride_n
 
 tensor_sum_s
   :: ForeignPtr Tensor
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-tensor_sum_s = cast2 Unmanaged.tensor_sum_s
+tensor_sum_s = _cast2 Unmanaged.tensor_sum_s
 
 tensor_sum_lbs
   :: ForeignPtr Tensor
@@ -275,7 +275,7 @@ tensor_sum_lbs
   -> CBool
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-tensor_sum_lbs = cast4 Unmanaged.tensor_sum_lbs
+tensor_sum_lbs = _cast4 Unmanaged.tensor_sum_lbs
 
 tensor_sum_Nbs
   :: ForeignPtr Tensor
@@ -283,13 +283,13 @@ tensor_sum_Nbs
   -> CBool
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-tensor_sum_Nbs = cast4 Unmanaged.tensor_sum_Nbs
+tensor_sum_Nbs = _cast4 Unmanaged.tensor_sum_Nbs
 
 tensor_nansum_s
   :: ForeignPtr Tensor
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-tensor_nansum_s = cast2 Unmanaged.tensor_nansum_s
+tensor_nansum_s = _cast2 Unmanaged.tensor_nansum_s
 
 tensor_nansum_lbs
   :: ForeignPtr Tensor
@@ -297,39 +297,39 @@ tensor_nansum_lbs
   -> CBool
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-tensor_nansum_lbs = cast4 Unmanaged.tensor_nansum_lbs
+tensor_nansum_lbs = _cast4 Unmanaged.tensor_nansum_lbs
 
 tensor_sum_to_size_l
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-tensor_sum_to_size_l = cast2 Unmanaged.tensor_sum_to_size_l
+tensor_sum_to_size_l = _cast2 Unmanaged.tensor_sum_to_size_l
 
 tensor_sqrt
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_sqrt = cast1 Unmanaged.tensor_sqrt
+tensor_sqrt = _cast1 Unmanaged.tensor_sqrt
 
 tensor_sqrt_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_sqrt_ = cast1 Unmanaged.tensor_sqrt_
+tensor_sqrt_ = _cast1 Unmanaged.tensor_sqrt_
 
 tensor_square
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_square = cast1 Unmanaged.tensor_square
+tensor_square = _cast1 Unmanaged.tensor_square
 
 tensor_square_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_square_ = cast1 Unmanaged.tensor_square_
+tensor_square_ = _cast1 Unmanaged.tensor_square_
 
 tensor_std_b
   :: ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-tensor_std_b = cast2 Unmanaged.tensor_std_b
+tensor_std_b = _cast2 Unmanaged.tensor_std_b
 
 tensor_std_lbb
   :: ForeignPtr Tensor
@@ -337,7 +337,7 @@ tensor_std_lbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-tensor_std_lbb = cast4 Unmanaged.tensor_std_lbb
+tensor_std_lbb = _cast4 Unmanaged.tensor_std_lbb
 
 tensor_std_llb
   :: ForeignPtr Tensor
@@ -345,7 +345,7 @@ tensor_std_llb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-tensor_std_llb = cast4 Unmanaged.tensor_std_llb
+tensor_std_llb = _cast4 Unmanaged.tensor_std_llb
 
 tensor_std_Nbb
   :: ForeignPtr Tensor
@@ -353,7 +353,7 @@ tensor_std_Nbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-tensor_std_Nbb = cast4 Unmanaged.tensor_std_Nbb
+tensor_std_Nbb = _cast4 Unmanaged.tensor_std_Nbb
 
 tensor_std_Nlb
   :: ForeignPtr Tensor
@@ -361,13 +361,13 @@ tensor_std_Nlb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-tensor_std_Nlb = cast4 Unmanaged.tensor_std_Nlb
+tensor_std_Nlb = _cast4 Unmanaged.tensor_std_Nlb
 
 tensor_prod_s
   :: ForeignPtr Tensor
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-tensor_prod_s = cast2 Unmanaged.tensor_prod_s
+tensor_prod_s = _cast2 Unmanaged.tensor_prod_s
 
 tensor_prod_lbs
   :: ForeignPtr Tensor
@@ -375,7 +375,7 @@ tensor_prod_lbs
   -> CBool
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-tensor_prod_lbs = cast4 Unmanaged.tensor_prod_lbs
+tensor_prod_lbs = _cast4 Unmanaged.tensor_prod_lbs
 
 tensor_prod_nbs
   :: ForeignPtr Tensor
@@ -383,138 +383,138 @@ tensor_prod_nbs
   -> CBool
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-tensor_prod_nbs = cast4 Unmanaged.tensor_prod_nbs
+tensor_prod_nbs = _cast4 Unmanaged.tensor_prod_nbs
 
 tensor_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_t = cast1 Unmanaged.tensor_t
+tensor_t = _cast1 Unmanaged.tensor_t
 
 tensor_t_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_t_ = cast1 Unmanaged.tensor_t_
+tensor_t_ = _cast1 Unmanaged.tensor_t_
 
 tensor_tan
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_tan = cast1 Unmanaged.tensor_tan
+tensor_tan = _cast1 Unmanaged.tensor_tan
 
 tensor_tan_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_tan_ = cast1 Unmanaged.tensor_tan_
+tensor_tan_ = _cast1 Unmanaged.tensor_tan_
 
 tensor_tanh
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_tanh = cast1 Unmanaged.tensor_tanh
+tensor_tanh = _cast1 Unmanaged.tensor_tanh
 
 tensor_tanh_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_tanh_ = cast1 Unmanaged.tensor_tanh_
+tensor_tanh_ = _cast1 Unmanaged.tensor_tanh_
 
 tensor_tile_l
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-tensor_tile_l = cast2 Unmanaged.tensor_tile_l
+tensor_tile_l = _cast2 Unmanaged.tensor_tile_l
 
 tensor_transpose_ll
   :: ForeignPtr Tensor
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor_transpose_ll = cast3 Unmanaged.tensor_transpose_ll
+tensor_transpose_ll = _cast3 Unmanaged.tensor_transpose_ll
 
 tensor_transpose_nn
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> ForeignPtr Dimname
   -> IO (ForeignPtr Tensor)
-tensor_transpose_nn = cast3 Unmanaged.tensor_transpose_nn
+tensor_transpose_nn = _cast3 Unmanaged.tensor_transpose_nn
 
 tensor_transpose__ll
   :: ForeignPtr Tensor
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor_transpose__ll = cast3 Unmanaged.tensor_transpose__ll
+tensor_transpose__ll = _cast3 Unmanaged.tensor_transpose__ll
 
 tensor_flip_l
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-tensor_flip_l = cast2 Unmanaged.tensor_flip_l
+tensor_flip_l = _cast2 Unmanaged.tensor_flip_l
 
 tensor_fliplr
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_fliplr = cast1 Unmanaged.tensor_fliplr
+tensor_fliplr = _cast1 Unmanaged.tensor_fliplr
 
 tensor_flipud
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_flipud = cast1 Unmanaged.tensor_flipud
+tensor_flipud = _cast1 Unmanaged.tensor_flipud
 
 tensor_roll_ll
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-tensor_roll_ll = cast3 Unmanaged.tensor_roll_ll
+tensor_roll_ll = _cast3 Unmanaged.tensor_roll_ll
 
 tensor_rot90_ll
   :: ForeignPtr Tensor
   -> Int64
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-tensor_rot90_ll = cast3 Unmanaged.tensor_rot90_ll
+tensor_rot90_ll = _cast3 Unmanaged.tensor_rot90_ll
 
 tensor_trunc
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_trunc = cast1 Unmanaged.tensor_trunc
+tensor_trunc = _cast1 Unmanaged.tensor_trunc
 
 tensor_trunc_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_trunc_ = cast1 Unmanaged.tensor_trunc_
+tensor_trunc_ = _cast1 Unmanaged.tensor_trunc_
 
 tensor_fix
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_fix = cast1 Unmanaged.tensor_fix
+tensor_fix = _cast1 Unmanaged.tensor_fix
 
 tensor_fix_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_fix_ = cast1 Unmanaged.tensor_fix_
+tensor_fix_ = _cast1 Unmanaged.tensor_fix_
 
 tensor_type_as_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_type_as_t = cast2 Unmanaged.tensor_type_as_t
+tensor_type_as_t = _cast2 Unmanaged.tensor_type_as_t
 
 tensor_unsqueeze_l
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor_unsqueeze_l = cast2 Unmanaged.tensor_unsqueeze_l
+tensor_unsqueeze_l = _cast2 Unmanaged.tensor_unsqueeze_l
 
 tensor_unsqueeze__l
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor_unsqueeze__l = cast2 Unmanaged.tensor_unsqueeze__l
+tensor_unsqueeze__l = _cast2 Unmanaged.tensor_unsqueeze__l
 
 tensor_var_b
   :: ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-tensor_var_b = cast2 Unmanaged.tensor_var_b
+tensor_var_b = _cast2 Unmanaged.tensor_var_b
 
 tensor_var_lbb
   :: ForeignPtr Tensor
@@ -522,7 +522,7 @@ tensor_var_lbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-tensor_var_lbb = cast4 Unmanaged.tensor_var_lbb
+tensor_var_lbb = _cast4 Unmanaged.tensor_var_lbb
 
 tensor_var_llb
   :: ForeignPtr Tensor
@@ -530,7 +530,7 @@ tensor_var_llb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-tensor_var_llb = cast4 Unmanaged.tensor_var_llb
+tensor_var_llb = _cast4 Unmanaged.tensor_var_llb
 
 tensor_var_Nbb
   :: ForeignPtr Tensor
@@ -538,7 +538,7 @@ tensor_var_Nbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-tensor_var_Nbb = cast4 Unmanaged.tensor_var_Nbb
+tensor_var_Nbb = _cast4 Unmanaged.tensor_var_Nbb
 
 tensor_var_Nlb
   :: ForeignPtr Tensor
@@ -546,33 +546,33 @@ tensor_var_Nlb
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-tensor_var_Nlb = cast4 Unmanaged.tensor_var_Nlb
+tensor_var_Nlb = _cast4 Unmanaged.tensor_var_Nlb
 
 tensor_view_as_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_view_as_t = cast2 Unmanaged.tensor_view_as_t
+tensor_view_as_t = _cast2 Unmanaged.tensor_view_as_t
 
 tensor_where_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_where_tt = cast3 Unmanaged.tensor_where_tt
+tensor_where_tt = _cast3 Unmanaged.tensor_where_tt
 
 tensor_norm_ss
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-tensor_norm_ss = cast3 Unmanaged.tensor_norm_ss
+tensor_norm_ss = _cast3 Unmanaged.tensor_norm_ss
 
 tensor_norm_s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_norm_s = cast2 Unmanaged.tensor_norm_s
+tensor_norm_s = _cast2 Unmanaged.tensor_norm_s
 
 tensor_norm_slbs
   :: ForeignPtr Tensor
@@ -581,7 +581,7 @@ tensor_norm_slbs
   -> CBool
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-tensor_norm_slbs = cast5 Unmanaged.tensor_norm_slbs
+tensor_norm_slbs = _cast5 Unmanaged.tensor_norm_slbs
 
 tensor_norm_slb
   :: ForeignPtr Tensor
@@ -589,7 +589,7 @@ tensor_norm_slb
   -> ForeignPtr IntArray
   -> CBool
   -> IO (ForeignPtr Tensor)
-tensor_norm_slb = cast4 Unmanaged.tensor_norm_slb
+tensor_norm_slb = _cast4 Unmanaged.tensor_norm_slb
 
 tensor_norm_sNbs
   :: ForeignPtr Tensor
@@ -598,7 +598,7 @@ tensor_norm_sNbs
   -> CBool
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-tensor_norm_sNbs = cast5 Unmanaged.tensor_norm_sNbs
+tensor_norm_sNbs = _cast5 Unmanaged.tensor_norm_sNbs
 
 tensor_norm_sNb
   :: ForeignPtr Tensor
@@ -606,103 +606,103 @@ tensor_norm_sNb
   -> ForeignPtr DimnameList
   -> CBool
   -> IO (ForeignPtr Tensor)
-tensor_norm_sNb = cast4 Unmanaged.tensor_norm_sNb
+tensor_norm_sNb = _cast4 Unmanaged.tensor_norm_sNb
 
 tensor_frexp
   :: ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-tensor_frexp = cast1 Unmanaged.tensor_frexp
+tensor_frexp = _cast1 Unmanaged.tensor_frexp
 
 tensor_clone_M
   :: ForeignPtr Tensor
   -> MemoryFormat
   -> IO (ForeignPtr Tensor)
-tensor_clone_M = cast2 Unmanaged.tensor_clone_M
+tensor_clone_M = _cast2 Unmanaged.tensor_clone_M
 
 tensor_positive
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_positive = cast1 Unmanaged.tensor_positive
+tensor_positive = _cast1 Unmanaged.tensor_positive
 
 tensor_resize_as__tM
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> MemoryFormat
   -> IO (ForeignPtr Tensor)
-tensor_resize_as__tM = cast3 Unmanaged.tensor_resize_as__tM
+tensor_resize_as__tM = _cast3 Unmanaged.tensor_resize_as__tM
 
 tensor_zero_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_zero_ = cast1 Unmanaged.tensor_zero_
+tensor_zero_ = _cast1 Unmanaged.tensor_zero_
 
 tensor_sub_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_sub_ts = cast3 Unmanaged.tensor_sub_ts
+tensor_sub_ts = _cast3 Unmanaged.tensor_sub_ts
 
 tensor_sub__ts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_sub__ts = cast3 Unmanaged.tensor_sub__ts
+tensor_sub__ts = _cast3 Unmanaged.tensor_sub__ts
 
 tensor_sub_ss
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_sub_ss = cast3 Unmanaged.tensor_sub_ss
+tensor_sub_ss = _cast3 Unmanaged.tensor_sub_ss
 
 tensor_sub__ss
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_sub__ss = cast3 Unmanaged.tensor_sub__ss
+tensor_sub__ss = _cast3 Unmanaged.tensor_sub__ss
 
 tensor_subtract_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_subtract_ts = cast3 Unmanaged.tensor_subtract_ts
+tensor_subtract_ts = _cast3 Unmanaged.tensor_subtract_ts
 
 tensor_subtract__ts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_subtract__ts = cast3 Unmanaged.tensor_subtract__ts
+tensor_subtract__ts = _cast3 Unmanaged.tensor_subtract__ts
 
 tensor_subtract_ss
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_subtract_ss = cast3 Unmanaged.tensor_subtract_ss
+tensor_subtract_ss = _cast3 Unmanaged.tensor_subtract_ss
 
 tensor_subtract__ss
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_subtract__ss = cast3 Unmanaged.tensor_subtract__ss
+tensor_subtract__ss = _cast3 Unmanaged.tensor_subtract__ss
 
 tensor_heaviside_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_heaviside_t = cast2 Unmanaged.tensor_heaviside_t
+tensor_heaviside_t = _cast2 Unmanaged.tensor_heaviside_t
 
 tensor_heaviside__t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_heaviside__t = cast2 Unmanaged.tensor_heaviside__t
+tensor_heaviside__t = _cast2 Unmanaged.tensor_heaviside__t
 
 tensor_addmm_ttss
   :: ForeignPtr Tensor
@@ -711,7 +711,7 @@ tensor_addmm_ttss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_addmm_ttss = cast5 Unmanaged.tensor_addmm_ttss
+tensor_addmm_ttss = _cast5 Unmanaged.tensor_addmm_ttss
 
 tensor_addmm__ttss
   :: ForeignPtr Tensor
@@ -720,7 +720,7 @@ tensor_addmm__ttss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_addmm__ttss = cast5 Unmanaged.tensor_addmm__ttss
+tensor_addmm__ttss = _cast5 Unmanaged.tensor_addmm__ttss
 
 tensor_sparse_resize__lll
   :: ForeignPtr Tensor
@@ -728,7 +728,7 @@ tensor_sparse_resize__lll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor_sparse_resize__lll = cast4 Unmanaged.tensor_sparse_resize__lll
+tensor_sparse_resize__lll = _cast4 Unmanaged.tensor_sparse_resize__lll
 
 tensor_sparse_resize_and_clear__lll
   :: ForeignPtr Tensor
@@ -736,159 +736,159 @@ tensor_sparse_resize_and_clear__lll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor_sparse_resize_and_clear__lll = cast4 Unmanaged.tensor_sparse_resize_and_clear__lll
+tensor_sparse_resize_and_clear__lll = _cast4 Unmanaged.tensor_sparse_resize_and_clear__lll
 
 tensor_sparse_mask_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_sparse_mask_t = cast2 Unmanaged.tensor_sparse_mask_t
+tensor_sparse_mask_t = _cast2 Unmanaged.tensor_sparse_mask_t
 
 tensor_to_dense_s
   :: ForeignPtr Tensor
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-tensor_to_dense_s = cast2 Unmanaged.tensor_to_dense_s
+tensor_to_dense_s = _cast2 Unmanaged.tensor_to_dense_s
 
 tensor_sparse_dim
   :: ForeignPtr Tensor
   -> IO (Int64)
-tensor_sparse_dim = cast1 Unmanaged.tensor_sparse_dim
+tensor_sparse_dim = _cast1 Unmanaged.tensor_sparse_dim
 
 tensor__dimI
   :: ForeignPtr Tensor
   -> IO (Int64)
-tensor__dimI = cast1 Unmanaged.tensor__dimI
+tensor__dimI = _cast1 Unmanaged.tensor__dimI
 
 tensor_dense_dim
   :: ForeignPtr Tensor
   -> IO (Int64)
-tensor_dense_dim = cast1 Unmanaged.tensor_dense_dim
+tensor_dense_dim = _cast1 Unmanaged.tensor_dense_dim
 
 tensor__dimV
   :: ForeignPtr Tensor
   -> IO (Int64)
-tensor__dimV = cast1 Unmanaged.tensor__dimV
+tensor__dimV = _cast1 Unmanaged.tensor__dimV
 
 tensor__nnz
   :: ForeignPtr Tensor
   -> IO (Int64)
-tensor__nnz = cast1 Unmanaged.tensor__nnz
+tensor__nnz = _cast1 Unmanaged.tensor__nnz
 
 tensor_coalesce
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_coalesce = cast1 Unmanaged.tensor_coalesce
+tensor_coalesce = _cast1 Unmanaged.tensor_coalesce
 
 tensor_is_coalesced
   :: ForeignPtr Tensor
   -> IO (CBool)
-tensor_is_coalesced = cast1 Unmanaged.tensor_is_coalesced
+tensor_is_coalesced = _cast1 Unmanaged.tensor_is_coalesced
 
 tensor__indices
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor__indices = cast1 Unmanaged.tensor__indices
+tensor__indices = _cast1 Unmanaged.tensor__indices
 
 tensor__values
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor__values = cast1 Unmanaged.tensor__values
+tensor__values = _cast1 Unmanaged.tensor__values
 
 tensor__coalesced__b
   :: ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-tensor__coalesced__b = cast2 Unmanaged.tensor__coalesced__b
+tensor__coalesced__b = _cast2 Unmanaged.tensor__coalesced__b
 
 tensor_indices
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_indices = cast1 Unmanaged.tensor_indices
+tensor_indices = _cast1 Unmanaged.tensor_indices
 
 tensor_values
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_values = cast1 Unmanaged.tensor_values
+tensor_values = _cast1 Unmanaged.tensor_values
 
 tensor_crow_indices
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_crow_indices = cast1 Unmanaged.tensor_crow_indices
+tensor_crow_indices = _cast1 Unmanaged.tensor_crow_indices
 
 tensor_col_indices
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_col_indices = cast1 Unmanaged.tensor_col_indices
+tensor_col_indices = _cast1 Unmanaged.tensor_col_indices
 
 tensor_unbind_l
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr TensorList)
-tensor_unbind_l = cast2 Unmanaged.tensor_unbind_l
+tensor_unbind_l = _cast2 Unmanaged.tensor_unbind_l
 
 tensor_unbind_n
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> IO (ForeignPtr TensorList)
-tensor_unbind_n = cast2 Unmanaged.tensor_unbind_n
+tensor_unbind_n = _cast2 Unmanaged.tensor_unbind_n
 
 tensor_to_sparse_l
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor_to_sparse_l = cast2 Unmanaged.tensor_to_sparse_l
+tensor_to_sparse_l = _cast2 Unmanaged.tensor_to_sparse_l
 
 tensor_to_sparse
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_to_sparse = cast1 Unmanaged.tensor_to_sparse
+tensor_to_sparse = _cast1 Unmanaged.tensor_to_sparse
 
 tensor_to_mkldnn_s
   :: ForeignPtr Tensor
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-tensor_to_mkldnn_s = cast2 Unmanaged.tensor_to_mkldnn_s
+tensor_to_mkldnn_s = _cast2 Unmanaged.tensor_to_mkldnn_s
 
 tensor_dequantize
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_dequantize = cast1 Unmanaged.tensor_dequantize
+tensor_dequantize = _cast1 Unmanaged.tensor_dequantize
 
 tensor_q_scale
   :: ForeignPtr Tensor
   -> IO (CDouble)
-tensor_q_scale = cast1 Unmanaged.tensor_q_scale
+tensor_q_scale = _cast1 Unmanaged.tensor_q_scale
 
 tensor_q_zero_point
   :: ForeignPtr Tensor
   -> IO (Int64)
-tensor_q_zero_point = cast1 Unmanaged.tensor_q_zero_point
+tensor_q_zero_point = _cast1 Unmanaged.tensor_q_zero_point
 
 tensor_q_per_channel_scales
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_q_per_channel_scales = cast1 Unmanaged.tensor_q_per_channel_scales
+tensor_q_per_channel_scales = _cast1 Unmanaged.tensor_q_per_channel_scales
 
 tensor_q_per_channel_zero_points
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_q_per_channel_zero_points = cast1 Unmanaged.tensor_q_per_channel_zero_points
+tensor_q_per_channel_zero_points = _cast1 Unmanaged.tensor_q_per_channel_zero_points
 
 tensor_q_per_channel_axis
   :: ForeignPtr Tensor
   -> IO (Int64)
-tensor_q_per_channel_axis = cast1 Unmanaged.tensor_q_per_channel_axis
+tensor_q_per_channel_axis = _cast1 Unmanaged.tensor_q_per_channel_axis
 
 tensor_int_repr
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_int_repr = cast1 Unmanaged.tensor_int_repr
+tensor_int_repr = _cast1 Unmanaged.tensor_int_repr
 
 tensor_qscheme
   :: ForeignPtr Tensor
   -> IO (QScheme)
-tensor_qscheme = cast1 Unmanaged.tensor_qscheme
+tensor_qscheme = _cast1 Unmanaged.tensor_qscheme
 
 tensor__autocast_to_reduced_precision_bbss
   :: ForeignPtr Tensor
@@ -897,14 +897,14 @@ tensor__autocast_to_reduced_precision_bbss
   -> ScalarType
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-tensor__autocast_to_reduced_precision_bbss = cast5 Unmanaged.tensor__autocast_to_reduced_precision_bbss
+tensor__autocast_to_reduced_precision_bbss = _cast5 Unmanaged.tensor__autocast_to_reduced_precision_bbss
 
 tensor__autocast_to_full_precision_bb
   :: ForeignPtr Tensor
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-tensor__autocast_to_full_precision_bb = cast3 Unmanaged.tensor__autocast_to_full_precision_bb
+tensor__autocast_to_full_precision_bb = _cast3 Unmanaged.tensor__autocast_to_full_precision_bb
 
 tensor_to_obbM
   :: ForeignPtr Tensor
@@ -913,7 +913,7 @@ tensor_to_obbM
   -> CBool
   -> MemoryFormat
   -> IO (ForeignPtr Tensor)
-tensor_to_obbM = cast5 Unmanaged.tensor_to_obbM
+tensor_to_obbM = _cast5 Unmanaged.tensor_to_obbM
 
 tensor_to_DsbbM
   :: ForeignPtr Tensor
@@ -923,7 +923,7 @@ tensor_to_DsbbM
   -> CBool
   -> MemoryFormat
   -> IO (ForeignPtr Tensor)
-tensor_to_DsbbM = cast6 Unmanaged.tensor_to_DsbbM
+tensor_to_DsbbM = _cast6 Unmanaged.tensor_to_DsbbM
 
 tensor_to_sbbM
   :: ForeignPtr Tensor
@@ -932,7 +932,7 @@ tensor_to_sbbM
   -> CBool
   -> MemoryFormat
   -> IO (ForeignPtr Tensor)
-tensor_to_sbbM = cast5 Unmanaged.tensor_to_sbbM
+tensor_to_sbbM = _cast5 Unmanaged.tensor_to_sbbM
 
 tensor_to_tbbM
   :: ForeignPtr Tensor
@@ -941,18 +941,18 @@ tensor_to_tbbM
   -> CBool
   -> MemoryFormat
   -> IO (ForeignPtr Tensor)
-tensor_to_tbbM = cast5 Unmanaged.tensor_to_tbbM
+tensor_to_tbbM = _cast5 Unmanaged.tensor_to_tbbM
 
 tensor_item
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Scalar)
-tensor_item = cast1 Unmanaged.tensor_item
+tensor_item = _cast1 Unmanaged.tensor_item
 
 tensor_set__S
   :: ForeignPtr Tensor
   -> ForeignPtr Storage
   -> IO (ForeignPtr Tensor)
-tensor_set__S = cast2 Unmanaged.tensor_set__S
+tensor_set__S = _cast2 Unmanaged.tensor_set__S
 
 tensor_set__Slll
   :: ForeignPtr Tensor
@@ -961,78 +961,78 @@ tensor_set__Slll
   -> ForeignPtr IntArray
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-tensor_set__Slll = cast5 Unmanaged.tensor_set__Slll
+tensor_set__Slll = _cast5 Unmanaged.tensor_set__Slll
 
 tensor_set__t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_set__t = cast2 Unmanaged.tensor_set__t
+tensor_set__t = _cast2 Unmanaged.tensor_set__t
 
 tensor_set_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_set_ = cast1 Unmanaged.tensor_set_
+tensor_set_ = _cast1 Unmanaged.tensor_set_
 
 tensor_is_set_to_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (CBool)
-tensor_is_set_to_t = cast2 Unmanaged.tensor_is_set_to_t
+tensor_is_set_to_t = _cast2 Unmanaged.tensor_is_set_to_t
 
 tensor_masked_fill__ts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_masked_fill__ts = cast3 Unmanaged.tensor_masked_fill__ts
+tensor_masked_fill__ts = _cast3 Unmanaged.tensor_masked_fill__ts
 
 tensor_masked_fill_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_masked_fill_ts = cast3 Unmanaged.tensor_masked_fill_ts
+tensor_masked_fill_ts = _cast3 Unmanaged.tensor_masked_fill_ts
 
 tensor_masked_fill__tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_masked_fill__tt = cast3 Unmanaged.tensor_masked_fill__tt
+tensor_masked_fill__tt = _cast3 Unmanaged.tensor_masked_fill__tt
 
 tensor_masked_fill_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_masked_fill_tt = cast3 Unmanaged.tensor_masked_fill_tt
+tensor_masked_fill_tt = _cast3 Unmanaged.tensor_masked_fill_tt
 
 tensor_masked_scatter__tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_masked_scatter__tt = cast3 Unmanaged.tensor_masked_scatter__tt
+tensor_masked_scatter__tt = _cast3 Unmanaged.tensor_masked_scatter__tt
 
 tensor_masked_scatter_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_masked_scatter_tt = cast3 Unmanaged.tensor_masked_scatter_tt
+tensor_masked_scatter_tt = _cast3 Unmanaged.tensor_masked_scatter_tt
 
 tensor_view_l
   :: ForeignPtr Tensor
   -> ForeignPtr IntArray
   -> IO (ForeignPtr Tensor)
-tensor_view_l = cast2 Unmanaged.tensor_view_l
+tensor_view_l = _cast2 Unmanaged.tensor_view_l
 
 tensor_view_s
   :: ForeignPtr Tensor
   -> ScalarType
   -> IO (ForeignPtr Tensor)
-tensor_view_s = cast2 Unmanaged.tensor_view_s
+tensor_view_s = _cast2 Unmanaged.tensor_view_s
 
 tensor_put__ttb
   :: ForeignPtr Tensor
@@ -1040,7 +1040,7 @@ tensor_put__ttb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-tensor_put__ttb = cast4 Unmanaged.tensor_put__ttb
+tensor_put__ttb = _cast4 Unmanaged.tensor_put__ttb
 
 tensor_put_ttb
   :: ForeignPtr Tensor
@@ -1048,7 +1048,7 @@ tensor_put_ttb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-tensor_put_ttb = cast4 Unmanaged.tensor_put_ttb
+tensor_put_ttb = _cast4 Unmanaged.tensor_put_ttb
 
 tensor_index_add__ltts
   :: ForeignPtr Tensor
@@ -1057,7 +1057,7 @@ tensor_index_add__ltts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_index_add__ltts = cast5 Unmanaged.tensor_index_add__ltts
+tensor_index_add__ltts = _cast5 Unmanaged.tensor_index_add__ltts
 
 tensor_index_add_ltts
   :: ForeignPtr Tensor
@@ -1066,7 +1066,7 @@ tensor_index_add_ltts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_index_add_ltts = cast5 Unmanaged.tensor_index_add_ltts
+tensor_index_add_ltts = _cast5 Unmanaged.tensor_index_add_ltts
 
 tensor_index_add_ntts
   :: ForeignPtr Tensor
@@ -1075,7 +1075,7 @@ tensor_index_add_ntts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_index_add_ntts = cast5 Unmanaged.tensor_index_add_ntts
+tensor_index_add_ntts = _cast5 Unmanaged.tensor_index_add_ntts
 
 tensor_index_fill__lts
   :: ForeignPtr Tensor
@@ -1083,7 +1083,7 @@ tensor_index_fill__lts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_index_fill__lts = cast4 Unmanaged.tensor_index_fill__lts
+tensor_index_fill__lts = _cast4 Unmanaged.tensor_index_fill__lts
 
 tensor_index_fill_lts
   :: ForeignPtr Tensor
@@ -1091,7 +1091,7 @@ tensor_index_fill_lts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_index_fill_lts = cast4 Unmanaged.tensor_index_fill_lts
+tensor_index_fill_lts = _cast4 Unmanaged.tensor_index_fill_lts
 
 tensor_index_fill__ltt
   :: ForeignPtr Tensor
@@ -1099,7 +1099,7 @@ tensor_index_fill__ltt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_index_fill__ltt = cast4 Unmanaged.tensor_index_fill__ltt
+tensor_index_fill__ltt = _cast4 Unmanaged.tensor_index_fill__ltt
 
 tensor_index_fill_ltt
   :: ForeignPtr Tensor
@@ -1107,7 +1107,7 @@ tensor_index_fill_ltt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_index_fill_ltt = cast4 Unmanaged.tensor_index_fill_ltt
+tensor_index_fill_ltt = _cast4 Unmanaged.tensor_index_fill_ltt
 
 tensor_index_fill__nts
   :: ForeignPtr Tensor
@@ -1115,7 +1115,7 @@ tensor_index_fill__nts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_index_fill__nts = cast4 Unmanaged.tensor_index_fill__nts
+tensor_index_fill__nts = _cast4 Unmanaged.tensor_index_fill__nts
 
 tensor_index_fill__ntt
   :: ForeignPtr Tensor
@@ -1123,7 +1123,7 @@ tensor_index_fill__ntt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_index_fill__ntt = cast4 Unmanaged.tensor_index_fill__ntt
+tensor_index_fill__ntt = _cast4 Unmanaged.tensor_index_fill__ntt
 
 tensor_index_fill_nts
   :: ForeignPtr Tensor
@@ -1131,7 +1131,7 @@ tensor_index_fill_nts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_index_fill_nts = cast4 Unmanaged.tensor_index_fill_nts
+tensor_index_fill_nts = _cast4 Unmanaged.tensor_index_fill_nts
 
 tensor_index_fill_ntt
   :: ForeignPtr Tensor
@@ -1139,7 +1139,7 @@ tensor_index_fill_ntt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_index_fill_ntt = cast4 Unmanaged.tensor_index_fill_ntt
+tensor_index_fill_ntt = _cast4 Unmanaged.tensor_index_fill_ntt
 
 tensor_scatter_ltt
   :: ForeignPtr Tensor
@@ -1147,7 +1147,7 @@ tensor_scatter_ltt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_scatter_ltt = cast4 Unmanaged.tensor_scatter_ltt
+tensor_scatter_ltt = _cast4 Unmanaged.tensor_scatter_ltt
 
 tensor_scatter__ltt
   :: ForeignPtr Tensor
@@ -1155,7 +1155,7 @@ tensor_scatter__ltt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_scatter__ltt = cast4 Unmanaged.tensor_scatter__ltt
+tensor_scatter__ltt = _cast4 Unmanaged.tensor_scatter__ltt
 
 tensor_scatter_lts
   :: ForeignPtr Tensor
@@ -1163,7 +1163,7 @@ tensor_scatter_lts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_scatter_lts = cast4 Unmanaged.tensor_scatter_lts
+tensor_scatter_lts = _cast4 Unmanaged.tensor_scatter_lts
 
 tensor_scatter__lts
   :: ForeignPtr Tensor
@@ -1171,7 +1171,7 @@ tensor_scatter__lts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_scatter__lts = cast4 Unmanaged.tensor_scatter__lts
+tensor_scatter__lts = _cast4 Unmanaged.tensor_scatter__lts
 
 tensor_scatter_ltts
   :: ForeignPtr Tensor
@@ -1180,7 +1180,7 @@ tensor_scatter_ltts
   -> ForeignPtr Tensor
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-tensor_scatter_ltts = cast5 Unmanaged.tensor_scatter_ltts
+tensor_scatter_ltts = _cast5 Unmanaged.tensor_scatter_ltts
 
 tensor_scatter__ltts
   :: ForeignPtr Tensor
@@ -1189,7 +1189,7 @@ tensor_scatter__ltts
   -> ForeignPtr Tensor
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-tensor_scatter__ltts = cast5 Unmanaged.tensor_scatter__ltts
+tensor_scatter__ltts = _cast5 Unmanaged.tensor_scatter__ltts
 
 tensor_scatter_ltss
   :: ForeignPtr Tensor
@@ -1198,7 +1198,7 @@ tensor_scatter_ltss
   -> ForeignPtr Scalar
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-tensor_scatter_ltss = cast5 Unmanaged.tensor_scatter_ltss
+tensor_scatter_ltss = _cast5 Unmanaged.tensor_scatter_ltss
 
 tensor_scatter__ltss
   :: ForeignPtr Tensor
@@ -1207,7 +1207,7 @@ tensor_scatter__ltss
   -> ForeignPtr Scalar
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-tensor_scatter__ltss = cast5 Unmanaged.tensor_scatter__ltss
+tensor_scatter__ltss = _cast5 Unmanaged.tensor_scatter__ltss
 
 tensor_scatter_ntt
   :: ForeignPtr Tensor
@@ -1215,7 +1215,7 @@ tensor_scatter_ntt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_scatter_ntt = cast4 Unmanaged.tensor_scatter_ntt
+tensor_scatter_ntt = _cast4 Unmanaged.tensor_scatter_ntt
 
 tensor_scatter_nts
   :: ForeignPtr Tensor
@@ -1223,7 +1223,7 @@ tensor_scatter_nts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_scatter_nts = cast4 Unmanaged.tensor_scatter_nts
+tensor_scatter_nts = _cast4 Unmanaged.tensor_scatter_nts
 
 tensor_scatter_add_ltt
   :: ForeignPtr Tensor
@@ -1231,7 +1231,7 @@ tensor_scatter_add_ltt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_scatter_add_ltt = cast4 Unmanaged.tensor_scatter_add_ltt
+tensor_scatter_add_ltt = _cast4 Unmanaged.tensor_scatter_add_ltt
 
 tensor_scatter_add__ltt
   :: ForeignPtr Tensor
@@ -1239,7 +1239,7 @@ tensor_scatter_add__ltt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_scatter_add__ltt = cast4 Unmanaged.tensor_scatter_add__ltt
+tensor_scatter_add__ltt = _cast4 Unmanaged.tensor_scatter_add__ltt
 
 tensor_scatter_add_ntt
   :: ForeignPtr Tensor
@@ -1247,7 +1247,7 @@ tensor_scatter_add_ntt
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_scatter_add_ntt = cast4 Unmanaged.tensor_scatter_add_ntt
+tensor_scatter_add_ntt = _cast4 Unmanaged.tensor_scatter_add_ntt
 
 tensor_scatter_reduce_ltsl
   :: ForeignPtr Tensor
@@ -1256,101 +1256,101 @@ tensor_scatter_reduce_ltsl
   -> ForeignPtr StdString
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor_scatter_reduce_ltsl = cast5 Unmanaged.tensor_scatter_reduce_ltsl
+tensor_scatter_reduce_ltsl = _cast5 Unmanaged.tensor_scatter_reduce_ltsl
 
 tensor_eq__s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_eq__s = cast2 Unmanaged.tensor_eq__s
+tensor_eq__s = _cast2 Unmanaged.tensor_eq__s
 
 tensor_eq__t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_eq__t = cast2 Unmanaged.tensor_eq__t
+tensor_eq__t = _cast2 Unmanaged.tensor_eq__t
 
 tensor_bitwise_and_s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_bitwise_and_s = cast2 Unmanaged.tensor_bitwise_and_s
+tensor_bitwise_and_s = _cast2 Unmanaged.tensor_bitwise_and_s
 
 tensor_bitwise_and_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_bitwise_and_t = cast2 Unmanaged.tensor_bitwise_and_t
+tensor_bitwise_and_t = _cast2 Unmanaged.tensor_bitwise_and_t
 
 tensor_bitwise_and__s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_bitwise_and__s = cast2 Unmanaged.tensor_bitwise_and__s
+tensor_bitwise_and__s = _cast2 Unmanaged.tensor_bitwise_and__s
 
 tensor_bitwise_and__t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_bitwise_and__t = cast2 Unmanaged.tensor_bitwise_and__t
+tensor_bitwise_and__t = _cast2 Unmanaged.tensor_bitwise_and__t
 
 tensor___and___s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor___and___s = cast2 Unmanaged.tensor___and___s
+tensor___and___s = _cast2 Unmanaged.tensor___and___s
 
 tensor___and___t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor___and___t = cast2 Unmanaged.tensor___and___t
+tensor___and___t = _cast2 Unmanaged.tensor___and___t
 
 tensor___iand___s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor___iand___s = cast2 Unmanaged.tensor___iand___s
+tensor___iand___s = _cast2 Unmanaged.tensor___iand___s
 
 tensor___iand___t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor___iand___t = cast2 Unmanaged.tensor___iand___t
+tensor___iand___t = _cast2 Unmanaged.tensor___iand___t
 
 tensor_bitwise_or_s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_bitwise_or_s = cast2 Unmanaged.tensor_bitwise_or_s
+tensor_bitwise_or_s = _cast2 Unmanaged.tensor_bitwise_or_s
 
 tensor_bitwise_or_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_bitwise_or_t = cast2 Unmanaged.tensor_bitwise_or_t
+tensor_bitwise_or_t = _cast2 Unmanaged.tensor_bitwise_or_t
 
 tensor_bitwise_or__s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_bitwise_or__s = cast2 Unmanaged.tensor_bitwise_or__s
+tensor_bitwise_or__s = _cast2 Unmanaged.tensor_bitwise_or__s
 
 tensor_bitwise_or__t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_bitwise_or__t = cast2 Unmanaged.tensor_bitwise_or__t
+tensor_bitwise_or__t = _cast2 Unmanaged.tensor_bitwise_or__t
 
 tensor___or___s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor___or___s = cast2 Unmanaged.tensor___or___s
+tensor___or___s = _cast2 Unmanaged.tensor___or___s
 
 tensor___or___t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor___or___t = cast2 Unmanaged.tensor___or___t
+tensor___or___t = _cast2 Unmanaged.tensor___or___t
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Type/Tensor/Tensor3.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Type/Tensor/Tensor3.hs
@@ -28,188 +28,188 @@ tensor___ior___s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor___ior___s = cast2 Unmanaged.tensor___ior___s
+tensor___ior___s = _cast2 Unmanaged.tensor___ior___s
 
 tensor___ior___t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor___ior___t = cast2 Unmanaged.tensor___ior___t
+tensor___ior___t = _cast2 Unmanaged.tensor___ior___t
 
 tensor_bitwise_xor_s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_bitwise_xor_s = cast2 Unmanaged.tensor_bitwise_xor_s
+tensor_bitwise_xor_s = _cast2 Unmanaged.tensor_bitwise_xor_s
 
 tensor_bitwise_xor_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_bitwise_xor_t = cast2 Unmanaged.tensor_bitwise_xor_t
+tensor_bitwise_xor_t = _cast2 Unmanaged.tensor_bitwise_xor_t
 
 tensor_bitwise_xor__s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_bitwise_xor__s = cast2 Unmanaged.tensor_bitwise_xor__s
+tensor_bitwise_xor__s = _cast2 Unmanaged.tensor_bitwise_xor__s
 
 tensor_bitwise_xor__t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_bitwise_xor__t = cast2 Unmanaged.tensor_bitwise_xor__t
+tensor_bitwise_xor__t = _cast2 Unmanaged.tensor_bitwise_xor__t
 
 tensor___xor___s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor___xor___s = cast2 Unmanaged.tensor___xor___s
+tensor___xor___s = _cast2 Unmanaged.tensor___xor___s
 
 tensor___xor___t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor___xor___t = cast2 Unmanaged.tensor___xor___t
+tensor___xor___t = _cast2 Unmanaged.tensor___xor___t
 
 tensor___ixor___s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor___ixor___s = cast2 Unmanaged.tensor___ixor___s
+tensor___ixor___s = _cast2 Unmanaged.tensor___ixor___s
 
 tensor___ixor___t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor___ixor___t = cast2 Unmanaged.tensor___ixor___t
+tensor___ixor___t = _cast2 Unmanaged.tensor___ixor___t
 
 tensor___lshift___s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor___lshift___s = cast2 Unmanaged.tensor___lshift___s
+tensor___lshift___s = _cast2 Unmanaged.tensor___lshift___s
 
 tensor___lshift___t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor___lshift___t = cast2 Unmanaged.tensor___lshift___t
+tensor___lshift___t = _cast2 Unmanaged.tensor___lshift___t
 
 tensor___ilshift___s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor___ilshift___s = cast2 Unmanaged.tensor___ilshift___s
+tensor___ilshift___s = _cast2 Unmanaged.tensor___ilshift___s
 
 tensor___ilshift___t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor___ilshift___t = cast2 Unmanaged.tensor___ilshift___t
+tensor___ilshift___t = _cast2 Unmanaged.tensor___ilshift___t
 
 tensor_bitwise_left_shift_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_bitwise_left_shift_t = cast2 Unmanaged.tensor_bitwise_left_shift_t
+tensor_bitwise_left_shift_t = _cast2 Unmanaged.tensor_bitwise_left_shift_t
 
 tensor_bitwise_left_shift__t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_bitwise_left_shift__t = cast2 Unmanaged.tensor_bitwise_left_shift__t
+tensor_bitwise_left_shift__t = _cast2 Unmanaged.tensor_bitwise_left_shift__t
 
 tensor_bitwise_left_shift_s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_bitwise_left_shift_s = cast2 Unmanaged.tensor_bitwise_left_shift_s
+tensor_bitwise_left_shift_s = _cast2 Unmanaged.tensor_bitwise_left_shift_s
 
 tensor_bitwise_left_shift__s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_bitwise_left_shift__s = cast2 Unmanaged.tensor_bitwise_left_shift__s
+tensor_bitwise_left_shift__s = _cast2 Unmanaged.tensor_bitwise_left_shift__s
 
 tensor___rshift___s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor___rshift___s = cast2 Unmanaged.tensor___rshift___s
+tensor___rshift___s = _cast2 Unmanaged.tensor___rshift___s
 
 tensor___rshift___t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor___rshift___t = cast2 Unmanaged.tensor___rshift___t
+tensor___rshift___t = _cast2 Unmanaged.tensor___rshift___t
 
 tensor___irshift___s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor___irshift___s = cast2 Unmanaged.tensor___irshift___s
+tensor___irshift___s = _cast2 Unmanaged.tensor___irshift___s
 
 tensor___irshift___t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor___irshift___t = cast2 Unmanaged.tensor___irshift___t
+tensor___irshift___t = _cast2 Unmanaged.tensor___irshift___t
 
 tensor_bitwise_right_shift_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_bitwise_right_shift_t = cast2 Unmanaged.tensor_bitwise_right_shift_t
+tensor_bitwise_right_shift_t = _cast2 Unmanaged.tensor_bitwise_right_shift_t
 
 tensor_bitwise_right_shift__t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_bitwise_right_shift__t = cast2 Unmanaged.tensor_bitwise_right_shift__t
+tensor_bitwise_right_shift__t = _cast2 Unmanaged.tensor_bitwise_right_shift__t
 
 tensor_bitwise_right_shift_s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_bitwise_right_shift_s = cast2 Unmanaged.tensor_bitwise_right_shift_s
+tensor_bitwise_right_shift_s = _cast2 Unmanaged.tensor_bitwise_right_shift_s
 
 tensor_bitwise_right_shift__s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_bitwise_right_shift__s = cast2 Unmanaged.tensor_bitwise_right_shift__s
+tensor_bitwise_right_shift__s = _cast2 Unmanaged.tensor_bitwise_right_shift__s
 
 tensor_tril__l
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor_tril__l = cast2 Unmanaged.tensor_tril__l
+tensor_tril__l = _cast2 Unmanaged.tensor_tril__l
 
 tensor_triu__l
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor_triu__l = cast2 Unmanaged.tensor_triu__l
+tensor_triu__l = _cast2 Unmanaged.tensor_triu__l
 
 tensor_digamma_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_digamma_ = cast1 Unmanaged.tensor_digamma_
+tensor_digamma_ = _cast1 Unmanaged.tensor_digamma_
 
 tensor_lerp__ts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_lerp__ts = cast3 Unmanaged.tensor_lerp__ts
+tensor_lerp__ts = _cast3 Unmanaged.tensor_lerp__ts
 
 tensor_lerp__tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_lerp__tt = cast3 Unmanaged.tensor_lerp__tt
+tensor_lerp__tt = _cast3 Unmanaged.tensor_lerp__tt
 
 tensor_addbmm__ttss
   :: ForeignPtr Tensor
@@ -218,7 +218,7 @@ tensor_addbmm__ttss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_addbmm__ttss = cast5 Unmanaged.tensor_addbmm__ttss
+tensor_addbmm__ttss = _cast5 Unmanaged.tensor_addbmm__ttss
 
 tensor_addbmm_ttss
   :: ForeignPtr Tensor
@@ -227,7 +227,7 @@ tensor_addbmm_ttss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_addbmm_ttss = cast5 Unmanaged.tensor_addbmm_ttss
+tensor_addbmm_ttss = _cast5 Unmanaged.tensor_addbmm_ttss
 
 tensor_random__llG
   :: ForeignPtr Tensor
@@ -235,20 +235,20 @@ tensor_random__llG
   -> Int64
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-tensor_random__llG = cast4 Unmanaged.tensor_random__llG
+tensor_random__llG = _cast4 Unmanaged.tensor_random__llG
 
 tensor_random__lG
   :: ForeignPtr Tensor
   -> Int64
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-tensor_random__lG = cast3 Unmanaged.tensor_random__lG
+tensor_random__lG = _cast3 Unmanaged.tensor_random__lG
 
 tensor_random__G
   :: ForeignPtr Tensor
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-tensor_random__G = cast2 Unmanaged.tensor_random__G
+tensor_random__G = _cast2 Unmanaged.tensor_random__G
 
 tensor_uniform__ddG
   :: ForeignPtr Tensor
@@ -256,7 +256,7 @@ tensor_uniform__ddG
   -> CDouble
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-tensor_uniform__ddG = cast4 Unmanaged.tensor_uniform__ddG
+tensor_uniform__ddG = _cast4 Unmanaged.tensor_uniform__ddG
 
 tensor_cauchy__ddG
   :: ForeignPtr Tensor
@@ -264,7 +264,7 @@ tensor_cauchy__ddG
   -> CDouble
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-tensor_cauchy__ddG = cast4 Unmanaged.tensor_cauchy__ddG
+tensor_cauchy__ddG = _cast4 Unmanaged.tensor_cauchy__ddG
 
 tensor_log_normal__ddG
   :: ForeignPtr Tensor
@@ -272,351 +272,351 @@ tensor_log_normal__ddG
   -> CDouble
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-tensor_log_normal__ddG = cast4 Unmanaged.tensor_log_normal__ddG
+tensor_log_normal__ddG = _cast4 Unmanaged.tensor_log_normal__ddG
 
 tensor_exponential__dG
   :: ForeignPtr Tensor
   -> CDouble
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-tensor_exponential__dG = cast3 Unmanaged.tensor_exponential__dG
+tensor_exponential__dG = _cast3 Unmanaged.tensor_exponential__dG
 
 tensor_geometric__dG
   :: ForeignPtr Tensor
   -> CDouble
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-tensor_geometric__dG = cast3 Unmanaged.tensor_geometric__dG
+tensor_geometric__dG = _cast3 Unmanaged.tensor_geometric__dG
 
 tensor_diag_l
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor_diag_l = cast2 Unmanaged.tensor_diag_l
+tensor_diag_l = _cast2 Unmanaged.tensor_diag_l
 
 tensor_cross_tl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor_cross_tl = cast3 Unmanaged.tensor_cross_tl
+tensor_cross_tl = _cast3 Unmanaged.tensor_cross_tl
 
 tensor_triu_l
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor_triu_l = cast2 Unmanaged.tensor_triu_l
+tensor_triu_l = _cast2 Unmanaged.tensor_triu_l
 
 tensor_tril_l
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor_tril_l = cast2 Unmanaged.tensor_tril_l
+tensor_tril_l = _cast2 Unmanaged.tensor_tril_l
 
 tensor_trace
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_trace = cast1 Unmanaged.tensor_trace
+tensor_trace = _cast1 Unmanaged.tensor_trace
 
 tensor_ne_s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_ne_s = cast2 Unmanaged.tensor_ne_s
+tensor_ne_s = _cast2 Unmanaged.tensor_ne_s
 
 tensor_ne_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_ne_t = cast2 Unmanaged.tensor_ne_t
+tensor_ne_t = _cast2 Unmanaged.tensor_ne_t
 
 tensor_ne__s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_ne__s = cast2 Unmanaged.tensor_ne__s
+tensor_ne__s = _cast2 Unmanaged.tensor_ne__s
 
 tensor_ne__t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_ne__t = cast2 Unmanaged.tensor_ne__t
+tensor_ne__t = _cast2 Unmanaged.tensor_ne__t
 
 tensor_not_equal_s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_not_equal_s = cast2 Unmanaged.tensor_not_equal_s
+tensor_not_equal_s = _cast2 Unmanaged.tensor_not_equal_s
 
 tensor_not_equal_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_not_equal_t = cast2 Unmanaged.tensor_not_equal_t
+tensor_not_equal_t = _cast2 Unmanaged.tensor_not_equal_t
 
 tensor_not_equal__s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_not_equal__s = cast2 Unmanaged.tensor_not_equal__s
+tensor_not_equal__s = _cast2 Unmanaged.tensor_not_equal__s
 
 tensor_not_equal__t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_not_equal__t = cast2 Unmanaged.tensor_not_equal__t
+tensor_not_equal__t = _cast2 Unmanaged.tensor_not_equal__t
 
 tensor_eq_s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_eq_s = cast2 Unmanaged.tensor_eq_s
+tensor_eq_s = _cast2 Unmanaged.tensor_eq_s
 
 tensor_eq_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_eq_t = cast2 Unmanaged.tensor_eq_t
+tensor_eq_t = _cast2 Unmanaged.tensor_eq_t
 
 tensor_ge_s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_ge_s = cast2 Unmanaged.tensor_ge_s
+tensor_ge_s = _cast2 Unmanaged.tensor_ge_s
 
 tensor_ge_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_ge_t = cast2 Unmanaged.tensor_ge_t
+tensor_ge_t = _cast2 Unmanaged.tensor_ge_t
 
 tensor_ge__s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_ge__s = cast2 Unmanaged.tensor_ge__s
+tensor_ge__s = _cast2 Unmanaged.tensor_ge__s
 
 tensor_ge__t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_ge__t = cast2 Unmanaged.tensor_ge__t
+tensor_ge__t = _cast2 Unmanaged.tensor_ge__t
 
 tensor_greater_equal_s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_greater_equal_s = cast2 Unmanaged.tensor_greater_equal_s
+tensor_greater_equal_s = _cast2 Unmanaged.tensor_greater_equal_s
 
 tensor_greater_equal_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_greater_equal_t = cast2 Unmanaged.tensor_greater_equal_t
+tensor_greater_equal_t = _cast2 Unmanaged.tensor_greater_equal_t
 
 tensor_greater_equal__s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_greater_equal__s = cast2 Unmanaged.tensor_greater_equal__s
+tensor_greater_equal__s = _cast2 Unmanaged.tensor_greater_equal__s
 
 tensor_greater_equal__t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_greater_equal__t = cast2 Unmanaged.tensor_greater_equal__t
+tensor_greater_equal__t = _cast2 Unmanaged.tensor_greater_equal__t
 
 tensor_le_s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_le_s = cast2 Unmanaged.tensor_le_s
+tensor_le_s = _cast2 Unmanaged.tensor_le_s
 
 tensor_le_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_le_t = cast2 Unmanaged.tensor_le_t
+tensor_le_t = _cast2 Unmanaged.tensor_le_t
 
 tensor_le__s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_le__s = cast2 Unmanaged.tensor_le__s
+tensor_le__s = _cast2 Unmanaged.tensor_le__s
 
 tensor_le__t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_le__t = cast2 Unmanaged.tensor_le__t
+tensor_le__t = _cast2 Unmanaged.tensor_le__t
 
 tensor_less_equal_s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_less_equal_s = cast2 Unmanaged.tensor_less_equal_s
+tensor_less_equal_s = _cast2 Unmanaged.tensor_less_equal_s
 
 tensor_less_equal_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_less_equal_t = cast2 Unmanaged.tensor_less_equal_t
+tensor_less_equal_t = _cast2 Unmanaged.tensor_less_equal_t
 
 tensor_less_equal__s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_less_equal__s = cast2 Unmanaged.tensor_less_equal__s
+tensor_less_equal__s = _cast2 Unmanaged.tensor_less_equal__s
 
 tensor_less_equal__t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_less_equal__t = cast2 Unmanaged.tensor_less_equal__t
+tensor_less_equal__t = _cast2 Unmanaged.tensor_less_equal__t
 
 tensor_gt_s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_gt_s = cast2 Unmanaged.tensor_gt_s
+tensor_gt_s = _cast2 Unmanaged.tensor_gt_s
 
 tensor_gt_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_gt_t = cast2 Unmanaged.tensor_gt_t
+tensor_gt_t = _cast2 Unmanaged.tensor_gt_t
 
 tensor_gt__s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_gt__s = cast2 Unmanaged.tensor_gt__s
+tensor_gt__s = _cast2 Unmanaged.tensor_gt__s
 
 tensor_gt__t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_gt__t = cast2 Unmanaged.tensor_gt__t
+tensor_gt__t = _cast2 Unmanaged.tensor_gt__t
 
 tensor_greater_s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_greater_s = cast2 Unmanaged.tensor_greater_s
+tensor_greater_s = _cast2 Unmanaged.tensor_greater_s
 
 tensor_greater_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_greater_t = cast2 Unmanaged.tensor_greater_t
+tensor_greater_t = _cast2 Unmanaged.tensor_greater_t
 
 tensor_greater__s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_greater__s = cast2 Unmanaged.tensor_greater__s
+tensor_greater__s = _cast2 Unmanaged.tensor_greater__s
 
 tensor_greater__t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_greater__t = cast2 Unmanaged.tensor_greater__t
+tensor_greater__t = _cast2 Unmanaged.tensor_greater__t
 
 tensor_lt_s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_lt_s = cast2 Unmanaged.tensor_lt_s
+tensor_lt_s = _cast2 Unmanaged.tensor_lt_s
 
 tensor_lt_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_lt_t = cast2 Unmanaged.tensor_lt_t
+tensor_lt_t = _cast2 Unmanaged.tensor_lt_t
 
 tensor_lt__s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_lt__s = cast2 Unmanaged.tensor_lt__s
+tensor_lt__s = _cast2 Unmanaged.tensor_lt__s
 
 tensor_lt__t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_lt__t = cast2 Unmanaged.tensor_lt__t
+tensor_lt__t = _cast2 Unmanaged.tensor_lt__t
 
 tensor_less_s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_less_s = cast2 Unmanaged.tensor_less_s
+tensor_less_s = _cast2 Unmanaged.tensor_less_s
 
 tensor_less_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_less_t = cast2 Unmanaged.tensor_less_t
+tensor_less_t = _cast2 Unmanaged.tensor_less_t
 
 tensor_less__s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_less__s = cast2 Unmanaged.tensor_less__s
+tensor_less__s = _cast2 Unmanaged.tensor_less__s
 
 tensor_less__t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_less__t = cast2 Unmanaged.tensor_less__t
+tensor_less__t = _cast2 Unmanaged.tensor_less__t
 
 tensor_take_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_take_t = cast2 Unmanaged.tensor_take_t
+tensor_take_t = _cast2 Unmanaged.tensor_take_t
 
 tensor_take_along_dim_tl
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor_take_along_dim_tl = cast3 Unmanaged.tensor_take_along_dim_tl
+tensor_take_along_dim_tl = _cast3 Unmanaged.tensor_take_along_dim_tl
 
 tensor_index_select_lt
   :: ForeignPtr Tensor
   -> Int64
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_index_select_lt = cast3 Unmanaged.tensor_index_select_lt
+tensor_index_select_lt = _cast3 Unmanaged.tensor_index_select_lt
 
 tensor_index_select_nt
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_index_select_nt = cast3 Unmanaged.tensor_index_select_nt
+tensor_index_select_nt = _cast3 Unmanaged.tensor_index_select_nt
 
 tensor_masked_select_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_masked_select_t = cast2 Unmanaged.tensor_masked_select_t
+tensor_masked_select_t = _cast2 Unmanaged.tensor_masked_select_t
 
 tensor_nonzero
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_nonzero = cast1 Unmanaged.tensor_nonzero
+tensor_nonzero = _cast1 Unmanaged.tensor_nonzero
 
 tensor_nonzero_numpy
   :: ForeignPtr Tensor
   -> IO (ForeignPtr TensorList)
-tensor_nonzero_numpy = cast1 Unmanaged.tensor_nonzero_numpy
+tensor_nonzero_numpy = _cast1 Unmanaged.tensor_nonzero_numpy
 
 tensor_argwhere
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_argwhere = cast1 Unmanaged.tensor_argwhere
+tensor_argwhere = _cast1 Unmanaged.tensor_argwhere
 
 tensor_gather_ltb
   :: ForeignPtr Tensor
@@ -624,7 +624,7 @@ tensor_gather_ltb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-tensor_gather_ltb = cast4 Unmanaged.tensor_gather_ltb
+tensor_gather_ltb = _cast4 Unmanaged.tensor_gather_ltb
 
 tensor_gather_ntb
   :: ForeignPtr Tensor
@@ -632,7 +632,7 @@ tensor_gather_ntb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-tensor_gather_ntb = cast4 Unmanaged.tensor_gather_ntb
+tensor_gather_ntb = _cast4 Unmanaged.tensor_gather_ntb
 
 tensor_addcmul_tts
   :: ForeignPtr Tensor
@@ -640,7 +640,7 @@ tensor_addcmul_tts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_addcmul_tts = cast4 Unmanaged.tensor_addcmul_tts
+tensor_addcmul_tts = _cast4 Unmanaged.tensor_addcmul_tts
 
 tensor_addcmul__tts
   :: ForeignPtr Tensor
@@ -648,7 +648,7 @@ tensor_addcmul__tts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_addcmul__tts = cast4 Unmanaged.tensor_addcmul__tts
+tensor_addcmul__tts = _cast4 Unmanaged.tensor_addcmul__tts
 
 tensor_addcdiv_tts
   :: ForeignPtr Tensor
@@ -656,7 +656,7 @@ tensor_addcdiv_tts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_addcdiv_tts = cast4 Unmanaged.tensor_addcdiv_tts
+tensor_addcdiv_tts = _cast4 Unmanaged.tensor_addcdiv_tts
 
 tensor_addcdiv__tts
   :: ForeignPtr Tensor
@@ -664,13 +664,13 @@ tensor_addcdiv__tts
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_addcdiv__tts = cast4 Unmanaged.tensor_addcdiv__tts
+tensor_addcdiv__tts = _cast4 Unmanaged.tensor_addcdiv__tts
 
 tensor_lstsq_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-tensor_lstsq_t = cast2 Unmanaged.tensor_lstsq_t
+tensor_lstsq_t = _cast2 Unmanaged.tensor_lstsq_t
 
 tensor_triangular_solve_tbbb
   :: ForeignPtr Tensor
@@ -679,7 +679,7 @@ tensor_triangular_solve_tbbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-tensor_triangular_solve_tbbb = cast5 Unmanaged.tensor_triangular_solve_tbbb
+tensor_triangular_solve_tbbb = _cast5 Unmanaged.tensor_triangular_solve_tbbb
 
 tensor_linalg_solve_triangular_tbbb
   :: ForeignPtr Tensor
@@ -688,97 +688,97 @@ tensor_linalg_solve_triangular_tbbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-tensor_linalg_solve_triangular_tbbb = cast5 Unmanaged.tensor_linalg_solve_triangular_tbbb
+tensor_linalg_solve_triangular_tbbb = _cast5 Unmanaged.tensor_linalg_solve_triangular_tbbb
 
 tensor_symeig_bb
   :: ForeignPtr Tensor
   -> CBool
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-tensor_symeig_bb = cast3 Unmanaged.tensor_symeig_bb
+tensor_symeig_bb = _cast3 Unmanaged.tensor_symeig_bb
 
 tensor_eig_b
   :: ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-tensor_eig_b = cast2 Unmanaged.tensor_eig_b
+tensor_eig_b = _cast2 Unmanaged.tensor_eig_b
 
 tensor_svd_bb
   :: ForeignPtr Tensor
   -> CBool
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor)))
-tensor_svd_bb = cast3 Unmanaged.tensor_svd_bb
+tensor_svd_bb = _cast3 Unmanaged.tensor_svd_bb
 
 tensor_swapaxes_ll
   :: ForeignPtr Tensor
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor_swapaxes_ll = cast3 Unmanaged.tensor_swapaxes_ll
+tensor_swapaxes_ll = _cast3 Unmanaged.tensor_swapaxes_ll
 
 tensor_swapaxes__ll
   :: ForeignPtr Tensor
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor_swapaxes__ll = cast3 Unmanaged.tensor_swapaxes__ll
+tensor_swapaxes__ll = _cast3 Unmanaged.tensor_swapaxes__ll
 
 tensor_swapdims_ll
   :: ForeignPtr Tensor
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor_swapdims_ll = cast3 Unmanaged.tensor_swapdims_ll
+tensor_swapdims_ll = _cast3 Unmanaged.tensor_swapdims_ll
 
 tensor_swapdims__ll
   :: ForeignPtr Tensor
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor_swapdims__ll = cast3 Unmanaged.tensor_swapdims__ll
+tensor_swapdims__ll = _cast3 Unmanaged.tensor_swapdims__ll
 
 tensor_cholesky_b
   :: ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-tensor_cholesky_b = cast2 Unmanaged.tensor_cholesky_b
+tensor_cholesky_b = _cast2 Unmanaged.tensor_cholesky_b
 
 tensor_cholesky_solve_tb
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-tensor_cholesky_solve_tb = cast3 Unmanaged.tensor_cholesky_solve_tb
+tensor_cholesky_solve_tb = _cast3 Unmanaged.tensor_cholesky_solve_tb
 
 tensor_solve_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-tensor_solve_t = cast2 Unmanaged.tensor_solve_t
+tensor_solve_t = _cast2 Unmanaged.tensor_solve_t
 
 tensor_cholesky_inverse_b
   :: ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr Tensor)
-tensor_cholesky_inverse_b = cast2 Unmanaged.tensor_cholesky_inverse_b
+tensor_cholesky_inverse_b = _cast2 Unmanaged.tensor_cholesky_inverse_b
 
 tensor_qr_b
   :: ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-tensor_qr_b = cast2 Unmanaged.tensor_qr_b
+tensor_qr_b = _cast2 Unmanaged.tensor_qr_b
 
 tensor_geqrf
   :: ForeignPtr Tensor
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-tensor_geqrf = cast1 Unmanaged.tensor_geqrf
+tensor_geqrf = _cast1 Unmanaged.tensor_geqrf
 
 tensor_orgqr_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_orgqr_t = cast2 Unmanaged.tensor_orgqr_t
+tensor_orgqr_t = _cast2 Unmanaged.tensor_orgqr_t
 
 tensor_ormqr_ttbb
   :: ForeignPtr Tensor
@@ -787,14 +787,14 @@ tensor_ormqr_ttbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr Tensor)
-tensor_ormqr_ttbb = cast5 Unmanaged.tensor_ormqr_ttbb
+tensor_ormqr_ttbb = _cast5 Unmanaged.tensor_ormqr_ttbb
 
 tensor_lu_solve_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_lu_solve_tt = cast3 Unmanaged.tensor_lu_solve_tt
+tensor_lu_solve_tt = _cast3 Unmanaged.tensor_lu_solve_tt
 
 tensor_multinomial_lbG
   :: ForeignPtr Tensor
@@ -802,108 +802,108 @@ tensor_multinomial_lbG
   -> CBool
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-tensor_multinomial_lbG = cast4 Unmanaged.tensor_multinomial_lbG
+tensor_multinomial_lbG = _cast4 Unmanaged.tensor_multinomial_lbG
 
 tensor_lgamma_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_lgamma_ = cast1 Unmanaged.tensor_lgamma_
+tensor_lgamma_ = _cast1 Unmanaged.tensor_lgamma_
 
 tensor_lgamma
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_lgamma = cast1 Unmanaged.tensor_lgamma
+tensor_lgamma = _cast1 Unmanaged.tensor_lgamma
 
 tensor_digamma
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_digamma = cast1 Unmanaged.tensor_digamma
+tensor_digamma = _cast1 Unmanaged.tensor_digamma
 
 tensor_polygamma__l
   :: ForeignPtr Tensor
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor_polygamma__l = cast2 Unmanaged.tensor_polygamma__l
+tensor_polygamma__l = _cast2 Unmanaged.tensor_polygamma__l
 
 tensor_erfinv
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_erfinv = cast1 Unmanaged.tensor_erfinv
+tensor_erfinv = _cast1 Unmanaged.tensor_erfinv
 
 tensor_erfinv_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_erfinv_ = cast1 Unmanaged.tensor_erfinv_
+tensor_erfinv_ = _cast1 Unmanaged.tensor_erfinv_
 
 tensor_i0
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_i0 = cast1 Unmanaged.tensor_i0
+tensor_i0 = _cast1 Unmanaged.tensor_i0
 
 tensor_i0_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_i0_ = cast1 Unmanaged.tensor_i0_
+tensor_i0_ = _cast1 Unmanaged.tensor_i0_
 
 tensor_sign
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_sign = cast1 Unmanaged.tensor_sign
+tensor_sign = _cast1 Unmanaged.tensor_sign
 
 tensor_sign_
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_sign_ = cast1 Unmanaged.tensor_sign_
+tensor_sign_ = _cast1 Unmanaged.tensor_sign_
 
 tensor_signbit
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_signbit = cast1 Unmanaged.tensor_signbit
+tensor_signbit = _cast1 Unmanaged.tensor_signbit
 
 tensor_dist_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_dist_ts = cast3 Unmanaged.tensor_dist_ts
+tensor_dist_ts = _cast3 Unmanaged.tensor_dist_ts
 
 tensor_atan2__t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_atan2__t = cast2 Unmanaged.tensor_atan2__t
+tensor_atan2__t = _cast2 Unmanaged.tensor_atan2__t
 
 tensor_atan2_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_atan2_t = cast2 Unmanaged.tensor_atan2_t
+tensor_atan2_t = _cast2 Unmanaged.tensor_atan2_t
 
 tensor_arctan2_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_arctan2_t = cast2 Unmanaged.tensor_arctan2_t
+tensor_arctan2_t = _cast2 Unmanaged.tensor_arctan2_t
 
 tensor_arctan2__t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_arctan2__t = cast2 Unmanaged.tensor_arctan2__t
+tensor_arctan2__t = _cast2 Unmanaged.tensor_arctan2__t
 
 tensor_lerp_ts
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_lerp_ts = cast3 Unmanaged.tensor_lerp_ts
+tensor_lerp_ts = _cast3 Unmanaged.tensor_lerp_ts
 
 tensor_lerp_tt
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_lerp_tt = cast3 Unmanaged.tensor_lerp_tt
+tensor_lerp_tt = _cast3 Unmanaged.tensor_lerp_tt
 
 tensor_histc_lss
   :: ForeignPtr Tensor
@@ -911,7 +911,7 @@ tensor_histc_lss
   -> ForeignPtr Scalar
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_histc_lss = cast4 Unmanaged.tensor_histc_lss
+tensor_histc_lss = _cast4 Unmanaged.tensor_histc_lss
 
 tensor_histogram_ttb
   :: ForeignPtr Tensor
@@ -919,7 +919,7 @@ tensor_histogram_ttb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-tensor_histogram_ttb = cast4 Unmanaged.tensor_histogram_ttb
+tensor_histogram_ttb = _cast4 Unmanaged.tensor_histogram_ttb
 
 tensor_histogram_latb
   :: ForeignPtr Tensor
@@ -928,149 +928,149 @@ tensor_histogram_latb
   -> ForeignPtr Tensor
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-tensor_histogram_latb = cast5 Unmanaged.tensor_histogram_latb
+tensor_histogram_latb = _cast5 Unmanaged.tensor_histogram_latb
 
 tensor_fmod_s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_fmod_s = cast2 Unmanaged.tensor_fmod_s
+tensor_fmod_s = _cast2 Unmanaged.tensor_fmod_s
 
 tensor_fmod__s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_fmod__s = cast2 Unmanaged.tensor_fmod__s
+tensor_fmod__s = _cast2 Unmanaged.tensor_fmod__s
 
 tensor_fmod_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_fmod_t = cast2 Unmanaged.tensor_fmod_t
+tensor_fmod_t = _cast2 Unmanaged.tensor_fmod_t
 
 tensor_fmod__t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_fmod__t = cast2 Unmanaged.tensor_fmod__t
+tensor_fmod__t = _cast2 Unmanaged.tensor_fmod__t
 
 tensor_hypot_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_hypot_t = cast2 Unmanaged.tensor_hypot_t
+tensor_hypot_t = _cast2 Unmanaged.tensor_hypot_t
 
 tensor_hypot__t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_hypot__t = cast2 Unmanaged.tensor_hypot__t
+tensor_hypot__t = _cast2 Unmanaged.tensor_hypot__t
 
 tensor_igamma_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_igamma_t = cast2 Unmanaged.tensor_igamma_t
+tensor_igamma_t = _cast2 Unmanaged.tensor_igamma_t
 
 tensor_igamma__t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_igamma__t = cast2 Unmanaged.tensor_igamma__t
+tensor_igamma__t = _cast2 Unmanaged.tensor_igamma__t
 
 tensor_igammac_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_igammac_t = cast2 Unmanaged.tensor_igammac_t
+tensor_igammac_t = _cast2 Unmanaged.tensor_igammac_t
 
 tensor_igammac__t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_igammac__t = cast2 Unmanaged.tensor_igammac__t
+tensor_igammac__t = _cast2 Unmanaged.tensor_igammac__t
 
 tensor_nextafter_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_nextafter_t = cast2 Unmanaged.tensor_nextafter_t
+tensor_nextafter_t = _cast2 Unmanaged.tensor_nextafter_t
 
 tensor_nextafter__t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_nextafter__t = cast2 Unmanaged.tensor_nextafter__t
+tensor_nextafter__t = _cast2 Unmanaged.tensor_nextafter__t
 
 tensor_remainder_s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_remainder_s = cast2 Unmanaged.tensor_remainder_s
+tensor_remainder_s = _cast2 Unmanaged.tensor_remainder_s
 
 tensor_remainder__s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_remainder__s = cast2 Unmanaged.tensor_remainder__s
+tensor_remainder__s = _cast2 Unmanaged.tensor_remainder__s
 
 tensor_remainder_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_remainder_t = cast2 Unmanaged.tensor_remainder_t
+tensor_remainder_t = _cast2 Unmanaged.tensor_remainder_t
 
 tensor_remainder__t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_remainder__t = cast2 Unmanaged.tensor_remainder__t
+tensor_remainder__t = _cast2 Unmanaged.tensor_remainder__t
 
 tensor_min
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_min = cast1 Unmanaged.tensor_min
+tensor_min = _cast1 Unmanaged.tensor_min
 
 tensor_fmin_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_fmin_t = cast2 Unmanaged.tensor_fmin_t
+tensor_fmin_t = _cast2 Unmanaged.tensor_fmin_t
 
 tensor_max
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_max = cast1 Unmanaged.tensor_max
+tensor_max = _cast1 Unmanaged.tensor_max
 
 tensor_fmax_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_fmax_t = cast2 Unmanaged.tensor_fmax_t
+tensor_fmax_t = _cast2 Unmanaged.tensor_fmax_t
 
 tensor_maximum_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_maximum_t = cast2 Unmanaged.tensor_maximum_t
+tensor_maximum_t = _cast2 Unmanaged.tensor_maximum_t
 
 tensor_max_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_max_t = cast2 Unmanaged.tensor_max_t
+tensor_max_t = _cast2 Unmanaged.tensor_max_t
 
 tensor_minimum_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_minimum_t = cast2 Unmanaged.tensor_minimum_t
+tensor_minimum_t = _cast2 Unmanaged.tensor_minimum_t
 
 tensor_min_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_min_t = cast2 Unmanaged.tensor_min_t
+tensor_min_t = _cast2 Unmanaged.tensor_min_t
 
 tensor_quantile_tlbs
   :: ForeignPtr Tensor
@@ -1079,7 +1079,7 @@ tensor_quantile_tlbs
   -> CBool
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-tensor_quantile_tlbs = cast5 Unmanaged.tensor_quantile_tlbs
+tensor_quantile_tlbs = _cast5 Unmanaged.tensor_quantile_tlbs
 
 tensor_quantile_dlbs
   :: ForeignPtr Tensor
@@ -1088,7 +1088,7 @@ tensor_quantile_dlbs
   -> CBool
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-tensor_quantile_dlbs = cast5 Unmanaged.tensor_quantile_dlbs
+tensor_quantile_dlbs = _cast5 Unmanaged.tensor_quantile_dlbs
 
 tensor_nanquantile_tlbs
   :: ForeignPtr Tensor
@@ -1097,7 +1097,7 @@ tensor_nanquantile_tlbs
   -> CBool
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-tensor_nanquantile_tlbs = cast5 Unmanaged.tensor_nanquantile_tlbs
+tensor_nanquantile_tlbs = _cast5 Unmanaged.tensor_nanquantile_tlbs
 
 tensor_nanquantile_dlbs
   :: ForeignPtr Tensor
@@ -1106,14 +1106,14 @@ tensor_nanquantile_dlbs
   -> CBool
   -> ForeignPtr StdString
   -> IO (ForeignPtr Tensor)
-tensor_nanquantile_dlbs = cast5 Unmanaged.tensor_nanquantile_dlbs
+tensor_nanquantile_dlbs = _cast5 Unmanaged.tensor_nanquantile_dlbs
 
 tensor_sort_lb
   :: ForeignPtr Tensor
   -> Int64
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-tensor_sort_lb = cast3 Unmanaged.tensor_sort_lb
+tensor_sort_lb = _cast3 Unmanaged.tensor_sort_lb
 
 tensor_sort_blb
   :: ForeignPtr Tensor
@@ -1121,14 +1121,14 @@ tensor_sort_blb
   -> Int64
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-tensor_sort_blb = cast4 Unmanaged.tensor_sort_blb
+tensor_sort_blb = _cast4 Unmanaged.tensor_sort_blb
 
 tensor_sort_nb
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-tensor_sort_nb = cast3 Unmanaged.tensor_sort_nb
+tensor_sort_nb = _cast3 Unmanaged.tensor_sort_nb
 
 tensor_sort_bnb
   :: ForeignPtr Tensor
@@ -1136,26 +1136,26 @@ tensor_sort_bnb
   -> ForeignPtr Dimname
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-tensor_sort_bnb = cast4 Unmanaged.tensor_sort_bnb
+tensor_sort_bnb = _cast4 Unmanaged.tensor_sort_bnb
 
 tensor_msort
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_msort = cast1 Unmanaged.tensor_msort
+tensor_msort = _cast1 Unmanaged.tensor_msort
 
 tensor_argsort_lb
   :: ForeignPtr Tensor
   -> Int64
   -> CBool
   -> IO (ForeignPtr Tensor)
-tensor_argsort_lb = cast3 Unmanaged.tensor_argsort_lb
+tensor_argsort_lb = _cast3 Unmanaged.tensor_argsort_lb
 
 tensor_argsort_nb
   :: ForeignPtr Tensor
   -> ForeignPtr Dimname
   -> CBool
   -> IO (ForeignPtr Tensor)
-tensor_argsort_nb = cast3 Unmanaged.tensor_argsort_nb
+tensor_argsort_nb = _cast3 Unmanaged.tensor_argsort_nb
 
 tensor_topk_llbb
   :: ForeignPtr Tensor
@@ -1164,17 +1164,17 @@ tensor_topk_llbb
   -> CBool
   -> CBool
   -> IO (ForeignPtr (StdTuple '(Tensor,Tensor)))
-tensor_topk_llbb = cast5 Unmanaged.tensor_topk_llbb
+tensor_topk_llbb = _cast5 Unmanaged.tensor_topk_llbb
 
 tensor_all
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_all = cast1 Unmanaged.tensor_all
+tensor_all = _cast1 Unmanaged.tensor_all
 
 tensor_any
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_any = cast1 Unmanaged.tensor_any
+tensor_any = _cast1 Unmanaged.tensor_any
 
 tensor_renorm_sls
   :: ForeignPtr Tensor
@@ -1182,7 +1182,7 @@ tensor_renorm_sls
   -> Int64
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_renorm_sls = cast4 Unmanaged.tensor_renorm_sls
+tensor_renorm_sls = _cast4 Unmanaged.tensor_renorm_sls
 
 tensor_renorm__sls
   :: ForeignPtr Tensor
@@ -1190,7 +1190,7 @@ tensor_renorm__sls
   -> Int64
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_renorm__sls = cast4 Unmanaged.tensor_renorm__sls
+tensor_renorm__sls = _cast4 Unmanaged.tensor_renorm__sls
 
 tensor_unfold_lll
   :: ForeignPtr Tensor
@@ -1198,61 +1198,61 @@ tensor_unfold_lll
   -> Int64
   -> Int64
   -> IO (ForeignPtr Tensor)
-tensor_unfold_lll = cast4 Unmanaged.tensor_unfold_lll
+tensor_unfold_lll = _cast4 Unmanaged.tensor_unfold_lll
 
 tensor_equal_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (CBool)
-tensor_equal_t = cast2 Unmanaged.tensor_equal_t
+tensor_equal_t = _cast2 Unmanaged.tensor_equal_t
 
 tensor_pow_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_pow_t = cast2 Unmanaged.tensor_pow_t
+tensor_pow_t = _cast2 Unmanaged.tensor_pow_t
 
 tensor_pow_s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_pow_s = cast2 Unmanaged.tensor_pow_s
+tensor_pow_s = _cast2 Unmanaged.tensor_pow_s
 
 tensor_pow__s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_pow__s = cast2 Unmanaged.tensor_pow__s
+tensor_pow__s = _cast2 Unmanaged.tensor_pow__s
 
 tensor_pow__t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_pow__t = cast2 Unmanaged.tensor_pow__t
+tensor_pow__t = _cast2 Unmanaged.tensor_pow__t
 
 tensor_float_power_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_float_power_t = cast2 Unmanaged.tensor_float_power_t
+tensor_float_power_t = _cast2 Unmanaged.tensor_float_power_t
 
 tensor_float_power_s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_float_power_s = cast2 Unmanaged.tensor_float_power_s
+tensor_float_power_s = _cast2 Unmanaged.tensor_float_power_s
 
 tensor_float_power__s
   :: ForeignPtr Tensor
   -> ForeignPtr Scalar
   -> IO (ForeignPtr Tensor)
-tensor_float_power__s = cast2 Unmanaged.tensor_float_power__s
+tensor_float_power__s = _cast2 Unmanaged.tensor_float_power__s
 
 tensor_float_power__t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_float_power__t = cast2 Unmanaged.tensor_float_power__t
+tensor_float_power__t = _cast2 Unmanaged.tensor_float_power__t
 
 tensor_normal__ddG
   :: ForeignPtr Tensor
@@ -1260,65 +1260,65 @@ tensor_normal__ddG
   -> CDouble
   -> ForeignPtr Generator
   -> IO (ForeignPtr Tensor)
-tensor_normal__ddG = cast4 Unmanaged.tensor_normal__ddG
+tensor_normal__ddG = _cast4 Unmanaged.tensor_normal__ddG
 
 tensor_alias
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_alias = cast1 Unmanaged.tensor_alias
+tensor_alias = _cast1 Unmanaged.tensor_alias
 
 tensor_isfinite
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_isfinite = cast1 Unmanaged.tensor_isfinite
+tensor_isfinite = _cast1 Unmanaged.tensor_isfinite
 
 tensor_isinf
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_isinf = cast1 Unmanaged.tensor_isinf
+tensor_isinf = _cast1 Unmanaged.tensor_isinf
 
 tensor_record_stream_s
   :: ForeignPtr Tensor
   -> ForeignPtr Stream
   -> IO (())
-tensor_record_stream_s = cast2 Unmanaged.tensor_record_stream_s
+tensor_record_stream_s = _cast2 Unmanaged.tensor_record_stream_s
 
 tensor_isposinf
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_isposinf = cast1 Unmanaged.tensor_isposinf
+tensor_isposinf = _cast1 Unmanaged.tensor_isposinf
 
 tensor_isneginf
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_isneginf = cast1 Unmanaged.tensor_isneginf
+tensor_isneginf = _cast1 Unmanaged.tensor_isneginf
 
 -- tensor_special_polygamma_t
 --   :: ForeignPtr Tensor
 --   -> ForeignPtr Tensor
 --   -> IO (ForeignPtr Tensor)
--- tensor_special_polygamma_t = cast2 Unmanaged.tensor_special_polygamma_t
+-- tensor_special_polygamma_t = _cast2 Unmanaged.tensor_special_polygamma_t
 
 tensor_det
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_det = cast1 Unmanaged.tensor_det
+tensor_det = _cast1 Unmanaged.tensor_det
 
 tensor_inner_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_inner_t = cast2 Unmanaged.tensor_inner_t
+tensor_inner_t = _cast2 Unmanaged.tensor_inner_t
 
 tensor_outer_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_outer_t = cast2 Unmanaged.tensor_outer_t
+tensor_outer_t = _cast2 Unmanaged.tensor_outer_t
 
 tensor_ger_t
   :: ForeignPtr Tensor
   -> ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-tensor_ger_t = cast2 Unmanaged.tensor_ger_t
+tensor_ger_t = _cast2 Unmanaged.tensor_ger_t
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Type/TensorIndex.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Type/TensorIndex.hs
@@ -23,37 +23,37 @@ import qualified Torch.Internal.Unmanaged.Type.TensorIndex as Unmanaged
 
 
 newTensorIndexList :: IO (ForeignPtr (StdVector TensorIndex))
-newTensorIndexList = cast0 Unmanaged.newTensorIndexList
+newTensorIndexList = _cast0 Unmanaged.newTensorIndexList
 
 newTensorIndexWithInt :: CInt -> IO (ForeignPtr TensorIndex)
-newTensorIndexWithInt = cast1 Unmanaged.newTensorIndexWithInt
+newTensorIndexWithInt = _cast1 Unmanaged.newTensorIndexWithInt
 
 newTensorIndexWithBool :: CBool -> IO (ForeignPtr TensorIndex)
-newTensorIndexWithBool = cast1 Unmanaged.newTensorIndexWithBool
+newTensorIndexWithBool = _cast1 Unmanaged.newTensorIndexWithBool
 
 newTensorIndexWithSlice :: CInt -> CInt -> CInt -> IO (ForeignPtr TensorIndex)
-newTensorIndexWithSlice = cast3 Unmanaged.newTensorIndexWithSlice
+newTensorIndexWithSlice = _cast3 Unmanaged.newTensorIndexWithSlice
 
 newTensorIndexWithTensor :: ForeignPtr Tensor -> IO (ForeignPtr TensorIndex)
-newTensorIndexWithTensor = cast1 Unmanaged.newTensorIndexWithTensor
+newTensorIndexWithTensor = _cast1 Unmanaged.newTensorIndexWithTensor
 
 newTensorIndexWithEllipsis :: IO (ForeignPtr TensorIndex)
-newTensorIndexWithEllipsis = cast0 Unmanaged.newTensorIndexWithEllipsis
+newTensorIndexWithEllipsis = _cast0 Unmanaged.newTensorIndexWithEllipsis
 
 newTensorIndexWithNone :: IO (ForeignPtr TensorIndex)
-newTensorIndexWithNone = cast0 Unmanaged.newTensorIndexWithNone
+newTensorIndexWithNone = _cast0 Unmanaged.newTensorIndexWithNone
 
 tensorIndexList_empty :: ForeignPtr (StdVector TensorIndex) -> IO (CBool)
-tensorIndexList_empty = cast1 Unmanaged.tensorIndexList_empty
+tensorIndexList_empty = _cast1 Unmanaged.tensorIndexList_empty
 
 tensorIndexList_size :: ForeignPtr (StdVector TensorIndex) -> IO (CSize)
-tensorIndexList_size = cast1 Unmanaged.tensorIndexList_size
+tensorIndexList_size = _cast1 Unmanaged.tensorIndexList_size
 
 tensorIndexList_push_back :: ForeignPtr (StdVector TensorIndex) -> ForeignPtr TensorIndex -> IO ()
-tensorIndexList_push_back = cast2 Unmanaged.tensorIndexList_push_back
+tensorIndexList_push_back = _cast2 Unmanaged.tensorIndexList_push_back
 
 index :: ForeignPtr Tensor -> ForeignPtr (StdVector TensorIndex) -> IO (ForeignPtr Tensor)
-index = cast2 Unmanaged.index
+index = _cast2 Unmanaged.index
 
 index_put_ :: ForeignPtr Tensor -> ForeignPtr (StdVector TensorIndex) -> ForeignPtr Tensor -> IO (ForeignPtr Tensor)
-index_put_ = cast3 Unmanaged.index_put_
+index_put_ = _cast3 Unmanaged.index_put_

--- a/libtorch-ffi/src/Torch/Internal/Managed/Type/TensorList.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Type/TensorList.hs
@@ -26,27 +26,27 @@ import qualified Torch.Internal.Unmanaged.Type.TensorList as Unmanaged
 
 newTensorList
   :: IO (ForeignPtr TensorList)
-newTensorList = cast0 Unmanaged.newTensorList
+newTensorList = _cast0 Unmanaged.newTensorList
 
 tensorList_empty
   :: ForeignPtr TensorList
   -> IO (CBool)
-tensorList_empty = cast1 Unmanaged.tensorList_empty
+tensorList_empty = _cast1 Unmanaged.tensorList_empty
 
 tensorList_size
   :: ForeignPtr TensorList
   -> IO (CSize)
-tensorList_size = cast1 Unmanaged.tensorList_size
+tensorList_size = _cast1 Unmanaged.tensorList_size
 
 tensorList_at_s
   :: ForeignPtr TensorList
   -> CSize
   -> IO (ForeignPtr Tensor)
-tensorList_at_s = cast2 Unmanaged.tensorList_at_s
+tensorList_at_s = _cast2 Unmanaged.tensorList_at_s
 
 tensorList_push_back_t
   :: ForeignPtr TensorList
   -> ForeignPtr Tensor
   -> IO (())
-tensorList_push_back_t = cast2 Unmanaged.tensorList_push_back_t
+tensorList_push_back_t = _cast2 Unmanaged.tensorList_push_back_t
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Type/TensorOptions.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Type/TensorOptions.hs
@@ -27,105 +27,105 @@ import qualified Torch.Internal.Unmanaged.Type.TensorOptions as Unmanaged
 newTensorOptions_s
   :: ScalarType
   -> IO (ForeignPtr TensorOptions)
-newTensorOptions_s = cast1 Unmanaged.newTensorOptions_s
+newTensorOptions_s = _cast1 Unmanaged.newTensorOptions_s
 
 tensorOptions_device_D
   :: ForeignPtr TensorOptions
   -> DeviceType
   -> IO (ForeignPtr TensorOptions)
-tensorOptions_device_D = cast2 Unmanaged.tensorOptions_device_D
+tensorOptions_device_D = _cast2 Unmanaged.tensorOptions_device_D
 
 tensorOptions_device_index_s
   :: ForeignPtr TensorOptions
   -> Int16
   -> IO (ForeignPtr TensorOptions)
-tensorOptions_device_index_s = cast2 Unmanaged.tensorOptions_device_index_s
+tensorOptions_device_index_s = _cast2 Unmanaged.tensorOptions_device_index_s
 
 tensorOptions_dtype_s
   :: ForeignPtr TensorOptions
   -> ScalarType
   -> IO (ForeignPtr TensorOptions)
-tensorOptions_dtype_s = cast2 Unmanaged.tensorOptions_dtype_s
+tensorOptions_dtype_s = _cast2 Unmanaged.tensorOptions_dtype_s
 
 tensorOptions_dtype
   :: ForeignPtr TensorOptions
   -> IO (ForeignPtr TensorOptions)
-tensorOptions_dtype = cast1 Unmanaged.tensorOptions_dtype
+tensorOptions_dtype = _cast1 Unmanaged.tensorOptions_dtype
 
 tensorOptions_layout_L
   :: ForeignPtr TensorOptions
   -> Layout
   -> IO (ForeignPtr TensorOptions)
-tensorOptions_layout_L = cast2 Unmanaged.tensorOptions_layout_L
+tensorOptions_layout_L = _cast2 Unmanaged.tensorOptions_layout_L
 
 tensorOptions_requires_grad_b
   :: ForeignPtr TensorOptions
   -> CBool
   -> IO (ForeignPtr TensorOptions)
-tensorOptions_requires_grad_b = cast2 Unmanaged.tensorOptions_requires_grad_b
+tensorOptions_requires_grad_b = _cast2 Unmanaged.tensorOptions_requires_grad_b
 
 tensorOptions_has_device
   :: ForeignPtr TensorOptions
   -> IO (CBool)
-tensorOptions_has_device = cast1 Unmanaged.tensorOptions_has_device
+tensorOptions_has_device = _cast1 Unmanaged.tensorOptions_has_device
 
 tensorOptions_device_index
   :: ForeignPtr TensorOptions
   -> IO (Int32)
-tensorOptions_device_index = cast1 Unmanaged.tensorOptions_device_index
+tensorOptions_device_index = _cast1 Unmanaged.tensorOptions_device_index
 
 tensorOptions_has_dtype
   :: ForeignPtr TensorOptions
   -> IO (CBool)
-tensorOptions_has_dtype = cast1 Unmanaged.tensorOptions_has_dtype
+tensorOptions_has_dtype = _cast1 Unmanaged.tensorOptions_has_dtype
 
 tensorOptions_layout
   :: ForeignPtr TensorOptions
   -> IO (Layout)
-tensorOptions_layout = cast1 Unmanaged.tensorOptions_layout
+tensorOptions_layout = _cast1 Unmanaged.tensorOptions_layout
 
 tensorOptions_has_layout
   :: ForeignPtr TensorOptions
   -> IO (CBool)
-tensorOptions_has_layout = cast1 Unmanaged.tensorOptions_has_layout
+tensorOptions_has_layout = _cast1 Unmanaged.tensorOptions_has_layout
 
 tensorOptions_requires_grad
   :: ForeignPtr TensorOptions
   -> IO (CBool)
-tensorOptions_requires_grad = cast1 Unmanaged.tensorOptions_requires_grad
+tensorOptions_requires_grad = _cast1 Unmanaged.tensorOptions_requires_grad
 
 tensorOptions_has_requires_grad
   :: ForeignPtr TensorOptions
   -> IO (CBool)
-tensorOptions_has_requires_grad = cast1 Unmanaged.tensorOptions_has_requires_grad
+tensorOptions_has_requires_grad = _cast1 Unmanaged.tensorOptions_has_requires_grad
 
 tensorOptions_backend
   :: ForeignPtr TensorOptions
   -> IO (Backend)
-tensorOptions_backend = cast1 Unmanaged.tensorOptions_backend
+tensorOptions_backend = _cast1 Unmanaged.tensorOptions_backend
 
 dtype_s
   :: ScalarType
   -> IO (ForeignPtr TensorOptions)
-dtype_s = cast1 Unmanaged.dtype_s
+dtype_s = _cast1 Unmanaged.dtype_s
 
 layout_L
   :: Layout
   -> IO (ForeignPtr TensorOptions)
-layout_L = cast1 Unmanaged.layout_L
+layout_L = _cast1 Unmanaged.layout_L
 
 device_D
   :: DeviceType
   -> IO (ForeignPtr TensorOptions)
-device_D = cast1 Unmanaged.device_D
+device_D = _cast1 Unmanaged.device_D
 
 device_index_s
   :: Int16
   -> IO (ForeignPtr TensorOptions)
-device_index_s = cast1 Unmanaged.device_index_s
+device_index_s = _cast1 Unmanaged.device_index_s
 
 requires_grad_b
   :: CBool
   -> IO (ForeignPtr TensorOptions)
-requires_grad_b = cast1 Unmanaged.requires_grad_b
+requires_grad_b = _cast1 Unmanaged.requires_grad_b
 

--- a/libtorch-ffi/src/Torch/Internal/Managed/Type/Tuple.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Type/Tuple.hs
@@ -27,114 +27,114 @@ import qualified Torch.Internal.Unmanaged.Type.Tuple as Unmanaged
 instance CppTuple2 (ForeignPtr (StdTuple '(Tensor,Tensor))) where
   type A (ForeignPtr (StdTuple '(Tensor,Tensor))) = ForeignPtr Tensor
   type B (ForeignPtr (StdTuple '(Tensor,Tensor))) = ForeignPtr Tensor
-  get0 v = cast1 (get0 :: Ptr (StdTuple '(Tensor,Tensor)) -> IO (Ptr Tensor)) v
-  get1 v = cast1 (get1 :: Ptr (StdTuple '(Tensor,Tensor)) -> IO (Ptr Tensor)) v
+  get0 v = _cast1 (get0 :: Ptr (StdTuple '(Tensor,Tensor)) -> IO (Ptr Tensor)) v
+  get1 v = _cast1 (get1 :: Ptr (StdTuple '(Tensor,Tensor)) -> IO (Ptr Tensor)) v
 
 instance CppTuple2 (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Tensor))) where
   type A (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Tensor))) = ForeignPtr Tensor
   type B (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Tensor))) = ForeignPtr Tensor
-  get0 v = cast1 (get0 :: Ptr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Tensor)) -> IO (Ptr Tensor)) v
-  get1 v = cast1 (get1 :: Ptr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Tensor)) -> IO (Ptr Tensor)) v
+  get0 v = _cast1 (get0 :: Ptr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Tensor)) -> IO (Ptr Tensor)) v
+  get1 v = _cast1 (get1 :: Ptr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Tensor)) -> IO (Ptr Tensor)) v
 
 instance CppTuple3 (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Tensor))) where
   type C (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Tensor))) = ForeignPtr Tensor
-  get2 v = cast1 (get2 :: Ptr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Tensor)) -> IO (Ptr Tensor)) v
+  get2 v = _cast1 (get2 :: Ptr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Tensor)) -> IO (Ptr Tensor)) v
 
 instance CppTuple4 (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Tensor))) where
   type D (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Tensor))) = ForeignPtr Tensor
-  get3 v = cast1 (get3 :: Ptr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Tensor)) -> IO (Ptr Tensor)) v
+  get3 v = _cast1 (get3 :: Ptr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Tensor)) -> IO (Ptr Tensor)) v
 
 instance CppTuple5 (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Tensor))) where
   type E (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Tensor))) = ForeignPtr Tensor
-  get4 v = cast1 (get4 :: Ptr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Tensor)) -> IO (Ptr Tensor)) v
+  get4 v = _cast1 (get4 :: Ptr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Tensor)) -> IO (Ptr Tensor)) v
 
 instance CppTuple2 (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,TensorList))) where
   type A (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,TensorList))) = ForeignPtr Tensor
   type B (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,TensorList))) = ForeignPtr Tensor
-  get0 v = cast1 (get0 :: Ptr (StdTuple '(Tensor,Tensor,Tensor,TensorList)) -> IO (Ptr Tensor)) v
-  get1 v = cast1 (get1 :: Ptr (StdTuple '(Tensor,Tensor,Tensor,TensorList)) -> IO (Ptr Tensor)) v
+  get0 v = _cast1 (get0 :: Ptr (StdTuple '(Tensor,Tensor,Tensor,TensorList)) -> IO (Ptr Tensor)) v
+  get1 v = _cast1 (get1 :: Ptr (StdTuple '(Tensor,Tensor,Tensor,TensorList)) -> IO (Ptr Tensor)) v
 
 instance CppTuple3 (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,TensorList))) where
   type C (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,TensorList))) = ForeignPtr Tensor
-  get2 v = cast1 (get2 :: Ptr (StdTuple '(Tensor,Tensor,Tensor,TensorList)) -> IO (Ptr Tensor)) v
+  get2 v = _cast1 (get2 :: Ptr (StdTuple '(Tensor,Tensor,Tensor,TensorList)) -> IO (Ptr Tensor)) v
 
 instance CppTuple4 (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,TensorList))) where
   type D (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,TensorList))) = ForeignPtr TensorList
-  get3 v = cast1 (get3 :: Ptr (StdTuple '(Tensor,Tensor,Tensor,TensorList)) -> IO (Ptr TensorList)) v
+  get3 v = _cast1 (get3 :: Ptr (StdTuple '(Tensor,Tensor,Tensor,TensorList)) -> IO (Ptr TensorList)) v
 
 instance CppTuple2 (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Int64))) where
   type A (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Int64))) = ForeignPtr Tensor
   type B (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Int64))) = ForeignPtr Tensor
-  get0 v = cast1 (get0 :: Ptr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Int64)) -> IO (Ptr Tensor)) v
-  get1 v = cast1 (get1 :: Ptr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Int64)) -> IO (Ptr Tensor)) v
+  get0 v = _cast1 (get0 :: Ptr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Int64)) -> IO (Ptr Tensor)) v
+  get1 v = _cast1 (get1 :: Ptr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Int64)) -> IO (Ptr Tensor)) v
 
 instance CppTuple3 (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Int64))) where
   type C (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Int64))) = ForeignPtr Tensor
-  get2 v = cast1 (get2 :: Ptr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Int64)) -> IO (Ptr Tensor)) v
+  get2 v = _cast1 (get2 :: Ptr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Int64)) -> IO (Ptr Tensor)) v
 
 instance CppTuple4 (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Int64))) where
   type D (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Int64))) = ForeignPtr Tensor
-  get3 v = cast1 (get3 :: Ptr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Int64)) -> IO (Ptr Tensor)) v
+  get3 v = _cast1 (get3 :: Ptr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Int64)) -> IO (Ptr Tensor)) v
 
 instance CppTuple5 (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Int64))) where
   type E (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Int64))) = Int64
-  get4 v = cast1 (get4 :: Ptr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Int64)) -> IO (Int64)) v
+  get4 v = _cast1 (get4 :: Ptr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Int64)) -> IO (Int64)) v
 
 instance CppTuple2 (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor))) where
   type A (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor))) = ForeignPtr Tensor
   type B (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor))) = ForeignPtr Tensor
-  get0 v = cast1 (get0 :: Ptr (StdTuple '(Tensor,Tensor,Tensor)) -> IO (Ptr Tensor)) v
-  get1 v = cast1 (get1 :: Ptr (StdTuple '(Tensor,Tensor,Tensor)) -> IO (Ptr Tensor)) v
+  get0 v = _cast1 (get0 :: Ptr (StdTuple '(Tensor,Tensor,Tensor)) -> IO (Ptr Tensor)) v
+  get1 v = _cast1 (get1 :: Ptr (StdTuple '(Tensor,Tensor,Tensor)) -> IO (Ptr Tensor)) v
 
 instance CppTuple3 (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor))) where
   type C (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor))) = ForeignPtr Tensor
-  get2 v = cast1 (get2 :: Ptr (StdTuple '(Tensor,Tensor,Tensor)) -> IO (Ptr Tensor)) v
+  get2 v = _cast1 (get2 :: Ptr (StdTuple '(Tensor,Tensor,Tensor)) -> IO (Ptr Tensor)) v
 
 instance CppTuple2 (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor))) where
   type A (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor))) = ForeignPtr Tensor
   type B (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor))) = ForeignPtr Tensor
-  get0 v = cast1 (get0 :: Ptr (StdTuple '(Tensor,Tensor,Tensor,Tensor)) -> IO (Ptr Tensor)) v
-  get1 v = cast1 (get1 :: Ptr (StdTuple '(Tensor,Tensor,Tensor,Tensor)) -> IO (Ptr Tensor)) v
+  get0 v = _cast1 (get0 :: Ptr (StdTuple '(Tensor,Tensor,Tensor,Tensor)) -> IO (Ptr Tensor)) v
+  get1 v = _cast1 (get1 :: Ptr (StdTuple '(Tensor,Tensor,Tensor,Tensor)) -> IO (Ptr Tensor)) v
 
 instance CppTuple3 (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor))) where
   type C (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor))) = ForeignPtr Tensor
-  get2 v = cast1 (get2 :: Ptr (StdTuple '(Tensor,Tensor,Tensor,Tensor)) -> IO (Ptr Tensor)) v
+  get2 v = _cast1 (get2 :: Ptr (StdTuple '(Tensor,Tensor,Tensor,Tensor)) -> IO (Ptr Tensor)) v
 
 instance CppTuple4 (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor))) where
   type D (ForeignPtr (StdTuple '(Tensor,Tensor,Tensor,Tensor))) = ForeignPtr Tensor
-  get3 v = cast1 (get3 :: Ptr (StdTuple '(Tensor,Tensor,Tensor,Tensor)) -> IO (Ptr Tensor)) v
+  get3 v = _cast1 (get3 :: Ptr (StdTuple '(Tensor,Tensor,Tensor,Tensor)) -> IO (Ptr Tensor)) v
 
 instance CppTuple2 (ForeignPtr (StdTuple '(Tensor,Tensor,CDouble,Int64))) where
   type A (ForeignPtr (StdTuple '(Tensor,Tensor,CDouble,Int64))) = ForeignPtr Tensor
   type B (ForeignPtr (StdTuple '(Tensor,Tensor,CDouble,Int64))) = ForeignPtr Tensor
-  get0 v = cast1 (get0 :: Ptr (StdTuple '(Tensor,Tensor,CDouble,Int64)) -> IO (Ptr Tensor)) v
-  get1 v = cast1 (get1 :: Ptr (StdTuple '(Tensor,Tensor,CDouble,Int64)) -> IO (Ptr Tensor)) v
+  get0 v = _cast1 (get0 :: Ptr (StdTuple '(Tensor,Tensor,CDouble,Int64)) -> IO (Ptr Tensor)) v
+  get1 v = _cast1 (get1 :: Ptr (StdTuple '(Tensor,Tensor,CDouble,Int64)) -> IO (Ptr Tensor)) v
 
 instance CppTuple3 (ForeignPtr (StdTuple '(Tensor,Tensor,CDouble,Int64))) where
   type C (ForeignPtr (StdTuple '(Tensor,Tensor,CDouble,Int64))) = CDouble
-  get2 v = cast1 (get2 :: Ptr (StdTuple '(Tensor,Tensor,CDouble,Int64)) -> IO (CDouble)) v
+  get2 v = _cast1 (get2 :: Ptr (StdTuple '(Tensor,Tensor,CDouble,Int64)) -> IO (CDouble)) v
 
 instance CppTuple4 (ForeignPtr (StdTuple '(Tensor,Tensor,CDouble,Int64))) where
   type D (ForeignPtr (StdTuple '(Tensor,Tensor,CDouble,Int64))) = Int64
-  get3 v = cast1 (get3 :: Ptr (StdTuple '(Tensor,Tensor,CDouble,Int64)) -> IO (Int64)) v
+  get3 v = _cast1 (get3 :: Ptr (StdTuple '(Tensor,Tensor,CDouble,Int64)) -> IO (Int64)) v
 
 instance CppTuple2 (ForeignPtr (StdTuple '(CDouble,Int64))) where
   type A (ForeignPtr (StdTuple '(CDouble,Int64))) = CDouble
   type B (ForeignPtr (StdTuple '(CDouble,Int64))) = Int64
-  get0 v = cast1 (get0 :: Ptr (StdTuple '(CDouble,Int64)) -> IO (CDouble)) v
-  get1 v = cast1 (get1 :: Ptr (StdTuple '(CDouble,Int64)) -> IO (Int64)) v
+  get0 v = _cast1 (get0 :: Ptr (StdTuple '(CDouble,Int64)) -> IO (CDouble)) v
+  get1 v = _cast1 (get1 :: Ptr (StdTuple '(CDouble,Int64)) -> IO (Int64)) v
 
 instance CppTuple2 (ForeignPtr (StdTuple '(CDouble,CDouble))) where
   type A (ForeignPtr (StdTuple '(CDouble,CDouble))) = CDouble
   type B (ForeignPtr (StdTuple '(CDouble,CDouble))) = CDouble
-  get0 v = cast1 (get0 :: Ptr (StdTuple '(CDouble,CDouble)) -> IO (CDouble)) v
-  get1 v = cast1 (get1 :: Ptr (StdTuple '(CDouble,CDouble)) -> IO (CDouble)) v
+  get0 v = _cast1 (get0 :: Ptr (StdTuple '(CDouble,CDouble)) -> IO (CDouble)) v
+  get1 v = _cast1 (get1 :: Ptr (StdTuple '(CDouble,CDouble)) -> IO (CDouble)) v
 
 instance CppTuple2 (ForeignPtr (StdTuple '(Tensor,Generator))) where
   type A (ForeignPtr (StdTuple '(Tensor,Generator))) = ForeignPtr Tensor
   type B (ForeignPtr (StdTuple '(Tensor,Generator))) = ForeignPtr Generator
-  get0 v = cast1 (get0 :: Ptr (StdTuple '(Tensor,Generator)) -> IO (Ptr Tensor)) v
-  get1 v = cast1 (get1 :: Ptr (StdTuple '(Tensor,Generator)) -> IO (Ptr Generator)) v
+  get0 v = _cast1 (get0 :: Ptr (StdTuple '(Tensor,Generator)) -> IO (Ptr Tensor)) v
+  get1 v = _cast1 (get1 :: Ptr (StdTuple '(Tensor,Generator)) -> IO (Ptr Generator)) v
   makeTuple2 (a,b) =
     withForeignPtr a $ \a' -> do
       withForeignPtr b $ \b' -> do

--- a/libtorch-ffi/src/Torch/Internal/Objects.hs
+++ b/libtorch-ffi/src/Torch/Internal/Objects.hs
@@ -16,6 +16,7 @@ foreign import ccall unsafe "hasktorch_finalizer.h &delete_c10dict"
 
 instance CppObject (C10Dict '(IValue,IValue)) where
   fromPtr ptr = newForeignPtr c_delete_c10dict ptr
+  {-# INLINE fromPtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_c10listivalue"
   c_delete_c10listivalue :: FunPtr ( Ptr (C10List IValue) -> IO ())
@@ -37,21 +38,27 @@ foreign import ccall unsafe "hasktorch_finalizer.h &delete_c10listbool"
 
 instance CppObject (C10List IValue) where
   fromPtr ptr = newForeignPtr c_delete_c10listivalue ptr
+  {-# INLINE fromPtr #-}
 
 instance CppObject (C10List Tensor) where
   fromPtr ptr = newForeignPtr c_delete_c10listtensor ptr
+  {-# INLINE fromPtr #-}
 
 instance CppObject (C10List (C10Optional Tensor)) where
   fromPtr ptr = newForeignPtr c_delete_c10listoptionaltensor ptr
+  {-# INLINE fromPtr #-}
 
 instance CppObject (C10List CDouble) where
   fromPtr ptr = newForeignPtr c_delete_c10listdouble ptr
+  {-# INLINE fromPtr #-}
 
 instance CppObject (C10List Int64) where
   fromPtr ptr = newForeignPtr c_delete_c10listint ptr
+  {-# INLINE fromPtr #-}
 
 instance CppObject (C10List CBool) where
   fromPtr ptr = newForeignPtr c_delete_c10listbool ptr
+  {-# INLINE fromPtr #-}
 
 
 
@@ -60,12 +67,14 @@ foreign import ccall unsafe "hasktorch_finalizer.h &delete_c10tuple"
 
 instance CppObject (C10Ptr IVTuple) where
   fromPtr ptr = newForeignPtr c_delete_c10tuple ptr
+  {-# INLINE fromPtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_context"
   c_delete_context :: FunPtr ( Ptr Context -> IO ())
 
 instance CppObject Context where
   fromPtr ptr = newForeignPtr c_delete_context ptr
+  {-# INLINE fromPtr #-}
 
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_dimname"
@@ -73,12 +82,14 @@ foreign import ccall unsafe "hasktorch_finalizer.h &delete_dimname"
 
 instance CppObject Dimname where
   fromPtr ptr = newForeignPtr c_delete_dimname ptr
+  {-# INLINE fromPtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_dimnamelist"
   c_delete_dimnamelist :: FunPtr ( Ptr DimnameList -> IO ())
 
 instance CppObject DimnameList where
   fromPtr ptr = newForeignPtr c_delete_dimnamelist ptr
+  {-# INLINE fromPtr #-}
 
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_generator"
@@ -86,6 +97,7 @@ foreign import ccall unsafe "hasktorch_finalizer.h &delete_generator"
 
 instance CppObject Generator where
   fromPtr ptr = newForeignPtr c_delete_generator ptr
+  {-# INLINE fromPtr #-}
 
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_ivalue"
@@ -93,6 +105,7 @@ foreign import ccall unsafe "hasktorch_finalizer.h &delete_ivalue"
 
 instance CppObject IValue where
   fromPtr ptr = newForeignPtr c_delete_ivalue ptr
+  {-# INLINE fromPtr #-}
 
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_ivaluelist"
@@ -100,42 +113,49 @@ foreign import ccall unsafe "hasktorch_finalizer.h &delete_ivaluelist"
 
 instance CppObject IValueList where
   fromPtr ptr = newForeignPtr c_delete_ivaluelist ptr
+  {-# INLINE fromPtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_intarray"
   c_delete_intarray :: FunPtr ( Ptr IntArray -> IO ())
 
 instance CppObject IntArray where
   fromPtr ptr = newForeignPtr c_delete_intarray ptr
+  {-# INLINE fromPtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_module"
   c_delete_module :: FunPtr ( Ptr Module -> IO ())
 
 instance CppObject Module where
   fromPtr ptr = newForeignPtr c_delete_module ptr
+  {-# INLINE fromPtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_jitgraph"
   c_delete_jitgraph :: FunPtr ( Ptr (SharedPtr JitGraph) -> IO ())
 
 instance CppObject (SharedPtr JitGraph) where
   fromPtr ptr = newForeignPtr c_delete_jitgraph ptr
+  {-# INLINE fromPtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_jitnode"
   c_delete_jitnode :: FunPtr ( Ptr JitNode -> IO ())
 
 instance CppObject JitNode where
   fromPtr ptr = newForeignPtr c_delete_jitnode ptr
+  {-# INLINE fromPtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_jitvalue"
   c_delete_jitvalue :: FunPtr ( Ptr JitValue -> IO ())
 
 instance CppObject JitValue where
   fromPtr ptr = newForeignPtr c_delete_jitvalue ptr
+  {-# INLINE fromPtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_scalar"
   c_delete_scalar :: FunPtr ( Ptr Scalar -> IO ())
 
 instance CppObject Scalar where
   fromPtr ptr = newForeignPtr c_delete_scalar ptr
+  {-# INLINE fromPtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_stdarraybool2"
   c_delete_stdarraybool2 :: FunPtr ( Ptr (StdArray '(CBool,2)) -> IO ())
@@ -148,18 +168,22 @@ foreign import ccall unsafe "hasktorch_finalizer.h &delete_stdarraybool4"
 
 instance CppObject (StdArray '(CBool,2)) where
   fromPtr ptr = newForeignPtr c_delete_stdarraybool2 ptr
+  {-# INLINE fromPtr #-}
 
 instance CppObject (StdArray '(CBool,3)) where
   fromPtr ptr = newForeignPtr c_delete_stdarraybool3 ptr
+  {-# INLINE fromPtr #-}
 
 instance CppObject (StdArray '(CBool,4)) where
   fromPtr ptr = newForeignPtr c_delete_stdarraybool4 ptr
+  {-# INLINE fromPtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_stdstring"
   c_delete_stdstring :: FunPtr ( Ptr StdString -> IO ())
 
 instance CppObject StdString where
   fromPtr ptr = newForeignPtr c_delete_stdstring ptr
+  {-# INLINE fromPtr #-}
 
 
 
@@ -168,6 +192,7 @@ foreign import ccall unsafe "hasktorch_finalizer.h &delete_storage"
 
 instance CppObject Storage where
   fromPtr ptr = newForeignPtr c_delete_storage ptr
+  {-# INLINE fromPtr #-}
 
 
 
@@ -176,12 +201,14 @@ foreign import ccall unsafe "hasktorch_finalizer.h &delete_symbol"
 
 instance CppObject Symbol where
   fromPtr ptr = newForeignPtr c_delete_symbol ptr
+  {-# INLINE fromPtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_tensor"
   c_delete_tensor  :: FunPtr( Ptr Tensor -> IO () )
 
 instance CppObject Tensor where
   fromPtr ptr = newForeignPtr c_delete_tensor ptr
+  {-# INLINE fromPtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_tensorindex"
   c_delete_tensorindex :: FunPtr ( Ptr TensorIndex -> IO ())
@@ -191,120 +218,141 @@ foreign import ccall unsafe "hasktorch_finalizer.h &delete_tensorindexlist"
 
 instance CppObject TensorIndex where
   fromPtr ptr = newForeignPtr c_delete_tensorindex ptr
+  {-# INLINE fromPtr #-}
 
 instance CppObject (StdVector TensorIndex) where
   fromPtr ptr = newForeignPtr c_delete_tensorindexlist ptr
+  {-# INLINE fromPtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_tensorlist"
   c_delete_tensorlist :: FunPtr ( Ptr TensorList -> IO ())
 
 instance CppObject TensorList where
   fromPtr ptr = newForeignPtr c_delete_tensorlist ptr
+  {-# INLINE fromPtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_tensoroptions"
   c_delete_tensoroptions :: FunPtr ( Ptr TensorOptions -> IO ())
 
 instance CppObject TensorOptions where
   fromPtr ptr = newForeignPtr c_delete_tensoroptions ptr
+  {-# INLINE fromPtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_tensortensor"
   c_delete_tensortensor :: FunPtr ( Ptr (StdTuple '(Tensor,Tensor)) -> IO ())
 
 instance CppObject (StdTuple '(Tensor,Tensor)) where
   fromPtr ptr = newForeignPtr c_delete_tensortensor ptr
+  {-# INLINE fromPtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_tensortensortensortensortensor"
   c_delete_tensortensortensortensortensor :: FunPtr ( Ptr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Tensor)) -> IO ())
 
 instance CppObject (StdTuple '(Tensor,Tensor,Tensor,Tensor,Tensor)) where
   fromPtr ptr = newForeignPtr c_delete_tensortensortensortensortensor ptr
+  {-# INLINE fromPtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_tensortensortensortensorlist"
   c_delete_tensortensortensortensorlist :: FunPtr ( Ptr (StdTuple '(Tensor,Tensor,Tensor,TensorList)) -> IO ())
 
 instance CppObject (StdTuple '(Tensor,Tensor,Tensor,TensorList)) where
   fromPtr ptr = newForeignPtr c_delete_tensortensortensortensorlist ptr
+  {-# INLINE fromPtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_tensortensortensortensorint64"
   c_delete_tensortensortensortensorint64 :: FunPtr ( Ptr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Int64)) -> IO ())
 
 instance CppObject (StdTuple '(Tensor,Tensor,Tensor,Tensor,Int64)) where
   fromPtr ptr = newForeignPtr c_delete_tensortensortensortensorint64 ptr
+  {-# INLINE fromPtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_tensortensortensor"
   c_delete_tensortensortensor :: FunPtr ( Ptr (StdTuple '(Tensor,Tensor,Tensor)) -> IO ())
 
 instance CppObject (StdTuple '(Tensor,Tensor,Tensor)) where
   fromPtr ptr = newForeignPtr c_delete_tensortensortensor ptr
+  {-# INLINE fromPtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_tensortensortensortensor"
   c_delete_tensortensortensortensor :: FunPtr ( Ptr (StdTuple '(Tensor,Tensor,Tensor,Tensor)) -> IO ())
 
 instance CppObject (StdTuple '(Tensor,Tensor,Tensor,Tensor)) where
   fromPtr ptr = newForeignPtr c_delete_tensortensortensortensor ptr
+  {-# INLINE fromPtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_cdoubleint64"
   c_delete_cdoubleint64 :: FunPtr ( Ptr (StdTuple '(CDouble,Int64)) -> IO ())
 
 instance CppObject (StdTuple '(CDouble,Int64)) where
   fromPtr ptr = newForeignPtr c_delete_cdoubleint64 ptr
+  {-# INLINE fromPtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_cdoublecdouble"
   c_delete_cdoublecdouble :: FunPtr ( Ptr (StdTuple '(CDouble,CDouble)) -> IO ())
 
 instance CppObject (StdTuple '(CDouble,CDouble)) where
   fromPtr ptr = newForeignPtr c_delete_cdoublecdouble ptr
+  {-# INLINE fromPtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_tensorgenerator"
   c_delete_tensorgenerator :: FunPtr ( Ptr (StdTuple '(Tensor,Generator)) -> IO ())
 
 instance CppObject (StdTuple '(Tensor,Generator)) where
   fromPtr ptr = newForeignPtr c_delete_tensorgenerator ptr
+  {-# INLINE fromPtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_tensortensorcdoubleint64"
   c_delete_tensortensorcdoubleint64 :: FunPtr ( Ptr (StdTuple '(Tensor,Tensor,CDouble,Int64)) -> IO ())
 
 instance CppObject (StdTuple '(Tensor,Tensor,CDouble,Int64)) where
   fromPtr ptr = newForeignPtr c_delete_tensortensorcdoubleint64 ptr
+  {-# INLINE fromPtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_optimizer"
   c_delete_optimizer  :: FunPtr( Ptr Optimizer -> IO () )
 
 instance CppObject Optimizer where
   fromPtr ptr = newForeignPtr c_delete_optimizer ptr
+  {-# INLINE fromPtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_stdvectordouble"
   c_delete_stdvectordouble :: FunPtr ( Ptr (StdVector CDouble) -> IO ())
 
 instance CppObject (StdVector CDouble) where
   fromPtr ptr = newForeignPtr c_delete_stdvectordouble ptr
+  {-# INLINE fromPtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_stdvectorint"
   c_delete_stdvectorint :: FunPtr ( Ptr (StdVector CInt) -> IO ())
 
 instance CppObject (StdVector CInt) where
   fromPtr ptr = newForeignPtr c_delete_stdvectorint ptr
+  {-# INLINE fromPtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_stdvectorbool"
   c_delete_stdvectorbool :: FunPtr ( Ptr (StdVector CBool) -> IO ())
 
 instance CppObject (StdVector CBool) where
   fromPtr ptr = newForeignPtr c_delete_stdvectorbool ptr
+  {-# INLINE fromPtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_stream"
   c_delete_stream :: FunPtr ( Ptr Stream -> IO ())
 
 instance CppObject Stream where
   fromPtr ptr = newForeignPtr c_delete_stream ptr
+  {-# INLINE fromPtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_arrayrefscalar"
   c_delete_arrayrefscalar :: FunPtr ( Ptr (ArrayRef Scalar) -> IO ())
 
 instance CppObject (ArrayRef Scalar) where
   fromPtr ptr = newForeignPtr c_delete_arrayrefscalar ptr
+  {-# INLINE fromPtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_vectorscalar"
   c_delete_vectorscalar :: FunPtr ( Ptr (StdVector Scalar) -> IO ())
 
 instance CppObject (StdVector Scalar) where
   fromPtr ptr = newForeignPtr c_delete_vectorscalar ptr
+  {-# INLINE fromPtr #-}

--- a/libtorch-ffi/src/Torch/Internal/Objects.hs
+++ b/libtorch-ffi/src/Torch/Internal/Objects.hs
@@ -14,345 +14,585 @@ import Torch.Internal.Class
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_c10dict"
   c_delete_c10dict  :: FunPtr( Ptr (C10Dict '(IValue,IValue)) -> IO () )
 
+foreign import ccall unsafe "hasktorch_finalizer.h delete_c10dict"
+  c_delete_c10dict'  :: Ptr (C10Dict '(IValue,IValue)) -> IO ()
+
 instance CppObject (C10Dict '(IValue,IValue)) where
   fromPtr ptr = newForeignPtr c_delete_c10dict ptr
   {-# INLINE fromPtr #-}
+  deletePtr ptr = c_delete_c10dict' ptr
+  {-# INLINE deletePtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_c10listivalue"
   c_delete_c10listivalue :: FunPtr ( Ptr (C10List IValue) -> IO ())
 
+foreign import ccall unsafe "hasktorch_finalizer.h delete_c10listivalue"
+  c_delete_c10listivalue' ::  Ptr (C10List IValue) -> IO ()
+
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_c10listtensor"
   c_delete_c10listtensor :: FunPtr ( Ptr (C10List Tensor) -> IO ())
+
+foreign import ccall unsafe "hasktorch_finalizer.h delete_c10listtensor"
+  c_delete_c10listtensor' ::  Ptr (C10List Tensor) -> IO ()
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_c10listoptionaltensor"
   c_delete_c10listoptionaltensor :: FunPtr ( Ptr (C10List (C10Optional Tensor)) -> IO ())
 
+foreign import ccall unsafe "hasktorch_finalizer.h delete_c10listoptionaltensor"
+  c_delete_c10listoptionaltensor' ::  Ptr (C10List (C10Optional Tensor)) -> IO ()
+
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_c10listdouble"
   c_delete_c10listdouble :: FunPtr ( Ptr (C10List CDouble) -> IO ())
+
+foreign import ccall unsafe "hasktorch_finalizer.h delete_c10listdouble"
+  c_delete_c10listdouble' ::  Ptr (C10List CDouble) -> IO ()
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_c10listint"
   c_delete_c10listint :: FunPtr ( Ptr (C10List Int64) -> IO ())
 
+foreign import ccall unsafe "hasktorch_finalizer.h delete_c10listint"
+  c_delete_c10listint' ::  Ptr (C10List Int64) -> IO ()
+
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_c10listbool"
   c_delete_c10listbool :: FunPtr ( Ptr (C10List CBool) -> IO ())
+
+foreign import ccall unsafe "hasktorch_finalizer.h delete_c10listbool"
+  c_delete_c10listbool' ::  Ptr (C10List CBool) -> IO ()
 
 instance CppObject (C10List IValue) where
   fromPtr ptr = newForeignPtr c_delete_c10listivalue ptr
   {-# INLINE fromPtr #-}
+  deletePtr ptr = c_delete_c10listivalue' ptr
+  {-# INLINE deletePtr #-}
 
 instance CppObject (C10List Tensor) where
   fromPtr ptr = newForeignPtr c_delete_c10listtensor ptr
   {-# INLINE fromPtr #-}
+  deletePtr ptr = c_delete_c10listtensor' ptr
+  {-# INLINE deletePtr #-}
 
 instance CppObject (C10List (C10Optional Tensor)) where
   fromPtr ptr = newForeignPtr c_delete_c10listoptionaltensor ptr
   {-# INLINE fromPtr #-}
+  deletePtr ptr = c_delete_c10listoptionaltensor' ptr
+  {-# INLINE deletePtr #-}
 
 instance CppObject (C10List CDouble) where
   fromPtr ptr = newForeignPtr c_delete_c10listdouble ptr
   {-# INLINE fromPtr #-}
+  deletePtr ptr = c_delete_c10listdouble' ptr
+  {-# INLINE deletePtr #-}
 
 instance CppObject (C10List Int64) where
   fromPtr ptr = newForeignPtr c_delete_c10listint ptr
   {-# INLINE fromPtr #-}
+  deletePtr ptr = c_delete_c10listint' ptr
+  {-# INLINE deletePtr #-}
 
 instance CppObject (C10List CBool) where
   fromPtr ptr = newForeignPtr c_delete_c10listbool ptr
   {-# INLINE fromPtr #-}
+  deletePtr ptr = c_delete_c10listbool' ptr
+  {-# INLINE deletePtr #-}
 
 
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_c10tuple"
   c_delete_c10tuple :: FunPtr ( Ptr (C10Ptr IVTuple) -> IO ())
 
+foreign import ccall unsafe "hasktorch_finalizer.h delete_c10tuple"
+  c_delete_c10tuple' ::  Ptr (C10Ptr IVTuple) -> IO ()
+
 instance CppObject (C10Ptr IVTuple) where
   fromPtr ptr = newForeignPtr c_delete_c10tuple ptr
   {-# INLINE fromPtr #-}
+  deletePtr ptr = c_delete_c10tuple' ptr
+  {-# INLINE deletePtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_context"
   c_delete_context :: FunPtr ( Ptr Context -> IO ())
 
+foreign import ccall unsafe "hasktorch_finalizer.h delete_context"
+  c_delete_context' ::  Ptr Context -> IO ()
+
 instance CppObject Context where
   fromPtr ptr = newForeignPtr c_delete_context ptr
   {-# INLINE fromPtr #-}
+  deletePtr ptr = c_delete_context' ptr
+  {-# INLINE deletePtr #-}
 
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_dimname"
   c_delete_dimname :: FunPtr ( Ptr Dimname -> IO ())
 
+foreign import ccall unsafe "hasktorch_finalizer.h delete_dimname"
+  c_delete_dimname' ::  Ptr Dimname -> IO ()
+
 instance CppObject Dimname where
   fromPtr ptr = newForeignPtr c_delete_dimname ptr
   {-# INLINE fromPtr #-}
+  deletePtr ptr = c_delete_dimname' ptr
+  {-# INLINE deletePtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_dimnamelist"
   c_delete_dimnamelist :: FunPtr ( Ptr DimnameList -> IO ())
 
+foreign import ccall unsafe "hasktorch_finalizer.h delete_dimnamelist"
+  c_delete_dimnamelist' ::  Ptr DimnameList -> IO ()
+
 instance CppObject DimnameList where
   fromPtr ptr = newForeignPtr c_delete_dimnamelist ptr
   {-# INLINE fromPtr #-}
+  deletePtr ptr = c_delete_dimnamelist' ptr
+  {-# INLINE deletePtr #-}
 
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_generator"
   c_delete_generator :: FunPtr ( Ptr Generator -> IO ())
 
+foreign import ccall unsafe "hasktorch_finalizer.h delete_generator"
+  c_delete_generator' ::  Ptr Generator -> IO ()
+
 instance CppObject Generator where
   fromPtr ptr = newForeignPtr c_delete_generator ptr
   {-# INLINE fromPtr #-}
+  deletePtr ptr = c_delete_generator' ptr
+  {-# INLINE deletePtr #-}
 
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_ivalue"
   c_delete_ivalue :: FunPtr ( Ptr IValue -> IO ())
 
+foreign import ccall unsafe "hasktorch_finalizer.h delete_ivalue"
+  c_delete_ivalue' ::  Ptr IValue -> IO ()
+
 instance CppObject IValue where
   fromPtr ptr = newForeignPtr c_delete_ivalue ptr
   {-# INLINE fromPtr #-}
+  deletePtr ptr = c_delete_ivalue' ptr
+  {-# INLINE deletePtr #-}
 
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_ivaluelist"
   c_delete_ivaluelist :: FunPtr ( Ptr IValueList -> IO ())
 
+foreign import ccall unsafe "hasktorch_finalizer.h delete_ivaluelist"
+  c_delete_ivaluelist' ::  Ptr IValueList -> IO ()
+
 instance CppObject IValueList where
   fromPtr ptr = newForeignPtr c_delete_ivaluelist ptr
   {-# INLINE fromPtr #-}
+  deletePtr ptr = c_delete_ivaluelist' ptr
+  {-# INLINE deletePtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_intarray"
   c_delete_intarray :: FunPtr ( Ptr IntArray -> IO ())
 
+foreign import ccall unsafe "hasktorch_finalizer.h delete_intarray"
+  c_delete_intarray' ::  Ptr IntArray -> IO ()
+
 instance CppObject IntArray where
   fromPtr ptr = newForeignPtr c_delete_intarray ptr
   {-# INLINE fromPtr #-}
+  deletePtr ptr = c_delete_intarray' ptr
+  {-# INLINE deletePtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_module"
   c_delete_module :: FunPtr ( Ptr Module -> IO ())
 
+foreign import ccall unsafe "hasktorch_finalizer.h delete_module"
+  c_delete_module' ::  Ptr Module -> IO ()
+
 instance CppObject Module where
   fromPtr ptr = newForeignPtr c_delete_module ptr
   {-# INLINE fromPtr #-}
+  deletePtr ptr = c_delete_module' ptr
+  {-# INLINE deletePtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_jitgraph"
   c_delete_jitgraph :: FunPtr ( Ptr (SharedPtr JitGraph) -> IO ())
 
+foreign import ccall unsafe "hasktorch_finalizer.h delete_jitgraph"
+  c_delete_jitgraph' ::  Ptr (SharedPtr JitGraph) -> IO ()
+
 instance CppObject (SharedPtr JitGraph) where
   fromPtr ptr = newForeignPtr c_delete_jitgraph ptr
   {-# INLINE fromPtr #-}
+  deletePtr ptr = c_delete_jitgraph' ptr
+  {-# INLINE deletePtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_jitnode"
   c_delete_jitnode :: FunPtr ( Ptr JitNode -> IO ())
 
+foreign import ccall unsafe "hasktorch_finalizer.h delete_jitnode"
+  c_delete_jitnode' ::  Ptr JitNode -> IO ()
+
 instance CppObject JitNode where
   fromPtr ptr = newForeignPtr c_delete_jitnode ptr
   {-# INLINE fromPtr #-}
+  deletePtr ptr = c_delete_jitnode' ptr
+  {-# INLINE deletePtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_jitvalue"
   c_delete_jitvalue :: FunPtr ( Ptr JitValue -> IO ())
 
+foreign import ccall unsafe "hasktorch_finalizer.h delete_jitvalue"
+  c_delete_jitvalue' ::  Ptr JitValue -> IO ()
+
 instance CppObject JitValue where
   fromPtr ptr = newForeignPtr c_delete_jitvalue ptr
   {-# INLINE fromPtr #-}
+  deletePtr ptr = c_delete_jitvalue' ptr
+  {-# INLINE deletePtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_scalar"
   c_delete_scalar :: FunPtr ( Ptr Scalar -> IO ())
 
+foreign import ccall unsafe "hasktorch_finalizer.h delete_scalar"
+  c_delete_scalar' ::  Ptr Scalar -> IO ()
+
 instance CppObject Scalar where
   fromPtr ptr = newForeignPtr c_delete_scalar ptr
   {-# INLINE fromPtr #-}
+  deletePtr ptr = c_delete_scalar' ptr
+  {-# INLINE deletePtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_stdarraybool2"
   c_delete_stdarraybool2 :: FunPtr ( Ptr (StdArray '(CBool,2)) -> IO ())
 
+foreign import ccall unsafe "hasktorch_finalizer.h delete_stdarraybool2"
+  c_delete_stdarraybool2' ::  Ptr (StdArray '(CBool,2)) -> IO ()
+
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_stdarraybool3"
   c_delete_stdarraybool3 :: FunPtr ( Ptr (StdArray '(CBool,3)) -> IO ())
+
+foreign import ccall unsafe "hasktorch_finalizer.h delete_stdarraybool3"
+  c_delete_stdarraybool3' ::  Ptr (StdArray '(CBool,3)) -> IO ()
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_stdarraybool4"
   c_delete_stdarraybool4 :: FunPtr ( Ptr (StdArray '(CBool,4)) -> IO ())
 
+foreign import ccall unsafe "hasktorch_finalizer.h delete_stdarraybool4"
+  c_delete_stdarraybool4' ::  Ptr (StdArray '(CBool,4)) -> IO ()
+
 instance CppObject (StdArray '(CBool,2)) where
   fromPtr ptr = newForeignPtr c_delete_stdarraybool2 ptr
   {-# INLINE fromPtr #-}
+  deletePtr ptr = c_delete_stdarraybool2' ptr
+  {-# INLINE deletePtr #-}
 
 instance CppObject (StdArray '(CBool,3)) where
   fromPtr ptr = newForeignPtr c_delete_stdarraybool3 ptr
   {-# INLINE fromPtr #-}
+  deletePtr ptr = c_delete_stdarraybool3' ptr
+  {-# INLINE deletePtr #-}
 
 instance CppObject (StdArray '(CBool,4)) where
   fromPtr ptr = newForeignPtr c_delete_stdarraybool4 ptr
   {-# INLINE fromPtr #-}
+  deletePtr ptr = c_delete_stdarraybool4' ptr
+  {-# INLINE deletePtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_stdstring"
   c_delete_stdstring :: FunPtr ( Ptr StdString -> IO ())
 
+foreign import ccall unsafe "hasktorch_finalizer.h delete_stdstring"
+  c_delete_stdstring' ::  Ptr StdString -> IO ()
+
 instance CppObject StdString where
   fromPtr ptr = newForeignPtr c_delete_stdstring ptr
   {-# INLINE fromPtr #-}
+  deletePtr ptr = c_delete_stdstring' ptr
+  {-# INLINE deletePtr #-}
 
 
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_storage"
   c_delete_storage :: FunPtr ( Ptr Storage -> IO ())
 
+foreign import ccall unsafe "hasktorch_finalizer.h delete_storage"
+  c_delete_storage' ::  Ptr Storage -> IO ()
+
 instance CppObject Storage where
   fromPtr ptr = newForeignPtr c_delete_storage ptr
   {-# INLINE fromPtr #-}
+  deletePtr ptr = c_delete_storage' ptr
+  {-# INLINE deletePtr #-}
 
 
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_symbol"
   c_delete_symbol :: FunPtr ( Ptr Symbol -> IO ())
 
+foreign import ccall unsafe "hasktorch_finalizer.h delete_symbol"
+  c_delete_symbol' ::  Ptr Symbol -> IO ()
+
 instance CppObject Symbol where
   fromPtr ptr = newForeignPtr c_delete_symbol ptr
   {-# INLINE fromPtr #-}
+  deletePtr ptr = c_delete_symbol' ptr
+  {-# INLINE deletePtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_tensor"
   c_delete_tensor  :: FunPtr( Ptr Tensor -> IO () )
 
+foreign import ccall unsafe "hasktorch_finalizer.h delete_tensor"
+  c_delete_tensor' :: Ptr Tensor -> IO () 
+
 instance CppObject Tensor where
   fromPtr ptr = newForeignPtr c_delete_tensor ptr
   {-# INLINE fromPtr #-}
+  deletePtr ptr = c_delete_tensor' ptr
+  {-# INLINE deletePtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_tensorindex"
   c_delete_tensorindex :: FunPtr ( Ptr TensorIndex -> IO ())
 
+foreign import ccall unsafe "hasktorch_finalizer.h delete_tensorindex"
+  c_delete_tensorindex' ::  Ptr TensorIndex -> IO ()
+
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_tensorindexlist"
   c_delete_tensorindexlist :: FunPtr ( Ptr (StdVector TensorIndex) -> IO ())
+
+foreign import ccall unsafe "hasktorch_finalizer.h delete_tensorindexlist"
+  c_delete_tensorindexlist' ::  Ptr (StdVector TensorIndex) -> IO ()
 
 instance CppObject TensorIndex where
   fromPtr ptr = newForeignPtr c_delete_tensorindex ptr
   {-# INLINE fromPtr #-}
+  deletePtr ptr = c_delete_tensorindex' ptr
+  {-# INLINE deletePtr #-}
 
 instance CppObject (StdVector TensorIndex) where
   fromPtr ptr = newForeignPtr c_delete_tensorindexlist ptr
   {-# INLINE fromPtr #-}
+  deletePtr ptr = c_delete_tensorindexlist' ptr
+  {-# INLINE deletePtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_tensorlist"
   c_delete_tensorlist :: FunPtr ( Ptr TensorList -> IO ())
 
+foreign import ccall unsafe "hasktorch_finalizer.h delete_tensorlist"
+  c_delete_tensorlist' ::  Ptr TensorList -> IO ()
+
 instance CppObject TensorList where
   fromPtr ptr = newForeignPtr c_delete_tensorlist ptr
   {-# INLINE fromPtr #-}
+  deletePtr ptr = c_delete_tensorlist' ptr
+  {-# INLINE deletePtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_tensoroptions"
   c_delete_tensoroptions :: FunPtr ( Ptr TensorOptions -> IO ())
 
+foreign import ccall unsafe "hasktorch_finalizer.h delete_tensoroptions"
+  c_delete_tensoroptions' ::  Ptr TensorOptions -> IO ()
+
 instance CppObject TensorOptions where
   fromPtr ptr = newForeignPtr c_delete_tensoroptions ptr
   {-# INLINE fromPtr #-}
+  deletePtr ptr = c_delete_tensoroptions' ptr
+  {-# INLINE deletePtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_tensortensor"
   c_delete_tensortensor :: FunPtr ( Ptr (StdTuple '(Tensor,Tensor)) -> IO ())
 
+foreign import ccall unsafe "hasktorch_finalizer.h delete_tensortensor"
+  c_delete_tensortensor' ::  Ptr (StdTuple '(Tensor,Tensor)) -> IO ()
+
 instance CppObject (StdTuple '(Tensor,Tensor)) where
   fromPtr ptr = newForeignPtr c_delete_tensortensor ptr
   {-# INLINE fromPtr #-}
+  deletePtr ptr = c_delete_tensortensor' ptr
+  {-# INLINE deletePtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_tensortensortensortensortensor"
   c_delete_tensortensortensortensortensor :: FunPtr ( Ptr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Tensor)) -> IO ())
 
+foreign import ccall unsafe "hasktorch_finalizer.h delete_tensortensortensortensortensor"
+  c_delete_tensortensortensortensortensor' ::  Ptr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Tensor)) -> IO ()
+
 instance CppObject (StdTuple '(Tensor,Tensor,Tensor,Tensor,Tensor)) where
   fromPtr ptr = newForeignPtr c_delete_tensortensortensortensortensor ptr
   {-# INLINE fromPtr #-}
+  deletePtr ptr = c_delete_tensortensortensortensortensor' ptr
+  {-# INLINE deletePtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_tensortensortensortensorlist"
   c_delete_tensortensortensortensorlist :: FunPtr ( Ptr (StdTuple '(Tensor,Tensor,Tensor,TensorList)) -> IO ())
 
+foreign import ccall unsafe "hasktorch_finalizer.h delete_tensortensortensortensorlist"
+  c_delete_tensortensortensortensorlist' ::  Ptr (StdTuple '(Tensor,Tensor,Tensor,TensorList)) -> IO ()
+
 instance CppObject (StdTuple '(Tensor,Tensor,Tensor,TensorList)) where
   fromPtr ptr = newForeignPtr c_delete_tensortensortensortensorlist ptr
   {-# INLINE fromPtr #-}
+  deletePtr ptr = c_delete_tensortensortensortensorlist' ptr
+  {-# INLINE deletePtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_tensortensortensortensorint64"
   c_delete_tensortensortensortensorint64 :: FunPtr ( Ptr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Int64)) -> IO ())
 
+foreign import ccall unsafe "hasktorch_finalizer.h delete_tensortensortensortensorint64"
+  c_delete_tensortensortensortensorint64' ::  Ptr (StdTuple '(Tensor,Tensor,Tensor,Tensor,Int64)) -> IO ()
+
 instance CppObject (StdTuple '(Tensor,Tensor,Tensor,Tensor,Int64)) where
   fromPtr ptr = newForeignPtr c_delete_tensortensortensortensorint64 ptr
   {-# INLINE fromPtr #-}
+  deletePtr ptr = c_delete_tensortensortensortensorint64' ptr
+  {-# INLINE deletePtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_tensortensortensor"
   c_delete_tensortensortensor :: FunPtr ( Ptr (StdTuple '(Tensor,Tensor,Tensor)) -> IO ())
 
+foreign import ccall unsafe "hasktorch_finalizer.h delete_tensortensortensor"
+  c_delete_tensortensortensor' ::  Ptr (StdTuple '(Tensor,Tensor,Tensor)) -> IO ()
+
 instance CppObject (StdTuple '(Tensor,Tensor,Tensor)) where
   fromPtr ptr = newForeignPtr c_delete_tensortensortensor ptr
   {-# INLINE fromPtr #-}
+  deletePtr ptr = c_delete_tensortensortensor' ptr
+  {-# INLINE deletePtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_tensortensortensortensor"
   c_delete_tensortensortensortensor :: FunPtr ( Ptr (StdTuple '(Tensor,Tensor,Tensor,Tensor)) -> IO ())
 
+foreign import ccall unsafe "hasktorch_finalizer.h delete_tensortensortensortensor"
+  c_delete_tensortensortensortensor' ::  Ptr (StdTuple '(Tensor,Tensor,Tensor,Tensor)) -> IO ()
+
 instance CppObject (StdTuple '(Tensor,Tensor,Tensor,Tensor)) where
   fromPtr ptr = newForeignPtr c_delete_tensortensortensortensor ptr
   {-# INLINE fromPtr #-}
+  deletePtr ptr = c_delete_tensortensortensortensor' ptr
+  {-# INLINE deletePtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_cdoubleint64"
   c_delete_cdoubleint64 :: FunPtr ( Ptr (StdTuple '(CDouble,Int64)) -> IO ())
 
+foreign import ccall unsafe "hasktorch_finalizer.h delete_cdoubleint64"
+  c_delete_cdoubleint64' ::  Ptr (StdTuple '(CDouble,Int64)) -> IO ()
+
 instance CppObject (StdTuple '(CDouble,Int64)) where
   fromPtr ptr = newForeignPtr c_delete_cdoubleint64 ptr
   {-# INLINE fromPtr #-}
+  deletePtr ptr = c_delete_cdoubleint64' ptr
+  {-# INLINE deletePtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_cdoublecdouble"
   c_delete_cdoublecdouble :: FunPtr ( Ptr (StdTuple '(CDouble,CDouble)) -> IO ())
 
+foreign import ccall unsafe "hasktorch_finalizer.h delete_cdoublecdouble"
+  c_delete_cdoublecdouble' ::  Ptr (StdTuple '(CDouble,CDouble)) -> IO ()
+
 instance CppObject (StdTuple '(CDouble,CDouble)) where
   fromPtr ptr = newForeignPtr c_delete_cdoublecdouble ptr
   {-# INLINE fromPtr #-}
+  deletePtr ptr = c_delete_cdoublecdouble' ptr
+  {-# INLINE deletePtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_tensorgenerator"
   c_delete_tensorgenerator :: FunPtr ( Ptr (StdTuple '(Tensor,Generator)) -> IO ())
 
+foreign import ccall unsafe "hasktorch_finalizer.h delete_tensorgenerator"
+  c_delete_tensorgenerator' ::  Ptr (StdTuple '(Tensor,Generator)) -> IO ()
+
 instance CppObject (StdTuple '(Tensor,Generator)) where
   fromPtr ptr = newForeignPtr c_delete_tensorgenerator ptr
   {-# INLINE fromPtr #-}
+  deletePtr ptr = c_delete_tensorgenerator' ptr
+  {-# INLINE deletePtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_tensortensorcdoubleint64"
   c_delete_tensortensorcdoubleint64 :: FunPtr ( Ptr (StdTuple '(Tensor,Tensor,CDouble,Int64)) -> IO ())
 
+foreign import ccall unsafe "hasktorch_finalizer.h delete_tensortensorcdoubleint64"
+  c_delete_tensortensorcdoubleint64' ::  Ptr (StdTuple '(Tensor,Tensor,CDouble,Int64)) -> IO ()
+
 instance CppObject (StdTuple '(Tensor,Tensor,CDouble,Int64)) where
   fromPtr ptr = newForeignPtr c_delete_tensortensorcdoubleint64 ptr
   {-# INLINE fromPtr #-}
+  deletePtr ptr = c_delete_tensortensorcdoubleint64' ptr
+  {-# INLINE deletePtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_optimizer"
   c_delete_optimizer  :: FunPtr( Ptr Optimizer -> IO () )
 
+foreign import ccall unsafe "hasktorch_finalizer.h delete_optimizer"
+  c_delete_optimizer' :: Ptr Optimizer -> IO () 
+
 instance CppObject Optimizer where
   fromPtr ptr = newForeignPtr c_delete_optimizer ptr
   {-# INLINE fromPtr #-}
+  deletePtr ptr = c_delete_optimizer' ptr
+  {-# INLINE deletePtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_stdvectordouble"
   c_delete_stdvectordouble :: FunPtr ( Ptr (StdVector CDouble) -> IO ())
 
+foreign import ccall unsafe "hasktorch_finalizer.h delete_stdvectordouble"
+  c_delete_stdvectordouble' ::  Ptr (StdVector CDouble) -> IO ()
+
 instance CppObject (StdVector CDouble) where
   fromPtr ptr = newForeignPtr c_delete_stdvectordouble ptr
   {-# INLINE fromPtr #-}
+  deletePtr ptr = c_delete_stdvectordouble' ptr
+  {-# INLINE deletePtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_stdvectorint"
   c_delete_stdvectorint :: FunPtr ( Ptr (StdVector CInt) -> IO ())
 
+foreign import ccall unsafe "hasktorch_finalizer.h delete_stdvectorint"
+  c_delete_stdvectorint' ::  Ptr (StdVector CInt) -> IO ()
+
 instance CppObject (StdVector CInt) where
   fromPtr ptr = newForeignPtr c_delete_stdvectorint ptr
   {-# INLINE fromPtr #-}
+  deletePtr ptr = c_delete_stdvectorint' ptr
+  {-# INLINE deletePtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_stdvectorbool"
   c_delete_stdvectorbool :: FunPtr ( Ptr (StdVector CBool) -> IO ())
 
+foreign import ccall unsafe "hasktorch_finalizer.h delete_stdvectorbool"
+  c_delete_stdvectorbool' ::  Ptr (StdVector CBool) -> IO ()
+
 instance CppObject (StdVector CBool) where
   fromPtr ptr = newForeignPtr c_delete_stdvectorbool ptr
   {-# INLINE fromPtr #-}
+  deletePtr ptr = c_delete_stdvectorbool' ptr
+  {-# INLINE deletePtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_stream"
   c_delete_stream :: FunPtr ( Ptr Stream -> IO ())
 
+foreign import ccall unsafe "hasktorch_finalizer.h delete_stream"
+  c_delete_stream' ::  Ptr Stream -> IO ()
+
 instance CppObject Stream where
   fromPtr ptr = newForeignPtr c_delete_stream ptr
   {-# INLINE fromPtr #-}
+  deletePtr ptr = c_delete_stream' ptr
+  {-# INLINE deletePtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_arrayrefscalar"
   c_delete_arrayrefscalar :: FunPtr ( Ptr (ArrayRef Scalar) -> IO ())
 
+foreign import ccall unsafe "hasktorch_finalizer.h delete_arrayrefscalar"
+  c_delete_arrayrefscalar' ::  Ptr (ArrayRef Scalar) -> IO ()
+
 instance CppObject (ArrayRef Scalar) where
   fromPtr ptr = newForeignPtr c_delete_arrayrefscalar ptr
   {-# INLINE fromPtr #-}
+  deletePtr ptr = c_delete_arrayrefscalar' ptr
+  {-# INLINE deletePtr #-}
 
 foreign import ccall unsafe "hasktorch_finalizer.h &delete_vectorscalar"
   c_delete_vectorscalar :: FunPtr ( Ptr (StdVector Scalar) -> IO ())
 
+foreign import ccall unsafe "hasktorch_finalizer.h delete_vectorscalar"
+  c_delete_vectorscalar' ::  Ptr (StdVector Scalar) -> IO ()
+
 instance CppObject (StdVector Scalar) where
   fromPtr ptr = newForeignPtr c_delete_vectorscalar ptr
   {-# INLINE fromPtr #-}
+  deletePtr ptr = c_delete_vectorscalar' ptr
+  {-# INLINE deletePtr #-}

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Autograd.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Autograd.hs
@@ -9,7 +9,7 @@ module Torch.Internal.Unmanaged.Autograd where
 
 import Foreign.Ptr
 import qualified Language.C.Inline.Cpp as C
-import qualified Language.C.Inline.Cpp.Exceptions as C
+import qualified Language.C.Inline.Cpp.Unsafe as C
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Types as C
 import Foreign.C.Types (CBool)

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Extra.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Extra.hs
@@ -17,7 +17,7 @@ import Foreign
 import Torch.Internal.Type
 
 import qualified Language.C.Inline.Cpp as C
-import qualified Language.C.Inline.Cpp.Exceptions as C
+import qualified Language.C.Inline.Cpp.Unsafe as C
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Types as C
 

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native0.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native0.hs
@@ -17,7 +17,7 @@ import Foreign
 import Torch.Internal.Type
 
 import qualified Language.C.Inline.Cpp as C
-import qualified Language.C.Inline.Cpp.Exceptions as C
+import qualified Language.C.Inline.Cpp.Unsafe as C
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Types as C
 

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native1.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native1.hs
@@ -17,7 +17,7 @@ import Foreign
 import Torch.Internal.Type
 
 import qualified Language.C.Inline.Cpp as C
-import qualified Language.C.Inline.Cpp.Exceptions as C
+import qualified Language.C.Inline.Cpp.Unsafe as C
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Types as C
 

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native10.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native10.hs
@@ -17,7 +17,7 @@ import Foreign
 import Torch.Internal.Type
 
 import qualified Language.C.Inline.Cpp as C
-import qualified Language.C.Inline.Cpp.Exceptions as C
+import qualified Language.C.Inline.Cpp.Unsafe as C
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Types as C
 

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native11.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native11.hs
@@ -17,7 +17,7 @@ import Foreign
 import Torch.Internal.Type
 
 import qualified Language.C.Inline.Cpp as C
-import qualified Language.C.Inline.Cpp.Exceptions as C
+import qualified Language.C.Inline.Cpp.Unsafe as C
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Types as C
 

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native12.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native12.hs
@@ -17,7 +17,7 @@ import Foreign
 import Torch.Internal.Type
 
 import qualified Language.C.Inline.Cpp as C
-import qualified Language.C.Inline.Cpp.Exceptions as C
+import qualified Language.C.Inline.Cpp.Unsafe as C
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Types as C
 

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native13.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native13.hs
@@ -17,7 +17,7 @@ import Foreign
 import Torch.Internal.Type
 
 import qualified Language.C.Inline.Cpp as C
-import qualified Language.C.Inline.Cpp.Exceptions as C
+import qualified Language.C.Inline.Cpp.Unsafe as C
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Types as C
 

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native14.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native14.hs
@@ -17,7 +17,7 @@ import Foreign
 import Torch.Internal.Type
 
 import qualified Language.C.Inline.Cpp as C
-import qualified Language.C.Inline.Cpp.Exceptions as C
+import qualified Language.C.Inline.Cpp.Unsafe as C
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Types as C
 

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native15.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native15.hs
@@ -17,7 +17,7 @@ import Foreign
 import Torch.Internal.Type
 
 import qualified Language.C.Inline.Cpp as C
-import qualified Language.C.Inline.Cpp.Exceptions as C
+import qualified Language.C.Inline.Cpp.Unsafe as C
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Types as C
 

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native2.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native2.hs
@@ -17,7 +17,7 @@ import Foreign
 import Torch.Internal.Type
 
 import qualified Language.C.Inline.Cpp as C
-import qualified Language.C.Inline.Cpp.Exceptions as C
+import qualified Language.C.Inline.Cpp.Unsafe as C
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Types as C
 

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native3.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native3.hs
@@ -17,7 +17,7 @@ import Foreign
 import Torch.Internal.Type
 
 import qualified Language.C.Inline.Cpp as C
-import qualified Language.C.Inline.Cpp.Exceptions as C
+import qualified Language.C.Inline.Cpp.Unsafe as C
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Types as C
 

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native4.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native4.hs
@@ -17,7 +17,7 @@ import Foreign
 import Torch.Internal.Type
 
 import qualified Language.C.Inline.Cpp as C
-import qualified Language.C.Inline.Cpp.Exceptions as C
+import qualified Language.C.Inline.Cpp.Unsafe as C
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Types as C
 

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native5.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native5.hs
@@ -17,7 +17,7 @@ import Foreign
 import Torch.Internal.Type
 
 import qualified Language.C.Inline.Cpp as C
-import qualified Language.C.Inline.Cpp.Exceptions as C
+import qualified Language.C.Inline.Cpp.Unsafe as C
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Types as C
 

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native6.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native6.hs
@@ -17,7 +17,7 @@ import Foreign
 import Torch.Internal.Type
 
 import qualified Language.C.Inline.Cpp as C
-import qualified Language.C.Inline.Cpp.Exceptions as C
+import qualified Language.C.Inline.Cpp.Unsafe as C
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Types as C
 

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native7.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native7.hs
@@ -17,7 +17,7 @@ import Foreign
 import Torch.Internal.Type
 
 import qualified Language.C.Inline.Cpp as C
-import qualified Language.C.Inline.Cpp.Exceptions as C
+import qualified Language.C.Inline.Cpp.Unsafe as C
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Types as C
 

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native8.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native8.hs
@@ -17,7 +17,7 @@ import Foreign
 import Torch.Internal.Type
 
 import qualified Language.C.Inline.Cpp as C
-import qualified Language.C.Inline.Cpp.Exceptions as C
+import qualified Language.C.Inline.Cpp.Unsafe as C
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Types as C
 

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native9.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Native/Native9.hs
@@ -17,7 +17,7 @@ import Foreign
 import Torch.Internal.Type
 
 import qualified Language.C.Inline.Cpp as C
-import qualified Language.C.Inline.Cpp.Exceptions as C
+import qualified Language.C.Inline.Cpp.Unsafe as C
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Types as C
 

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Optim.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Optim.hs
@@ -15,7 +15,7 @@ import Foreign.C.Types
 import Foreign.Ptr
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Inline.Cpp as C
-import qualified Language.C.Inline.Cpp.Exceptions as C
+import qualified Language.C.Inline.Cpp.Unsafe as C
 import qualified Language.C.Types as C
 import Torch.Internal.Type
 import Torch.Internal.Unmanaged.Helper

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Serialize.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Serialize.hs
@@ -10,7 +10,7 @@ module Torch.Internal.Unmanaged.Serialize where
 import Foreign.Ptr
 import Foreign.C.String
 import qualified Language.C.Inline.Cpp as C
-import qualified Language.C.Inline.Cpp.Exceptions as C
+import qualified Language.C.Inline.Cpp.Unsafe as C
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Types as C
 

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/TensorFactories.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/TensorFactories.hs
@@ -17,7 +17,7 @@ import Foreign
 import Torch.Internal.Type
 
 import qualified Language.C.Inline.Cpp as C
-import qualified Language.C.Inline.Cpp.Exceptions as C
+import qualified Language.C.Inline.Cpp.Unsafe as C
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Types as C
 

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/C10Dict.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/C10Dict.hs
@@ -12,7 +12,7 @@ module Torch.Internal.Unmanaged.Type.C10Dict where
 
 
 import qualified Language.C.Inline.Cpp as C
-import qualified Language.C.Inline.Cpp.Exceptions as C
+import qualified Language.C.Inline.Cpp.Unsafe as C
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Types as C
 import qualified Data.Map as Map

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/C10List.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/C10List.hs
@@ -12,7 +12,7 @@ module Torch.Internal.Unmanaged.Type.C10List where
 
 
 import qualified Language.C.Inline.Cpp as C
-import qualified Language.C.Inline.Cpp.Exceptions as C
+import qualified Language.C.Inline.Cpp.Unsafe as C
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Types as C
 import qualified Data.Map as Map

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/C10Tuple.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/C10Tuple.hs
@@ -12,7 +12,7 @@ module Torch.Internal.Unmanaged.Type.C10Tuple where
 
 
 import qualified Language.C.Inline.Cpp as C
-import qualified Language.C.Inline.Cpp.Exceptions as C
+import qualified Language.C.Inline.Cpp.Unsafe as C
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Types as C
 import qualified Data.Map as Map

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Context.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Context.hs
@@ -12,7 +12,7 @@ module Torch.Internal.Unmanaged.Type.Context where
 
 
 import qualified Language.C.Inline.Cpp as C
-import qualified Language.C.Inline.Cpp.Exceptions as C
+import qualified Language.C.Inline.Cpp.Unsafe as C
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Types as C
 import qualified Data.Map as Map

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Dimname.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Dimname.hs
@@ -12,7 +12,7 @@ module Torch.Internal.Unmanaged.Type.Dimname where
 
 
 import qualified Language.C.Inline.Cpp as C
-import qualified Language.C.Inline.Cpp.Exceptions as C
+import qualified Language.C.Inline.Cpp.Unsafe as C
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Types as C
 import qualified Data.Map as Map

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/DimnameList.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/DimnameList.hs
@@ -12,7 +12,7 @@ module Torch.Internal.Unmanaged.Type.DimnameList where
 
 
 import qualified Language.C.Inline.Cpp as C
-import qualified Language.C.Inline.Cpp.Exceptions as C
+import qualified Language.C.Inline.Cpp.Unsafe as C
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Types as C
 import qualified Data.Map as Map

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Extra.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Extra.hs
@@ -12,7 +12,7 @@ module Torch.Internal.Unmanaged.Type.Extra where
 
 
 import qualified Language.C.Inline.Cpp as C
-import qualified Language.C.Inline.Cpp.Exceptions as C
+import qualified Language.C.Inline.Cpp.Unsafe as C
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Types as C
 import qualified Data.Map as Map
@@ -28,7 +28,7 @@ C.include "<ATen/Functions.h>"
 C.include "<ATen/Tensor.h>"
 C.include "<ATen/TensorOperators.h>"
 C.include "<vector>"
-
+C.include "<torch/csrc/autograd/generated/variable_factories.h>"
 
 tensor_assign1_l
   :: Ptr Tensor
@@ -94,4 +94,55 @@ tensor_names _obj =
         vec->push_back(ref[i]);
       }
       return vec;
+  }|]
+
+tensor_to_device
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_to_device reference input =
+  [C.throwBlock| at::Tensor* {
+      auto d = (*$(at::Tensor* reference)).device();
+      return new at::Tensor((*$(at::Tensor* input)).to(d));
+  }|]
+
+new_empty_tensor
+  :: [Int]
+  -> Ptr TensorOptions
+  -> IO (Ptr Tensor)
+new_empty_tensor [x] _options = do
+  let x' = fromIntegral x
+  [C.throwBlock| at::Tensor* {
+    return new at::Tensor(torch::empty({$(int x')}, *$(at::TensorOptions* _options)));
+  }|]
+
+new_empty_tensor [x,y] _options = do
+  let x' = fromIntegral x
+      y' = fromIntegral y
+  [C.throwBlock| at::Tensor* {
+    return new at::Tensor(torch::empty({$(int x'),$(int y')}, *$(at::TensorOptions* _options)));
+  }|]
+
+new_empty_tensor [x,y,z] _options = do
+  let x' = fromIntegral x
+      y' = fromIntegral y
+      z' = fromIntegral z
+  [C.throwBlock| at::Tensor* {
+    return new at::Tensor(torch::empty({$(int x'),$(int y'),$(int z')}, *$(at::TensorOptions* _options)));
+  }|]
+
+new_empty_tensor _size _options = do
+  let len = fromIntegral $ length _size
+  shape <- [C.throwBlock| std::vector<int64_t>* {
+    return new std::vector<int64_t>($(int len));
+  }|]
+  ptr <- [C.throwBlock| int64_t* {
+    return $(std::vector<int64_t>* shape)->data();
+  }|]
+  pokeArray ptr (map fromIntegral _size)
+
+  [C.throwBlock| at::Tensor* {
+    auto v = new at::Tensor(torch::empty(*$(std::vector<int64_t>* shape), *$(at::TensorOptions* _options)));
+    delete $(std::vector<int64_t>* shape);
+    return v;
   }|]

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Generator.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Generator.hs
@@ -12,7 +12,7 @@ module Torch.Internal.Unmanaged.Type.Generator where
 
 
 import qualified Language.C.Inline.Cpp as C
-import qualified Language.C.Inline.Cpp.Exceptions as C
+import qualified Language.C.Inline.Cpp.Unsafe as C
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Types as C
 import qualified Data.Map as Map

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/IValue.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/IValue.hs
@@ -14,7 +14,7 @@ module Torch.Internal.Unmanaged.Type.IValue where
 
 
 import qualified Language.C.Inline.Cpp as C
-import qualified Language.C.Inline.Cpp.Exceptions as C
+import qualified Language.C.Inline.Cpp.Unsafe as C
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Types as C
 import qualified Data.Map as Map

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/IValueList.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/IValueList.hs
@@ -12,7 +12,7 @@ module Torch.Internal.Unmanaged.Type.IValueList where
 
 
 import qualified Language.C.Inline.Cpp as C
-import qualified Language.C.Inline.Cpp.Exceptions as C
+import qualified Language.C.Inline.Cpp.Unsafe as C
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Types as C
 import qualified Data.Map as Map

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Module.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Module.hs
@@ -18,7 +18,8 @@ import Foreign.C.String
 import Foreign.C.Types
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Inline.Cpp as C
-import qualified Language.C.Inline.Cpp.Exceptions as C
+import qualified Language.C.Inline.Cpp.Unsafe as C
+import qualified Language.C.Inline.Cpp.Exceptions as Safe
 import qualified Language.C.Types as C
 import Torch.Internal.Type
 import Torch.Internal.Unmanaged.Helper
@@ -270,7 +271,7 @@ trace moduleName functionName func inputs =
     (callbackHelper $ \inputs' -> castPtr <$> func (castPtr inputs'))
     freeHaskellFunPtr
     $ \funcPtr ->
-      [C.throwBlock| torch::jit::script::Module* {
+      [Safe.throwBlock| torch::jit::script::Module* {
         torch::jit::script::Module self($(char* moduleName));
         auto vars_in = *$(std::vector<at::Tensor>* inputs);
         auto tfunc = $(void* (*funcPtr)(void*));
@@ -301,7 +302,7 @@ traceAsGraph func inputs =
     (callbackHelper $ \inputs' -> castPtr <$> func (castPtr inputs'))
     freeHaskellFunPtr
     $ \funcPtr ->
-      [C.throwBlock| std::shared_ptr<torch::jit::Graph>* {
+      [Safe.throwBlock| std::shared_ptr<torch::jit::Graph>* {
         torch::jit::script::Module self("MyModule");
         auto vars_in = *$(std::vector<at::Tensor>* inputs);
         auto tfunc = $(void* (*funcPtr)(void*));
@@ -340,7 +341,7 @@ graphOutputs graph = do
     (callbackHelper $ \inputs' -> castPtr <$> func (castPtr inputs'))
     freeHaskellFunPtr
     $ \funcPtr ->
-      [C.throwBlock| void {
+      [Safe.throwBlock| void {
         auto tfunc = $(void* (*funcPtr)(void*));
         typedef torch::jit::Value* (*Func)(torch::jit::Value*);
         auto func = (Func)tfunc;
@@ -361,7 +362,7 @@ graphInputs graph = do
     (callbackHelper $ \inputs' -> castPtr <$> func (castPtr inputs'))
     freeHaskellFunPtr
     $ \funcPtr ->
-      [C.throwBlock| void {
+      [Safe.throwBlock| void {
         auto tfunc = $(void* (*funcPtr)(void*));
         typedef torch::jit::Value* (*Func)(torch::jit::Value*);
         auto func = (Func)tfunc;
@@ -382,7 +383,7 @@ graphNodes graph = do
     (callbackHelper $ \inputs' -> castPtr <$> func (castPtr inputs'))
     freeHaskellFunPtr
     $ \funcPtr ->
-      [C.throwBlock| void {
+      [Safe.throwBlock| void {
         auto tfunc = $(void* (*funcPtr)(void*));
         typedef torch::jit::Node* (*Func)(torch::jit::Node*);
         auto func = (Func)tfunc;
@@ -403,7 +404,7 @@ nodeInputs node = do
     (callbackHelper $ \inputs' -> castPtr <$> func (castPtr inputs'))
     freeHaskellFunPtr
     $ \funcPtr ->
-      [C.throwBlock| void {
+      [Safe.throwBlock| void {
         auto tfunc = $(void* (*funcPtr)(void*));
         typedef torch::jit::Value* (*Func)(torch::jit::Value*);
         auto func = (Func)tfunc;
@@ -424,7 +425,7 @@ nodeOutputs node = do
     (callbackHelper $ \inputs' -> castPtr <$> func (castPtr inputs'))
     freeHaskellFunPtr
     $ \funcPtr ->
-      [C.throwBlock| void {
+      [Safe.throwBlock| void {
         auto tfunc = $(void* (*funcPtr)(void*));
         typedef torch::jit::Value* (*Func)(torch::jit::Value*);
         auto func = (Func)tfunc;

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Scalar.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Scalar.hs
@@ -12,7 +12,7 @@ module Torch.Internal.Unmanaged.Type.Scalar where
 
 
 import qualified Language.C.Inline.Cpp as C
-import qualified Language.C.Inline.Cpp.Exceptions as C
+import qualified Language.C.Inline.Cpp.Unsafe as C
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Types as C
 import qualified Data.Map as Map

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/StdArray.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/StdArray.hs
@@ -12,7 +12,7 @@ module Torch.Internal.Unmanaged.Type.StdArray where
 
 
 import qualified Language.C.Inline.Cpp as C
-import qualified Language.C.Inline.Cpp.Exceptions as C
+import qualified Language.C.Inline.Cpp.Unsafe as C
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Types as C
 import qualified Data.Map as Map

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/StdString.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/StdString.hs
@@ -12,7 +12,7 @@ module Torch.Internal.Unmanaged.Type.StdString where
 
 
 import qualified Language.C.Inline.Cpp as C
-import qualified Language.C.Inline.Cpp.Exceptions as C
+import qualified Language.C.Inline.Cpp.Unsafe as C
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Types as C
 import qualified Data.Map as Map

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/StdVector.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/StdVector.hs
@@ -12,7 +12,7 @@ module Torch.Internal.Unmanaged.Type.StdVector where
 
 
 import qualified Language.C.Inline.Cpp as C
-import qualified Language.C.Inline.Cpp.Exceptions as C
+import qualified Language.C.Inline.Cpp.Unsafe as C
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Types as C
 import qualified Data.Map as Map

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Storage.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Storage.hs
@@ -12,7 +12,7 @@ module Torch.Internal.Unmanaged.Type.Storage where
 
 
 import qualified Language.C.Inline.Cpp as C
-import qualified Language.C.Inline.Cpp.Exceptions as C
+import qualified Language.C.Inline.Cpp.Unsafe as C
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Types as C
 import qualified Data.Map as Map

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Symbol.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Symbol.hs
@@ -12,7 +12,7 @@ module Torch.Internal.Unmanaged.Type.Symbol where
 
 
 import qualified Language.C.Inline.Cpp as C
-import qualified Language.C.Inline.Cpp.Exceptions as C
+import qualified Language.C.Inline.Cpp.Unsafe as C
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Types as C
 import qualified Data.Map as Map

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Tensor/Tensor0.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Tensor/Tensor0.hs
@@ -12,6 +12,8 @@ module Torch.Internal.Unmanaged.Type.Tensor.Tensor0 where
 
 
 import qualified Language.C.Inline.Cpp as C
+import qualified Language.C.Inline.Cpp.Unsafe as Unsafe
+import qualified Language.C.Inline.Unsafe as CUnsafe
 import qualified Language.C.Inline.Cpp.Exceptions as C
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Types as C
@@ -113,6 +115,22 @@ tensor_dim
   -> IO (Int64)
 tensor_dim _obj =
   [C.throwBlock| int64_t { return (*$(at::Tensor* _obj)).dim(
+    );
+  }|]
+
+tensor_dim_unsafe
+  :: Ptr Tensor
+  -> IO (Int64)
+tensor_dim_unsafe _obj =
+  [Unsafe.throwBlock| int64_t { return (*$(at::Tensor* _obj)).dim(
+    );
+  }|]
+
+tensor_dim_c_unsafe
+  :: Ptr Tensor
+  -> IO (Int64)
+tensor_dim_c_unsafe _obj =
+  [CUnsafe.block| int64_t { return (*$(at::Tensor* _obj)).dim(
     );
   }|]
 

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Tensor/Tensor0.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Tensor/Tensor0.hs
@@ -12,9 +12,8 @@ module Torch.Internal.Unmanaged.Type.Tensor.Tensor0 where
 
 
 import qualified Language.C.Inline.Cpp as C
-import qualified Language.C.Inline.Cpp.Unsafe as Unsafe
+import qualified Language.C.Inline.Cpp.Unsafe as C
 import qualified Language.C.Inline.Unsafe as CUnsafe
-import qualified Language.C.Inline.Cpp.Exceptions as C
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Types as C
 import qualified Data.Map as Map
@@ -122,7 +121,7 @@ tensor_dim_unsafe
   :: Ptr Tensor
   -> IO (Int64)
 tensor_dim_unsafe _obj =
-  [Unsafe.throwBlock| int64_t { return (*$(at::Tensor* _obj)).dim(
+  [C.throwBlock| int64_t { return (*$(at::Tensor* _obj)).dim(
     );
   }|]
 
@@ -539,7 +538,7 @@ tensor_sizes
   :: Ptr Tensor
   -> IO (Ptr IntArray)
 tensor_sizes _obj =
-  [C.throwBlock| std::vector<int64_t>* { return new std::vector<int64_t>((*$(at::Tensor* _obj)).sizes(
+  [CUnsafe.block| std::vector<int64_t>* { return new std::vector<int64_t>((*$(at::Tensor* _obj)).sizes(
     ).vec());
   }|]
 

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Tensor/Tensor1.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Tensor/Tensor1.hs
@@ -12,7 +12,7 @@ module Torch.Internal.Unmanaged.Type.Tensor.Tensor1 where
 
 
 import qualified Language.C.Inline.Cpp as C
-import qualified Language.C.Inline.Cpp.Exceptions as C
+import qualified Language.C.Inline.Cpp.Unsafe as C
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Types as C
 import qualified Data.Map as Map

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Tensor/Tensor2.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Tensor/Tensor2.hs
@@ -12,7 +12,7 @@ module Torch.Internal.Unmanaged.Type.Tensor.Tensor2 where
 
 
 import qualified Language.C.Inline.Cpp as C
-import qualified Language.C.Inline.Cpp.Exceptions as C
+import qualified Language.C.Inline.Cpp.Unsafe as C
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Types as C
 import qualified Data.Map as Map

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Tensor/Tensor3.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Tensor/Tensor3.hs
@@ -12,7 +12,7 @@ module Torch.Internal.Unmanaged.Type.Tensor.Tensor3 where
 
 
 import qualified Language.C.Inline.Cpp as C
-import qualified Language.C.Inline.Cpp.Exceptions as C
+import qualified Language.C.Inline.Cpp.Unsafe as C
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Types as C
 import qualified Data.Map as Map

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/TensorIndex.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/TensorIndex.hs
@@ -12,7 +12,7 @@ module Torch.Internal.Unmanaged.Type.TensorIndex where
 
 
 import qualified Language.C.Inline.Cpp as C
-import qualified Language.C.Inline.Cpp.Exceptions as C
+import qualified Language.C.Inline.Cpp.Unsafe as C
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Types as C
 import qualified Data.Map as Map

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/TensorList.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/TensorList.hs
@@ -12,7 +12,7 @@ module Torch.Internal.Unmanaged.Type.TensorList where
 
 
 import qualified Language.C.Inline.Cpp as C
-import qualified Language.C.Inline.Cpp.Exceptions as C
+import qualified Language.C.Inline.Cpp.Unsafe as C
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Types as C
 import qualified Data.Map as Map

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/TensorOptions.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/TensorOptions.hs
@@ -12,7 +12,7 @@ module Torch.Internal.Unmanaged.Type.TensorOptions where
 
 
 import qualified Language.C.Inline.Cpp as C
-import qualified Language.C.Inline.Cpp.Exceptions as C
+import qualified Language.C.Inline.Cpp.Unsafe as C
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Types as C
 import qualified Data.Map as Map

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Tuple.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Type/Tuple.hs
@@ -20,7 +20,7 @@ import Torch.Internal.Type
 import Torch.Internal.Class
 
 import qualified Language.C.Inline.Cpp as C
-import qualified Language.C.Inline.Cpp.Exceptions as C
+import qualified Language.C.Inline.Cpp.Unsafe as C
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Types as C
 import qualified Data.Map as Map

--- a/setup-cabal.sh
+++ b/setup-cabal.sh
@@ -5,7 +5,7 @@ ghc --version
 
 curl https://www.stackage.org/nightly-2022-10-11/cabal.config |\
 sed -e 's/with-compiler: .*$//g' |\
-sed -e 's/.*inline-c-cpp.*//g' > cabal.project.freeze
+sed -e 's/.*inline-c.*//g' > cabal.project.freeze
 
 case "$(uname)" in
   "Darwin")

--- a/stack.yaml
+++ b/stack.yaml
@@ -41,6 +41,14 @@ extra-deps:
   commit: 32d7abec6a21c42a5f960d7f4133d604e8be79ec
 - union-find-array-0.1.0.3@sha256:242e066ec516d61f262947e5794edc7bbc11fd538a0415c03ac0c01b028cfa8a,1372
 - clay-0.14.0@sha256:382eced24317f9ed0f7a0a4789cdfc6fc8dd32895cdb0c4ea50a1613bee08af3,2128
+- git: https://github.com/hasktorch/inline-c
+  commit: 5b1a54e81f4c726faf35c15a8e39a4d86c52c6ba
+  subdirs:
+  - inline-c
+- git: https://github.com/hasktorch/inline-c
+  commit: 5b1a54e81f4c726faf35c15a8e39a4d86c52c6ba
+  subdirs:
+  - inline-c-cpp
 
 allow-newer: true
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -41,12 +41,12 @@ extra-deps:
   commit: 32d7abec6a21c42a5f960d7f4133d604e8be79ec
 - union-find-array-0.1.0.3@sha256:242e066ec516d61f262947e5794edc7bbc11fd538a0415c03ac0c01b028cfa8a,1372
 - clay-0.14.0@sha256:382eced24317f9ed0f7a0a4789cdfc6fc8dd32895cdb0c4ea50a1613bee08af3,2128
-- git: https://github.com/hasktorch/inline-c
-  commit: 5b1a54e81f4c726faf35c15a8e39a4d86c52c6ba
+- git: https://github.com/fpco/inline-c
+  commit: 2d0fe9b2f0aa0e1aefc7bfed95a501e59486afb0
   subdirs:
   - inline-c
-- git: https://github.com/hasktorch/inline-c
-  commit: 5b1a54e81f4c726faf35c15a8e39a4d86c52c6ba
+- git: https://github.com/fpco/inline-c
+  commit: 2d0fe9b2f0aa0e1aefc7bfed95a501e59486afb0
   subdirs:
   - inline-c-cpp
 


### PR DESCRIPTION
Calling FFI is slow. It takes more than 1us.
For example, even a small tensor takes more than 1us.

Here are the details inside.

|  Operation  |  Operating Time  |　Link |
| ---- | ---- | ---- |
|  libtorch's adder  |  900ns | https://discuss.pytorch.org/t/too-much-c-api-overhead/164381 |
|  newForeignPtr with cfinalizer  |  80ns | https://gitlab.haskell.org/ghc/ghc/-/issues/22394 |
|  Safe call of FFI |  100ns | https://qiita.com/mod_poppo/items/793fdb08e62591d6f3fb  |
|  Storing Exception of C++ |  100ns | https://github.com/fpco/inline-c/pull/140  |
|  Useless cast  where no exception occurs|  100ns  |   |

This PR improves as follows.

|  Operation  |  Operating Time  |　Link |
| ---- | ---- | ---- |
|  Safe call of FFI |  100ns  -> 10ns | https://qiita.com/mod_poppo/items/793fdb08e62591d6f3fb  |
|  Storing Exception of C++ |  100ns  -> 30ns |   https://github.com/fpco/inline-c/pull/140 |
|  Useless cast  where no exception occurs|  100ns -> 0ns  |   |


