### PR TITLE
Fix JIT

### DIFF
--- a/hasktorch/bench/Runtime.hs
+++ b/hasktorch/bench/Runtime.hs
@@ -137,8 +137,8 @@ main = do
         C.env (pure (aT', bT', subT', vT')) $ \ ~(aT, bT, subT, vT) ->
             C.bgroup "Hasktorch" [ 
                              C.bench "multiplication" $ C.nf (T.matmul aT) bT,
-                             C.bench "repeated multiplication" $ C.nf ( T.sumAll . T.matmul bT . T.matmul aT . T.matmul aT) bT,
-                             C.bench "repeated multiplication with JIT" $ C.nf ( T.sumAll . T.matmul bT . T.matmul aT . T.matmul aT) bT,
+                             C.bench "repeated multiplication" $ C.nf (T.sumAll . T.matmul bT . T.matmul aT . T.matmul aT) bT,
+                             C.bench "repeated multiplication with JIT" $ C.nf (jit $ T.sumAll . T.matmul bT . T.matmul aT . T.matmul aT) bT,
                              C.bench "multiplicationV" $ C.nf (T.matmul aT) subT,
                              -- C.bench "qr factorization" $ C.nf (\v -> TI.qr v True) aT,
                              C.bench "transpose" $ C.nf TI.t aT,

--- a/hasktorch/src/Torch/Jit.hs
+++ b/hasktorch/src/Torch/Jit.hs
@@ -33,8 +33,8 @@ jitIO (ScriptCache cache) func input = do
       script' <- toScriptModule m
       atomically $ writeTVar cache (Just script')
       return script'
-  IVTensorList r0 <- forwardStoch script (map IVTensor input)
-  return r0
+  IVTensor r0 <- forwardStoch script (map IVTensor input)
+  return [r0]
 
 jit :: ScriptCache -> ([Tensor] -> [Tensor]) -> [Tensor] -> [Tensor]
 jit cache func input = unsafePerformIO $ jitIO cache (return . func) input


### PR DESCRIPTION
Current JIT function throws runtime an exception, because the trace of torchscript does not support the output-type of tensor-list.
This PR fixes the bug.