### PR TITLE
added all systems and a pytorch hack to allow aarch64 builds

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
     ...
   } @ inputs:
     flake-parts.lib.mkFlake {inherit inputs;} {
-      systems = ["x86_64-linux"];
+      systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" ];
       imports = [
         ./nix/nixpkgs-instances.nix
       ];

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,5 +1,6 @@
 final: prev: let
-  inherit (final) lib libtorch-bin;
+  inherit (final) lib;
+  inherit (final.python3Packages) pytorch;
   inherit
     (final.haskell.lib)
     overrideCabal
@@ -12,6 +13,7 @@ final: prev: let
     doJailbreak
     dontCheck
     ;
+    libtorch-bin = pytorch.dev;
   torch = libtorch-bin;
   c10 = libtorch-bin;
   torch_cpu = libtorch-bin;


### PR DESCRIPTION
instead of depending on libtorch-bin this patch uses python3Packages.pytorch.dev for libtorch. this allows a build for more platforms than the binary mechanism