### PR TITLE
CI #684: revise caching for the cabal workflows

### DIFF
--- a/.github/workflows/cabal-linux.yml
+++ b/.github/workflows/cabal-linux.yml
@@ -6,10 +6,14 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    env:
+      GHC: '9.2.8'
     steps:
+
     - uses: actions/checkout@v4
       with:
         submodules: true
+
     - name: Setup packages
       run: |
         sudo apt update -qq
@@ -21,43 +25,79 @@ jobs:
         sudo apt -y --allow-downgrades --allow-remove-essential --allow-change-held-packages install build-essential zlib1g-dev liblapack-dev libblas-dev devscripts debhelper python3-pip cmake curl wget unzip git libtinfo-dev python3 python3-yaml
         sudo apt -y install libtorch=1.11.0+cpu-1 libtokenizers=0.1-1
 
-        echo "$HOME/.cabal/bin" >> $GITHUB_PATH
-        echo "$HOME/.ghcup/bin" >> $GITHUB_PATH
-        ## GHCup is preinstalled on the GHA runners
-        # curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
-        ghcup install ghc 9.2.8
-        ghcup set ghc 9.2.8
-        ghcup install cabal
-    - name: Cache .cabal
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cabal/store
-          dist-newstyle
-        key: ${{ runner.os }}-cabal-${{ hashFiles('**/fallible.cabal') }}
-        restore-keys: |
-          ${{ runner.os }}-cabal-
-    - name: Build
+    - name: Setup Haskell
       run: |
-        source setenv
-        #APT installs libtorch and libtokenizers.
-        #pushd deps/ ; ./get-deps.sh -a cpu -c; popd
+        echo "$HOME/.ghcup/bin" >> "${GITHUB_PATH}"
+        ghcup install ghc --set ${{ env.GHC }}
+        mkdir -p ~/.cabal
+      # The presence of ~/.cabal should switch cabal 3.10 to not use the XDG layout.
+
+      ## GHCup is preinstalled on the GHA runners. This would be the magic incantation to install it:
+      # curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
+      ## Cabal is preinstalled on the GHA runners
+      # ghcup install cabal
+
+    - name: Information about the Haskell setup
+      run: |
+        echo "PATH = ${PATH}"
+        echo "GHC is $(which ghc)"
+        echo "Cabal is $(which cabal)"
+        echo "GHC_VERSION=$(ghc --numeric-version)"     >> "${GITHUB_ENV}"
+        echo "CABAL_VERSION=$(cabal --numeric-version)" >> "${GITHUB_ENV}"
+
+    - name: Generate install-plan
+      run: |
+        # source setenv
         ./setup-cabal.sh
         cabal v2-update
-        cabal v2-install hspec-discover
-        cabal v2-build --jobs=2 all
-    - name: Test
+        cabal v2-build --jobs=2 all --dry-run
+      ## The latter leaves a build plan in dist-newstyle/cache/plan.json
+
+    - name: Restore cached dependencies
+      uses: actions/cache/restore@v3
+      id:   cache
+      with:
+        # We don't cache dist-newstyle because it is fat and in practice hardly reused.
+        path: ~/.cabal/store
+        # Append the build plan to the cache key so that a new cache gets saved when dependencies update.
+        # `plan.json` is a good cache key because it does not contain time stamps (unlike `cabal.project.freeze`).
+        key:          ${{ runner.os }}-cabal-${{ env.CABAL_VERSION }}-ghc-${{ env.GHC_VERSION }}-plan-${{ hashFiles('**/plan.json') }}
+        restore-keys: ${{ runner.os }}-cabal-${{ env.CABAL_VERSION }}-ghc-${{ env.GHC_VERSION }}-
+
+    - name: Install dependencies
       run: |
-        source setenv
+        # source setenv
+        cabal v2-build --jobs=2 all --only-dependencies
+
+    - name: Cache dependencies
+      if:   ${{ steps.cache.outputs.cache-hit != 'true' }}
+      uses: actions/cache/save@v3
+      with:
+        path: ~/.cabal/store
+        key: ${{ steps.cache.outputs.cache-primary-key }}
+
+    - name: Build
+      run: |
+        # source setenv
+        cabal v2-build --jobs=2 all
+
+    - name: Tests
+      run: |
+        # source setenv
         cabal v2-test --jobs=2 all
+
+    - name: Runs
+      run: |
+        # source setenv
         cabal v2-exec codegen-exe
-        cabal exec xor-mlp
+        cabal v2-exec xor-mlp
+
     - name: Benchmark
       run: |
-        export PATH=/opt/ghc/bin:$PATH
-        source setenv
-        cabal bench hasktorch:runtime --benchmark-options='--output benchmark-runtime.html'
-        cabal bench hasktorch:alloc --benchmark-options='--output benchmark-alloc.html'
+        # source setenv
+        cabal v2-bench hasktorch:runtime --benchmark-options='--output benchmark-runtime.html'
+        cabal v2-bench hasktorch:alloc   --benchmark-options='--output benchmark-alloc.html'
+
     - name: Archive benchmark results
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/cabal-macos.yaml
+++ b/.github/workflows/cabal-macos.yaml
@@ -5,49 +5,81 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: macOS-latest
+    env:
+      GHC: '9.2.8'
     steps:
+
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - name: Setup tool-chains
+
+    - name: Setup packages
       run: |
         /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
         brew install libomp || true
         pip3 install pyyaml || true
-        #brew install ghc@9.02 || true
-        #brew install cabal-install || true
         brew tap hasktorch/libtorch-prebuild https://github.com/hasktorch/homebrew-libtorch-prebuild || true
         brew install libtorch-prebuild@1.11 || true
         brew tap hasktorch/tokenizers https://github.com/hasktorch/tokenizers || true
         brew install libtokenizers || true
         #pushd deps/ ; ./get-deps.sh -a cpu -c ;popd
 
-        echo "$HOME/.cabal/bin" >> $GITHUB_PATH
-        echo "$HOME/.ghcup/bin" >> $GITHUB_PATH
-        ## GHCup is preinstalled on the GHA runners
-        # curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
-        ghcup install ghc 9.2.8
-        ghcup set ghc 9.2.8
-        ghcup install cabal
-    - name: Cache .cabal
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cabal/store
-          dist-newstyle
-        key: ${{ runner.os }}-cabal-ghc928-${{ hashFiles('**/fallible.cabal') }}
-        restore-keys: |
-          ${{ runner.os }}-cabal-ghc924-
-    - name: Build
+    - name: Setup Haskell
       run: |
-        #. setenv
+        echo "$HOME/.ghcup/bin" >> "${GITHUB_PATH}"
+        ghcup install ghc --set ${{ env.GHC }}
+
+      ## GHCup is preinstalled on the GHA runners. This would be the magic incantation to install it:
+      # curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
+      ## Cabal is preinstalled on the GHA runners
+      # ghcup install cabal
+
+    - name: Information about the Haskell setup
+      run: |
+        echo "PATH = ${PATH}"
+        echo "GHC is $(which ghc)"
+        echo "Cabal is $(which cabal)"
+        echo "GHC_VERSION=$(ghc --numeric-version)"     >> "${GITHUB_ENV}"
+        echo "CABAL_VERSION=$(cabal --numeric-version)" >> "${GITHUB_ENV}"
+
+    - name: Generate install-plan
+      run: |
         ./setup-cabal.sh
         cabal v2-update
-        cabal v2-install hspec-discover
-        cabal v2-build --jobs=2 all
-    - name: Test
+        cabal v2-build --jobs=2 all --dry-run
+      ## The latter leaves a build plan in dist-newstyle/cache/plan.json
+
+    - name: Restore cached dependencies
+      uses: actions/cache/restore@v3
+      id:   cache
+      with:
+        # We don't cache dist-newstyle because it is fat and in practice hardly reused.
+        path: ~/.cabal/store
+        # Append the build plan to the cache key so that a new cache gets saved when dependencies update.
+        # `plan.json` is a good cache key because it does not contain time stamps (unlike `cabal.project.freeze`).
+        key:          ${{ runner.os }}-cabal-${{ env.CABAL_VERSION }}-ghc-${{ env.GHC_VERSION }}-plan-${{ hashFiles('**/plan.json') }}
+        restore-keys: ${{ runner.os }}-cabal-${{ env.CABAL_VERSION }}-ghc-${{ env.GHC_VERSION }}-
+
+    - name: Install dependencies
       run: |
-        #. setenv
+        cabal v2-build --jobs=2 all --only-dependencies
+
+    - name: Cache dependencies
+      if:   ${{ steps.cache.outputs.cache-hit != 'true' }}
+      uses: actions/cache/save@v3
+      with:
+        path: ~/.cabal/store
+        key: ${{ steps.cache.outputs.cache-primary-key }}
+
+    - name: Build
+      run: |
+        cabal v2-build --jobs=2 all
+
+    - name: Tests
+      run: |
         cabal v2-test --jobs=2 all
+
+    - name: Runs
+      run: |
         cabal v2-exec codegen-exe
         cabal exec xor-mlp


### PR DESCRIPTION
This commit restructures the workflows `cabal-linux` and `cabal-macos`.

Caching
-------

1. Only cache dependencies.

   From looking into PR runs I deduced that `cabal` hardly reuses anything from `dist-newstyle`.
   Thus, this local build directory is dropped from the cache, only the global `~/.cabal/store` is now cached.
   This dramatically reduces the cache sizes (here with GHC 9.2.8):

   | cabal  | linux  | macos  |
   |--------|--------|--------|
   | before | 450 MB | 250 MB |
   | after  |  85 MB | 100 MB |

2. Save dependency cache early.

   Splitting `actions/cache` into `/restore` and `/save` step,
   we can immediately cache the dependencies after they have been build.
   So they will be preserved even if later the building of `hasktorch` or some test fails.
   This will speed up the next attempt, because currently around 30min are spent on building the dependencies.
   This is half of the build time on `cabal-macos` and short of 40% on `cabal-linux`.

3. Use more precise cache keys.

   The new cache keys feature 4 components:
   1. OS
   2. Cabal version
   3. GHC version
   4. Hash of the build plan

   The latter is created by a `cabal build all --dry-run` that determines all the versions of the dependencies.

   Caches can be restored even if the build plan changes, but not if Cabal or GHC version change.
   - Build products from other GHCs can in general not be reused.
   - Build products from other Cabal versions might be risky to reuse.

Other changes
-------------

- Skip installation of `Cabal` as it is preinstalled on the GHA runners.

- Skip installation of `hspec-discover` as it is not used in the code base (probably it was used in the past).
  Consequently, we do not need `.cabal/bin` in the `PATH`.

- Break job into smaller steps.  This has two advantages:
  1. We get timing info for each step at our fingertips.
  2. In case of breakage, individual step are easier to link to in the logs.

- Drop the `source setenv` step everywhere.
  It seems unnecessary.

- Print some information about the Haskell setup, e.g. paths.
  Useful for debugging.
