### PR TITLE
Revive tutorial deployment on master

### DIFF
--- a/.github/workflows/cabal-linux.yml
+++ b/.github/workflows/cabal-linux.yml
@@ -111,6 +111,17 @@ jobs:
         name: tutorial
         path: public/tutorial
 
+    # Same deployment the (now dead-commented) stack-linux step performed
+    # until 2024-01: publish the rendered tutorial to the website repository.
+    - name: Deploy tutorial
+      if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+      uses: peaceiris/actions-gh-pages@v4
+      with:
+        deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+        external_repository: hasktorch/hasktorch.github.io
+        publish_branch: tutorial
+        publish_dir: ./public
+
     # - name: Benchmark
     #   run: |
     #     cabal v2-bench hasktorch:runtime --benchmark-options='--output benchmark-runtime.html'


### PR DESCRIPTION
Auto-deployment to hasktorch.github.io (branch tutorial) worked until 2024-01 and died with tintin; the tutorial renders again since #515, so restore the deploy step on cabal-linux (same key/repo/branch/layout, gh-pages action v4).