### PR TITLE
Add tutorial Part V: data pipelines, optimizers, saving and loading

### DIFF
--- a/hasktorch/doc/16-data-pipelines.md
+++ b/hasktorch/doc/16-data-pipelines.md
@@ -1,0 +1,204 @@
+---
+title: Data Pipelines
+---
+
+# Data Pipelines
+
+Every training loop so far generated its batches on the fly. Real
+datasets live in files, are bigger than memory, and need to be
+decoded, shuffled, and batched while the GPU is busy with the
+previous batch. `Torch.Data` is Hasktorch's answer: streaming data
+loaders built on [pipes](https://hackage.haskell.org/package/pipes),
+which read in constant memory and prefetch on background threads.
+
+```haskell top hide
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+import Inliterate.Import (AskInliterate)
+```
+
+```haskell top
+import Control.Monad (foldM)
+import Control.Monad.Cont (runContT)
+import Control.Monad.IO.Class (liftIO)
+import qualified Data.Vector as V
+import GHC.Generics (Generic)
+import Pipes (ListT, enumerate)
+import qualified Pipes.Prelude as P
+import Pipes.Safe (SafeT, runSafeT)
+import Torch
+import Torch.Data.CsvDatastream
+import Torch.Data.StreamedPipeline (datastreamOpts, streamFrom')
+```
+
+```haskell top hide
+instance AskInliterate Tensor
+instance AskInliterate Point
+```
+
+## Two kinds of dataset
+
+`Torch.Data` mirrors the two dataset notions of PyTorch. A
+*map-style* dataset is indexed — it knows its keys and can fetch any
+sample directly (PyTorch's `Dataset`):
+
+```haskell
+class Ord k => Dataset m dataset k sample where
+  getItem :: dataset -> k -> m sample
+  keys :: dataset -> Set k
+```
+
+A *datastream* is only a stream — samples arrive in whatever order
+the source produces them, which is all you can ask of a file being
+read front to back, a network socket, or an infinite generator
+(PyTorch's `IterableDataset`):
+
+```haskell
+class Monad m => Datastream m seed dataset sample where
+  streamSamples :: dataset -> seed -> ListT m sample
+```
+
+Both are consumed the same way: a `streamFrom` function turns the
+dataset into a `ListT` of samples — an ordinary pipes stream — and
+the training loop is a fold over it. Nothing dataset-specific leaks
+into the loop.
+
+## CSV files decode into records
+
+The most common concrete datastream is `CsvDatastream` from
+`Torch.Data.CsvDatastream`. It decodes rows with
+[cassava](https://hackage.haskell.org/package/cassava), so a row
+schema is an ordinary Haskell record — the same move the named-tensor
+chapter made for dimensions, applied to files:
+
+```haskell top
+data Point = Point
+  { px :: Float,
+    py :: Float
+  }
+  deriving (Generic, Show, FromRecord)
+```
+
+Let's make ourselves a small CSV file with points on the line
+\(y = 3x + 1\):
+
+```haskell do
+writeFile "/tmp/points.csv" $
+  unlines [show x ++ "," ++ show (3 * x + 1) | x <- [0.0, 0.01 .. 2.0 :: Float]]
+```
+
+A datastream over it is a value describing *how* to read the file —
+nothing is opened yet:
+
+```haskell top
+stream :: CsvDatastream Point
+stream = (csvDatastream "/tmp/points.csv") {batchSize = 16}
+```
+
+`streamFrom'` runs it. The stream lives in `SafeT IO` (from
+`pipes-safe`) so the file handle is released even if the consumer
+dies, and the result comes as a continuation (`runContT`) that scopes
+the background prefetch thread. The stream yields batches — here
+`V.Vector Point` of length 16:
+
+```haskell do
+batches <- runSafeT $
+  runContT (streamFrom' datastreamOpts stream [()]) $ \input ->
+    P.toListM (enumerate input)
+```
+
+```haskell eval
+length batches
+```
+
+```haskell eval
+V.toList (V.take 3 (head batches))
+```
+
+## Training is a fold over the stream
+
+An epoch folds a model over the batches; `Pipes.Prelude.foldM` is the
+loop. Batches become tensors with plain list conversions:
+
+```haskell top
+toBatch :: V.Vector Point -> (Tensor, Tensor)
+toBatch b = (asTensor (map ((: []) . px) l), asTensor (map py l))
+  where
+    l = V.toList b
+
+trainEpoch :: Linear -> ListT (SafeT IO) (V.Vector Point) -> SafeT IO Linear
+trainEpoch model input = P.foldM step (pure model) pure (enumerate input)
+  where
+    step m batch = do
+      let (xs, ys) = toBatch batch
+          loss = mseLoss ys (squeezeAll (linear m xs))
+      fst <$> liftIO (runStep m GD loss 1e-1)
+```
+
+Epochs re-run the stream from the top — the datastream value is
+reusable, so an epoch loop is just `foldM` over epoch numbers:
+
+```haskell do
+model0 <- sample (LinearSpec 1 1)
+trained <- runSafeT $
+  foldM
+    (\m _epoch -> runContT (streamFrom' datastreamOpts stream [()]) (trainEpoch m))
+    model0
+    [1 .. 20 :: Int]
+```
+
+The file said \(y = 3x + 1\); the model should agree (`Torch.NN`
+uses duplicate record fields across its layer types, so we match the
+`Linear` constructor positionally instead of using the `weight` and
+`bias` accessors):
+
+```haskell do
+let Linear w b = trained
+```
+
+```haskell eval
+toDependent w
+```
+
+```haskell eval
+toDependent b
+```
+
+## Shuffling, prefetch, and parallelism
+
+Everything above streamed sequentially. The knobs:
+
+- **Shuffling.** `stream {bufferedShuffle = Just 1000}` keeps a
+  buffer of 1000 records, yielding random elements from it as it
+  refills — the streaming compromise, since a true shuffle would need
+  the whole file. (Our file is sorted by `x`, so for real training
+  you would want this; a buffer at least the file's size gives a full
+  shuffle.) Map-style datasets can do better: `streamFromMap` takes a
+  random generator and visits *keys* in shuffled order.
+- **Prefetch.** `datastreamOpts` has a `bufferSize` (default 4):
+  batches are produced on a background thread into a bounded queue,
+  so decoding the next batch overlaps with training on the current
+  one.
+- **Sharding.** The `[()]` we passed is the list of *seeds*. Each
+  seed starts its own concurrent copy of the stream, and the streams
+  are interleaved — seeds can be file shards, worker ids, or random
+  generators. For CSV there is one file, so one unit seed.
+- **Parallel preprocessing.** `Torch.Data.Utils.pmap` maps a
+  function over a stream on its own thread (the iris example uses it
+  to move record-to-tensor conversion off the training thread), and
+  `collate` regroups sample streams into batches.
+
+`dropLast` (default `True`) discards a final ragged batch, which is
+why 201 rows became 12 batches of 16 rather than 12 and a half.
+
+## Where to look next
+
+The [iris-classification](https://github.com/hasktorch/hasktorch/tree/master/examples/iris-classification)
+example is this chapter on a real file; the
+[static-mnist](https://github.com/hasktorch/hasktorch/tree/master/examples/static-mnist)
+examples stream MNIST through the same interface with the typed API,
+using the loader from `Torch.Vision`. The next chapter looks at what
+the fold does with each batch: the [optimizers](17-optimizers.html).

--- a/hasktorch/doc/17-optimizers.md
+++ b/hasktorch/doc/17-optimizers.md
@@ -1,0 +1,184 @@
+---
+title: Optimizers
+---
+
+# Optimizers
+
+Every training loop in this tutorial ends in the same line:
+
+```haskell
+(model', optim') <- runStep model optim loss learningRate
+```
+
+This chapter is about what stands behind that line. Hasktorch ships
+two optimizer families with the same interface: purely functional
+optimizers written in Haskell, whose state is an ordinary value, and
+bindings to libtorch's C++ optimizers, which update parameters
+in place. They are interchangeable in the loop — we will run the
+exact same code with both — but they make opposite trade-offs.
+
+```haskell top hide
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+import Inliterate.Import (AskInliterate)
+```
+
+```haskell top
+import Data.Default.Class (def)
+import GHC.Generics (Generic)
+import Torch
+import Torch.Optim.CppOptim
+```
+
+```haskell top hide
+instance AskInliterate Tensor
+```
+
+## The interface
+
+```haskell
+class Optimizer optimizer where
+  step :: LearningRate -> Gradients -> [Tensor] -> optimizer -> ([Tensor], optimizer)
+  runStep :: Parameterized model
+          => model -> optimizer -> Loss -> LearningRate -> IO (model, optimizer)
+```
+
+`step` is the mathematical content: given gradients and parameters,
+produce new parameters and the optimizer's next state. `runStep`
+wraps it with the autograd call (`grad'`) and the flattening of the
+model record into a parameter list — that is the line the training
+loops use.
+
+A test problem hard enough to tell optimizers apart — the Rosenbrock
+banana function, whose minimum at \((1, 1)\) hides at the end of a
+long, curved, nearly-flat valley:
+
+```haskell top
+data XY = XY {x :: Parameter, y :: Parameter}
+  deriving (Generic, Show, Parameterized)
+
+rosenbrock :: XY -> Tensor
+rosenbrock XY {..} = (1 - x') ^ 2 + 100 * (y' - x' * x') ^ 2
+  where
+    x' = toDependent x
+    y' = toDependent y
+
+optimize :: Optimizer o => o -> LearningRate -> Int -> XY -> IO (XY, o)
+optimize opt lr steps p0 = foldLoop (p0, opt) steps $
+  \(p, o) _ -> runStep p o (rosenbrock p) lr
+
+result :: XY -> Tensor
+result XY {..} = stack (Dim 0) [toDependent x, toDependent y]
+```
+
+## Optimizer state is a value
+
+The Haskell-side optimizers live in `Torch.Optim`: `GD`, `GDM`
+(momentum), `Adagrad`, `Adam`, `AdamW`. Their state is a plain
+record — `GD` has none, `GDM` carries momentum tensors, `Adam`
+carries its two moment estimates and a step counter (built with
+`mkAdam`, which needs the parameter list to size those tensors):
+
+```haskell do
+p0 <- XY <$> makeIndependent (asTensor (-1.2 :: Float))
+         <*> makeIndependent (asTensor (1.0 :: Float))
+(gdP, _) <- optimize GD 1e-3 2000 p0
+(adamP, adamState) <- optimize (mkAdam 0 0.9 0.999 (flattenParameters p0)) 2e-2 2000 p0
+```
+
+Starting from the classic \((-1.2, 1)\), after 2000 steps each —
+gradient descent is still crawling along the valley floor:
+
+```haskell eval
+result gdP
+```
+
+while Adam's per-coordinate step sizes have carried it to within a
+few percent of the minimum:
+
+```haskell eval
+result adamP
+```
+
+Because the optimizer state is a value, there is nothing hidden to
+manage: checkpointing an optimizer is saving a record of tensors,
+inspecting it is pattern matching. Adam's internal step counter, for
+instance, is right there:
+
+```haskell eval
+iter adamState
+```
+
+The price is allocation: every step builds fresh parameter and state
+tensors and the old ones become garbage.
+
+## The C++ optimizers update in place
+
+`Torch.Optim.CppOptim` binds libtorch's native optimizers — SGD,
+Adagrad, RMSprop, Adam, AdamW, and L-BFGS, which has no Haskell-side
+counterpart. Each is configured by an options record with a
+`Data.Default` instance, and `initOptimizer` registers the model's
+parameters with a C++ optimizer object:
+
+```haskell do
+p1 <- XY <$> makeIndependent (asTensor (-1.2 :: Float))
+         <*> makeIndependent (asTensor (1.0 :: Float))
+cppAdam <- initOptimizer (def {adamLr = 2e-2} :: AdamOptions) p1
+(cppP, _) <- optimize cppAdam 0 2000 p1
+```
+
+```haskell eval
+result cppP
+```
+
+It lands on the same numbers as the pure Adam run above, up to
+floating-point noise — same algorithm, same trajectory.
+
+Note what did *not* change: `optimize` is the same function, because
+`CppOptimizerState` has an `Optimizer` instance. Two differences hide
+in that call, though. The learning rate argument is ignored — the `0`
+above is a dummy, because a C++ optimizer's hyperparameters live in
+its options (change them mid-run with `cppOptimizerSetLr`).
+And the step is genuinely in-place: the parameter tensors now live
+inside the C++ optimizer, which overwrites them on every step. The
+model returned by `runStep` is rebuilt around those same tensors, so
+the *old* model value silently changes too — the underlying binding
+is honestly named `unsafeStep`. Keep only the newest model and this
+never bites; keep a history of models for comparison and it will.
+In exchange, a step allocates nothing new for parameters or state,
+which for large models means less garbage-collector pressure and a
+smaller resident set. (`runStep` also nudges the collector each step
+— `performGC` plus a `malloc_trim` — so that memory held by dead
+foreign tensors actually returns to the OS during training.)
+
+## Parameter groups
+
+PyTorch training recipes routinely split parameters into groups —
+the classic case is AdamW with weight decay on the weights but *not*
+on biases and normalization parameters. The AdamW binding exposes
+this: `initAdamwWithGroups` takes the decayed and undecayed parameter
+lists separately, and per-group learning rates can be scheduled
+afterwards:
+
+```haskell
+optim <- initAdamwWithGroups (def {adamwPgWeightDecay = 1e-2}) decayed undecayed
+cppOptimizerSetGroupLr optim 0 (lr * warmupFactor)
+```
+
+This is the piece you need to port a modern transformer training
+recipe faithfully; the pure optimizers have no equivalent yet.
+
+## Choosing
+
+Use the **pure optimizers** when you want the state visible — for
+teaching, for reproducibility experiments, for checkpointing as
+ordinary values, or with the typed API, where `Torch.Typed.Optim`
+provides typed `GD`/`GDM`/`Adam`. Use the **C++ optimizers** when
+throughput and memory matter, when you need L-BFGS or parameter
+groups, or when you are matching a PyTorch training run
+step-for-step (`Torch.Typed.Optim.CppOptim` wraps them for the typed
+API too). The training loop does not care which you picked — which is
+the point of `runStep` being a typeclass method.

--- a/hasktorch/doc/18-serialization.md
+++ b/hasktorch/doc/18-serialization.md
@@ -1,0 +1,119 @@
+---
+title: Saving and Loading
+---
+
+# Saving and Loading
+
+A trained model that dies with its process was never trained. This
+chapter covers Hasktorch's serialization story: checkpointing models
+from Haskell, and — since the weights are ordinary libtorch tensors —
+exchanging them with PyTorch in both directions.
+
+```haskell top hide
+{-# LANGUAGE ScopedTypeVariables #-}
+import Inliterate.Import (AskInliterate)
+```
+
+```haskell top
+import Torch
+import Torch.Script (IValue (..))
+import Torch.Serialize
+```
+
+```haskell top hide
+instance AskInliterate Tensor
+instance AskInliterate IValue
+instance AskInliterate Bool
+```
+
+## Checkpointing a model
+
+`Torch.Serialize.saveParams` writes any `Parameterized` model — the
+same typeclass the optimizers flatten with — and `loadParams` reads
+one back. Loading is functional: you give it a model value of the
+right shape to serve as the skeleton, and it returns a *new* value
+with the stored parameters in place:
+
+```haskell do
+model <- sample (LinearSpec 3 1)
+saveParams model "/tmp/linear-checkpoint.pt"
+
+fresh <- sample (LinearSpec 3 1)
+restored <- loadParams fresh "/tmp/linear-checkpoint.pt"
+```
+
+The freshly sampled model disagrees with the original, the restored
+one is exact:
+
+```haskell do
+let probe = asTensor [[1, 2, 3 :: Float]]
+```
+
+```haskell eval
+[linear model probe, linear fresh probe, linear restored probe]
+```
+
+That is the whole checkpointing API. The file holds the flattened
+parameter list, so it does not remember your record's field names —
+which is fine for save-and-resume with the same code, and is exactly
+the underlying `save`/`load` pair, which serialize a bare `[Tensor]`
+when you have no model record at all.
+
+## Interop with PyTorch: pickle
+
+For crossing the language border there is a second format. PyTorch
+checkpoints are pickled dictionaries — `torch.save(model.state_dict(),
+path)` — and `Torch.Serialize` speaks it directly through the
+`IValue` type from the TorchScript bindings
+([chapter 15](15-torchscript-and-jit.html)): `pickleSave` and
+`pickleLoad` map dictionaries to `IVGenericDict`, tensors to
+`IVTensor`, and so on. A state dict is built by hand from the
+parameters and their names:
+
+```haskell do
+let Linear w b = model
+    stateDict =
+      IVGenericDict
+        [ (IVString "weight", IVTensor (toDependent w)),
+          (IVString "bias", IVTensor (toDependent b))
+        ]
+pickleSave stateDict "/tmp/state_dict.pth"
+reloaded <- pickleLoad "/tmp/state_dict.pth"
+```
+
+```haskell eval
+reloaded
+```
+
+The file we just wrote is a regular PyTorch checkpoint; on the Python
+side it loads with plain `torch.load`:
+
+```python
+>>> torch.load("/tmp/state_dict.pth")
+{'weight': tensor([[...]]), 'bias': tensor([...])}
+```
+
+The reverse direction works the same — save from Python with
+`torch.save(dict(model.state_dict()), path)` (the `dict(...)` matters:
+an `OrderedDict` subclass confuses the unpickler), then `pickleLoad`
+it and match on the `IVGenericDict` to pull tensors out by name.
+Names and shapes are yours to reconcile with your Haskell record;
+for shipping a *whole* model rather than weights — architecture
+included — TorchScript's `torch.jit.trace` plus
+`Torch.Script.loadScript` is the better vehicle, as chapter 15 shows.
+
+## The typed API
+
+`Torch.Typed.Serialize` mirrors the untyped pair: `saveParameters`
+and `loadParameters` work on any typed model whose parameters
+flatten to an `HList` of tensors, and `loadParametersWithSpec`
+builds the model from its spec and the file in one step. The shapes
+in the model's type must match what was saved — the file format
+cannot check this for you, but the surrounding program is checked as
+always, so a shape mismatch surfaces at the load site rather than
+mid-training.
+
+One honest caveat applies to every format here: loading a checkpoint
+executes no code, but pickle files from untrusted sources are still
+untrusted input to a C++ parser — treat model files with the same
+care as any other binary you download.

--- a/hasktorch/doc/index.md
+++ b/hasktorch/doc/index.md
@@ -58,11 +58,20 @@ derived from them.
 
 15. [TorchScript and the JIT](15-torchscript-and-jit.html) — tracing models from Haskell, and measured reality about fusion
 
+## Part V — Training in practice
+
+The engineering around the math: getting data in, updating
+parameters efficiently, and getting trained models out.
+
+16. [Data Pipelines](16-data-pipelines.html) — streaming datasets in constant memory: CSV rows as records, shuffling, prefetch
+17. [Optimizers](17-optimizers.html) — purely functional optimizers whose state is a value, and libtorch's in-place ones; when each wins
+18. [Saving and Loading](18-serialization.html) — checkpoints, and pickle interop with PyTorch in both directions
+
 Chapters 1–6 assume no Haskell type-level programming at all.
 Chapters 7–10 use type-level naturals and records. Chapters 11–15 are
-where the research-flavoured ideas live — each grounded in code that
-is compiled, executed, and tested in CI, with the rendered output on
-these very pages.
+where the research-flavoured ideas live, and 16–18 need only Part I
+again — every chapter is grounded in code that is compiled, executed,
+and tested in CI, with the rendered output on these very pages.
 
 Looking for a reference? See the [API docs][api-docs] hosted on
 [hasktorch.org][hasktorch-org].


### PR DESCRIPTION
Three chapters on the engineering the tutorial had skipped, each with live, executed examples:

- 16 Data Pipelines: Dataset vs Datastream, CSV rows decoded into records with cassava, a training fold over a streamed file, and the shuffle/prefetch/sharding knobs.
- 17 Optimizers: the pure Haskell optimizers whose state is a plain value and libtorch's in-place C++ optimizers, run through the same runStep loop on the Rosenbrock function (Adam reaches the minimum the same way in both, GD demonstrably crawls); honest notes on unsafeStep's in-place semantics and AdamW parameter groups.
- 18 Saving and Loading: saveParams/loadParams checkpointing, and state-dict interop with PyTorch in both directions via pickleSave/pickleLoad and IValue.