### PR TITLE
indexSelect' must use an Int64/32 tensor for indices

### DIFF
--- a/hasktorch/src/Torch/Tensor.hs
+++ b/hasktorch/src/Torch/Tensor.hs
@@ -312,7 +312,7 @@ indexSelect' ::
   Tensor ->
   -- | output
   Tensor
-indexSelect' dim indexList t = unsafePerformIO $ (cast3 ATen.index_select_tlt) t dim (asTensor indexList)
+indexSelect' dim indexList t = unsafePerformIO $ (cast3 ATen.index_select_tlt) t dim (_toDevice (device t) (asTensor indexList))
 
 -- | Slices the input tensor along the selected dimension at the given range.
 sliceDim ::

--- a/hasktorch/src/Torch/Tensor.hs
+++ b/hasktorch/src/Torch/Tensor.hs
@@ -312,7 +312,7 @@ indexSelect' ::
   Tensor ->
   -- | output
   Tensor
-indexSelect' dim indexList t = unsafePerformIO $ (cast3 ATen.index_select_tlt) t dim (asTensor' indexList t)
+indexSelect' dim indexList t = unsafePerformIO $ (cast3 ATen.index_select_tlt) t dim (asTensor indexList)
 
 -- | Slices the input tensor along the selected dimension at the given range.
 sliceDim ::


### PR DESCRIPTION
Bug: Exception: index_select(): Expected dtype int32 or int64 for index

Solution: Do not convert Tensor using `asTensor' indexList t`, as this would convert the type of `indexList` to the type of `t`. Rather use `asTensor indexList`. Another approach would be `asTensor' indexList int64_opts`, which would however always perform a transformation to `int64`.