### PR TITLE
Remove redundant constraints in .cabal files, drop fork of union-find-array

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,25 @@
+# Format of a line:
+#
+# Proper Name <Proper@email> commit name <commit@email>
+# \-----------+------------/ \----------+-------------/
+#             |                         |
+#          replace                     find
+#
+# <Proper@email> is never optional and cannot appear by itself.
+# Besides that, the other parts are optional (as long as 2 parts
+# are present).
+
+# Please keep this file in alphabetic order!
+
+##############################################################################
+Austin Huang <austinh@alum.mit.edu> austinvhuang
+Austin Huang <austinh@alum.mit.edu> <austinhuang@Austins-MacBook-Pro.local>
+Junji Hashimoto <junji.hashimoto@gmail.com> junji hashimoto
+Junji Hashimoto <junji.hashimoto@gmail.com> <junjihashimoto@users.noreply.github.com>
+Junji Hashimoto <junji.hashimoto@gmail.com> <junji.hashimoto@gree.net>
+Matthias Meschede <MMesch@users.noreply.github.com> MMesch
+Sam Stites <sam@stites.io> stites
+Sam Stites <sam@stites.io> <stites@users.noreply.github.com>
+Shiv Kumar <championballer08@gmail.com> championballer
+Tim Pierson <tim.pierson@gmail.com> o1lo01ol1o
+Tim Pierson <tim.pierson@gmail.com> <o1lo01ol1o@users.noreply.github.com>

--- a/cabal.project
+++ b/cabal.project
@@ -40,10 +40,11 @@ source-repository-package
     location: https://github.com/hasktorch/term-rewriting
     tag: 54221f58b28c9f36db9bac437231e6142c8cca3a
 
-source-repository-package
-    type: git
-    location: https://github.com/hasktorch/union-find-array
-    tag: 2e94a0e7bdd15d5a7425aca05d64cca8816f2a23
+-- 2024-04-30 fork is obsolete with union-find-array-0.1.0.4
+-- source-repository-package
+--     type: git
+--     location: https://github.com/hasktorch/union-find-array
+--     tag: 2e94a0e7bdd15d5a7425aca05d64cca8816f2a23
 
 write-ghc-environment-files: always
 tests: true

--- a/codegen/codegen.cabal
+++ b/codegen/codegen.cabal
@@ -46,7 +46,7 @@ executable codegen-exe
   main-is:             Main.hs
   default-language:    Haskell2010
   build-depends:
-      base >= 4.7 && < 5
+      base
     , codegen
     , optparse-applicative >= 0.14.3.0
   extra-libraries:     stdc++

--- a/hasktorch/hasktorch.cabal
+++ b/hasktorch/hasktorch.cabal
@@ -184,7 +184,7 @@ test-suite spec
                     , IndexSpec
   default-language: Haskell2010
   ghc-options:         -fplugin GHC.TypeLits.Normalise -fplugin GHC.TypeLits.KnownNat.Solver -fplugin GHC.TypeLits.Extra.Solver -fconstraint-solver-iterations=0
-  build-depends:      base >= 4.7 && < 5
+  build-depends:      base
                     , ghc-typelits-extra
                     , ghc-typelits-knownnat
                     , ghc-typelits-natnormalise
@@ -218,8 +218,8 @@ test-suite doctests
   default-language:   Haskell2010
   build-depends:      doctest >=0.16.0.1 && <0.23
                     , async
-                    , base >= 4.7 && < 5
-                    , libtorch-ffi == 2.0.*
+                    , base
+                    , libtorch-ffi
                     , finite-typelits
                     , ghc-typelits-extra
                     , ghc-typelits-knownnat
@@ -242,7 +242,7 @@ benchmark runtime
   main-is: Runtime.hs
   hs-source-dirs: bench
   build-depends:
-      base >=4.7 && <5
+      base
     , criterion
     , deepseq
     , hmatrix
@@ -262,7 +262,7 @@ benchmark alloc
   main-is: Alloc.hs
   hs-source-dirs: bench
   build-depends:
-      base >=4.7 && <5
+      base
     , deepseq
     , hmatrix
     , mwc-random

--- a/libtorch-ffi/libtorch-ffi.cabal
+++ b/libtorch-ffi/libtorch-ffi.cabal
@@ -199,7 +199,7 @@ test-suite spec
                  , CudaSpec
                  , GeneratorSpec
   default-language: Haskell2010
-  build-depends:       base >= 4.7 && < 5
+  build-depends:       base
                      , libtorch-ffi
                      , hspec
                      , safe-exceptions

--- a/libtorch-ffi/libtorch-ffi.cabal
+++ b/libtorch-ffi/libtorch-ffi.cabal
@@ -2,7 +2,7 @@ cabal-version:       3.0
 name:                libtorch-ffi
 version:             2.0.0.0
 -- The prefix(2.0) of this version("2.0.0.0") is the same as libtorch's one.
-synopsis:            test out alternative options for ffi interface to libtorch 1.x
+synopsis:            test out alternative options for ffi interface to libtorch 2.x
 -- description:
 homepage:            https://github.com/hasktorch/hasktorch#readme
 license:             BSD-3-Clause


### PR DESCRIPTION
- **Drop redundant constraints**
- **Fix synopsis**
- **Fork of union-find-array is obsolete**
