### PR TITLE
Add symlinks of libtorch not to add extra-include-dirs

### DIFF
--- a/.github/workflows/nix-haddock-linux.yml
+++ b/.github/workflows/nix-haddock-linux.yml
@@ -22,13 +22,7 @@ jobs:
         sudo apt autoclean -y || true
         docker rmi $(docker image ls -aq)
         df -h
-    - uses: cachix/install-nix-action@v16
-      with:
-        install_url: https://nixos-nix-install-tests.cachix.org/serve/i6laym9jw3wg9mw6ncyrk6gjx4l34vvx/install
-        install_options: '--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve'
-        extra_nix_config: |
-          experimental-features = nix-command flakes
-        nix_path: nixpkgs=channel:nixos-unstable
+    - uses: cachix/install-nix-action@v18
     - run: nix-env -iA cachix -f https://cachix.org/api/v1/install
     - run: cachix use hasktorch
     - run: |

--- a/.github/workflows/nix-linux-cu10.yml
+++ b/.github/workflows/nix-linux-cu10.yml
@@ -51,7 +51,7 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
           nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@v8
+      - uses: cachix/cachix-action@v12
         with:
           name: hasktorch
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'

--- a/.github/workflows/nix-linux-cu10.yml
+++ b/.github/workflows/nix-linux-cu10.yml
@@ -44,13 +44,7 @@ jobs:
           df -h
           cat /proc/cpuinfo
           cat /proc/meminfo
-      - uses: cachix/install-nix-action@v16
-        with:
-          install_url: https://nixos-nix-install-tests.cachix.org/serve/i6laym9jw3wg9mw6ncyrk6gjx4l34vvx/install
-          install_options: '--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve'
-          extra_nix_config: |
-            experimental-features = nix-command flakes
-          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/install-nix-action@v18
       - uses: cachix/cachix-action@v12
         with:
           name: hasktorch

--- a/.github/workflows/nix-linux-cu11.yml
+++ b/.github/workflows/nix-linux-cu11.yml
@@ -51,7 +51,7 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
           nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@v8
+      - uses: cachix/cachix-action@v12
         with:
           name: hasktorch
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'

--- a/.github/workflows/nix-linux-cu11.yml
+++ b/.github/workflows/nix-linux-cu11.yml
@@ -44,13 +44,7 @@ jobs:
           df -h
           cat /proc/cpuinfo
           cat /proc/meminfo
-      - uses: cachix/install-nix-action@v16
-        with:
-          install_url: https://nixos-nix-install-tests.cachix.org/serve/i6laym9jw3wg9mw6ncyrk6gjx4l34vvx/install
-          install_options: '--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve'
-          extra_nix_config: |
-            experimental-features = nix-command flakes
-          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/install-nix-action@v18
       - uses: cachix/cachix-action@v12
         with:
           name: hasktorch

--- a/.github/workflows/nix-linux.yml
+++ b/.github/workflows/nix-linux.yml
@@ -48,7 +48,7 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
           nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@v8
+      - uses: cachix/cachix-action@v12
         with:
           name: hasktorch
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'

--- a/.github/workflows/nix-linux.yml
+++ b/.github/workflows/nix-linux.yml
@@ -41,13 +41,7 @@ jobs:
           df -h
           cat /proc/cpuinfo
           cat /proc/meminfo
-      - uses: cachix/install-nix-action@v16
-        with:
-          install_url: https://nixos-nix-install-tests.cachix.org/serve/i6laym9jw3wg9mw6ncyrk6gjx4l34vvx/install
-          install_options: '--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve'
-          extra_nix_config: |
-            experimental-features = nix-command flakes
-          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/install-nix-action@v18
       - uses: cachix/cachix-action@v12
         with:
           name: hasktorch

--- a/.github/workflows/stack-nix-linux.yml
+++ b/.github/workflows/stack-nix-linux.yml
@@ -28,7 +28,7 @@ jobs:
           install_options: '--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve'
           extra_nix_config: |
             experimental-features = nix-command flakes
-      - uses: cachix/cachix-action@v10
+      - uses: cachix/cachix-action@v12
         with:
           name: hasktorch
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'

--- a/.github/workflows/stack-nix-linux.yml
+++ b/.github/workflows/stack-nix-linux.yml
@@ -22,12 +22,7 @@ jobs:
           sudo apt update -qq
           sudo apt -y --allow-downgrades --allow-remove-essential --allow-change-held-packages install cmake curl wget unzip git libtinfo-dev python3 python3-yaml
           (wget -qO- https://get.haskellstack.org/ | sh) || true
-      - uses: cachix/install-nix-action@v16
-        with:
-          install_url: https://nixos-nix-install-tests.cachix.org/serve/vij683ly7sl95nnhb67bdjjfabclr85m/install
-          install_options: '--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve'
-          extra_nix_config: |
-            experimental-features = nix-command flakes
+      - uses: cachix/install-nix-action@v18
       - uses: cachix/cachix-action@v12
         with:
           name: hasktorch

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -82,7 +82,6 @@ let
           configureFlags = [
             "--extra-lib-dirs=${pkgs.torch.out}/lib"
             "--extra-include-dirs=${pkgs.torch.dev}/include"
-            "--extra-include-dirs=${pkgs.torch.dev}/include/torch/csrc/api/include"
           ];
           flags = {
             cuda = cudaSupport;

--- a/nix/libtorch.nix
+++ b/nix/libtorch.nix
@@ -54,6 +54,12 @@ in stdenv.mkDerivation {
     substituteInPlace \
       $dev/share/cmake/Caffe2/Caffe2Targets-release.cmake \
       --replace \''${_IMPORT_PREFIX}/lib "$out/lib" \
+
+    pushd $dev/include/torch
+    for i in csrc/api/include/torch/* ; do
+      ln -s $i
+    done
+    popd
   '';
 
   postFixup = let

--- a/nix/stack-shell.nix
+++ b/nix/stack-shell.nix
@@ -37,7 +37,6 @@ let
     name = "hasktorch-stack-dev-shell";
 
     extraArgs = [
-      "--extra-include-dirs=${pkgs.torch.dev}/include/torch/csrc/api/include"
     ];
 
     inherit buildInputs;

--- a/shell.nix
+++ b/shell.nix
@@ -22,9 +22,6 @@ hasktorchProject.shellFor {
   # buildInputs = with haskellPackages; [ ];
 
   shellHook = lib.strings.concatStringsSep "\n" [
-    # make sure correct libtorch is in cpath for cabal
-    "export CPATH=${torch}/include/torch/csrc/api/include"
-
     # set dynamic libraries for cuda support
     (lib.optionalString cudaSupport "export LD_LIBRARY_PATH=\"$LD_LIBRARY_PATH:/run/opengl-driver/lib\"")
 


### PR DESCRIPTION
libtorch needs two include paths (/usr/include/torch and /usr/include/torch/csrc/api/include/).
So users need to add the extra-include-dirs of /usr/include/torch/csrc/api/include/. 

This PR adds symlinks of /usr/include/torch/csrc/api/include/* to /usr/include/ not to add the extra-include-dirs.
