### PR TITLE
Expose parameter group interface

### DIFF
--- a/hasktorch/src/Torch/Optim/CppOptim.hs
+++ b/hasktorch/src/Torch/Optim/CppOptim.hs
@@ -241,3 +241,42 @@ saveState (CppOptimizerState _ optimizer) file = cast2 LibTorch.save optimizer f
 
 loadState :: CppOptimizerState option -> FilePath -> IO ()
 loadState (CppOptimizerState _ optimizer) file = cast2 LibTorch.load optimizer file
+
+data AdamwParamGroupOptions = AdamwParamGroupOptions
+  { adamwPgLr :: Double,
+    adamwPgBetas :: (Double, Double),
+    adamwPgEps :: Double,
+    adamwPgWeightDecay :: Double,
+    adamwPgAmsgrad :: Bool
+  }
+  deriving (Show, Eq)
+
+instance Default AdamwParamGroupOptions where
+  def =
+    AdamwParamGroupOptions
+      { adamwPgLr = 1e-3,
+        adamwPgBetas = (0.9, 0.999),
+        adamwPgEps = 1e-8,
+        adamwPgWeightDecay = 1e-2,
+        adamwPgAmsgrad = False
+      }
+
+initAdamwWithGroups :: AdamwParamGroupOptions -> [Tensor] -> [Tensor] -> IO (CppOptimizerState AdamwParamGroupOptions)
+initAdamwWithGroups opt@AdamwParamGroupOptions {..} decayParams noDecayParams = do
+  v <- cast8 LibTorch.adamwWithParamGroups adamwPgLr (fst adamwPgBetas) (snd adamwPgBetas) adamwPgEps adamwPgWeightDecay adamwPgAmsgrad decayParams noDecayParams
+  return $ CppOptimizerState opt v
+
+cppOptimizerStepOnly :: CppOptimizerState option -> IO ()
+cppOptimizerStepOnly (CppOptimizerState _ optimizer) = cast1 LibTorch.stepOnly optimizer
+
+cppOptimizerZeroGrad :: CppOptimizerState option -> IO ()
+cppOptimizerZeroGrad (CppOptimizerState _ optimizer) = cast1 LibTorch.zeroGrad optimizer
+
+cppOptimizerSetGrads :: CppOptimizerState option -> [Tensor] -> IO ()
+cppOptimizerSetGrads (CppOptimizerState _ optimizer) grads = cast2 LibTorch.setParamGrads optimizer grads
+
+cppOptimizerGetAllParams :: CppOptimizerState option -> IO [Tensor]
+cppOptimizerGetAllParams (CppOptimizerState _ optimizer) = cast1 LibTorch.getAllParams optimizer
+
+cppOptimizerSetLr :: CppOptimizerState option -> Double -> IO ()
+cppOptimizerSetLr (CppOptimizerState _ optimizer) lr = cast2 LibTorch.setLr optimizer lr

--- a/libtorch-ffi/src/Torch/Internal/Managed/Optim.hs
+++ b/libtorch-ffi/src/Torch/Internal/Managed/Optim.hs
@@ -148,3 +148,30 @@ save = _cast2 Unmanaged.save
 
 load :: ForeignPtr Optimizer -> ForeignPtr StdString -> IO ()
 load = _cast2 Unmanaged.load
+
+adamwWithParamGroups
+  :: CDouble
+  -> CDouble
+  -> CDouble
+  -> CDouble
+  -> CDouble
+  -> CBool
+  -> ForeignPtr TensorList
+  -> ForeignPtr TensorList
+  -> IO (ForeignPtr Optimizer)
+adamwWithParamGroups = _cast8 Unmanaged.adamwWithParamGroups
+
+getAllParams :: ForeignPtr Optimizer -> IO (ForeignPtr TensorList)
+getAllParams = _cast1 Unmanaged.getAllParams
+
+stepOnly :: ForeignPtr Optimizer -> IO ()
+stepOnly = _cast1 Unmanaged.stepOnly
+
+zeroGrad :: ForeignPtr Optimizer -> IO ()
+zeroGrad = _cast1 Unmanaged.zeroGrad
+
+setParamGrads :: ForeignPtr Optimizer -> ForeignPtr TensorList -> IO ()
+setParamGrads = _cast2 Unmanaged.setParamGrads
+
+setLr :: ForeignPtr Optimizer -> CDouble -> IO ()
+setLr = _cast2 Unmanaged.setLr

--- a/libtorch-ffi/src/Torch/Internal/Unmanaged/Optim.hs
+++ b/libtorch-ffi/src/Torch/Internal/Unmanaged/Optim.hs
@@ -261,10 +261,17 @@ lbfgs lr max_iter max_eval tolerance_grad tolerance_change history_size (Just li
     return dynamic_cast<torch::optim::Optimizer*>(optimizer);
   }|]
 
-getParams :: Ptr Optimizer -> IO (Ptr TensorList) 
+getParams :: Ptr Optimizer -> IO (Ptr TensorList)
 getParams optimizer =
   [C.throwBlock| std::vector<at::Tensor>* {
-    return new std::vector<at::Tensor>($(torch::optim::Optimizer* optimizer)->param_groups().at(0).params());
+    auto optimizer = $(torch::optim::Optimizer* optimizer);
+    std::vector<at::Tensor>* result = new std::vector<at::Tensor>();
+    for(auto& group : optimizer->param_groups()){
+      for(auto& p : group.params()){
+        result->push_back(p);
+      }
+    }
+    return result;
   }|]
 
 step :: Ptr Optimizer -> (Ptr TensorList -> IO (Ptr Tensor)) -> IO (Ptr Tensor)
@@ -280,7 +287,13 @@ step optimizer lossFunc =
         auto func = (Func)tfunc;
         auto v = optimizer->step([&]{
           optimizer->zero_grad();
-          auto loss = func(&(optimizer->param_groups().at(0).params()));
+          std::vector<at::Tensor> all_params;
+          for(auto& group : optimizer->param_groups()){
+            for(auto& p : group.params()){
+              all_params.push_back(p);
+            }
+          }
+          auto loss = func(&all_params);
           loss->backward();
           return *loss;
         });
@@ -304,7 +317,13 @@ stepWithGenerator optimizer generator lossFunc =
         auto func = (Func)tfunc;
         auto v = optimizer->step([&]{
           optimizer->zero_grad();
-          auto lossWithGenerator = func(&(optimizer->param_groups().at(0).params()),&generator);
+          std::vector<at::Tensor> all_params;
+          for(auto& group : optimizer->param_groups()){
+            for(auto& p : group.params()){
+              all_params.push_back(p);
+            }
+          }
+          auto lossWithGenerator = func(&all_params,&generator);
           auto loss = std::get<0>(*lossWithGenerator);
           generator = std::get<1>(*lossWithGenerator);
           loss.backward();
@@ -326,7 +345,13 @@ unsafeStep optimizer loss =
     optimizer->zero_grad();
     loss->backward();
     optimizer->step();
-    return new std::vector<at::Tensor>(optimizer->param_groups().at(0).params());
+    std::vector<at::Tensor>* result = new std::vector<at::Tensor>();
+    for(auto& group : optimizer->param_groups()){
+      for(auto& p : group.params()){
+        result->push_back(p);
+      }
+    }
+    return result;
   }|]
 
 save :: Ptr Optimizer -> Ptr StdString -> IO ()
@@ -341,4 +366,95 @@ load optimizer filename =
   [C.throwBlock| void {
     std::ifstream input(*$(std::string* filename));
     torch::load(*$(torch::optim::Optimizer* optimizer),input);
+  }|]
+
+adamwWithParamGroups
+  :: CDouble
+  -> CDouble
+  -> CDouble
+  -> CDouble
+  -> CDouble
+  -> CBool
+  -> Ptr TensorList
+  -> Ptr TensorList
+  -> IO (Ptr Optimizer)
+adamwWithParamGroups adamLr adamBetas0 adamBetas1 adamEps adamWeightDecay adamAmsgrad decayParams noDecayParams =
+  [C.throwBlock| torch::optim::Optimizer* {
+    std::vector<at::Tensor>* decay_params = $(std::vector<at::Tensor>* decayParams);
+    std::vector<at::Tensor>* no_decay_params = $(std::vector<at::Tensor>* noDecayParams);
+    std::vector<at::Tensor> dp;
+    for(int i=0;i<decay_params->size();i++){
+      dp.push_back((*decay_params)[i].detach().set_requires_grad(true));
+    }
+    std::vector<at::Tensor> ndp;
+    for(int i=0;i<no_decay_params->size();i++){
+      ndp.push_back((*no_decay_params)[i].detach().set_requires_grad(true));
+    }
+    auto options_decay = torch::optim::AdamWOptions()
+      .lr($(double adamLr))
+      .betas(std::make_tuple($(double adamBetas0),$(double adamBetas1)))
+      .eps($(double adamEps))
+      .weight_decay($(double adamWeightDecay))
+      .amsgrad($(bool adamAmsgrad));
+    auto options_no_decay = torch::optim::AdamWOptions()
+      .lr($(double adamLr))
+      .betas(std::make_tuple($(double adamBetas0),$(double adamBetas1)))
+      .eps($(double adamEps))
+      .weight_decay(0.0)
+      .amsgrad($(bool adamAmsgrad));
+    std::vector<torch::optim::OptimizerParamGroup> param_groups;
+    param_groups.emplace_back(torch::optim::OptimizerParamGroup(ndp, std::make_unique<torch::optim::AdamWOptions>(options_no_decay)));
+    param_groups.emplace_back(torch::optim::OptimizerParamGroup(dp, std::make_unique<torch::optim::AdamWOptions>(options_decay)));
+    torch::optim::AdamW* optimizer = new torch::optim::AdamW(param_groups);
+    optimizer->zero_grad();
+    return dynamic_cast<torch::optim::Optimizer*>(optimizer);
+  }|]
+
+getAllParams :: Ptr Optimizer -> IO (Ptr TensorList)
+getAllParams optimizer =
+  [C.throwBlock| std::vector<at::Tensor>* {
+    auto optimizer = $(torch::optim::Optimizer* optimizer);
+    std::vector<at::Tensor>* result = new std::vector<at::Tensor>();
+    for(auto& group : optimizer->param_groups()){
+      for(auto& p : group.params()){
+        result->push_back(p);
+      }
+    }
+    return result;
+  }|]
+
+stepOnly :: Ptr Optimizer -> IO ()
+stepOnly optimizer =
+  [C.throwBlock| void {
+    $(torch::optim::Optimizer* optimizer)->step();
+  }|]
+
+zeroGrad :: Ptr Optimizer -> IO ()
+zeroGrad optimizer =
+  [C.throwBlock| void {
+    $(torch::optim::Optimizer* optimizer)->zero_grad();
+  }|]
+
+setParamGrads :: Ptr Optimizer -> Ptr TensorList -> IO ()
+setParamGrads optimizer grads =
+  [C.throwBlock| void {
+    auto optimizer = $(torch::optim::Optimizer* optimizer);
+    auto grads = $(std::vector<at::Tensor>* grads);
+    int idx = 0;
+    for(auto& group : optimizer->param_groups()){
+      for(auto& p : group.params()){
+        p.mutable_grad() = (*grads)[idx];
+        idx++;
+      }
+    }
+  }|]
+
+setLr :: Ptr Optimizer -> CDouble -> IO ()
+setLr optimizer newLr =
+  [C.throwBlock| void {
+    auto optimizer = $(torch::optim::Optimizer* optimizer);
+    for(auto& group : optimizer->param_groups()){
+      auto& options = static_cast<torch::optim::AdamWOptions&>(group.options());
+      options.lr($(double newLr));
+    }
   }|]


### PR DESCRIPTION
I need a way to access parameter group as described in [torch.optim](https://docs.pytorch.org/docs/stable/optim.html) to implement per-parameter weight decay in AdamW. I couldn't find an existing way to do that that is in line with the PyTorch convention. This is a draft to showcase an implementation that works in my case. Is there a better way to do this with Hasktorch's conventions?