### PR TITLE
CI: some workflow simplifications

### DIFF
--- a/.github/workflows/cabal-linux.yml
+++ b/.github/workflows/cabal-linux.yml
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        submodules: true
     - name: Setup packages
       run: |
         sudo apt update -qq
@@ -25,9 +27,6 @@ jobs:
         ghcup install ghc 9.2.8
         ghcup set ghc 9.2.8
         ghcup install cabal
-    - name: Setup repos
-      run: |
-        git submodule init && git submodule update
     - name: Cache .cabal
       uses: actions/cache@v3
       with:

--- a/.github/workflows/cabal-linux.yml
+++ b/.github/workflows/cabal-linux.yml
@@ -23,7 +23,8 @@ jobs:
 
         echo "$HOME/.cabal/bin" >> $GITHUB_PATH
         echo "$HOME/.ghcup/bin" >> $GITHUB_PATH
-        curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
+        ## GHCup is preinstalled on the GHA runners
+        # curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
         ghcup install ghc 9.2.8
         ghcup set ghc 9.2.8
         ghcup install cabal

--- a/.github/workflows/cabal-macos.yaml
+++ b/.github/workflows/cabal-macos.yaml
@@ -24,7 +24,8 @@ jobs:
 
         echo "$HOME/.cabal/bin" >> $GITHUB_PATH
         echo "$HOME/.ghcup/bin" >> $GITHUB_PATH
-        curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
+        ## GHCup is preinstalled on the GHA runners
+        # curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
         ghcup install ghc 9.2.8
         ghcup set ghc 9.2.8
         ghcup install cabal

--- a/.github/workflows/cabal-macos.yaml
+++ b/.github/workflows/cabal-macos.yaml
@@ -7,9 +7,8 @@ jobs:
     runs-on: macOS-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Setup repo
-      run: |
-        git submodule init && git submodule update
+      with:
+        submodules: true
     - name: Setup tool-chains
       run: |
         /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"

--- a/.github/workflows/stack-linux.yml
+++ b/.github/workflows/stack-linux.yml
@@ -24,7 +24,8 @@ jobs:
         sudo rm -f /etc/apt/sources.list.d/sbt.list
         sudo apt update -qq
         sudo apt -y --allow-downgrades --allow-remove-essential --allow-change-held-packages install cmake curl wget unzip git libtinfo-dev python3 python3-yaml
-        (wget -qO- https://get.haskellstack.org/ | sh) || true
+      ## Stack is preinstalled on the GHA runners
+      #  (wget -qO- https://get.haskellstack.org/ | sh) || true
     - name: Cache .stack
       uses: actions/cache@v3
       with:
@@ -40,7 +41,7 @@ jobs:
           ${{ runner.os }}-stack-
     - name: Build
       run: |
-        export PATH=/opt/ghc/bin:$PATH
+        # export PATH=/opt/ghc/bin:$PATH
         source setenv
         pushd deps/ ; ./get-deps.sh -a cpu -c; popd
         stack build \
@@ -54,7 +55,7 @@ jobs:
           untyped-nlp
     - name: Test
       run: |
-        export PATH=/opt/ghc/bin:$PATH
+        # export PATH=/opt/ghc/bin:$PATH
         source setenv
         stack test codegen
         stack test libtorch-ffi

--- a/.github/workflows/stack-linux.yml
+++ b/.github/workflows/stack-linux.yml
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        submodules: true
     - name: free disk space
       run: |
         sudo swapoff -a
@@ -23,9 +25,6 @@ jobs:
         sudo apt update -qq
         sudo apt -y --allow-downgrades --allow-remove-essential --allow-change-held-packages install cmake curl wget unzip git libtinfo-dev python3 python3-yaml
         (wget -qO- https://get.haskellstack.org/ | sh) || true
-    - name: Setup repos
-      run: |
-        git submodule init && git submodule update
     - name: Cache .stack
       uses: actions/cache@v3
       with:

--- a/.github/workflows/stack-macos.yaml
+++ b/.github/workflows/stack-macos.yaml
@@ -14,8 +14,9 @@ jobs:
         /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
         brew install libomp || true
         pip3 install pyyaml || true
+        ## Stack is preinstalled on the GHA runners
         #wget -qO- https://get.haskellstack.org/ | sed -e 's/^STACK_VERSION=.*/STACK_VERSION="1.9.3"/g' | sh || true
-        wget -qO- https://get.haskellstack.org/ | sh || true
+        #wget -qO- https://get.haskellstack.org/ | sh || true
         clang --version
         stack --version
         brew tap hasktorch/libtorch-prebuild https://github.com/hasktorch/homebrew-libtorch-prebuild || true

--- a/.github/workflows/stack-macos.yaml
+++ b/.github/workflows/stack-macos.yaml
@@ -7,9 +7,8 @@ jobs:
     runs-on: macOS-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Setup repo
-      run: |
-        git submodule init && git submodule update
+      with:
+        submodules: true
     - name: Setup tool-chains
       run: |
         /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"

--- a/.github/workflows/stack-nix-linux.yml
+++ b/.github/workflows/stack-nix-linux.yml
@@ -21,7 +21,8 @@ jobs:
           sudo rm -f /etc/apt/sources.list.d/sbt.list
           sudo apt update -qq
           sudo apt -y --allow-downgrades --allow-remove-essential --allow-change-held-packages install cmake curl wget unzip git libtinfo-dev python3 python3-yaml
-          (wget -qO- https://get.haskellstack.org/ | sh) || true
+        ## Stack is preinstalled on the GHA runners
+        #  (wget -qO- https://get.haskellstack.org/ | sh) || true
       - uses: cachix/install-nix-action@v18
       - uses: cachix/cachix-action@v12
         with:


### PR DESCRIPTION
This PR makes some cosmetic simplifications on the workflows.
- CI: setup submodules with actions/checkout
- CI: Stack is preinstalled on the GHA runners, no need to install it
- CI: GHCup is preinstalled on the GHA runners, no need to install it

I have some more ideas for CI cosmetics, like removing redundant instructions or steps. Let me know whether such work is welcome in general or whether this would conflict with some principles behind the CI setup.

So far, I commented out redundant installation steps, let me know whether you prefer that I fully delete them.

