### PR TITLE
Drop the deploy-key push; the website deploys itself from the artifact

### DIFF
--- a/.github/workflows/cabal-linux.yml
+++ b/.github/workflows/cabal-linux.yml
@@ -111,16 +111,10 @@ jobs:
         name: tutorial
         path: public/tutorial
 
-    # Same deployment the (now dead-commented) stack-linux step performed
-    # until 2024-01: publish the rendered tutorial to the website repository.
-    - name: Deploy tutorial
-      if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-      uses: peaceiris/actions-gh-pages@v4
-      with:
-        deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
-        external_repository: hasktorch/hasktorch.github.io
-        publish_branch: tutorial
-        publish_dir: ./public
+    # The tutorial artifact uploaded above is consumed by
+    # hasktorch/hasktorch.github.io's deploy-pages workflow, which assembles
+    # the website (haddocks + tutorial) and deploys it branchlessly via
+    # actions/deploy-pages.  No deploy key is involved.
 
     # - name: Benchmark
     #   run: |


### PR DESCRIPTION
The revived peaceiris deploy failed (the ACTIONS_DEPLOY_KEY expired
some time after 2024-01), and it turns out the tutorial branch it
pushed to was never served directly anyway - the site serves master,
so the old pipeline additionally relied on a manual merge.
hasktorch.github.io now has a branchless deploy-pages workflow that
downloads this workflow's `tutorial` artifact and assembles the site,
with no secrets on either side.  cabal-linux only needs to keep
uploading the artifact.

