### PR TITLE
Add gradWithOptions

### DIFF
--- a/hasktorch/hasktorch.cabal
+++ b/hasktorch/hasktorch.cabal
@@ -107,7 +107,7 @@ library
   cpp-options:        -D__APPLE__
  build-depends:       async >= 2.2.5 && < 2.3
                     , base >= 4.7 && < 5
-                    , libtorch-ffi == 2.0.1.*
+                    , libtorch-ffi >= 2.0.1.10 && < 2.0.2
                     , libtorch-ffi-helper == 2.0.0.*
                     , finite-typelits >= 0.1 && < 0.3
                     , ghc-typelits-extra >= 0.4.6 && < 0.5

--- a/libtorch-ffi/libtorch-ffi.cabal
+++ b/libtorch-ffi/libtorch-ffi.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.0
 name:                libtorch-ffi
-version:             2.0.1.9
+version:             2.0.1.10
 -- The prefix(2.0) of this version("2.0.0.0") is the same as libtorch's one.
 synopsis:            Haskell bindings for PyTorch
 description:         This package provides Haskell bindings to libtorch, the C++ library underlying PyTorch, specifically designed for the Hasktorch ecosystem.

--- a/libtorch-ffi/src/Torch/Internal/Managed/Autograd.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Autograd.hs
@@ -14,6 +14,8 @@ import Foreign.C.Types (CBool)
 grad :: ForeignPtr Tensor -> ForeignPtr TensorList -> IO (ForeignPtr TensorList)
 grad = _cast2 Unmanaged.grad
 
+gradWithOptions :: Bool -> Bool -> Bool -> ForeignPtr Tensor -> ForeignPtr TensorList -> IO (ForeignPtr TensorList)
+gradWithOptions = _cast5 Unmanaged.gradWithOptions
 
 makeIndependent :: ForeignPtr Tensor -> CBool -> IO (ForeignPtr Tensor)
 makeIndependent = _cast2 Unmanaged.makeIndependent


### PR DESCRIPTION
See https://github.com/hasktorch/hasktorch/issues/765 .

```
$ cabal repl hasktorch
ghci> import Torch.Autograd
ghci> import Data.Default.Class
ghci> x = ones' [1]
ghci> x' <- makeIndependent x
ghci> grad ((toDependent x')^3) [x']
[Tensor Float [1] [ 3.0000   ]]
ghci> grad (head $ grad ((toDependent x')^3) [x']) [x']
Cannot show stacktrace
Differentiated tensor not require grad*** Exception: CppStdException e "Differentiated tensor not require grad"(Just "std::runtime_error")
ghci> grad (head $ gradWithOptions (def {createGraph = True }) ((toDependent x')^3) [x']) [x']
[Tensor Float [1] [ 6.0000   ]]
```