### PR TITLE
Implement TensorLike instance for storable/unboxed vectors

### DIFF
--- a/hasktorch/hasktorch.cabal
+++ b/hasktorch/hasktorch.cabal
@@ -211,6 +211,7 @@ test-suite spec
                     , lens-family-core
                     , data-default-class
                     , half
+                    , vector
 
 test-suite doctests
   if os(darwin) || flag(disable-doctest)


### PR DESCRIPTION
This PR adds a TensorLike instance for Data.Vector.{Storable,Unboxed}.Vector a, allowing storable vectors to be used directly as tensor-like data structures. 