### PR TITLE
Fix: Missing delete_tensortensorint64int64tensortensor in csrc

### DIFF
--- a/libtorch-ffi/csrc/hasktorch_finializer.cpp
+++ b/libtorch-ffi/csrc/hasktorch_finializer.cpp
@@ -181,6 +181,10 @@ void delete_tensortensorint64int64tensor(std::tuple<at::Tensor,at::Tensor,int64_
   delete object;
 }
 
+void delete_tensortensorint64int64tensortensor(std::tuple<at::Tensor,at::Tensor,int64_t,int64_t,at::Tensor,at::Tensor>* object){
+  delete object;
+}
+
 void delete_tensorlisttensor(std::tuple<std::vector<at::Tensor>,at::Tensor>* object){
   delete object;
 }
@@ -340,6 +344,8 @@ showObject(int flag, void* ptr, void* fptr){
     std::cout << age << ":" << "(tensor,tensor,double,int)" << ":" << std::hex << (ptr) << std::dec << std::endl;
   }else if(fptr == (void*)delete_tensortensorint64int64tensor){
     std::cout << age << ":" << "(tensor,tensor,int,int,tensor)" << ":" << std::hex << (ptr) << std::dec << std::endl;
+  }else if(fptr == (void*)delete_tensortensorint64int64tensortensor){
+    std::cout << age << ":" << "(tensor,tensor,int,int,tensor,tensor)" << ":" << std::hex << (ptr) << std::dec << std::endl;
   }else if(fptr == (void*)delete_tensorlisttensor){
     std::cout << age << ":" << "(tensorlist,tensor)" << ":" << std::hex << (ptr) << std::dec << std::endl;
   }else if(fptr == (void*)delete_tensortensorlist){

--- a/libtorch-ffi/csrc/hasktorch_finializer.h
+++ b/libtorch-ffi/csrc/hasktorch_finializer.h
@@ -104,6 +104,8 @@ extern "C" {
 
   void delete_tensortensorint64int64tensor(std::tuple<at::Tensor,at::Tensor,int64_t,int64_t,at::Tensor>* ptr);
 
+  void delete_tensortensorint64int64tensortensor(std::tuple<at::Tensor,at::Tensor,int64_t,int64_t,at::Tensor,at::Tensor>* ptr);
+
   void delete_tensorlisttensor(std::tuple<std::vector<at::Tensor>,at::Tensor>* ptr);
 
   void delete_tensortensorlist(std::tuple<at::Tensor,std::vector<at::Tensor>>* ptr);


### PR DESCRIPTION
libtorch-ffi's haskell codes have delete_tensortensorint64int64tensortensor.
However libtorch-ffi's c codes do not have delete_tensortensorint64int64tensortensor.
This PR fixes the missing symbol.

```
$ git grep -h 'finalizer.h delete.*' libtorch-ffi -e 's/.*\(delete.*\)"/\1/g' | sort |uniq  > delete_symbols.txt
$ git grep -h 'finalizer.h delete.*' libtorch-ffi/src | sed -e 's/.*\(delete.*\)"/\1/g' | sort |uniq  > haskell.txt
$ git grep -h 'delete.*' libtorch-ffi/csrc/hasktorch_finializer.h | sed -e 's/.* \(delete_.*\)(.*/\1/g' |sort | uniq > csrc.txt
$ diff haskell.txt csrc.txt
46d45
< delete_tensortensorint64int64tensortensor
51a51
> delete_tensortensortensortensorint64int64int64int64tensor
53a54,55
> delete_tensortensortensortensortensortensor
> delete_tensortensortensortensortensortensortensor
```
