### PR TITLE
Fixes for Nix setup

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -5,7 +5,7 @@ packages:
     hasktorch/*.cabal
     examples/*.cabal
     experimental/untyped-nlp/untyped-nlp.cabal
-    experimental/dataloader-cifar10/dataloader-cifar10.cabal
+--  experimental/dataloader-cifar10/dataloader-cifar10.cabal
     experimental/bounding-box/bounding-box.cabal
 
 -- source-repository-package
@@ -24,20 +24,20 @@ packages:
 --     location: https://github.com/hasktorch/type-errors-pretty
 --     tag: 32d7abec6a21c42a5f960d7f4133d604e8be79ec
 
-source-repository-package
-    type: git
-    location: https://github.com/hasktorch/streaming-cassava
-    tag: 1ecc4742beae22a2fe32e445a54d1990b6200249
+-- source-repository-package
+--     type: git
+--     location: https://github.com/hasktorch/streaming-cassava
+--     tag: 1ecc4742beae22a2fe32e445a54d1990b6200249
 
-source-repository-package
-    type: git
-    location: https://github.com/hasktorch/indexed-extras
-    tag: 7a0c4e918578e7620a46d4f0546fbdaec933ede0
+-- source-repository-package
+--     type: git
+--     location: https://github.com/hasktorch/indexed-extras
+--     tag: 7a0c4e918578e7620a46d4f0546fbdaec933ede0
 
-source-repository-package
-    type: git
-    location: https://github.com/hasktorch/term-rewriting
-    tag: 54221f58b28c9f36db9bac437231e6142c8cca3a
+-- source-repository-package
+--     type: git
+--     location: https://github.com/hasktorch/term-rewriting
+--     tag: 54221f58b28c9f36db9bac437231e6142c8cca3a
 
 -- 2024-04-30 fork is obsolete with union-find-array-0.1.0.4
 -- source-repository-package

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1749398372,
-        "narHash": "sha256-tYBdgS56eXYaWVW3fsnPQ/nFlgWi/Z2Ymhyu21zVM98=",
+        "lastModified": 1754487366,
+        "narHash": "sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "9305fe4e5c2a6fcf5ba6a3ff155720fbe4076569",
+        "rev": "af66ad14b28a127c5c0f3bbb298218fc63528a18",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1750386251,
-        "narHash": "sha256-1ovgdmuDYVo5OUC5NzdF+V4zx2uT8RtsgZahxidBTyw=",
+        "lastModified": 1754895929,
+        "narHash": "sha256-cHSg9CMqEx0e06UkWJLRuLlolRCgPE8zwdEp3JwYRGI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "076e8c6678d8c54204abcb4b1b14c366835a58bb",
+        "rev": "9585e9192aadc13ec3e49f33f8333bd3cda524df",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1748740939,
-        "narHash": "sha256-rQaysilft1aVMwF14xIdGS3sj1yHlI6oKQNBRTF40cc=",
+        "lastModified": 1753579242,
+        "narHash": "sha256-zvaMGVn14/Zz8hnp4VWT9xVnhc8vuL3TStRqwk22biA=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "656a64127e9d791a334452c6b6606d17539476e2",
+        "rev": "0f36c44e01a6129be94e3ade315a5883f0228a6e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -71,9 +71,17 @@
           default = self'.devShells.cpu;
           cpu = pkgs.haskell.packages.${ghc}.shellFor {
             inherit packages;
+            nativeBuildInputs = with pkgs; [
+              cabal-install
+              haskell-language-server
+            ];
           };
           cuda = pkgsCuda.haskell.packages.${ghc}.shellFor {
             inherit packages;
+            nativeBuildInputs = with pkgsCuda; [
+              cabal-install
+              haskell-language-server
+            ];
           };
         };
         apps = {

--- a/flake.nix
+++ b/flake.nix
@@ -59,14 +59,14 @@
         devShells = let
           packages = p:
             with p; [
-              codegen
-              hasktorch
               # Cannot be built until type-level-rewrite-rules supports GHC 9.8
               # hasktorch-gradually-typed
+              cabal-install
+              codegen
+              hasktorch
               libtorch-ffi
               libtorch-ffi-helper
-              cabal-install
-            ];
+            ] ++ [self'.packages.examples];
         in {
           default = self'.devShells.cpu;
           cpu = pkgs.haskell.packages.${ghc}.shellFor {

--- a/flake.nix
+++ b/flake.nix
@@ -51,7 +51,7 @@
         packages =
           {
             examples =
-              pkgs.haskell.packages.ghc965.callCabal2nix "examples"
+              pkgs.haskell.packages.${ghc}.callCabal2nix "examples"
               ./examples {};
           }
           // (mkHasktorchPackageSet "cuda" pkgsCuda)

--- a/libtorch-ffi/Setup.hs
+++ b/libtorch-ffi/Setup.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 import Data.List (isPrefixOf)
 import Distribution.Simple
 import Distribution.Simple.Program
@@ -21,6 +23,14 @@ import GHC.IO.Exception
 import Control.Exception
 import Codec.Archive.Zip
 
+#if MIN_VERSION_Cabal(3,14,0)
+import Distribution.Utils.Path (makeSymbolicPath)
+#else
+
+makeSymbolicPath :: a -> a
+makeSymbolicPath = id
+#endif
+
 main :: IO ()
 main = defaultMainWithHooks $ simpleUserHooks
   { preConf = \_ _ -> do
@@ -41,10 +51,10 @@ main = defaultMainWithHooks $ simpleUserHooks
               includeDir = libtorchDir </> "include"
 
           let updatedFlags = flags
-                { configExtraLibDirs      = libDir : configExtraLibDirs flags
+                { configExtraLibDirs      = makeSymbolicPath libDir : configExtraLibDirs flags
                 , configExtraIncludeDirs  =
-                    includeDir
-                    : (includeDir </> "torch" </> "csrc" </> "api" </> "include")
+                    makeSymbolicPath includeDir
+                    : makeSymbolicPath (includeDir </> "torch" </> "csrc" </> "api" </> "include")
                     : configExtraIncludeDirs flags
                 }
           -- Call the default configuration hook with updated flags

--- a/libtorch-ffi/libtorch-ffi.cabal
+++ b/libtorch-ffi/libtorch-ffi.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.0
 name:                libtorch-ffi
-version:             2.0.1.7
+version:             2.0.1.8
 -- The prefix(2.0) of this version("2.0.0.0") is the same as libtorch's one.
 synopsis:            Haskell bindings for PyTorch
 description:         This package provides Haskell bindings to libtorch, the C++ library underlying PyTorch, specifically designed for the Hasktorch ecosystem.

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -33,13 +33,7 @@ in {
               #     dontCheck
               #     #  disableLibraryProfiling
               #   ];
-              hasktorch =
-                lib.pipe
-                (hfinal.callCabal2nix "hasktorch" ../hasktorch {})
-                [
-                  dontCheck
-                  #  disableLibraryProfiling
-                ];
+              hasktorch = hfinal.callCabal2nix "hasktorch" ../hasktorch {};
               libtorch-ffi-helper = hfinal.callCabal2nix "libtorch-ffi-helper" ../libtorch-ffi-helper {};
               libtorch-ffi =
                 lib.pipe


### PR DESCRIPTION
This PR makes changes based on #744 and allows users to build the main libraries hasktorch, libtorch-ffi, codegen and examples using both Nix and cabal. It also adds `cabal-install` and `haskell-language-server` to the devshell for easier development.  