### PR TITLE
Fix duplicate LC_RPATH crash for dynamic executables on macOS

### DIFF
--- a/libtorch-ffi/Setup.hs
+++ b/libtorch-ffi/Setup.hs
@@ -64,9 +64,17 @@ main = defaultMainWithHooks $ simpleUserHooks
           -- Call the default configuration hook with updated flags
           lbi <- confHook simpleUserHooks (gpd, hbi) updatedFlags
           
-          -- Add RPath so the binary finds the libs at runtime
+          -- Add RPath so the binary finds the libs at runtime.
+          --
+          -- Exception: for dynamically-linked executables on macOS, Cabal
+          -- already emits an rpath entry for every extra-lib-dir, so adding
+          -- one here produces a binary with a duplicate LC_RPATH — which
+          -- recent dyld rejects at load time ("duplicate LC_RPATH ...").
+          let dynExe = fromFlagOrDefault False (configDynExe flags)
           case buildOS of
-            OSX -> return $ lbi { withPrograms = addRPath libDir $ addLdClassicFlag (withPrograms lbi) }
+            OSX
+              | dynExe -> return $ lbi { withPrograms = addLdClassicFlag (withPrograms lbi) }
+              | otherwise -> return $ lbi { withPrograms = addRPath libDir $ addLdClassicFlag (withPrograms lbi) }
             Linux -> return $ lbi { withPrograms = addRPath libDir (withPrograms lbi) }
             _ -> return $ lbi
   }


### PR DESCRIPTION
cabal-macos has failed on every master merge since 3b4f543c: the libtorch-ffi test binary dies at load with

  dyld: duplicate LC_RPATH '~/.cache/libtorch/2.9.1/macos-arm64/cpu/lib'

The duplication has two sources: Setup.hs adds the libtorch lib dir as an rpath via -optl, and, because the repo's cabal.project sets executable-dynamic: True, Cabal itself also emits an rpath entry for every extra-lib-dir on darwin.  Older dyld tolerated the duplicate; the current macos-latest runner image rejects it at load time, which is why the job was green on 2026-06-03 and red on the next master push seven weeks later with no relevant change in between.  stack is unaffected because it does not build dynamic executables.

Skip the manual rpath when configDynExe is set on macOS; Cabal's own entry already covers it.  Static configurations keep the manual rpath, and Linux is unchanged (duplicate DT_RUNPATH entries are harmless there).