### PR TITLE
Added CLI arguments to MNIST examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,10 @@ $ cabal test examples   # Build and run the Hasktorch example test suites.
 To run the MNIST CNN example, run:
 
 ```sh
-$ cd examples                   # Change to the examples directory.
-$ ./datasets/download-mnist.sh  # Download the MNIST dataset.
-$ mv mnist data                 # Move the MNIST dataset to the data directory.
-$ export DEVICE=cpu             # Set device to CPU for the MNIST CNN example.
-$ cabal run static-mnist-cnn    # Run the MNIST CNN example.
+$ cd examples                            # Change to the examples directory.
+$ ./datasets/download-mnist.sh           # Download the MNIST dataset.
+$ export DEVICE=cpu                      # Set device to CPU for the MNIST CNN example.
+$ cabal run static-mnist-cnn -- ./mnist/ # Run the MNIST CNN example.
 ```
 
 
@@ -107,11 +106,10 @@ $ cabal test examples   # Build and run the Hasktorch example test suites.
 To run the MNIST CNN example, run:
 
 ```sh
-$ cd examples                   # Change to the examples directory.
-$ ./datasets/download-mnist.sh  # Download the MNIST dataset.
-$ mv mnist data                 # Move the MNIST dataset to the data directory.
-$ export DEVICE="cuda:0"        # Set device to CUDA for the MNIST CNN example.
-$ cabal run static-mnist-cnn    # Run the MNIST CNN example.
+$ cd examples                            # Change to the examples directory.
+$ ./datasets/download-mnist.sh           # Download the MNIST dataset.
+$ export DEVICE="cuda:0"                 # Set device to CUDA for the MNIST CNN example.
+$ cabal run static-mnist-cnn -- ./mnist/ # Run the MNIST CNN example.
 ```
 
 
@@ -144,11 +142,10 @@ $ cabal test examples   # Build and run the Hasktorch example test suites.
 To run the MNIST CNN example, run:
 
 ```sh
-$ cd examples                   # Change to the examples directory.
-$ ./datasets/download-mnist.sh  # Download the MNIST dataset.
-$ mv mnist data                 # Move the MNIST dataset to the data directory.
-$ export DEVICE=cpu             # Set device to CPU for the MNIST CNN example.
-$ cabal run static-mnist-cnn    # Run the MNIST CNN example.
+$ cd examples                            # Change to the examples directory.
+$ ./datasets/download-mnist.sh           # Download the MNIST dataset.
+$ export DEVICE=cpu                      # Set device to CPU for the MNIST CNN example.
+$ cabal run static-mnist-cnn -- ./mnist/ # Run the MNIST CNN example.
 ```
 
 
@@ -183,11 +180,10 @@ $ stack test examples   # Build and run the Hasktorch example test suites.
 To run the MNIST CNN example, run:
 
 ```sh
-$ cd examples                   # Change to the examples directory.
-$ ./datasets/download-mnist.sh  # Download the MNIST dataset.
-$ mv mnist data                 # Move the MNIST dataset to the data directory.
-$ export DEVICE=cpu             # Set device to CPU for the MNIST CNN example.
-$ stack run static-mnist-cnn     # Run the MNIST CNN example.
+$ cd examples                            # Change to the examples directory.
+$ ./datasets/download-mnist.sh           # Download the MNIST dataset.
+$ export DEVICE=cpu                      # Set device to CPU for the MNIST CNN example.
+$ cabal run static-mnist-cnn -- ./mnist/ # Run the MNIST CNN example.
 ```
 
 ### macos+stack+cpu
@@ -220,11 +216,10 @@ $ stack test examples   # Build and run the Hasktorch example test suites.
 To run the MNIST CNN example, run:
 
 ```sh
-$ cd examples                   # Change to the examples directory.
-$ ./datasets/download-mnist.sh  # Download the MNIST dataset.
-$ mv mnist data                 # Move the MNIST dataset to the data directory.
-$ export DEVICE=cpu             # Set device to CPU for the MNIST CNN example.
-$ stack run static-mnist-cnn     # Run the MNIST CNN example.
+$ cd examples                            # Change to the examples directory.
+$ ./datasets/download-mnist.sh           # Download the MNIST dataset.
+$ export DEVICE=cpu                      # Set device to CPU for the MNIST CNN example.
+$ cabal run static-mnist-cnn -- ./mnist/ # Run the MNIST CNN example.
 ```
 
 
@@ -262,11 +257,10 @@ $ cabal test examples   # Build and run the Hasktorch example test suites.
 To run the MNIST CNN example, run:
 
 ```sh
-$ cd examples                   # Change to the examples directory.
-$ ./datasets/download-mnist.sh  # Download the MNIST dataset.
-$ mv mnist data                 # Move the MNIST dataset to the data directory.
-$ export DEVICE=cpu             # Set device to CPU for the MNIST CNN example.
-$ cabal run static-mnist-cnn    # Run the MNIST CNN example.
+$ cd examples                            # Change to the examples directory.
+$ ./datasets/download-mnist.sh           # Download the MNIST dataset.
+$ export DEVICE=cpu                      # Set device to CPU for the MNIST CNN example.
+$ cabal run static-mnist-cnn -- ./mnist/ # Run the MNIST CNN example.
 ```
 
 
@@ -310,11 +304,10 @@ $ cabal test examples   # Build and run the Hasktorch example test suites.
 To run the MNIST CNN example, run:
 
 ```sh
-$ cd examples                   # Change to the examples directory.
-$ ./datasets/download-mnist.sh  # Download the MNIST dataset.
-$ mv mnist data                 # Move the MNIST dataset to the data directory.
-$ export DEVICE="cuda:0"        # Set device to CUDA for the MNIST CNN example.
-$ cabal run static-mnist-cnn    # Run the MNIST CNN example.
+$ cd examples                            # Change to the examples directory.
+$ ./datasets/download-mnist.sh           # Download the MNIST dataset.
+$ export DEVICE="cuda:0"                 # Set device to CUDA for the MNIST CNN example.
+$ cabal run static-mnist-cnn -- ./mnist/ # Run the MNIST CNN example.
 ```
 
 ### docker+jupyterlab+cuda11

--- a/examples/mnist-mixed-precision/Main.hs
+++ b/examples/mnist-mixed-precision/Main.hs
@@ -102,6 +102,7 @@ fromLocalModel model = over (types @Tensor @a) func model
 
 main :: IO ()
 main = do
+  args <- getArgs
   deviceStr <- try (getEnv "DEVICE") :: IO (Either SomeException String)
   dtypeStr <- try (getEnv "DTYPE") :: IO (Either SomeException String)
   let device' = case deviceStr of
@@ -116,7 +117,10 @@ main = do
         Right "bfloat16" -> BFloat16
         Right type' -> error $ "Unknown dtype setting: " ++ type'
         _ -> Float
-  (trainData, testData) <- initMnist "data"
+      dataPath = case args of
+        [] -> error $ "No data path provided"
+        _ -> head args
+  (trainData, testData) <- initMnist dataPath
   let trainMnist = V.MNIST {batchSize = 32, mnistData = trainData}
       testMnist = V.MNIST {batchSize = 1, mnistData = testData}
       spec = MLPSpec 784 64 32 10

--- a/examples/mnist-mlp/Main.hs
+++ b/examples/mnist-mlp/Main.hs
@@ -17,6 +17,7 @@ import Pipes
 import qualified Pipes.Prelude as P
 import Torch
 import Torch.Serialize
+import System.Environment (getArgs)  
 import Torch.Typed.Vision (initMnist)
 import qualified Torch.Vision as V
 import Prelude hiding (exp)
@@ -74,7 +75,12 @@ displayImages model (testImg, testLabel) = do
 
 main :: IO ()
 main = do
-  (trainData, testData) <- initMnist "data"
+  args <- getArgs
+  let
+      dataPath = case args of
+        [] -> error $ "No data path provided"
+        _ -> head args
+  (trainData, testData) <- initMnist dataPath
   let trainMnist = V.MNIST {batchSize = 32, mnistData = trainData}
       testMnist = V.MNIST {batchSize = 1, mnistData = testData}
       spec = MLPSpec 784 64 32 10

--- a/examples/static-mnist-mlp/Main.hs
+++ b/examples/static-mnist-mlp/Main.hs
@@ -132,8 +132,9 @@ type HiddenFeatures1 = 256
 train' ::
   forall (device :: (DeviceType, Nat)).
   _ =>
+  String ->
   IO ()
-train' = do
+train' dataPath = do
   let dropoutProb = 0.5
       learningRate = 0.1
   manual_seed_L 123
@@ -147,13 +148,18 @@ train' = do
           dropoutProb
       )
   let initOptim = mkAdam 0 0.9 0.999 (flattenParameters initModel)
-  train @BatchSize @device initModel initOptim mlp learningRate "static-mnist-mlp.pt"
+  train @BatchSize @device initModel initOptim mlp learningRate "static-mnist-mlp.pt" dataPath
 
 main :: IO ()
 main = do
+  args :: [String] <- getArgs
+  let
+      dataPath :: String = case args of
+        [] -> error $ "No data path provided"
+        _ -> head args
   deviceStr <- try (getEnv "DEVICE") :: IO (Either SomeException String)
   case deviceStr of
-    Right "cpu" -> train' @'( 'CPU, 0)
-    Right "cuda:0" -> train' @'( 'CUDA, 0)
+    Right "cpu" -> train' @'( 'CPU, 0) dataPath
+    Right "cuda:0" -> train' @'( 'CUDA, 0) dataPath
     Right device -> error $ "Unknown device setting: " ++ device
-    _ -> train' @'( 'CPU, 0)
+    _ -> train' @'( 'CPU, 0) dataPath

--- a/examples/static-mnist/Common.hs
+++ b/examples/static-mnist/Common.hs
@@ -109,10 +109,11 @@ train ::
   ) ->
   LearningRate device 'Float ->
   String ->
+  String ->
   IO ()
-train initModel initOptim forward learningRate ptFile = do
+train initModel initOptim forward learningRate ptFile dataPath = do
   let numEpochs = 1000
-  (trainingData, testData) <- mkMnist @device @batchSize
+  (trainingData, testData) <- mkMnist dataPath
   foldLoop_
     (initModel, initOptim)
     numEpochs
@@ -157,7 +158,7 @@ train initModel initOptim forward learningRate ptFile = do
         begin = pure (0, 0)
         done = pure
 
-mkMnist :: IO (MNIST IO device batchSize, MNIST IO device batchSize)
-mkMnist = do
-  (train, test) <- initMnist "data"
+mkMnist :: String -> IO (MNIST IO device batchSize, MNIST IO device batchSize)
+mkMnist dataPath = do
+  (train, test) <- initMnist dataPath
   return (MNIST train, MNIST test)

--- a/nix/datasets.nix
+++ b/nix/datasets.nix
@@ -1,0 +1,54 @@
+{
+  fetchurl,
+  gzip,
+  lib,
+  linkFarm,
+  symlinkJoin,
+}: let
+  attrsToList = attrs:
+    map
+    (name: {
+      inherit name;
+      value = attrs.${name};
+    })
+    (builtins.attrNames attrs);
+in rec {
+  mnist = linkFarm "mnist" (
+    lib.pipe mnistParts [
+      attrsToList
+      (map (
+        {
+          name,
+          value,
+        }: {
+          inherit name;
+          path = value;
+        }
+      ))
+    ]
+  );
+  mnistParts = let
+    base = "https://ossci-datasets.s3.amazonaws.com/mnist";
+  in {
+    "train-images-idx3-ubyte.gz" = fetchurl {
+      url = "${base}/train-images-idx3-ubyte.gz";
+      hash = "sha256-RA/Kv3PMVG+iFHXoHqNwJlYF9WviEKQCTSyo8gNSNgk=";
+      curlOptsList = ["-HUser-Agent: Wget/1.21.4"];
+    };
+    "train-labels-idx1-ubyte.gz" = fetchurl {
+      url = "${base}/train-labels-idx1-ubyte.gz";
+      hash = "sha256-NVJTSgpVi77WrtMrMMSVzKI9Vn7FLKyL4aBzDoAQJVw=";
+      curlOptsList = ["-HUser-Agent: Wget/1.21.4"];
+    };
+    "t10k-images-idx3-ubyte.gz" = fetchurl {
+      url = "${base}/t10k-images-idx3-ubyte.gz";
+      hash = "sha256-jUIsewocHHkkWlvPB/6G4z7q/ueSuEWErsJ29aLbxOY=";
+      curlOptsList = ["-HUser-Agent: Wget/1.21.4"];
+    };
+    "t10k-labels-idx1-ubyte.gz" = fetchurl {
+      url = "${base}/t10k-labels-idx1-ubyte.gz";
+      hash = "sha256-965g+S4A7G3r0jpgiMMdvSNx7KP/oN7677JZkkIErsY=";
+      curlOptsList = ["-HUser-Agent: Wget/1.21.4"];
+    };
+  };
+}


### PR DESCRIPTION
* Added CLI arguments to MNIST examples
* Added nix derivation for mnist datasets

These changes were added to accommodate the changes being made in #700. Since the nix store is read only and we don't want to ship mnist with hasktorch, it makes more sense to have CLI arguments to the mnist examples.