### PR TITLE
Make the attention training spec deterministic

### DIFF
--- a/hasktorch/test/Torch/Typed/AttentionSpec.hs
+++ b/hasktorch/test/Torch/Typed/AttentionSpec.hs
@@ -24,6 +24,7 @@ import Data.List (elemIndices)
 import Data.Vector.Sized (Vector)
 import GHC.Generics (Generic)
 import Test.Hspec
+import Torch.Internal.Managed.Type.Context (manual_seed_L)
 import Prelude
 import qualified Torch.DType as D
 import qualified Torch.Device as D
@@ -124,7 +125,7 @@ predictions m = map argmaxRow (UT.asValue (toDynamic (gptForward m tokens)) :: [
     argmaxRow row = head (elemIndices (maximum row) row)
 
 spec :: Spec
-spec = describe "a decoder block, equation by equation" $ do
+spec = describe "a decoder block, equation by equation" $ beforeAll_ (manual_seed_L 42) $ do
   it "the causal mask never lets position i attend to j > i" $ do
     let m = UT.asValue (toDynamic causalMask) :: [[Float]]
     and [m !! i !! j == 0 | i <- [0 .. 7], j <- [0 .. i]] `shouldBe` True
@@ -140,5 +141,5 @@ spec = describe "a decoder block, equation by equation" $ do
         [1 .. 1000 :: Int]
     let loss1 = toFloat (lossOf trained)
     loss0 `shouldSatisfy` (> 0.5) -- untrained: near ln 4 ≈ 1.39
-    loss1 `shouldSatisfy` (< 0.1) -- trained: near zero
+    loss1 `shouldSatisfy` (< 0.2) -- trained: near zero
     predictions trained `shouldBe` [1, 2, 3, 0, 1, 2, 3, 0]


### PR DESCRIPTION
The 'learns next-token prediction' test trained from random init with a tight threshold and no seed, so it was flaky — it failed master's cabal-linux run 30197365297 with code that passed the run before. Pin the ATen seed and relax the trained-loss threshold to 0.2; the exact-prediction assertion remains the strong check.