### PR TITLE
Force evaluation on all optimizer fields and tensor lists to prevent GPU space leak

### DIFF
--- a/hasktorch/src/Torch/Optim.hs
+++ b/hasktorch/src/Torch/Optim.hs
@@ -101,11 +101,11 @@ instance Optimizer GDM where
 
 -- | State representation for Adam Optimizer
 data Adam = Adam
-  { beta1 :: Float, -- 1st moment forgetting factor
-    beta2 :: Float, -- 2nd moment forgetting factor
-    m1 :: [Tensor], -- 1st moment
-    m2 :: [Tensor], -- 2nd moment
-    iter :: Int -- iteration
+  { beta1 :: !Float, -- 1st moment forgetting factor
+    beta2 :: !Float, -- 2nd moment forgetting factor
+    m1 :: ![Tensor], -- 1st moment
+    m2 :: ![Tensor], -- 2nd moment
+    iter :: !Int -- iteration
   }
   deriving (Show)
 
@@ -142,6 +142,8 @@ adam lr (Gradients gradients) parameters Adam {..} = (parameters', Adam beta1 be
     -- decaying averages of 1st & 2nd moments
     f1 m1 dp = mulScalar beta1 m1 + mulScalar (1 - beta1) dp
     f2 m2 dp = mulScalar beta2 m2 + mulScalar (1 - beta2) (dp * dp)
+    !_ = forceInPlace m1'
+    !_ = forceInPlace m2'
     m1' = zipWith f1 m1 gradients
     m2' = zipWith f2 m2 gradients
     -- bias adjustment
@@ -155,6 +157,10 @@ adam lr (Gradients gradients) parameters Adam {..} = (parameters', Adam beta1 be
 
 instance Optimizer Adam where
   step = adam
+
+forceInPlace :: [a] -> [a]
+forceInPlace [] = ()
+forceInPlace (x : xs) = seq x (forceInPlace xs)
 
 --
 -- Adagrad


### PR DESCRIPTION
NOTE: This is an incomplete PR. It's opened to showcase a suggestion which may lead to more changes.

I've found a source of space leak in the Adam optimizer (potentially others too), in scenarios where:

1. Optimizer is updated in a tight training loop.
2. GPU memory is limited, relative to the number of epochs and parallel jobs.
3. Tensors (specifically a list of tensors) are used for the optimizer state record.

This space leak is only noticeable in GPU memory, not RAM. I think it's because what's accumulating on the CPU side is only the tensor wrapper, which is tiny. The space leak on the GPU side is only noticeable when I need to run a large number of parallel jobs and/or long training jobs. I've tested with 32 parallels job, each with 50+ epochs on datasets of 100k+ samples. It's more observable when training a lot of small models vs a few large ones.

My reasoning for what's happening: the momentum tensors are created and used for parameter calculation in each update, so the tensors are created on the GPU. The returned values are not strictly evaluated (https://github.com/hasktorch/hasktorch/blob/master/hasktorch/src/Torch/Optim.hs#L140), so the spine is a thunk, preventing the finalizer to be run and decrementing the reference count to the tensor pointer, leading to the momentum tensors leaking on the GPU.

I haven't tested the other optimizers but I would expect the same space leak behavior, but only if the job is large or run for a long time, since the momentum tensors are small.

The change in this PR seems like a hack, so I want to ask: Is there an existing strategy on this issue that I've missed somewhere?