### PR TITLE
CI: bump to latest `actions/checkout` and `actions/cache`; bump GHC to 9.2.8

### DIFF
--- a/.github/workflows/cabal-linux.yml
+++ b/.github/workflows/cabal-linux.yml
@@ -7,7 +7,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup packages
       run: |
         sudo apt update -qq
@@ -29,7 +29,7 @@ jobs:
       run: |
         git submodule init && git submodule update
     - name: Cache .cabal
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ~/.cabal/store

--- a/.github/workflows/cabal-linux.yml
+++ b/.github/workflows/cabal-linux.yml
@@ -22,8 +22,8 @@ jobs:
         echo "$HOME/.cabal/bin" >> $GITHUB_PATH
         echo "$HOME/.ghcup/bin" >> $GITHUB_PATH
         curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
-        ghcup install ghc 9.2.4
-        ghcup set ghc 9.2.4
+        ghcup install ghc 9.2.8
+        ghcup set ghc 9.2.8
         ghcup install cabal
     - name: Setup repos
       run: |

--- a/.github/workflows/cabal-macos.yaml
+++ b/.github/workflows/cabal-macos.yaml
@@ -26,8 +26,8 @@ jobs:
         echo "$HOME/.cabal/bin" >> $GITHUB_PATH
         echo "$HOME/.ghcup/bin" >> $GITHUB_PATH
         curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
-        ghcup install ghc 9.2.4
-        ghcup set ghc 9.2.4
+        ghcup install ghc 9.2.8
+        ghcup set ghc 9.2.8
         ghcup install cabal
     - name: Cache .cabal
       uses: actions/cache@v3
@@ -35,9 +35,9 @@ jobs:
         path: |
           ~/.cabal/store
           dist-newstyle
-        key: ${{ runner.os }}-cabal-ghc924-${{ hashFiles('**/fallible.cabal') }}
+        key: ${{ runner.os }}-cabal-ghc928-${{ hashFiles('**/fallible.cabal') }}
         restore-keys: |
-          ${{ runner.os }}-cabal-ghc902-
+          ${{ runner.os }}-cabal-ghc924-
     - name: Build
       run: |
         #. setenv

--- a/.github/workflows/cabal-macos.yaml
+++ b/.github/workflows/cabal-macos.yaml
@@ -6,7 +6,7 @@ jobs:
   build:
     runs-on: macOS-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup repo
       run: |
         git submodule init && git submodule update
@@ -30,7 +30,7 @@ jobs:
         ghcup set ghc 9.2.4
         ghcup install cabal
     - name: Cache .cabal
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ~/.cabal/store

--- a/.github/workflows/nix-haddock-linux.yml
+++ b/.github/workflows/nix-haddock-linux.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: free disk space
       run: |
         sudo swapoff -a

--- a/.github/workflows/nix-linux-cu10.yml
+++ b/.github/workflows/nix-linux-cu10.yml
@@ -12,7 +12,7 @@ jobs:
   # tests:
   #   runs-on: ubuntu-latest
   #   steps:
-  #     - uses: actions/checkout@v2
+  #     - uses: actions/checkout@v4
   #     - name: free disk space
   #       run: |
   #         sudo swapoff -a
@@ -34,7 +34,7 @@ jobs:
     if: github.repository == 'hasktorch/hasktorch'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: free disk space
         run: |
           sudo apt -y purge ghc* cabal-install* php* || true

--- a/.github/workflows/nix-linux-cu11.yml
+++ b/.github/workflows/nix-linux-cu11.yml
@@ -12,7 +12,7 @@ jobs:
   # tests:
   #   runs-on: ubuntu-latest
   #   steps:
-  #     - uses: actions/checkout@v2
+  #     - uses: actions/checkout@v4
   #     - name: free disk space
   #       run: |
   #         sudo swapoff -a
@@ -34,7 +34,7 @@ jobs:
     if: github.repository == 'hasktorch/hasktorch'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: free disk space
         run: |
           sudo apt -y purge ghc* cabal-install* php* || true

--- a/.github/workflows/nix-linux.yml
+++ b/.github/workflows/nix-linux.yml
@@ -9,7 +9,7 @@ jobs:
   # tests:
   #   runs-on: ubuntu-latest
   #   steps:
-  #     - uses: actions/checkout@v2
+  #     - uses: actions/checkout@v4
   #     - name: free disk space
   #       run: |
   #         sudo swapoff -a
@@ -31,7 +31,7 @@ jobs:
     if: github.repository == 'hasktorch/hasktorch'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: free disk space
         run: |
           sudo apt -y purge ghc* cabal-install* php* || true

--- a/.github/workflows/stack-linux.yml
+++ b/.github/workflows/stack-linux.yml
@@ -27,7 +27,6 @@ jobs:
       run: |
         git submodule init && git submodule update
     - name: Cache .stack
-      id: cache-stack
       uses: actions/cache@v3
       with:
         path: |

--- a/.github/workflows/stack-linux.yml
+++ b/.github/workflows/stack-linux.yml
@@ -7,7 +7,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: free disk space
       run: |
         sudo swapoff -a
@@ -28,7 +28,7 @@ jobs:
         git submodule init && git submodule update
     - name: Cache .stack
       id: cache-stack
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ~/.stack

--- a/.github/workflows/stack-macos.yaml
+++ b/.github/workflows/stack-macos.yaml
@@ -23,7 +23,6 @@ jobs:
         brew install libtorch-prebuild@1.11 || true
         #pushd deps/ ; ./get-deps.sh -a cpu -c ;popd
     - name: Cache .stack
-      id: cache-stack
       uses: actions/cache@v3
       with:
         path: |

--- a/.github/workflows/stack-macos.yaml
+++ b/.github/workflows/stack-macos.yaml
@@ -6,7 +6,7 @@ jobs:
   build:
     runs-on: macOS-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup repo
       run: |
         git submodule init && git submodule update
@@ -24,7 +24,7 @@ jobs:
         #pushd deps/ ; ./get-deps.sh -a cpu -c ;popd
     - name: Cache .stack
       id: cache-stack
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ~/.stack

--- a/.github/workflows/stack-nix-linux.yml
+++ b/.github/workflows/stack-nix-linux.yml
@@ -6,7 +6,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: free disk space
         run: |
           sudo swapoff -a
@@ -32,7 +32,7 @@ jobs:
           .github/workflows/setup-iohk-cache.sh
       - name: Cache .stack
         id: cache-stack
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.stack

--- a/.github/workflows/stack-nix-linux.yml
+++ b/.github/workflows/stack-nix-linux.yml
@@ -31,7 +31,6 @@ jobs:
       - run: |
           .github/workflows/setup-iohk-cache.sh
       - name: Cache .stack
-        id: cache-stack
         uses: actions/cache@v3
         with:
           path: |


### PR DESCRIPTION
- CI: bump actions/checkout to v4 and actions/cache to v3 (latest versions)
   This will silence a deprecation warning for node 12 when running the CI.
- CI: bump GHC from 9.2.4 to 9.2.8
   This follows a previous commit bumping to LTS 20.26 (which is GHC 9.2.8).
- CI: cosmetics: removed unused "id: cache-stack"
