### PR TITLE
Add a picture of the NN to `examples/autograd/`

### DIFF
--- a/examples/autograd/Main.hs
+++ b/examples/autograd/Main.hs
@@ -19,7 +19,7 @@ main = do
       w2 = toDependent wi2
       h1 = relu $ (transpose2D x) `matmul` w1
       h2 = sigmoid $ h1 `matmul` w2
-      loss = (h2 -0) ^ 2
+      loss = (h2 - 0) ^ 2
   let gradients = grad loss [wi1, wi2]
 
   printTensor "The input features:" x

--- a/examples/autograd/README.md
+++ b/examples/autograd/README.md
@@ -1,20 +1,20 @@
 # Basic data flow through autograd
 
-This example contains a very simple multi layer model meant to understand how autograd is used in Hasktorch to compute gradients. To be able to verify the results of the model, the weights have been taken equal to 1. ReLU and Sigmoid activations have been applied and mean squared error has been used for the loss. Results can be verified with the derivation of graidents done below. 
+This example contains a very simple multi layer model meant to understand how autograd is used in Hasktorch to compute gradients. To be able to verify the results of the model, the weights have been taken equal to 1. ReLU and Sigmoid activations have been applied and mean squared error has been used for the loss. Results can be verified with the derivation of graidents done below.
 
-For Hasktorch, the autograd function takes the loss along with a list of Independent Tensors (need to be specifically made here) with respect to which the derivative is to found. But for the normal operation, the tensors should be dependent tensors, as would be clear in the code. 
+For Hasktorch, the autograd function takes the loss along with a list of Independent Tensors (need to be specifically made here) with respect to which the derivative is to found. But for the normal operation, the tensors should be dependent tensors, as would be clear in the code.
 
 # Derivation of the gradients w.r.t. Loss
 <div align = "center">
 
-### Output of the model (Sigmoid Activation) : 
+### Output of the model (Sigmoid Activation) :
 
 <img src="https://render.githubusercontent.com/render/math?math=y = \frac{1}{1%2Be^{-y_{in}}}" width=100px height=30px>
 </div>
 
 <div align = "center">
 
-### Hidden layer output (ReLU Activation) : 
+### Hidden layer output (ReLU Activation) :
 <img src="https://render.githubusercontent.com/render/math?math=h = \max(a_{in},0)" width=100px height=30px>
 
 </div>
@@ -66,7 +66,7 @@ The gradient for other weights in the layer can also be derived in a similar man
 
 # Running the Example
 
-Setup environment variables (run this from the top-level hasktorch project 
+Setup environment variables (run this from the top-level hasktorch project
 directory where the `setenv` file is):
 
 ```
@@ -77,4 +77,4 @@ Building and running:
 
 ```
 stack run autograd
-``` 
+```

--- a/examples/autograd/README.md
+++ b/examples/autograd/README.md
@@ -1,10 +1,10 @@
 # Basic data flow through autograd
 
-This example contains a very simple multi layer model meant to understand how autograd is used in Hasktorch to compute gradients. To be able to verify the results of the model, the weights have been taken equal to 1. ReLU and Sigmoid activations have been applied and mean squared error has been used for the loss. Results can be verified with the derivation of graidents done below.
+This example contains a very simple multi layer model meant to understand how autograd is used in Hasktorch to compute gradients. To be able to verify the results of the model, the weights have been taken equal to 1. ReLU and Sigmoid activations have been applied and mean squared error has been used for the loss. Results can be verified with the derivation of gradients done below.
 
 For Hasktorch, the autograd function takes the loss along with a list of Independent Tensors (need to be specifically made here) with respect to which the derivative is to found. But for the normal operation, the tensors should be dependent tensors, as would be clear in the code.
 
-# Derivation of the gradients w.r.t. Loss
+## Derivation of the gradients w.r.t. Loss
 <div align = "center">
 
 ### Output of the model (Sigmoid Activation) :
@@ -64,7 +64,7 @@ The gradient for other weights in the layer can also be derived in a similar man
 </div>
 
 
-# Running the Example
+## Running the Example
 
 Setup environment variables (run this from the top-level hasktorch project
 directory where the `setenv` file is):

--- a/examples/autograd/README.md
+++ b/examples/autograd/README.md
@@ -4,6 +4,14 @@ This example contains a very simple multi layer model meant to understand how au
 
 For Hasktorch, the autograd function takes the loss along with a list of Independent Tensors (need to be specifically made here) with respect to which the derivative is to found. But for the normal operation, the tensors should be dependent tensors, as would be clear in the code.
 
+## Architecture of the neural network
+
+(Visualization created at https://alexlenail.me/NN-SVG/)
+
+<div align = "center">
+<img  src="nn.svg">
+</div>
+
 ## Derivation of the gradients w.r.t. Loss
 <div align = "center">
 

--- a/examples/autograd/nn.svg
+++ b/examples/autograd/nn.svg
@@ -1,0 +1,59 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1000" height="500" style="cursor: move;">
+<g transform="translate(-900,-650) scale(2.0)">
+<path class="link" marker-end="" d="M514.5,370.5, 694.5,430.5" style="stroke-width: 0.5; stroke-opacity: 1; stroke: rgb(80, 80, 80); fill: none;">
+</path>
+<path class="link" marker-end="" d="M514.5,370.5, 694.5,470.5" style="stroke-width: 0.5; stroke-opacity: 1; stroke: rgb(80, 80, 80); fill: none;">
+</path>
+<path class="link" marker-end="" d="M514.5,410.5, 694.5,430.5" style="stroke-width: 0.5; stroke-opacity: 1; stroke: rgb(80, 80, 80); fill: none;">
+</path>
+<path class="link" marker-end="" d="M514.5,410.5, 694.5,470.5" style="stroke-width: 0.5; stroke-opacity: 1; stroke: rgb(80, 80, 80); fill: none;">
+</path>
+<path class="link" marker-end="" d="M514.5,450.5, 694.5,430.5" style="stroke-width: 0.5; stroke-opacity: 1; stroke: rgb(80, 80, 80); fill: none;">
+</path>
+<path class="link" marker-end="" d="M514.5,450.5, 694.5,470.5" style="stroke-width: 0.5; stroke-opacity: 1; stroke: rgb(80, 80, 80); fill: none;">
+</path>
+<path class="link" marker-end="" d="M514.5,490.5, 694.5,430.5" style="stroke-width: 0.5; stroke-opacity: 1; stroke: rgb(80, 80, 80); fill: none;">
+</path>
+<path class="link" marker-end="" d="M514.5,490.5, 694.5,470.5" style="stroke-width: 0.5; stroke-opacity: 1; stroke: rgb(80, 80, 80); fill: none;">
+</path>
+<path class="link" marker-end="" d="M694.5,390.5, 874.5,430.5" style="stroke-width: 0.5; stroke-opacity: 1; stroke: rgb(80, 80, 80); fill: none;">
+</path>
+<path class="link" marker-end="" d="M694.5,430.5, 874.5,430.5" style="stroke-width: 0.5; stroke-opacity: 1; stroke: rgb(80, 80, 80); fill: none;">
+</path>
+<path class="link" marker-end="" d="M694.5,470.5, 874.5,430.5" style="stroke-width: 0.5; stroke-opacity: 1; stroke: rgb(80, 80, 80); fill: none;">
+</path>
+<path class="link" marker-end="" d="M514.5,370.5, 694.5,390.5" style="stroke-width: 0.5; stroke-opacity: 1; stroke: rgb(80, 80, 80); fill: none;">
+</path>
+<path class="link" marker-end="" d="M514.5,410.5, 694.5,390.5" style="stroke-width: 0.5; stroke-opacity: 1; stroke: rgb(80, 80, 80); fill: none;">
+</path>
+<path class="link" marker-end="" d="M514.5,450.5, 694.5,390.5" style="stroke-width: 0.5; stroke-opacity: 1; stroke: rgb(80, 80, 80); fill: none;">
+</path>
+<path class="link" marker-end="" d="M514.5,490.5, 694.5,390.5" style="stroke-width: 0.5; stroke-opacity: 1; stroke: rgb(80, 80, 80); fill: none;">
+</path>
+<circle r="10" class="node" id="0_0" cx="514.5" cy="370.5" style="fill: rgb(255, 255, 255); stroke: rgb(51, 51, 51);">
+</circle>
+<circle r="10" class="node" id="0_1" cx="514.5" cy="410.5" style="fill: rgb(255, 255, 255); stroke: rgb(51, 51, 51);">
+</circle>
+<circle r="10" class="node" id="0_2" cx="514.5" cy="450.5" style="fill: rgb(255, 255, 255); stroke: rgb(51, 51, 51);">
+</circle>
+<circle r="10" class="node" id="0_3" cx="514.5" cy="490.5" style="fill: rgb(255, 255, 255); stroke: rgb(51, 51, 51);">
+</circle>
+<circle r="10" class="node" id="1_0" cx="694.5" cy="390.5" style="fill: rgb(255, 255, 255); stroke: rgb(51, 51, 51);">
+</circle>
+<circle r="10" class="node" id="1_1" cx="694.5" cy="430.5" style="fill: rgb(255, 255, 255); stroke: rgb(51, 51, 51);">
+</circle>
+<circle r="10" class="node" id="1_2" cx="694.5" cy="470.5" style="fill: rgb(255, 255, 255); stroke: rgb(51, 51, 51);">
+</circle>
+<circle r="10" class="node" id="2_0" cx="874.5" cy="430.5" style="fill: rgb(255, 255, 255); stroke: rgb(51, 51, 51);">
+</circle>
+<text class="text" dy=".35em" x="479.5" y="530.5" style="font-size: 12px;">Input Layer ∈ ℝ⁴</text>
+<text class="text" dy=".35em" x="659.5" y="530.5" style="font-size: 12px;">Hidden Layer ∈ ℝ³</text>
+<text class="text" dy=".35em" x="839.5" y="530.5" style="font-size: 12px;">Output Layer ∈ ℝ¹</text>
+</g>
+<defs>
+<marker id="arrow" viewBox="0 -5 10 10" markerWidth="7" markerHeight="7" orient="auto" refX="40">
+<path d="M0,-5L10,0L0,5" style="stroke: rgb(80, 80, 80); fill: none;">
+</path>
+</marker>
+</defs>
+</svg>


### PR DESCRIPTION
Reading through the example `autograd`, I found it helpful to have a picture of the NN before me.
I generated one at https://alexlenail.me/NN-SVG/

Commits:
- examples/autograd: Whitespace changes
- examples/autograd/README: fix a typo; correct level of subheadings
- examples/autograd/README: add a visualization (SVG) of the NN
