### PR TITLE
Fix build errors for all github workflows

### DIFF
--- a/.github/workflows/cabal-linux.yml
+++ b/.github/workflows/cabal-linux.yml
@@ -45,7 +45,9 @@ jobs:
 
     - name: Generate install-plan
       run: |
+        export XDG_CACHE_HOME=/tmp/xdg-cache
         source setenv
+        ./deps/get-deps.sh
         ./setup-cabal.sh
         cabal v2-update
         cabal v2-build --jobs=2 all --dry-run

--- a/.github/workflows/cabal-linux.yml
+++ b/.github/workflows/cabal-linux.yml
@@ -47,6 +47,8 @@ jobs:
       run: |
         export XDG_CACHE_HOME=/tmp/xdg-cache
         source setenv
+        echo "XDG_CACHE_HOME=$XDG_CACHE_HOME" >> "$GITHUB_ENV"
+        echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
         ./deps/get-deps.sh
         ./setup-cabal.sh
         cabal v2-update
@@ -84,7 +86,7 @@ jobs:
     - name: Tests
       run: |
         source setenv
-        cabal v2-test --jobs=2 all
+        cabal v2-test -fdisable-doctest --jobs=2 all
 
     - name: Runs
       run: |

--- a/.github/workflows/cabal-macos.yaml
+++ b/.github/workflows/cabal-macos.yaml
@@ -21,8 +21,7 @@ jobs:
     - name: Setup packages
       run: |
         /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-        brew install libomp || true
-        pip3 install pyyaml || true
+        brew install libomp python || true
         source setenv
         echo "DYLD_LIBRARY_PATH=/opt/homebrew/lib:/opt/homebrew/opt/libomp/lib:$DYLD_LIBRARY_PATH" >> "${GITHUB_ENV}"
 
@@ -38,6 +37,8 @@ jobs:
     #   timeout-minutes: 15
     - name: Generate install-plan
       run: |
+        export XDG_CACHE_HOME=/tmp/xdg-cache
+        ./deps/get-deps.sh
         source setenv
         echo "DYLD_LIBRARY_PATH=/opt/homebrew/lib:/opt/homebrew/opt/libomp/lib:$DYLD_LIBRARY_PATH" >> "${GITHUB_ENV}"
         ./setup-cabal.sh

--- a/.github/workflows/cabal-macos.yaml
+++ b/.github/workflows/cabal-macos.yaml
@@ -22,7 +22,15 @@ jobs:
       run: |
         /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
         brew install libomp python || true
+        python3 -m venv .venv
+        source .venv/bin/activate
+        pip3 install pyyaml
+        pip3 install dataclasses
+        pip3 install typing_extensions
+        export XDG_CACHE_HOME=/tmp/xdg-cache
         source setenv
+        ./deps/get-deps.sh
+        echo "XDG_CACHE_HOME=$XDG_CACHE_HOME" >> "$GITHUB_ENV"
         echo "DYLD_LIBRARY_PATH=/opt/homebrew/lib:/opt/homebrew/opt/libomp/lib:$DYLD_LIBRARY_PATH" >> "${GITHUB_ENV}"
 
     - name: Information about the Haskell setup
@@ -37,10 +45,6 @@ jobs:
     #   timeout-minutes: 15
     - name: Generate install-plan
       run: |
-        export XDG_CACHE_HOME=/tmp/xdg-cache
-        ./deps/get-deps.sh
-        source setenv
-        echo "DYLD_LIBRARY_PATH=/opt/homebrew/lib:/opt/homebrew/opt/libomp/lib:$DYLD_LIBRARY_PATH" >> "${GITHUB_ENV}"
         ./setup-cabal.sh
         cat cabal.project.local
         cabal v2-update
@@ -75,7 +79,7 @@ jobs:
 
     - name: Tests
       run: |
-        cabal v2-test --jobs=2 all
+        cabal v2-test -fdisable-doctest --jobs=2 all
 
     - name: Runs
       run: |

--- a/.github/workflows/nix-linux.yml
+++ b/.github/workflows/nix-linux.yml
@@ -18,6 +18,15 @@ jobs:
         with:
           name: hasktorch
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+      - name: Resolve LIBTORCH path
+        run: |
+          echo "XDG_CACHE_HOME=$RUNNER_TEMP/xdg-cache" >> "$GITHUB_ENV"
+          mkdir -p "$RUNNER_TEMP/xdg-cache"
+          LIBTORCH_STORE_PATH="$(nix build .#libtorch-2_5_0-cpu --print-out-paths)"
+          ln -sfn "$LIBTORCH_STORE_PATH/libtorch" "$RUNNER_TEMP/xdg-cache/libtorch"
+          echo "LIBTORCH_HOME=$RUNNER_TEMP/xdg-cache/libtorch" >> "$GITHUB_ENV"
+          echo "CMAKE_PREFIX_PATH=$RUNNER_TEMP/xdg-cache/libtorch" >> "$GITHUB_ENV"
+          echo "LD_LIBRARY_PATH=$RUNNER_TEMP/xdg-cache/libtorch/lib:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
       - run: |
             nix build .#codegen-cpu
             nix build .#hasktorch-cpu

--- a/.github/workflows/nix-linux.yml
+++ b/.github/workflows/nix-linux.yml
@@ -2,6 +2,9 @@ name: nix-linux
 
 on: [push, pull_request]
 
+env:
+  HOME: /home/runner
+
 jobs:
   build-cache:
     runs-on: ubuntu-latest

--- a/.github/workflows/nix-linux.yml
+++ b/.github/workflows/nix-linux.yml
@@ -18,15 +18,6 @@ jobs:
         with:
           name: hasktorch
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
-      - name: Resolve LIBTORCH path
-        run: |
-          echo "XDG_CACHE_HOME=$RUNNER_TEMP/xdg-cache" >> "$GITHUB_ENV"
-          mkdir -p "$RUNNER_TEMP/xdg-cache"
-          LIBTORCH_STORE_PATH="$(nix build .#libtorch-2_5_0-cpu --print-out-paths)"
-          ln -sfn "$LIBTORCH_STORE_PATH/libtorch" "$RUNNER_TEMP/xdg-cache/libtorch"
-          echo "LIBTORCH_HOME=$RUNNER_TEMP/xdg-cache/libtorch" >> "$GITHUB_ENV"
-          echo "CMAKE_PREFIX_PATH=$RUNNER_TEMP/xdg-cache/libtorch" >> "$GITHUB_ENV"
-          echo "LD_LIBRARY_PATH=$RUNNER_TEMP/xdg-cache/libtorch/lib:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
       - run: |
             nix build .#codegen-cpu
             nix build .#hasktorch-cpu

--- a/.github/workflows/stack-linux.yml
+++ b/.github/workflows/stack-linux.yml
@@ -28,6 +28,13 @@ jobs:
         sudo rm -f /etc/apt/sources.list.d/sbt.list
         sudo apt-get update -qq
         sudo apt-get -y --allow-downgrades --allow-remove-essential --allow-change-held-packages install cmake curl wget unzip git libtinfo6 libncurses-dev python3 python3-yaml
+        export XDG_CACHE_HOME=/tmp/xdg-cache
+        source setenv
+        echo "XDG_CACHE_HOME=$XDG_CACHE_HOME" >> "$GITHUB_ENV"
+        echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
+        ./deps/get-deps.sh
+        ./setup-cabal.sh
+
       ## Stack is preinstalled on the GHA runners
       #  (wget -qO- https://get.haskellstack.org/ | sh) || true
     - name: Cache .stack
@@ -45,8 +52,6 @@ jobs:
           ${{ runner.os }}-stack-
     - name: Build
       run: |
-        # export PATH=/opt/ghc/bin:$PATH
-        source setenv
         stack build \
           libtorch-ffi \
           libtorch-ffi-helper \
@@ -59,10 +64,11 @@ jobs:
     - name: Test
       run: |
         # export PATH=/opt/ghc/bin:$PATH
+        export XDG_CACHE_HOME=/tmp/xdg-cache
         source setenv
         stack test codegen
         stack test libtorch-ffi
-        stack test hasktorch
+        stack test --flag hasktorch:disable-doctest hasktorch
         stack exec codegen-exe
         stack exec xor-mlp
     # - name: Build tutorial

--- a/.github/workflows/stack-macos.yaml
+++ b/.github/workflows/stack-macos.yaml
@@ -17,14 +17,15 @@ jobs:
     - name: Setup tool-chains
       run: |
         /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-        brew install libomp || true
-        pip3 install pyyaml || true
+        brew install libomp python || true
         ## Stack is preinstalled on the GHA runners
         #wget -qO- https://get.haskellstack.org/ | sed -e 's/^STACK_VERSION=.*/STACK_VERSION="1.9.3"/g' | sh || true
         #wget -qO- https://get.haskellstack.org/ | sh || true
         clang --version
         stack --version
+        export XDG_CACHE_HOME=/tmp/xdg-cache
         source setenv
+        ./deps/get-deps.sh
         echo "DYLD_LIBRARY_PATH=/opt/homebrew/lib:/opt/homebrew/opt/libomp/lib:$DYLD_LIBRARY_PATH" >> "${GITHUB_ENV}"
         ./setup-cabal.sh
     - name: Cache .stack

--- a/.github/workflows/stack-macos.yaml
+++ b/.github/workflows/stack-macos.yaml
@@ -18,6 +18,11 @@ jobs:
       run: |
         /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
         brew install libomp python || true
+        python3 -m venv .venv
+        source .venv/bin/activate
+        pip3 install pyyaml
+        pip3 install dataclasses
+        pip3 install typing_extensions
         ## Stack is preinstalled on the GHA runners
         #wget -qO- https://get.haskellstack.org/ | sed -e 's/^STACK_VERSION=.*/STACK_VERSION="1.9.3"/g' | sh || true
         #wget -qO- https://get.haskellstack.org/ | sh || true
@@ -25,8 +30,9 @@ jobs:
         stack --version
         export XDG_CACHE_HOME=/tmp/xdg-cache
         source setenv
-        ./deps/get-deps.sh
+        echo "XDG_CACHE_HOME=$XDG_CACHE_HOME" >> "$GITHUB_ENV"
         echo "DYLD_LIBRARY_PATH=/opt/homebrew/lib:/opt/homebrew/opt/libomp/lib:$DYLD_LIBRARY_PATH" >> "${GITHUB_ENV}"
+        ./deps/get-deps.sh
         ./setup-cabal.sh
     - name: Cache .stack
       uses: actions/cache@v4
@@ -59,7 +65,7 @@ jobs:
         #. setenv
         stack test --stack-yaml stack-macos.yaml codegen
         stack test --stack-yaml stack-macos.yaml libtorch-ffi
-        stack test --stack-yaml stack-macos.yaml hasktorch
+        stack test --flag hasktorch:disable-doctest --stack-yaml stack-macos.yaml hasktorch
         stack exec --stack-yaml stack-macos.yaml codegen-exe
         stack exec --stack-yaml stack-macos.yaml xor-mlp
         stack exec --stack-yaml stack-macos.yaml regression

--- a/deps/get-deps.sh
+++ b/deps/get-deps.sh
@@ -107,8 +107,20 @@ if [ "$SKIP_DOWNLOAD" = 0 ] ; then
         unzip libtorch-macos.zip -d "$XDG_CACHE_HOME"
         rm libtorch-macos.zip
       fi
-      wget https://github.com/hasktorch/tokenizers/releases/download/libtokenizers-v0.1/libtokenizers-macos.zip
-      unzip libtokenizers-macos.zip -d "$XDG_CACHE_HOME"
+      case "$(uname -m)" in
+        "x86_64")
+          wget https://github.com/hasktorch/tokenizers/releases/download/libtokenizers-v0.1/libtokenizers-macos.zip
+          unzip libtokenizers-macos.zip -d "$XDG_CACHE_HOME"
+          ;;
+        "arm64")
+          wget https://github.com/hasktorch/tokenizers/releases/download/libtokenizers-v0.1/libtokenizers-macos-arm64.zip
+          unzip libtokenizers-macos.zip -d "$XDG_CACHE_HOME"
+          ;;
+        "arm64e")
+          wget https://github.com/hasktorch/tokenizers/releases/download/libtokenizers-v0.1/libtokenizers-macos-arm64.zip
+          unzip libtokenizers-macos.zip -d "$XDG_CACHE_HOME"
+          ;;
+      esac
       ;;
     "Linux")
       if [ "$USE_NIGHTLY" = 1 ] ; then

--- a/deps/get-deps.sh
+++ b/deps/get-deps.sh
@@ -114,11 +114,11 @@ if [ "$SKIP_DOWNLOAD" = 0 ] ; then
           ;;
         "arm64")
           wget https://github.com/hasktorch/tokenizers/releases/download/libtokenizers-v0.1/libtokenizers-macos-arm64.zip
-          unzip libtokenizers-macos.zip -d "$XDG_CACHE_HOME"
+          unzip libtokenizers-macos-arm64.zip -d "$XDG_CACHE_HOME"
           ;;
         "arm64e")
           wget https://github.com/hasktorch/tokenizers/releases/download/libtokenizers-v0.1/libtokenizers-macos-arm64.zip
-          unzip libtokenizers-macos.zip -d "$XDG_CACHE_HOME"
+          unzip libtokenizers-macos-arm64.zip -d "$XDG_CACHE_HOME"
           ;;
       esac
       ;;

--- a/deps/get-deps.sh
+++ b/deps/get-deps.sh
@@ -96,28 +96,28 @@ if [ "$SKIP_DOWNLOAD" = 0 ] ; then
     "Darwin")
       if [ "$USE_NIGHTLY" = 1 ] ; then
         wget https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-latest.zip
-        unzip libtorch-macos-latest.zip
+        unzip libtorch-macos-latest.zip -d "$XDG_CACHE_HOME"
         rm libtorch-macos-latest.zip
       elif [ "$USE_BINARY_FOR_CI" = 1 ] ; then
         wget https://github.com/hasktorch/libtorch-binary-for-ci/releases/download/${VERSION}/cpu-libtorch-macos-latest.zip
-        unzip cpu-libtorch-macos-latest.zip
+        unzip cpu-libtorch-macos-latest.zip -d "$XDG_CACHE_HOME"
         rm cpu-libtorch-macos-latest.zip
       else
         wget -O libtorch-macos.zip https://download.pytorch.org/libtorch/cpu/libtorch-macos-arm64-${VERSION}.zip
-        unzip libtorch-macos.zip
+        unzip libtorch-macos.zip -d "$XDG_CACHE_HOME"
         rm libtorch-macos.zip
       fi
       wget https://github.com/hasktorch/tokenizers/releases/download/libtokenizers-v0.1/libtokenizers-macos.zip
-      unzip libtokenizers-macos.zip
+      unzip libtokenizers-macos.zip -d "$XDG_CACHE_HOME"
       ;;
     "Linux")
       if [ "$USE_NIGHTLY" = 1 ] ; then
         wget https://download.pytorch.org/libtorch/nightly/${COMPUTE_ARCH}/libtorch-cxx11-abi-shared-with-deps-latest.zip
-        unzip libtorch-cxx11-abi-shared-with-deps-latest.zip
+        unzip libtorch-cxx11-abi-shared-with-deps-latest.zip -d "$XDG_CACHE_HOME"
         rm libtorch-cxx11-abi-shared-with-deps-latest.zip
       elif [ "$USE_BINARY_FOR_CI" = 1 ] ; then
         wget https://github.com/hasktorch/libtorch-binary-for-ci/releases/download/${VERSION}/${COMPUTE_ARCH}-libtorch-cxx11-abi-shared-with-deps-latest.zip
-        unzip ${COMPUTE_ARCH}-libtorch-cxx11-abi-shared-with-deps-latest.zip
+        unzip ${COMPUTE_ARCH}-libtorch-cxx11-abi-shared-with-deps-latest.zip -d "$XDG_CACHE_HOME"
         rm ${COMPUTE_ARCH}-libtorch-cxx11-abi-shared-with-deps-latest.zip
       else
 	case "${COMPUTE_ARCH}" in
@@ -129,12 +129,12 @@ if [ "$SKIP_DOWNLOAD" = 0 ] ; then
                   usage_exit
 	esac
 	wget -O libtorch-cxx11-abi-shared-with-deps-${VERSION}.zip "$URL"
-        unzip libtorch-cxx11-abi-shared-with-deps-${VERSION}.zip
+        unzip libtorch-cxx11-abi-shared-with-deps-${VERSION}.zip -d "$XDG_CACHE_HOME"
         rm libtorch-cxx11-abi-shared-with-deps-${VERSION}.zip
       fi
 
       wget https://github.com/hasktorch/tokenizers/releases/download/libtokenizers-v0.1/libtokenizers-linux.zip
-      unzip libtokenizers-linux.zip
+      unzip libtokenizers-linux.zip -d "$XDG_CACHE_HOME"
       ;;
   esac
 fi
@@ -147,23 +147,19 @@ echo "Generate ATen files."
 if [ ! -e pytorch ] ; then
     git clone https://github.com/pytorch/pytorch.git
 else
-    pushd pytorch
+    pushd ./pytorch
     git pull origin v$VERSION
     popd
 fi
 
-pushd pytorch
+pushd ./pytorch
 git checkout v$VERSION
 
 if [[ ! -d build ]]; then
 mkdir build
 fi
 
-
-PYTHON=python
-if ! (python --version | grep "Python 2") ;then
-    PYTHON=python3
-fi
+PYTHON=python3
 
 if ! ($PYTHON -c 'import yaml') ; then
     $PYTHON -m pip install --user pyyaml
@@ -203,6 +199,6 @@ esac
 
 popd
 
-pushd ../spec
-  ln -fs ../deps/pytorch/build/aten/src/ATen/Declarations.yaml
+pushd ./spec
+  ln -fs ../pytorch/build/aten/src/ATen/Declarations.yaml
 popd

--- a/flake.nix
+++ b/flake.nix
@@ -52,10 +52,7 @@
           {
             examples =
               pkgs.haskell.packages.ghc965.callCabal2nix "examples"
-              ./examples {
-                export XDG_CACHE_HOME=$TMPDIR
-                export LIBTORCH_HOME=$TMPDIR/libtorch
-              };
+              ./examples {};
           }
           // (mkHasktorchPackageSet "cuda" pkgsCuda)
           // (mkHasktorchPackageSet "cpu" pkgs);

--- a/flake.nix
+++ b/flake.nix
@@ -44,6 +44,12 @@
           hash = "sha256-VFbzEB8LJiVsKIpb2KkSOdvJQY6uR9RyvratKiY8wUs=";
           stripRoot = false; # keep the top-level "libtorch" folder
         };
+        libtokenizers = pkgs.fetchzip {
+          name = "libtokenizers.zip";
+          url = "https://github.com/hasktorch/tokenizers/releases/download/libtokenizers-v0.1/libtokenizers-linux.zip";
+          hash = "sha256-F/WtJeibyyofr0wgps+1vBQ5kWF2vzaygbJbJTX3EeU=";
+          stripRoot = false; # keep the top-level "libtorch" folder
+        };
         mkHasktorchPackageSet = t: p:
           lib.mapAttrs' (name: value: lib.nameValuePair "${name}-${t}" value) (lib.genAttrs [
             "codegen"
@@ -66,6 +72,8 @@
                     export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
                     export LIBTORCH_SKIP_DOWNLOAD=1
                     ln -sfn ${libtorch_2_5_0_cpu}/libtorch "$XDG_CACHE_HOME/libtorch"
+                    export LIBTOKENIZERS_SKIP_DOWNLOAD=1
+                    ln -sfn ${libtokenizers}/libtokenizers "$XDG_CACHE_HOME/libtokenizers"
                     export LIBTORCH_HOME="$XDG_CACHE_HOME/libtorch"
                     export CMAKE_PREFIX_PATH="$LIBTORCH_HOME"
                   '';
@@ -76,6 +84,8 @@
                     export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
                     export LIBTORCH_SKIP_DOWNLOAD=1
                     ln -sfn ${libtorch_2_5_0_cpu}/libtorch "$XDG_CACHE_HOME/libtorch"
+                    export LIBTOKENIZERS_SKIP_DOWNLOAD=1
+                    ln -sfn ${libtokenizers}/libtokenizers "$XDG_CACHE_HOME/libtokenizers"
                     export LIBTORCH_HOME="$XDG_CACHE_HOME/libtorch"
                     export CMAKE_PREFIX_PATH="$LIBTORCH_HOME"
                   '';
@@ -86,6 +96,8 @@
                     export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
                     export LIBTORCH_SKIP_DOWNLOAD=1
                     ln -sfn ${libtorch_2_5_0_cpu}/libtorch "$XDG_CACHE_HOME/libtorch"
+                    export LIBTOKENIZERS_SKIP_DOWNLOAD=1
+                    ln -sfn ${libtokenizers}/libtokenizers "$XDG_CACHE_HOME/libtokenizers"
                     export LIBTORCH_HOME="$XDG_CACHE_HOME/libtorch"
                     export CMAKE_PREFIX_PATH="$LIBTORCH_HOME"
                   '';

--- a/flake.nix
+++ b/flake.nix
@@ -47,7 +47,7 @@
         libtokenizers = pkgs.fetchzip {
           name = "libtokenizers.zip";
           url = "https://github.com/hasktorch/tokenizers/releases/download/libtokenizers-v0.1/libtokenizers-linux.zip";
-          hash = "sha256-F/WtJeibyyofr0wgps+1vBQ5kWF2vzaygbJbJTX3EeU=";
+          hash = "sha256-9XJLgvS+j01IX2Dh+9K5J9khU/8RnS4IqwBOkf+An4g=";
           stripRoot = false; # keep the top-level "libtorch" folder
         };
         mkHasktorchPackageSet = t: p:

--- a/flake.nix
+++ b/flake.nix
@@ -51,8 +51,27 @@
         packages =
           {
             examples =
-              pkgs.haskell.packages.ghc965.callCabal2nix "examples"
-              ./examples {};
+              (pkgs.haskell.packages.ghc965.callCabal2nix "examples"
+              ./examples {}).overrideAttrs (old: {
+                  preConfigure = (old.preConfigure or "") + ''
+                    export HOME="$TMPDIR"
+                    export XDG_CACHE_HOME="$TMPDIR"
+                    export HASKTORCH_LIB_PATH="$XDG_CACHE_HOME/libtorch/lib:$XDG_CACHE_HOME/mklml/lib/:$XDG_CACHE_HOME/libtokenizers/lib"
+                    export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
+                  '';
+                  preBuild = (old.preBuild or "") + ''
+                    export HOME="$TMPDIR"
+                    export XDG_CACHE_HOME="$TMPDIR"
+                    export HASKTORCH_LIB_PATH="$XDG_CACHE_HOME/libtorch/lib:$XDG_CACHE_HOME/mklml/lib/:$XDG_CACHE_HOME/libtokenizers/lib"
+                    export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
+                  '';
+                  preInstall = (old.preInstall or "") + ''
+                    export HOME="$TMPDIR"
+                    export XDG_CACHE_HOME="$TMPDIR"
+                    export HASKTORCH_LIB_PATH="$XDG_CACHE_HOME/libtorch/lib:$XDG_CACHE_HOME/mklml/lib/:$XDG_CACHE_HOME/libtokenizers/lib"
+                    export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
+                  '';
+                });
           }
           // (mkHasktorchPackageSet "cuda" pkgsCuda)
           // (mkHasktorchPackageSet "cpu" pkgs);

--- a/flake.nix
+++ b/flake.nix
@@ -38,6 +38,12 @@
       }: let
         ghc = "ghc984";
         mnist = (pkgs.callPackage ./nix/datasets.nix {}).mnist;
+        libtorch_2_5_0_cpu = pkgs.fetchzip {
+          name = "libtorch-2.5.0-cpu.zip";
+          url = "https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-2.5.0%2Bcpu.zip";
+          hash = "sha256-gUzPhc4Z8rTPhIm89pPoLP0Ww17ono+/xgMW46E/Tro=";
+          stripRoot = false; # keep the top-level "libtorch" folder
+        };
         mkHasktorchPackageSet = t: p:
           lib.mapAttrs' (name: value: lib.nameValuePair "${name}-${t}" value) (lib.genAttrs [
             "codegen"
@@ -58,18 +64,30 @@
                     export XDG_CACHE_HOME="$TMPDIR"
                     export HASKTORCH_LIB_PATH="$XDG_CACHE_HOME/libtorch/lib:$XDG_CACHE_HOME/mklml/lib/:$XDG_CACHE_HOME/libtokenizers/lib"
                     export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
+                    export LIBTORCH_SKIP_DOWNLOAD=1
+                    ln -sfn ${libtorch_2_5_0_cpu}/libtorch "$XDG_CACHE_HOME/libtorch"
+                    export LIBTORCH_HOME="$XDG_CACHE_HOME/libtorch"
+                    export CMAKE_PREFIX_PATH="$LIBTORCH_HOME"
                   '';
                   preBuild = (old.preBuild or "") + ''
                     export HOME="$TMPDIR"
                     export XDG_CACHE_HOME="$TMPDIR"
                     export HASKTORCH_LIB_PATH="$XDG_CACHE_HOME/libtorch/lib:$XDG_CACHE_HOME/mklml/lib/:$XDG_CACHE_HOME/libtokenizers/lib"
                     export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
+                    export LIBTORCH_SKIP_DOWNLOAD=1
+                    ln -sfn ${libtorch_2_5_0_cpu}/libtorch "$XDG_CACHE_HOME/libtorch"
+                    export LIBTORCH_HOME="$XDG_CACHE_HOME/libtorch"
+                    export CMAKE_PREFIX_PATH="$LIBTORCH_HOME"
                   '';
                   preInstall = (old.preInstall or "") + ''
                     export HOME="$TMPDIR"
                     export XDG_CACHE_HOME="$TMPDIR"
                     export HASKTORCH_LIB_PATH="$XDG_CACHE_HOME/libtorch/lib:$XDG_CACHE_HOME/mklml/lib/:$XDG_CACHE_HOME/libtokenizers/lib"
                     export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
+                    export LIBTORCH_SKIP_DOWNLOAD=1
+                    ln -sfn ${libtorch_2_5_0_cpu}/libtorch "$XDG_CACHE_HOME/libtorch"
+                    export LIBTORCH_HOME="$XDG_CACHE_HOME/libtorch"
+                    export CMAKE_PREFIX_PATH="$LIBTORCH_HOME"
                   '';
                 });
           }

--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,7 @@
         libtorch_2_5_0_cpu = pkgs.fetchzip {
           name = "libtorch-2.5.0-cpu.zip";
           url = "https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-2.5.0%2Bcpu.zip";
-          hash = "sha256-gUzPhc4Z8rTPhIm89pPoLP0Ww17ono+/xgMW46E/Tro=";
+          hash = "sha256-VFbzEB8LJiVsKIpb2KkSOdvJQY6uR9RyvratKiY8wUs=";
           stripRoot = false; # keep the top-level "libtorch" folder
         };
         mkHasktorchPackageSet = t: p:

--- a/hasktorch/Setup.hs
+++ b/hasktorch/Setup.hs
@@ -153,8 +153,8 @@ computeTokenizerURL :: IO (String, String)
 computeTokenizerURL = do
   pure $ case buildOS of
     OSX -> case buildArch of
-            AArch64 -> ( "https://github.com/hasktorch/tokenizers/releases/download/libtokenizers-v0.1/libtokenizers-macos.zip"
-                       , "libtokenizers-macos-arm64.zip" )
+            AArch64 -> ( "https://github.com/hasktorch/tokenizers/releases/download/libtokenizers-v0.1/libtokenizers-macos-arm64.zip"
+                       , "libtokenizers-macos.zip" )
             X86_64  -> ( "https://github.com/hasktorch/tokenizers/releases/download/libtokenizers-v0.1/libtokenizers-macos.zip"
                        , "libtokenizers-macos.zip" )
             _       -> error "Unsupported macOS arch"

--- a/hasktorch/Setup.hs
+++ b/hasktorch/Setup.hs
@@ -23,6 +23,7 @@ main :: IO ()
 main = defaultMainWithHooks $ addDoctestsUserHook "doctests" $  simpleUserHooks
   { preConf = \_ _ -> do
       _ <- ensureLibtorch 
+      _ <- ensureLibtokenizers
       pure emptyHookedBuildInfo
   , confHook = \(gpd, hbi) flags -> do
       libtorchDir <- getGlobalLibtorchDir
@@ -82,7 +83,8 @@ ensureLibtorch = do
         then pure dest
         else do
           putStrLn $ "libtorch not found in global cache, installing to " <> dest
-          downloadAndExtractLibtorchTo dest
+          torchResources <- computeTorchURL
+          downloadAndExtractLibTo torchResources dest
           -- Create an idempotence marker that checks
           -- if we've already downloaded torch.
           -- Since we'll be moving everything this will
@@ -90,10 +92,36 @@ ensureLibtorch = do
           writeFile marker ""
           pure dest
 
-downloadAndExtractLibtorchTo :: FilePath -> IO ()
-downloadAndExtractLibtorchTo dest = do
+ensureLibtokenizers :: IO FilePath
+ensureLibtokenizers = do
+  skip <- lookupEnv "LIBTOKENIZERS_SKIP_DOWNLOAD"
+  case skip of
+    Just _ -> do
+      putStrLn "LIBTOKENIZERS_SKIP_DOWNLOAD set; assuming libtokenizers exists globally."
+      getXdgDirectory XdgCache ""
+    Nothing -> do
+      -- This will unpack to libtokenizers so no need to
+      -- to create a custom directory in cache
+      dest <- getXdgDirectory XdgCache ""
+      let marker = dest </> ".ok"
+      exists <- doesFileExist marker
+      present <- doesDirectoryExist dest
+      if present && exists
+        then pure dest
+        else do
+          putStrLn $ "libtokenizers not found in global cache, installing to " <> dest
+          tokenizerResources <- computeTokenizerURL
+          downloadAndExtractLibTo tokenizerResources dest
+          -- Create an idempotence marker that checks
+          -- if we've already downloaded torch.
+          -- Since we'll be moving everything this will
+          -- be the our main reference.
+          writeFile marker ""
+          pure dest
+
+downloadAndExtractLibTo :: (String, String) -> FilePath -> IO ()
+downloadAndExtractLibTo (url, fileName) dest = do
   createDirectoryIfMissing True dest
-  (url, fileName) <- computeURL
   putStrLn $ "Downloading libtorch from: " ++ url
   withSystemTempDirectory "libtorch-download" $ \tmpDir -> do
     let downloadPath = tmpDir </> fileName
@@ -108,7 +136,7 @@ downloadAndExtractLibtorchTo dest = do
     -- We want to move the directory since this operation is atomic.
     -- If that doesn't work we fall back to copying.
     (renameDirectory src dest) `catch` (\(_::IOException) -> copyTree src dest)
-    putStrLn "libtorch extracted successfully (global cache)."
+    putStrLn "library extracted successfully (global cache)."
 
 copyTree :: FilePath -> FilePath -> IO ()
 copyTree src dest = do
@@ -121,8 +149,17 @@ copyTree src dest = do
           if isDir then copyTree s d else copyFile s d
         ) entries
 
-computeURL :: IO (String, String)
-computeURL = do
+computeTokenizerURL :: IO (String, String)
+computeTokenizerURL = do
+  pure $ case buildOS of
+    OSX -> ( "https://github.com/hasktorch/tokenizers/releases/download/libtokenizers-v0.1/libtokenizers-macos.zip"
+           , "libtokenizers-macos.zip" )
+    Linux -> ( "https://github.com/hasktorch/tokenizers/releases/download/libtokenizers-v0.1/libtokenizers-macos.zip"
+           , "libtokenizers-macos.zip" )
+    Windows -> error "Windows not supported by this setup"
+
+computeTorchURL :: IO (String, String)
+computeTorchURL = do
   flavor <- getCudaFlavor
   let v = libtorchVersion
   pure $ case buildOS of

--- a/hasktorch/Setup.hs
+++ b/hasktorch/Setup.hs
@@ -152,9 +152,13 @@ copyTree src dest = do
 computeTokenizerURL :: IO (String, String)
 computeTokenizerURL = do
   pure $ case buildOS of
-    OSX -> ( "https://github.com/hasktorch/tokenizers/releases/download/libtokenizers-v0.1/libtokenizers-macos.zip"
-           , "libtokenizers-macos.zip" )
-    Linux -> ( "https://github.com/hasktorch/tokenizers/releases/download/libtokenizers-v0.1/libtokenizers-macos.zip"
+    OSX -> case buildArch of
+            AArch64 -> ( "https://github.com/hasktorch/tokenizers/releases/download/libtokenizers-v0.1/libtokenizers-macos.zip"
+                       , "libtokenizers-macos-arm64.zip" )
+            X86_64  -> ( "https://github.com/hasktorch/tokenizers/releases/download/libtokenizers-v0.1/libtokenizers-macos.zip"
+                       , "libtokenizers-macos.zip" )
+            _       -> error "Unsupported macOS arch"
+    Linux -> ( "https://github.com/hasktorch/tokenizers/releases/download/libtokenizers-v0.1/libtokenizers-linux.zip"
            , "libtokenizers-macos.zip" )
     Windows -> error "Windows not supported by this setup"
 

--- a/hasktorch/Setup.hs
+++ b/hasktorch/Setup.hs
@@ -154,12 +154,12 @@ computeTokenizerURL = do
   pure $ case buildOS of
     OSX -> case buildArch of
             AArch64 -> ( "https://github.com/hasktorch/tokenizers/releases/download/libtokenizers-v0.1/libtokenizers-macos-arm64.zip"
-                       , "libtokenizers-macos.zip" )
+                       , "libtokenizers.zip" )
             X86_64  -> ( "https://github.com/hasktorch/tokenizers/releases/download/libtokenizers-v0.1/libtokenizers-macos.zip"
-                       , "libtokenizers-macos.zip" )
+                       , "libtokenizers.zip" )
             _       -> error "Unsupported macOS arch"
     Linux -> ( "https://github.com/hasktorch/tokenizers/releases/download/libtokenizers-v0.1/libtokenizers-linux.zip"
-           , "libtokenizers-macos.zip" )
+           , "libtokenizers.zip" )
     Windows -> error "Windows not supported by this setup"
 
 computeTorchURL :: IO (String, String)

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -25,31 +25,132 @@ in {
             prev.haskell.packages.${ghcName}.extend
             (hfinal: hprev: {
               # Hasktorch Packages
-              codegen = hfinal.callCabal2nix "codegen" ../codegen {};
+              codegen = (hfinal.callCabal2nix "codegen" ../codegen {}).overrideAttrs (old: {
+                  preConfigure = (old.preConfigure or "") + ''
+                    export HOME="$TMPDIR"
+                    export XDG_CACHE_HOME="$TMPDIR"
+                    export HASKTORCH_LIB_PATH="$XDG_CACHE_HOME/libtorch/lib:$XDG_CACHE_HOME/mklml/lib/:$XDG_CACHE_HOME/libtokenizers/lib"
+                    export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
+                  '';
+                  preBuild = (old.preBuild or "") + ''
+                    export HOME="$TMPDIR"
+                    export XDG_CACHE_HOME="$TMPDIR"
+                    export HASKTORCH_LIB_PATH="$XDG_CACHE_HOME/libtorch/lib:$XDG_CACHE_HOME/mklml/lib/:$XDG_CACHE_HOME/libtokenizers/lib"
+                    export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
+                  '';
+                  preInstall = (old.preInstall or "") + ''
+                    export HOME="$TMPDIR"
+                    export XDG_CACHE_HOME="$TMPDIR"
+                    export HASKTORCH_LIB_PATH="$XDG_CACHE_HOME/libtorch/lib:$XDG_CACHE_HOME/mklml/lib/:$XDG_CACHE_HOME/libtokenizers/lib"
+                    export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
+                  '';
+                });
               hasktorch-gradually-typed =
                 lib.pipe
                 (hfinal.callCabal2nix "hasktorch-gradually-typed" ../experimental/gradually-typed {})
                 [
+                  (drv: drv.overrideAttrs (old: {
+                    preConfigure = (old.preConfigure or "") + ''
+                      export HOME="$TMPDIR"
+                      export XDG_CACHE_HOME="$TMPDIR"
+                      export HASKTORCH_LIB_PATH="$XDG_CACHE_HOME/libtorch/lib:$XDG_CACHE_HOME/mklml/lib/:$XDG_CACHE_HOME/libtokenizers/lib"
+                      export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
+                    '';
+                    preBuild = (old.preBuild or "") + ''
+                      export HOME="$TMPDIR"
+                      export XDG_CACHE_HOME="$TMPDIR"
+                      export HASKTORCH_LIB_PATH="$XDG_CACHE_HOME/libtorch/lib:$XDG_CACHE_HOME/mklml/lib/:$XDG_CACHE_HOME/libtokenizers/lib"
+                      export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
+                    '';
+                    preInstall = (old.preInstall or "") + ''
+                      export HOME="$TMPDIR"
+                      export XDG_CACHE_HOME="$TMPDIR"
+                      export HASKTORCH_LIB_PATH="$XDG_CACHE_HOME/libtorch/lib:$XDG_CACHE_HOME/mklml/lib/:$XDG_CACHE_HOME/libtokenizers/lib"
+                      export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
+                    '';
+                  }))
                   dontCheck
                   #  disableLibraryProfiling
                 ];
               hasktorch =
                 lib.pipe
-                (hfinal.callCabal2nix "hasktorch" ../hasktorch {})
-                [
-                  dontCheck
-                  #  disableLibraryProfiling
-                ];
-              libtorch-ffi-helper = hfinal.callCabal2nix "libtorch-ffi-helper" ../libtorch-ffi-helper {};
+                  (hfinal.callCabal2nix "hasktorch" ../hasktorch {})
+                  [
+                    (drv: drv.overrideAttrs (old: {
+                      preConfigure = (old.preConfigure or "") + ''
+                        export HOME="$TMPDIR"
+                        export XDG_CACHE_HOME="$TMPDIR"
+                        export HASKTORCH_LIB_PATH="$XDG_CACHE_HOME/libtorch/lib:$XDG_CACHE_HOME/mklml/lib/:$XDG_CACHE_HOME/libtokenizers/lib"
+                        export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
+                      '';
+                      preBuild = (old.preBuild or "") + ''
+                        export HOME="$TMPDIR"
+                        export XDG_CACHE_HOME="$TMPDIR"
+                        export HASKTORCH_LIB_PATH="$XDG_CACHE_HOME/libtorch/lib:$XDG_CACHE_HOME/mklml/lib/:$XDG_CACHE_HOME/libtokenizers/lib"
+                        export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
+                      '';
+                      preInstall = (old.preInstall or "") + ''
+                        export HOME="$TMPDIR"
+                        export XDG_CACHE_HOME="$TMPDIR"
+                        export HASKTORCH_LIB_PATH="$XDG_CACHE_HOME/libtorch/lib:$XDG_CACHE_HOME/mklml/lib/:$XDG_CACHE_HOME/libtokenizers/lib"
+                        export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
+                      '';
+                    }))
+                    dontCheck
+                    # disableLibraryProfiling
+                  ];
+
+              libtorch-ffi-helper =
+                (hfinal.callCabal2nix "libtorch-ffi-helper" ../libtorch-ffi-helper {}).overrideAttrs (old: {
+                  preConfigure = (old.preConfigure or "") + ''
+                    export HOME="$TMPDIR"
+                    export XDG_CACHE_HOME="$TMPDIR"
+                    export HASKTORCH_LIB_PATH="$XDG_CACHE_HOME/libtorch/lib:$XDG_CACHE_HOME/mklml/lib/:$XDG_CACHE_HOME/libtokenizers/lib"
+                    export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
+                  '';
+                  preBuild = (old.preBuild or "") + ''
+                    export HOME="$TMPDIR"
+                    export XDG_CACHE_HOME="$TMPDIR"
+                    export HASKTORCH_LIB_PATH="$XDG_CACHE_HOME/libtorch/lib:$XDG_CACHE_HOME/mklml/lib/:$XDG_CACHE_HOME/libtokenizers/lib"
+                    export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
+                  '';
+                  preInstall = (old.preInstall or "") + ''
+                    export HOME="$TMPDIR"
+                    export XDG_CACHE_HOME="$TMPDIR"
+                    export HASKTORCH_LIB_PATH="$XDG_CACHE_HOME/libtorch/lib:$XDG_CACHE_HOME/mklml/lib/:$XDG_CACHE_HOME/libtokenizers/lib"
+                    export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
+                  '';
+                });
+
               libtorch-ffi =
                 lib.pipe
-                (hfinal.callCabal2nix "libtorch-ffi" ../libtorch-ffi {
-                  inherit torch c10 torch_cpu;
+                  (hfinal.callCabal2nix "libtorch-ffi" ../libtorch-ffi {
+                    inherit torch c10 torch_cpu;
                   })
-                [
-                  (appendConfigureFlag
-                    "--extra-include-dirs=${lib.getDev torch}/include/torch/csrc/api/include")
-                ];
+                  [
+                    (drv: drv.overrideAttrs (old: {
+                      preConfigure = (old.preConfigure or "") + ''
+                        export HOME="$TMPDIR"
+                        export XDG_CACHE_HOME="$TMPDIR"
+                        export HASKTORCH_LIB_PATH="$XDG_CACHE_HOME/libtorch/lib:$XDG_CACHE_HOME/mklml/lib/:$XDG_CACHE_HOME/libtokenizers/lib"
+                        export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
+                      '';
+                      preBuild = (old.preBuild or "") + ''
+                        export HOME="$TMPDIR"
+                        export XDG_CACHE_HOME="$TMPDIR"
+                        export HASKTORCH_LIB_PATH="$XDG_CACHE_HOME/libtorch/lib:$XDG_CACHE_HOME/mklml/lib/:$XDG_CACHE_HOME/libtokenizers/lib"
+                        export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
+                      '';
+                      preInstall = (old.preInstall or "") + ''
+                        export HOME="$TMPDIR"
+                        export XDG_CACHE_HOME="$TMPDIR"
+                        export HASKTORCH_LIB_PATH="$XDG_CACHE_HOME/libtorch/lib:$XDG_CACHE_HOME/mklml/lib/:$XDG_CACHE_HOME/libtokenizers/lib"
+                        export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
+                      '';
+                    }))
+                    (appendConfigureFlag
+                      "--extra-include-dirs=${lib.getDev torch}/include/torch/csrc/api/include")
+                  ];
 
               # Hasktorch Forks
               # WARNING: Does not build with GHC 9.8

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -25,40 +25,26 @@ in {
             prev.haskell.packages.${ghcName}.extend
             (hfinal: hprev: {
               # Hasktorch Packages
-              codegen = hfinal.callCabal2nix "codegen" ../codegen {
-                export XDG_CACHE_HOME=$TMPDIR
-                export LIBTORCH_HOME=$TMPDIR/libtorch
-              };
+              codegen = hfinal.callCabal2nix "codegen" ../codegen {};
               hasktorch-gradually-typed =
                 lib.pipe
-                (hfinal.callCabal2nix "hasktorch-gradually-typed" ../experimental/gradually-typed {
-                  export XDG_CACHE_HOME=$TMPDIR
-                  export LIBTORCH_HOME=$TMPDIR/libtorch
-                })
+                (hfinal.callCabal2nix "hasktorch-gradually-typed" ../experimental/gradually-typed {})
                 [
                   dontCheck
                   #  disableLibraryProfiling
                 ];
               hasktorch =
                 lib.pipe
-                (hfinal.callCabal2nix "hasktorch" ../hasktorch {
-                  export XDG_CACHE_HOME=$TMPDIR
-                  export LIBTORCH_HOME=$TMPDIR/libtorch
-                })
+                (hfinal.callCabal2nix "hasktorch" ../hasktorch {})
                 [
                   dontCheck
                   #  disableLibraryProfiling
                 ];
-              libtorch-ffi-helper = hfinal.callCabal2nix "libtorch-ffi-helper" ../libtorch-ffi-helper {
-                export XDG_CACHE_HOME=$TMPDIR
-                export LIBTORCH_HOME=$TMPDIR/libtorch
-              };
+              libtorch-ffi-helper = hfinal.callCabal2nix "libtorch-ffi-helper" ../libtorch-ffi-helper {};
               libtorch-ffi =
                 lib.pipe
                 (hfinal.callCabal2nix "libtorch-ffi" ../libtorch-ffi {
                   inherit torch c10 torch_cpu;
-                  export XDG_CACHE_HOME=$TMPDIR
-                  export LIBTORCH_HOME=$TMPDIR/libtorch
                   })
                 [
                   (appendConfigureFlag

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -20,6 +20,12 @@ final: prev: let
     hash = "sha256-VFbzEB8LJiVsKIpb2KkSOdvJQY6uR9RyvratKiY8wUs=";
     stripRoot = false;
   };
+  libtokenizers = pkgs.fetchzip {
+    name = "libtokenizers.zip";
+    url = "https://github.com/hasktorch/tokenizers/releases/download/libtokenizers-v0.1/libtokenizers-linux.zip";
+    hash = "sha256-F/WtJeibyyofr0wgps+1vBQ5kWF2vzaygbJbJTX3EeU=";
+    stripRoot = false; # keep the top-level "libtorch" folder
+  };
 in {
   haskell =
     prev.haskell
@@ -40,6 +46,8 @@ in {
                     export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
                     export LIBTORCH_SKIP_DOWNLOAD=1
                     ln -sfn ${libtorch_2_5_0_cpu}/libtorch "$XDG_CACHE_HOME/libtorch"
+                    export LIBTOKENIZERS_SKIP_DOWNLOAD=1
+                    ln -sfn ${libtokenizers}/libtokenizers "$XDG_CACHE_HOME/libtokenizers"
                     export LIBTORCH_HOME="$XDG_CACHE_HOME/libtorch"
                     export CMAKE_PREFIX_PATH="$LIBTORCH_HOME"
                   '';
@@ -50,6 +58,8 @@ in {
                     export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
                     export LIBTORCH_SKIP_DOWNLOAD=1
                     ln -sfn ${libtorch_2_5_0_cpu}/libtorch "$XDG_CACHE_HOME/libtorch"
+                    export LIBTOKENIZERS_SKIP_DOWNLOAD=1
+                    ln -sfn ${libtokenizers}/libtokenizers "$XDG_CACHE_HOME/libtokenizers"
                     export LIBTORCH_HOME="$XDG_CACHE_HOME/libtorch"
                     export CMAKE_PREFIX_PATH="$LIBTORCH_HOME"
                   '';
@@ -60,6 +70,8 @@ in {
                     export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
                     export LIBTORCH_SKIP_DOWNLOAD=1
                     ln -sfn ${libtorch_2_5_0_cpu}/libtorch "$XDG_CACHE_HOME/libtorch"
+                    export LIBTOKENIZERS_SKIP_DOWNLOAD=1
+                    ln -sfn ${libtokenizers}/libtokenizers "$XDG_CACHE_HOME/libtokenizers"
                     export LIBTORCH_HOME="$XDG_CACHE_HOME/libtorch"
                     export CMAKE_PREFIX_PATH="$LIBTORCH_HOME"
                   '';
@@ -76,6 +88,8 @@ in {
                       export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
                       export LIBTORCH_SKIP_DOWNLOAD=1
                       ln -sfn ${libtorch_2_5_0_cpu}/libtorch "$XDG_CACHE_HOME/libtorch"
+                      export LIBTOKENIZERS_SKIP_DOWNLOAD=1
+                      ln -sfn ${libtokenizers}/libtokenizers "$XDG_CACHE_HOME/libtokenizers"
                       export LIBTORCH_HOME="$XDG_CACHE_HOME/libtorch"
                       export CMAKE_PREFIX_PATH="$LIBTORCH_HOME"
                     '';
@@ -86,6 +100,8 @@ in {
                       export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
                       export LIBTORCH_SKIP_DOWNLOAD=1
                       ln -sfn ${libtorch_2_5_0_cpu}/libtorch "$XDG_CACHE_HOME/libtorch"
+                      export LIBTOKENIZERS_SKIP_DOWNLOAD=1
+                      ln -sfn ${libtokenizers}/libtokenizers "$XDG_CACHE_HOME/libtokenizers"
                       export LIBTORCH_HOME="$XDG_CACHE_HOME/libtorch"
                       export CMAKE_PREFIX_PATH="$LIBTORCH_HOME"
                     '';
@@ -96,6 +112,8 @@ in {
                       export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
                       export LIBTORCH_SKIP_DOWNLOAD=1
                       ln -sfn ${libtorch_2_5_0_cpu}/libtorch "$XDG_CACHE_HOME/libtorch"
+                      export LIBTOKENIZERS_SKIP_DOWNLOAD=1
+                      ln -sfn ${libtokenizers}/libtokenizers "$XDG_CACHE_HOME/libtokenizers"
                       export LIBTORCH_HOME="$XDG_CACHE_HOME/libtorch"
                       export CMAKE_PREFIX_PATH="$LIBTORCH_HOME"
                     '';
@@ -115,6 +133,8 @@ in {
                         export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
                         export LIBTORCH_SKIP_DOWNLOAD=1
                         ln -sfn ${libtorch_2_5_0_cpu}/libtorch "$XDG_CACHE_HOME/libtorch"
+                        export LIBTOKENIZERS_SKIP_DOWNLOAD=1
+                        ln -sfn ${libtokenizers}/libtokenizers "$XDG_CACHE_HOME/libtokenizers"
                         export LIBTORCH_HOME="$XDG_CACHE_HOME/libtorch"
                         export CMAKE_PREFIX_PATH="$LIBTORCH_HOME"
                       '';
@@ -125,6 +145,8 @@ in {
                         export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
                         export LIBTORCH_SKIP_DOWNLOAD=1
                         ln -sfn ${libtorch_2_5_0_cpu}/libtorch "$XDG_CACHE_HOME/libtorch"
+                        export LIBTOKENIZERS_SKIP_DOWNLOAD=1
+                        ln -sfn ${libtokenizers}/libtokenizers "$XDG_CACHE_HOME/libtokenizers"
                         export LIBTORCH_HOME="$XDG_CACHE_HOME/libtorch"
                         export CMAKE_PREFIX_PATH="$LIBTORCH_HOME"
                       '';
@@ -135,6 +157,8 @@ in {
                         export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
                         export LIBTORCH_SKIP_DOWNLOAD=1
                         ln -sfn ${libtorch_2_5_0_cpu}/libtorch "$XDG_CACHE_HOME/libtorch"
+                        export LIBTOKENIZERS_SKIP_DOWNLOAD=1
+                        ln -sfn ${libtokenizers}/libtokenizers "$XDG_CACHE_HOME/libtokenizers"
                         export LIBTORCH_HOME="$XDG_CACHE_HOME/libtorch"
                         export CMAKE_PREFIX_PATH="$LIBTORCH_HOME"
                       '';
@@ -152,6 +176,8 @@ in {
                     export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
                     export LIBTORCH_SKIP_DOWNLOAD=1
                     ln -sfn ${libtorch_2_5_0_cpu}/libtorch "$XDG_CACHE_HOME/libtorch"
+                    export LIBTOKENIZERS_SKIP_DOWNLOAD=1
+                    ln -sfn ${libtokenizers}/libtokenizers "$XDG_CACHE_HOME/libtokenizers"
                     export LIBTORCH_HOME="$XDG_CACHE_HOME/libtorch"
                     export CMAKE_PREFIX_PATH="$LIBTORCH_HOME"
                   '';
@@ -162,6 +188,8 @@ in {
                     export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
                     export LIBTORCH_SKIP_DOWNLOAD=1
                     ln -sfn ${libtorch_2_5_0_cpu}/libtorch "$XDG_CACHE_HOME/libtorch"
+                    export LIBTOKENIZERS_SKIP_DOWNLOAD=1
+                    ln -sfn ${libtokenizers}/libtokenizers "$XDG_CACHE_HOME/libtokenizers"
                     export LIBTORCH_HOME="$XDG_CACHE_HOME/libtorch"
                     export CMAKE_PREFIX_PATH="$LIBTORCH_HOME"
                   '';
@@ -172,6 +200,8 @@ in {
                     export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
                     export LIBTORCH_SKIP_DOWNLOAD=1
                     ln -sfn ${libtorch_2_5_0_cpu}/libtorch "$XDG_CACHE_HOME/libtorch"
+                    export LIBTOKENIZERS_SKIP_DOWNLOAD=1
+                    ln -sfn ${libtokenizers}/libtokenizers "$XDG_CACHE_HOME/libtokenizers"
                     export LIBTORCH_HOME="$XDG_CACHE_HOME/libtorch"
                     export CMAKE_PREFIX_PATH="$LIBTORCH_HOME"
                   '';
@@ -191,6 +221,8 @@ in {
                         export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
                         export LIBTORCH_SKIP_DOWNLOAD=1
                         ln -sfn ${libtorch_2_5_0_cpu}/libtorch "$XDG_CACHE_HOME/libtorch"
+                        export LIBTOKENIZERS_SKIP_DOWNLOAD=1
+                        ln -sfn ${libtokenizers}/libtokenizers "$XDG_CACHE_HOME/libtokenizers"
                         export LIBTORCH_HOME="$XDG_CACHE_HOME/libtorch"
                         export CMAKE_PREFIX_PATH="$LIBTORCH_HOME"
                       '';
@@ -201,6 +233,8 @@ in {
                         export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
                         export LIBTORCH_SKIP_DOWNLOAD=1
                         ln -sfn ${libtorch_2_5_0_cpu}/libtorch "$XDG_CACHE_HOME/libtorch"
+                        export LIBTOKENIZERS_SKIP_DOWNLOAD=1
+                        ln -sfn ${libtokenizers}/libtokenizers "$XDG_CACHE_HOME/libtokenizers"
                         export LIBTORCH_HOME="$XDG_CACHE_HOME/libtorch"
                         export CMAKE_PREFIX_PATH="$LIBTORCH_HOME"
                       '';
@@ -211,6 +245,8 @@ in {
                         export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
                         export LIBTORCH_SKIP_DOWNLOAD=1
                         ln -sfn ${libtorch_2_5_0_cpu}/libtorch "$XDG_CACHE_HOME/libtorch"
+                        export LIBTOKENIZERS_SKIP_DOWNLOAD=1
+                        ln -sfn ${libtokenizers}/libtokenizers "$XDG_CACHE_HOME/libtokenizers"
                         export LIBTORCH_HOME="$XDG_CACHE_HOME/libtorch"
                         export CMAKE_PREFIX_PATH="$LIBTORCH_HOME"
                       '';

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -17,7 +17,7 @@ final: prev: let
   libtorch_2_5_0_cpu = final.fetchzip {
     name = "libtorch-2.5.0-cpu.zip";
     url  = "https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-2.5.0%2Bcpu.zip";
-    hash = "sha256-gUzPhc4Z8rTPhIm89pPoLP0Ww17ono+/xgMW46E/Tro=";
+    hash = "sha256-VFbzEB8LJiVsKIpb2KkSOdvJQY6uR9RyvratKiY8wUs=";
     stripRoot = false;
   };
 in {

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -14,6 +14,12 @@ final: prev: let
   c10 = libtorch-bin;
   torch_cpu = libtorch-bin;
   ghcName = "ghc984";
+  libtorch_2_5_0_cpu = final.fetchzip {
+    name = "libtorch-2.5.0-cpu.zip";
+    url  = "https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-2.5.0%2Bcpu.zip";
+    hash = "sha256-gUzPhc4Z8rTPhIm89pPoLP0Ww17ono+/xgMW46E/Tro=";
+    stripRoot = false;
+  };
 in {
   haskell =
     prev.haskell

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -25,24 +25,37 @@ in {
             prev.haskell.packages.${ghcName}.extend
             (hfinal: hprev: {
               # Hasktorch Packages
+              libtorch-2_5_0-cpu = libtorch_2_5_0_cpu;
               codegen = (hfinal.callCabal2nix "codegen" ../codegen {}).overrideAttrs (old: {
                   preConfigure = (old.preConfigure or "") + ''
                     export HOME="$TMPDIR"
                     export XDG_CACHE_HOME="$TMPDIR"
                     export HASKTORCH_LIB_PATH="$XDG_CACHE_HOME/libtorch/lib:$XDG_CACHE_HOME/mklml/lib/:$XDG_CACHE_HOME/libtokenizers/lib"
                     export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
+                    export LIBTORCH_SKIP_DOWNLOAD=1
+                    ln -sfn ${libtorch_2_5_0_cpu}/libtorch "$XDG_CACHE_HOME/libtorch"
+                    export LIBTORCH_HOME="$XDG_CACHE_HOME/libtorch"
+                    export CMAKE_PREFIX_PATH="$LIBTORCH_HOME"
                   '';
                   preBuild = (old.preBuild or "") + ''
                     export HOME="$TMPDIR"
                     export XDG_CACHE_HOME="$TMPDIR"
                     export HASKTORCH_LIB_PATH="$XDG_CACHE_HOME/libtorch/lib:$XDG_CACHE_HOME/mklml/lib/:$XDG_CACHE_HOME/libtokenizers/lib"
                     export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
+                    export LIBTORCH_SKIP_DOWNLOAD=1
+                    ln -sfn ${libtorch_2_5_0_cpu}/libtorch "$XDG_CACHE_HOME/libtorch"
+                    export LIBTORCH_HOME="$XDG_CACHE_HOME/libtorch"
+                    export CMAKE_PREFIX_PATH="$LIBTORCH_HOME"
                   '';
                   preInstall = (old.preInstall or "") + ''
                     export HOME="$TMPDIR"
                     export XDG_CACHE_HOME="$TMPDIR"
                     export HASKTORCH_LIB_PATH="$XDG_CACHE_HOME/libtorch/lib:$XDG_CACHE_HOME/mklml/lib/:$XDG_CACHE_HOME/libtokenizers/lib"
                     export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
+                    export LIBTORCH_SKIP_DOWNLOAD=1
+                    ln -sfn ${libtorch_2_5_0_cpu}/libtorch "$XDG_CACHE_HOME/libtorch"
+                    export LIBTORCH_HOME="$XDG_CACHE_HOME/libtorch"
+                    export CMAKE_PREFIX_PATH="$LIBTORCH_HOME"
                   '';
                 });
               hasktorch-gradually-typed =
@@ -55,18 +68,30 @@ in {
                       export XDG_CACHE_HOME="$TMPDIR"
                       export HASKTORCH_LIB_PATH="$XDG_CACHE_HOME/libtorch/lib:$XDG_CACHE_HOME/mklml/lib/:$XDG_CACHE_HOME/libtokenizers/lib"
                       export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
+                      export LIBTORCH_SKIP_DOWNLOAD=1
+                      ln -sfn ${libtorch_2_5_0_cpu}/libtorch "$XDG_CACHE_HOME/libtorch"
+                      export LIBTORCH_HOME="$XDG_CACHE_HOME/libtorch"
+                      export CMAKE_PREFIX_PATH="$LIBTORCH_HOME"
                     '';
                     preBuild = (old.preBuild or "") + ''
                       export HOME="$TMPDIR"
                       export XDG_CACHE_HOME="$TMPDIR"
                       export HASKTORCH_LIB_PATH="$XDG_CACHE_HOME/libtorch/lib:$XDG_CACHE_HOME/mklml/lib/:$XDG_CACHE_HOME/libtokenizers/lib"
                       export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
+                      export LIBTORCH_SKIP_DOWNLOAD=1
+                      ln -sfn ${libtorch_2_5_0_cpu}/libtorch "$XDG_CACHE_HOME/libtorch"
+                      export LIBTORCH_HOME="$XDG_CACHE_HOME/libtorch"
+                      export CMAKE_PREFIX_PATH="$LIBTORCH_HOME"
                     '';
                     preInstall = (old.preInstall or "") + ''
                       export HOME="$TMPDIR"
                       export XDG_CACHE_HOME="$TMPDIR"
                       export HASKTORCH_LIB_PATH="$XDG_CACHE_HOME/libtorch/lib:$XDG_CACHE_HOME/mklml/lib/:$XDG_CACHE_HOME/libtokenizers/lib"
                       export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
+                      export LIBTORCH_SKIP_DOWNLOAD=1
+                      ln -sfn ${libtorch_2_5_0_cpu}/libtorch "$XDG_CACHE_HOME/libtorch"
+                      export LIBTORCH_HOME="$XDG_CACHE_HOME/libtorch"
+                      export CMAKE_PREFIX_PATH="$LIBTORCH_HOME"
                     '';
                   }))
                   dontCheck
@@ -82,18 +107,30 @@ in {
                         export XDG_CACHE_HOME="$TMPDIR"
                         export HASKTORCH_LIB_PATH="$XDG_CACHE_HOME/libtorch/lib:$XDG_CACHE_HOME/mklml/lib/:$XDG_CACHE_HOME/libtokenizers/lib"
                         export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
+                        export LIBTORCH_SKIP_DOWNLOAD=1
+                        ln -sfn ${libtorch_2_5_0_cpu}/libtorch "$XDG_CACHE_HOME/libtorch"
+                        export LIBTORCH_HOME="$XDG_CACHE_HOME/libtorch"
+                        export CMAKE_PREFIX_PATH="$LIBTORCH_HOME"
                       '';
                       preBuild = (old.preBuild or "") + ''
                         export HOME="$TMPDIR"
                         export XDG_CACHE_HOME="$TMPDIR"
                         export HASKTORCH_LIB_PATH="$XDG_CACHE_HOME/libtorch/lib:$XDG_CACHE_HOME/mklml/lib/:$XDG_CACHE_HOME/libtokenizers/lib"
                         export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
+                        export LIBTORCH_SKIP_DOWNLOAD=1
+                        ln -sfn ${libtorch_2_5_0_cpu}/libtorch "$XDG_CACHE_HOME/libtorch"
+                        export LIBTORCH_HOME="$XDG_CACHE_HOME/libtorch"
+                        export CMAKE_PREFIX_PATH="$LIBTORCH_HOME"
                       '';
                       preInstall = (old.preInstall or "") + ''
                         export HOME="$TMPDIR"
                         export XDG_CACHE_HOME="$TMPDIR"
                         export HASKTORCH_LIB_PATH="$XDG_CACHE_HOME/libtorch/lib:$XDG_CACHE_HOME/mklml/lib/:$XDG_CACHE_HOME/libtokenizers/lib"
                         export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
+                        export LIBTORCH_SKIP_DOWNLOAD=1
+                        ln -sfn ${libtorch_2_5_0_cpu}/libtorch "$XDG_CACHE_HOME/libtorch"
+                        export LIBTORCH_HOME="$XDG_CACHE_HOME/libtorch"
+                        export CMAKE_PREFIX_PATH="$LIBTORCH_HOME"
                       '';
                     }))
                     dontCheck
@@ -107,18 +144,30 @@ in {
                     export XDG_CACHE_HOME="$TMPDIR"
                     export HASKTORCH_LIB_PATH="$XDG_CACHE_HOME/libtorch/lib:$XDG_CACHE_HOME/mklml/lib/:$XDG_CACHE_HOME/libtokenizers/lib"
                     export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
+                    export LIBTORCH_SKIP_DOWNLOAD=1
+                    ln -sfn ${libtorch_2_5_0_cpu}/libtorch "$XDG_CACHE_HOME/libtorch"
+                    export LIBTORCH_HOME="$XDG_CACHE_HOME/libtorch"
+                    export CMAKE_PREFIX_PATH="$LIBTORCH_HOME"
                   '';
                   preBuild = (old.preBuild or "") + ''
                     export HOME="$TMPDIR"
                     export XDG_CACHE_HOME="$TMPDIR"
                     export HASKTORCH_LIB_PATH="$XDG_CACHE_HOME/libtorch/lib:$XDG_CACHE_HOME/mklml/lib/:$XDG_CACHE_HOME/libtokenizers/lib"
                     export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
+                    export LIBTORCH_SKIP_DOWNLOAD=1
+                    ln -sfn ${libtorch_2_5_0_cpu}/libtorch "$XDG_CACHE_HOME/libtorch"
+                    export LIBTORCH_HOME="$XDG_CACHE_HOME/libtorch"
+                    export CMAKE_PREFIX_PATH="$LIBTORCH_HOME"
                   '';
                   preInstall = (old.preInstall or "") + ''
                     export HOME="$TMPDIR"
                     export XDG_CACHE_HOME="$TMPDIR"
                     export HASKTORCH_LIB_PATH="$XDG_CACHE_HOME/libtorch/lib:$XDG_CACHE_HOME/mklml/lib/:$XDG_CACHE_HOME/libtokenizers/lib"
                     export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
+                    export LIBTORCH_SKIP_DOWNLOAD=1
+                    ln -sfn ${libtorch_2_5_0_cpu}/libtorch "$XDG_CACHE_HOME/libtorch"
+                    export LIBTORCH_HOME="$XDG_CACHE_HOME/libtorch"
+                    export CMAKE_PREFIX_PATH="$LIBTORCH_HOME"
                   '';
                 });
 
@@ -134,18 +183,30 @@ in {
                         export XDG_CACHE_HOME="$TMPDIR"
                         export HASKTORCH_LIB_PATH="$XDG_CACHE_HOME/libtorch/lib:$XDG_CACHE_HOME/mklml/lib/:$XDG_CACHE_HOME/libtokenizers/lib"
                         export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
+                        export LIBTORCH_SKIP_DOWNLOAD=1
+                        ln -sfn ${libtorch_2_5_0_cpu}/libtorch "$XDG_CACHE_HOME/libtorch"
+                        export LIBTORCH_HOME="$XDG_CACHE_HOME/libtorch"
+                        export CMAKE_PREFIX_PATH="$LIBTORCH_HOME"
                       '';
                       preBuild = (old.preBuild or "") + ''
                         export HOME="$TMPDIR"
                         export XDG_CACHE_HOME="$TMPDIR"
                         export HASKTORCH_LIB_PATH="$XDG_CACHE_HOME/libtorch/lib:$XDG_CACHE_HOME/mklml/lib/:$XDG_CACHE_HOME/libtokenizers/lib"
                         export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
+                        export LIBTORCH_SKIP_DOWNLOAD=1
+                        ln -sfn ${libtorch_2_5_0_cpu}/libtorch "$XDG_CACHE_HOME/libtorch"
+                        export LIBTORCH_HOME="$XDG_CACHE_HOME/libtorch"
+                        export CMAKE_PREFIX_PATH="$LIBTORCH_HOME"
                       '';
                       preInstall = (old.preInstall or "") + ''
                         export HOME="$TMPDIR"
                         export XDG_CACHE_HOME="$TMPDIR"
                         export HASKTORCH_LIB_PATH="$XDG_CACHE_HOME/libtorch/lib:$XDG_CACHE_HOME/mklml/lib/:$XDG_CACHE_HOME/libtokenizers/lib"
                         export LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$LD_LIBRARY_PATH
+                        export LIBTORCH_SKIP_DOWNLOAD=1
+                        ln -sfn ${libtorch_2_5_0_cpu}/libtorch "$XDG_CACHE_HOME/libtorch"
+                        export LIBTORCH_HOME="$XDG_CACHE_HOME/libtorch"
+                        export CMAKE_PREFIX_PATH="$LIBTORCH_HOME"
                       '';
                     }))
                     (appendConfigureFlag

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -20,7 +20,7 @@ final: prev: let
     hash = "sha256-VFbzEB8LJiVsKIpb2KkSOdvJQY6uR9RyvratKiY8wUs=";
     stripRoot = false;
   };
-  libtokenizers = pkgs.fetchzip {
+  libtokenizers = final.fetchzip {
     name = "libtokenizers.zip";
     url = "https://github.com/hasktorch/tokenizers/releases/download/libtokenizers-v0.1/libtokenizers-linux.zip";
     hash = "sha256-F/WtJeibyyofr0wgps+1vBQ5kWF2vzaygbJbJTX3EeU=";

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -23,7 +23,7 @@ final: prev: let
   libtokenizers = final.fetchzip {
     name = "libtokenizers.zip";
     url = "https://github.com/hasktorch/tokenizers/releases/download/libtokenizers-v0.1/libtokenizers-linux.zip";
-    hash = "sha256-F/WtJeibyyofr0wgps+1vBQ5kWF2vzaygbJbJTX3EeU=";
+    hash = "sha256-9XJLgvS+j01IX2Dh+9K5J9khU/8RnS4IqwBOkf+An4g=";
     stripRoot = false; # keep the top-level "libtorch" folder
   };
 in {

--- a/setenv
+++ b/setenv
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
 
+if [ -z "${XDG_CACHE_HOME:-}" ]; then
+  export XDG_CACHE_HOME="$HOME/.cache"
+fi
+
 # execute this command if needed when building on OSX if there are linker errors.
 # dylib files in extra-lib-dirs  don't get forwarded to ghc
 # in some versions of OSX. See https://github.com/commercialhaskell/stack/issues/1826
-HASKTORCH_LIB_PATH="$XDG_CACHE_HOME/libtorch/lib/:$XDG_CACHE_HOME/mklml/lib/:$XDG_CACHE_HOME/libtokenizers/lib/"
+HASKTORCH_LIB_PATH="$XDG_CACHE_HOME/libtorch/lib:$XDG_CACHE_HOME/mklml/lib/:$XDG_CACHE_HOME/libtokenizers/lib"
 
 function add_vendor_lib_path {
     case "$(uname)" in

--- a/setup-cabal.sh
+++ b/setup-cabal.sh
@@ -28,20 +28,19 @@ USED_NUM_CPU=`echo $USED_MEM_GB $USED_NUM_CPU | awk '{if($1<$2) {print $1} else 
 USED_MEM_GB=`echo $USED_NUM_CPU | awk '{print ($1)"G"}'`
 USED_MEMX2_GB=`echo $USED_NUM_CPU | awk '{print ($1 * 2)"G"}'`
 
-
 cat <<EOF > cabal.project.local
 
 package libtorch-ffi
-  extra-include-dirs: $(pwd)/deps/libtorch/include/torch/csrc/api/include
-  extra-include-dirs: $(pwd)/deps/libtorch/include
-  extra-lib-dirs: $(pwd)/deps/libtorch/lib
+  extra-include-dirs: $XDG_CACHE_HOME/libtorch/include/torch/csrc/api/include
+  extra-include-dirs: $XDG_CACHE_HOME/libtorch/include
+  extra-lib-dirs: $XDG_CACHE_HOME/libtorch/lib
   extra-include-dirs: /opt/homebrew/include
   extra-lib-dirs: /opt/homebrew/lib
   extra-lib-dirs: /opt/homebrew/opt/libomp/lib
 
 package *
-  extra-lib-dirs: $(pwd)/deps/libtorch/lib
-  extra-lib-dirs: $(pwd)/deps/libtokenizers/lib
+  extra-lib-dirs: $XDG_CACHE_HOME/libtorch/lib
+  extra-lib-dirs: $XDG_CACHE_HOME/libtokenizers/lib
   extra-lib-dirs: /opt/homebrew/lib
   extra-lib-dirs: /opt/homebrew/opt/libomp/lib
 

--- a/spec/cppclass/gen-ivalue.sh
+++ b/spec/cppclass/gen-ivalue.sh
@@ -11,7 +11,7 @@ constructors:
 methods:
 EOF
 
-cat deps/libtorch/include/ATen/core/ivalue.h \
+cat "$XDG_CACHE_HOME/libtorch/include/ATen/core/ivalue.h" \
   | grep -vi c10 \
   | grep -vi TensorImpl \
   | perl -ne 'BEGIN{$f=0;}; {if (/struct CAFFE2_API IValue/){$f=1;}; if (/^};/ || /struct CAFFE2_API WeakIValue/){print $_;$f=0;}; if($f==1){print $_;}};' \


### PR DESCRIPTION
Various changes:
* download the required zip files in nix and place them in the runner/sandbox environments.
* pass enviroment variables to github_env so they persist between stages
* install the correct tokenizers depending on machine architecture
* for macos workflows, install packages in a virtual environment
* skip doctests for now in hasktorch. Will re-enable in a follow-up