### PR TITLE
chore: Update hasktorch to setup the same torch library as libtorch

### DIFF
--- a/.github/disabled-workflows/nix-haddock-linux.yml
+++ b/.github/disabled-workflows/nix-haddock-linux.yml
@@ -17,9 +17,9 @@ jobs:
       run: |
         sudo swapoff -a
         sudo rm -f /swapfile
-        sudo apt -y purge ghc* cabal-install* php* || true
-        sudo apt autoremove -y || true
-        sudo apt autoclean -y || true
+        sudo apt-get -y purge ghc* cabal-install* php* || true
+        sudo apt-get autoremove -y || true
+        sudo apt-get autoclean -y || true
         docker rmi $(docker image ls -aq)
         df -h
     - uses: cachix/install-nix-action@v23

--- a/.github/disabled-workflows/nix-linux-cu10.yml
+++ b/.github/disabled-workflows/nix-linux-cu10.yml
@@ -17,9 +17,9 @@ jobs:
   #       run: |
   #         sudo swapoff -a
   #         sudo rm -f /swapfile
-  #         sudo apt -y purge ghc* cabal-install* php* || true
-  #         sudo apt autoremove -y || true
-  #         sudo apt autoclean -y || true
+  #         sudo apt-get -y purge ghc* cabal-install* php* || true
+  #         sudo apt-get autoremove -y || true
+  #         sudo apt-get autoclean -y || true
   #         docker rmi $(docker image ls -aq)
   #         df -h
   #     - uses: cachix/install-nix-action@v10
@@ -37,9 +37,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: free disk space
         run: |
-          sudo apt -y purge ghc* cabal-install* php* || true
-          sudo apt autoremove -y || true
-          sudo apt autoclean -y || true
+          sudo apt-get -y purge ghc* cabal-install* php* || true
+          sudo apt-get autoremove -y || true
+          sudo apt-get autoclean -y || true
           docker rmi $(docker image ls -aq)
           df -h
           cat /proc/cpuinfo

--- a/.github/disabled-workflows/nix-linux-cu11.yml
+++ b/.github/disabled-workflows/nix-linux-cu11.yml
@@ -17,9 +17,9 @@ jobs:
   #       run: |
   #         sudo swapoff -a
   #         sudo rm -f /swapfile
-  #         sudo apt -y purge ghc* cabal-install* php* || true
-  #         sudo apt autoremove -y || true
-  #         sudo apt autoclean -y || true
+  #         sudo apt-get -y purge ghc* cabal-install* php* || true
+  #         sudo apt-get autoremove -y || true
+  #         sudo apt-get autoclean -y || true
   #         docker rmi $(docker image ls -aq)
   #         df -h
   #     - uses: cachix/install-nix-action@v10
@@ -37,9 +37,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: free disk space
         run: |
-          sudo apt -y purge ghc* cabal-install* php* || true
-          sudo apt autoremove -y || true
-          sudo apt autoclean -y || true
+          sudo apt-get -y purge ghc* cabal-install* php* || true
+          sudo apt-get autoremove -y || true
+          sudo apt-get autoclean -y || true
           docker rmi $(docker image ls -aq)
           df -h
           cat /proc/cpuinfo

--- a/.github/disabled-workflows/nix-linux.yml
+++ b/.github/disabled-workflows/nix-linux.yml
@@ -14,9 +14,9 @@ jobs:
   #       run: |
   #         sudo swapoff -a
   #         sudo rm -f /swapfile
-  #         sudo apt -y purge ghc* cabal-install* php* || true
-  #         sudo apt autoremove -y || true
-  #         sudo apt autoclean -y || true
+  #         sudo apt-get -y purge ghc* cabal-install* php* || true
+  #         sudo apt-get autoremove -y || true
+  #         sudo apt-get autoclean -y || true
   #         docker rmi $(docker image ls -aq)
   #         df -h
   #     - uses: cachix/install-nix-action@v10
@@ -34,9 +34,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: free disk space
         run: |
-          sudo apt -y purge ghc* cabal-install* php* || true
-          sudo apt autoremove -y || true
-          sudo apt autoclean -y || true
+          sudo apt-get -y purge ghc* cabal-install* php* || true
+          sudo apt-get autoremove -y || true
+          sudo apt-get autoclean -y || true
           docker rmi $(docker image ls -aq)
           df -h
           cat /proc/cpuinfo

--- a/.github/disabled-workflows/stack-nix-linux.yml
+++ b/.github/disabled-workflows/stack-nix-linux.yml
@@ -11,16 +11,16 @@ jobs:
         run: |
           sudo swapoff -a
           sudo rm -f /swapfile
-          sudo apt -y purge ghc* cabal-install* php* || true
-          sudo apt autoremove -y || true
-          sudo apt autoclean -y || true
+          sudo apt-get -y purge ghc* cabal-install* php* || true
+          sudo apt-get autoremove -y || true
+          sudo apt-get autoclean -y || true
           docker rmi $(docker image ls -aq)
           df -h
       - name: Setup packages
         run: |
           sudo rm -f /etc/apt/sources.list.d/sbt.list
-          sudo apt update -qq
-          sudo apt -y --allow-downgrades --allow-remove-essential --allow-change-held-packages install cmake curl wget unzip git libtinfo-dev python3 python3-yaml
+          sudo apt-get update -qq && sudo apt-get upgrade
+          sudo apt-get -y --allow-downgrades --allow-remove-essential --allow-change-held-packages install cmake curl wget unzip git libtinfo-dev python3 python3-yaml
         ## Stack is preinstalled on the GHA runners
         #  (wget -qO- https://get.haskellstack.org/ | sh) || true
       - uses: cachix/install-nix-action@v23

--- a/.github/workflows/cabal-linux.yml
+++ b/.github/workflows/cabal-linux.yml
@@ -16,14 +16,14 @@ jobs:
 
     - name: Setup packages
       run: |
-        sudo apt update -qq
-        sudo apt -y --allow-downgrades --allow-remove-essential --allow-change-held-packages install locales software-properties-common apt-transport-https
-        sudo bash -c "echo deb [trusted=yes] https://apt-hasktorch.com/apt ./ > /etc/apt/sources.list.d/libtorch.list"
+        sudo apt-get update -qq && sudo apt-get upgrade
+        sudo apt-get -y --allow-downgrades --allow-remove-essential --allow-change-held-packages install locales software-properties-common apt-transport-https
+        sudo bash -c "echo deb [trusted=yes] https://apt-hasktorch.com/apt-get ./ > /etc/apt/sources.list.d/libtorch.list"
         sudo rm -f /etc/apt/sources.list.d/sbt.list
-        sudo apt update -qq
-        sudo apt -y purge ghc* cabal-install* php* || true
-        sudo apt -y --allow-downgrades --allow-remove-essential --allow-change-held-packages install build-essential zlib1g-dev liblapack-dev libblas-dev devscripts debhelper python3-pip cmake curl wget unzip git libtinfo-dev python3 python3-yaml
-        sudo apt -y install libtorch=2.0.0+cpu-1 libtokenizers=0.1-1
+        sudo apt-get update -qq && sudo apt-get upgrade
+        sudo apt-get -y purge ghc* cabal-install* php* || true
+        sudo apt-get -y --allow-downgrades --allow-remove-essential --allow-change-held-packages install build-essential zlib1g-dev liblapack-dev libblas-dev devscripts debhelper python3-pip cmake curl wget unzip git libtinfo-dev python3 python3-yaml
+        sudo apt-get -y install libtorch=2.0.0+cpu-1 libtokenizers=0.1-1
 
     - name: Setup Haskell
       run: |

--- a/.github/workflows/stack-linux.yml
+++ b/.github/workflows/stack-linux.yml
@@ -14,9 +14,9 @@ jobs:
       run: |
         sudo swapoff -a
         sudo rm -f /swapfile
-        sudo apt -y purge ghc* cabal-install* php* || true
-        sudo apt autoremove -y || true
-        sudo apt autoclean -y || true
+        sudo apt-get -y purge ghc* cabal-install* php* || true
+        sudo apt-get autoremove -y || true
+        sudo apt-get autoclean -y || true
         df -h
     - uses: haskell-actions/setup@v2.7.10
       with:
@@ -26,8 +26,8 @@ jobs:
     - name: Setup packages
       run: |
         sudo rm -f /etc/apt/sources.list.d/sbt.list
-        sudo apt update -qq
-        sudo apt -y --allow-downgrades --allow-remove-essential --allow-change-held-packages install cmake curl wget unzip git libtinfo-dev python3 python3-yaml
+        sudo apt-get update -qq && sudo apt-get upgrade
+        sudo apt-get -y --allow-downgrades --allow-remove-essential --allow-change-held-packages install cmake curl wget unzip git libtinfo-dev python3 python3-yaml
       ## Stack is preinstalled on the GHA runners
       #  (wget -qO- https://get.haskellstack.org/ | sh) || true
     - name: Cache .stack

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,12 @@ FROM nvidia/cuda:10.1-devel-ubuntu18.04
 
 WORKDIR /hasktorch
 
-RUN apt update -qq
-RUN apt -y --allow-downgrades --allow-remove-essential --allow-change-held-packages install locales software-properties-common apt-transport-https
+RUN apt-get update -qq && apt-get upgrade
+RUN apt-get -y --allow-downgrades --allow-remove-essential --allow-change-held-packages install locales software-properties-common apt-transport-https
 RUN add-apt-repository -y ppa:hvr/ghc
-RUN apt update -qq
-RUN apt -y purge ghc* cabal-install* || true
-RUN apt -y --allow-downgrades --allow-remove-essential --allow-change-held-packages install build-essential zlib1g-dev liblapack-dev libblas-dev ghc-8.6.5 cabal-install-3.0 devscripts debhelper python3-pip cmake curl wget unzip git libtinfo-dev python3 python3-yaml
+RUN apt-get update -qq && apt-get upgrade
+RUN apt-get -y purge ghc* cabal-install* || true
+RUN apt-get -y --allow-downgrades --allow-remove-essential --allow-change-held-packages install build-essential zlib1g-dev liblapack-dev libblas-dev ghc-8.6.5 cabal-install-3.0 devscripts debhelper python3-pip cmake curl wget unzip git libtinfo-dev python3 python3-yaml
 
 COPY . /hasktorch
 

--- a/hasktorch/Setup.hs
+++ b/hasktorch/Setup.hs
@@ -1,6 +1,145 @@
-module Main where
-
-import Distribution.Extra.Doctest (defaultMainWithDoctests)
+import Distribution.Extra.Doctest        (addDoctestsUserHook)
+import Distribution.Simple
+import Distribution.Simple.Setup
+import Distribution.Simple.LocalBuildInfo
+import Distribution.Types.LocalBuildInfo
+import Distribution.Types.GenericPackageDescription
+import Distribution.Types.HookedBuildInfo
+import Distribution.PackageDescription
+import Distribution.System
+import System.Directory
+import System.FilePath
+import System.Process
+import System.IO.Temp
+import Control.Monad
+import Network.HTTP.Simple
+import qualified Data.ByteString.Lazy as LBS
+import System.Environment (lookupEnv)
+import Data.Maybe (fromMaybe)
+import GHC.IO.Exception
+import Control.Exception
 
 main :: IO ()
-main = defaultMainWithDoctests "doctests"
+main = defaultMainWithHooks $ addDoctestsUserHook "doctests" $  simpleUserHooks
+  { preConf = \_ _ -> do
+      _ <- ensureLibtorch 
+      pure emptyHookedBuildInfo
+  , confHook = \(gpd, hbi) flags -> do
+      libtorchDir <- getGlobalLibtorchDir
+      let libDir     = libtorchDir </> "lib"
+          includeDir = libtorchDir </> "include"
+      let updatedFlags = flags
+            { configExtraLibDirs      = libDir : configExtraLibDirs flags
+            , configExtraIncludeDirs  =
+                includeDir
+                : (includeDir </> "torch" </> "csrc" </> "api" </> "include")
+                : configExtraIncludeDirs flags
+            }
+      confHook simpleUserHooks (gpd, hbi) updatedFlags
+  }
+
+libtorchVersion :: String
+libtorchVersion = "2.5.0"
+
+getGlobalLibtorchDir :: IO FilePath
+getGlobalLibtorchDir = do
+  mHome <- lookupEnv "LIBTORCH_HOME"
+  base <- case mHome of
+    Just h  -> pure h
+    Nothing -> do
+      -- XDG cache (Linux/macOS). Falls back to ~/.cache
+      cache <- getXdgDirectory XdgCache "libtorch"
+      pure cache
+  flavor <- getCudaFlavor
+  pure $ base </> libtorchVersion </> platformTag </> flavor
+
+platformTag :: FilePath
+platformTag =
+  case (buildOS, buildArch) of
+    (OSX,    AArch64) -> "macos-arm64"
+    (OSX,    X86_64)  -> "macos-x86_64"
+    (Linux,  X86_64)  -> "linux-x86_64"
+    -- add more as needed
+    _ -> error $ "Unsupported platform: " <> show (buildOS, buildArch)
+
+getCudaFlavor :: IO String
+getCudaFlavor = do
+  fromMaybe "cpu" <$> lookupEnv "LIBTORCH_CUDA_VERSION"  -- "cpu" | "cu117" | "cu118" | "cu121"
+
+ensureLibtorch :: IO FilePath
+ensureLibtorch = do
+  skip <- lookupEnv "LIBTORCH_SKIP_DOWNLOAD"
+  case skip of
+    Just _ -> do
+      putStrLn "LIBTORCH_SKIP_DOWNLOAD set; assuming libtorch exists globally."
+      getGlobalLibtorchDir
+    Nothing -> do
+      dest <- getGlobalLibtorchDir
+      let marker = dest </> ".ok"
+      exists <- doesFileExist marker
+      present <- doesDirectoryExist dest
+      if present && exists
+        then pure dest
+        else do
+          putStrLn $ "libtorch not found in global cache, installing to " <> dest
+          downloadAndExtractLibtorchTo dest
+          -- Create an idempotence marker that checks
+          -- if we've already downloaded torch.
+          -- Since we'll be moving everything this will
+          -- be the our main reference.
+          writeFile marker ""
+          pure dest
+
+downloadAndExtractLibtorchTo :: FilePath -> IO ()
+downloadAndExtractLibtorchTo dest = do
+  createDirectoryIfMissing True dest
+  (url, fileName) <- computeURL
+  putStrLn $ "Downloading libtorch from: " ++ url
+  withSystemTempDirectory "libtorch-download" $ \tmpDir -> do
+    let downloadPath = tmpDir </> fileName
+    request  <- parseRequest url
+    response <- httpLBS request
+    LBS.writeFile downloadPath (getResponseBody response)
+    putStrLn "Download complete. Extracting..."
+    callProcess "unzip" ["-q", downloadPath, "-d", tmpDir]
+    let unpacked = tmpDir </> "libtorch"
+    exists <- doesDirectoryExist unpacked
+    let src = if exists then unpacked else tmpDir
+    -- We want to move the directory since this operation is atomic.
+    -- If that doesn't work we fall back to copying.
+    (renameDirectory src dest) `catch` (\(_::IOException) -> copyTree src dest)
+    putStrLn "libtorch extracted successfully (global cache)."
+
+copyTree :: FilePath -> FilePath -> IO ()
+copyTree src dest = do
+  createDirectoryIfMissing True dest
+  entries <- listDirectory src
+  mapM_ (\e -> do
+          let s = src  </> e
+              d = dest </> e
+          isDir <- doesDirectoryExist s
+          if isDir then copyTree s d else copyFile s d
+        ) entries
+
+computeURL :: IO (String, String)
+computeURL = do
+  flavor <- getCudaFlavor
+  let v = libtorchVersion
+  pure $ case buildOS of
+    OSX -> case buildArch of
+      AArch64 -> ( "https://download.pytorch.org/libtorch/cpu/libtorch-macos-arm64-" ++ v ++ ".zip"
+                 , "libtorch-macos-arm64.zip" )
+      X86_64  -> ( "https://download.pytorch.org/libtorch/cpu/libtorch-macos-x86_64-" ++ v ++ ".zip"
+                 , "libtorch-macos-x86_64.zip" )
+      _       -> error "Unsupported macOS arch"
+    Linux -> case flavor of
+      "cpu"  -> ( "https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-" ++ v ++ "%2Bcpu.zip"
+                , "libtorch-linux.zip" )
+      "cu117"-> ( "https://download.pytorch.org/libtorch/cu117/libtorch-cxx11-abi-shared-with-deps-" ++ v ++ "%2Bcu117.zip"
+                , "libtorch-linux-cu117.zip" )
+      "cu118"-> ( "https://download.pytorch.org/libtorch/cu118/libtorch-cxx11-abi-shared-with-deps-" ++ v ++ "%2Bcu118.zip"
+                , "libtorch-linux-cu118.zip" )
+      "cu121"-> ( "https://download.pytorch.org/libtorch/cu121/libtorch-cxx11-abi-shared-with-deps-" ++ v ++ "%2Bcu121.zip"
+                , "libtorch-linux-cu121.zip" )
+      _      -> error $ "Unsupported CUDA version: " ++ flavor
+    Windows -> error "Windows not supported by this setup"

--- a/hasktorch/hasktorch.cabal
+++ b/hasktorch/hasktorch.cabal
@@ -18,9 +18,15 @@ extra-source-files:
 
 custom-setup
   setup-depends:
-      base >= 4.9 && < 5
-    , Cabal >= 3.10.1.0 && < 3.16
-    , cabal-doctest >=1.0.9 && <1.1
+    base >= 4.7 && < 5,
+    Cabal >= 3.0 && < 4,
+    cabal-doctest >=1.0.9 && <1.1,
+    directory >= 1.3 && < 2,
+    filepath >= 1.4 && < 2,
+    process >= 1.6 && < 2,
+    temporary >= 1.3 && < 2,
+    http-conduit >= 2.3 && < 3,
+    bytestring >= 0.10 && < 1
 
 Flag disable-doctest
  Description: Disable doctest. ToDo: This flag is to avoid relocation-error of ghci for macos.

--- a/setenv
+++ b/setenv
@@ -3,7 +3,7 @@
 # execute this command if needed when building on OSX if there are linker errors.
 # dylib files in extra-lib-dirs  don't get forwarded to ghc
 # in some versions of OSX. See https://github.com/commercialhaskell/stack/issues/1826
-HASKTORCH_LIB_PATH="$(pwd)/deps/libtorch/lib/:$(pwd)/deps/mklml/lib/:$(pwd)/deps/libtokenizers/lib/"
+HASKTORCH_LIB_PATH="$(HOME)/.cache/libtorch/lib/:$(HOME)/.cache/mklml/lib/:$(HOME)/.cache/libtokenizers/lib/"
 
 function add_vendor_lib_path {
     case "$(uname)" in


### PR DESCRIPTION
The current configuration will have version failures. We also set the environment to the newly installed hasktorch lib.

Also some minor fixes to yaml file:
* Prefer apt-get (or scripts) vs apt (for human interactive use)
* apt-update && apt-upgrade so dependencies can build.