### PR TITLE
Fix the test of lstsq, because it does not allow zero as A.

### DIFF
--- a/deps/get-wheel.sh
+++ b/deps/get-wheel.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -eu
+
+VERSION=1.11.0
+
+case "$(uname)-$(uname -p)" in
+    "Darwin-arm")
+	wget -O torch.zip "https://download.pytorch.org/whl/cpu/torch-${VERSION}-cp310-none-macosx_11_0_arm64.whl"
+	unzip torch.zip
+	ln -s torch libtorch
+	;;
+esac

--- a/hasktorch/test/FunctionalSpec.hs
+++ b/hasktorch/test/FunctionalSpec.hs
@@ -97,7 +97,7 @@ spec = do
         next release. Please use :func:`torch.lstsq` instead.
   -}
   it "lstsq" $ do
-    let (x, qr) = lstsq (ones' [5, 2]) (ones' [5, 3])
+    let (x, qr) = lstsq (eye' 5 2) (eye' 5 3)
     shape x `shouldBe` [5, 2]
     shape qr `shouldBe` [5, 3]
   it "diag" $ do


### PR DESCRIPTION
When macOS, hasktorch's test fails, because lstsq does not allow zero matrix as an argument.
This PR fixes the error.