### PR TITLE
Add vmap, vmap2, and vscan to Torch.Typed.Representable

### DIFF
--- a/hasktorch/doc/08-named-tensors.md
+++ b/hasktorch/doc/08-named-tensors.md
@@ -177,3 +177,39 @@ and shape inside a structure — a `'[3, 4]` layer sitting next to a
 structure*", which is what makes targeted surgery on a model — swap
 these embeddings, freeze that projection — expressible as one
 traversal.
+
+## Lineage: "Tensor Considered Harmful"
+
+The case for named dimensions was made by Alexander Rush's essay
+[Tensor Considered Harmful](https://blog.rush-nlp.com/named-tensor.html)
+(2019, with the `namedtensor` library; it later grew into the *Named
+Tensor Notation* paper and PyTorch's experimental named tensors). The
+essay diagnoses three traps of positional tensors — dimensions kept
+private *by convention* only, broadcasting *by alignment* rather than
+by meaning, and access *by comments* (`# batch x height x width`) —
+and proposes a discipline: dimensions get human-readable names, no
+function takes a `dim` argument, broadcasting matches by name, and
+positional indexing is banned.
+
+Hasktorch's named tensors are that proposal pushed one level up: the
+names live in the *types*, so the discipline is checked by the
+compiler instead of at runtime.
+
+| Tensor Considered Harmful | Hasktorch |
+|---|---|
+| names are runtime strings: `("batch", "height", …)` | names are types: `'[Batch n, Height, Width]` — misspelling one is a compile error, and each name carries its *size* |
+| `.mean("batch")` — "no function should have a dim argument" | `meanNamedDim @Batch`, `sumNamedDim @Batch`, `sortNamedDim @Seq` — `FindDim` locates the axis by name at compile time |
+| broadcasting by name matching, checked when the op runs | shapes are types, so an inconsistent combination fails to *compile*; underneath, execution still uses positional kernels |
+| "ban dimension based indexing" | indexing is by one bounds-checked `Finite` per named dimension (`index t (b :. h :. HNil)`, chapter section above) |
+| `.split(h=…)` / `.stack(bh=…)` reshape by name | `dimGroup` / `dimUngroup` name a compound axis (`Compose (Vector 3) RGB`), and `dimUp` / `dimDown` go further — the dimension becomes actual Haskell structure ([chapter 12](12-dimensions.html)) |
+| "private dimensions should be protected": a rotation should not know about `batch` | `vmap` and `emapS` take functions written against the *element* shape only; the batch dimension does not appear in their types at all ([chapter 12](12-dimensions.html)) |
+| names should impose no runtime cost | `NamedTensor` is a zero-cost wrapper over the positional tensor; every name is erased at compile time |
+
+Two things here have no counterpart in the essay. Names are
+*structured*: a dimension can be a record (`RGB`), so its positions
+are fields you can pattern-match — the essay's names identify an
+axis, but cannot give its positions meanings. And the static setting
+changes what "checking" means: the essay's names are verified while
+the program runs, per operation; here a shape mistake is a type
+error before anything runs, which is also why the names can be
+erased completely.

--- a/hasktorch/doc/11-graded-and-staged.md
+++ b/hasktorch/doc/11-graded-and-staged.md
@@ -95,6 +95,14 @@ two instantiations of a formula built from `+`, `*`, comparisons and
 `whereE` agree bit-for-bit (IEEE basic operations are deterministic);
 only transcendental functions differ within float tolerance.
 
+The element of an `emap` need not be a scalar: `emapS` and
+`ezipWithS` read the *trailing dimensions* of a tensor as the inside
+of a compound element — a batch of triangles `'[Batch n, Vector 3,
+RGB]` becomes a batch of `Vector 3 (RGB a)` values, and a polymorphic
+function on that structure runs once, vectorized over the batch. The
+[Moving Dimensions chapter](12-dimensions.html) demonstrates this
+where it compares transparency with `vmap`.
+
 ## Case study: non-maximum suppression
 
 `Torch.Typed.Vision` implements NMS in this style. The whole

--- a/hasktorch/doc/12-dimensions.md
+++ b/hasktorch/doc/12-dimensions.md
@@ -40,6 +40,7 @@ import Torch (Tensor)
 import Data.Default.Class (Default, def)
 import Data.Vector.Sized (Vector)
 import GHC.Generics (Generic)
+import Data.Functor.Compose (Compose, getCompose)
 import Torch.HList
 import qualified Torch.Typed as T
 import Torch.Typed.Representable
@@ -214,6 +215,47 @@ reach without tracing is `vmap`-fusing an *arbitrary opaque* slice
 function; for the structured-element case, unrolling gets you there
 today.
 
+### Naming a compound dimension
+
+The triangle's two axes can also be *one* dimension with a name. A
+partially applied `Compose` is a legal shape entry whose size is the
+product of its factors (`ToNat (Compose f g) = ToNat f * ToNat g`,
+following hasktorch-naperian's `Size (Compose f g) = Size f * Size g`
+instance), and since it needs no type argument, an ordinary nullary
+synonym names it:
+
+```haskell top
+type TriangleDim = Compose (Vector 3) RGB
+```
+
+`dimGroup` moves between the factored and the grouped spelling — it
+is a `reshape`, so no data moves:
+
+```haskell do
+let gTris = dimGroup tris :: T.NamedTensor '( 'T.CPU, 0) 'T.Float '[Vector 2, TriangleDim]
+```
+
+```haskell eval
+T.toDynamic gTris
+```
+
+The nine positions are row-major over (vertex, channel), matching
+`Log (Compose f g) = (Log f, Log g)`. Everything in this chapter
+works on the grouped dimension — `dimUp` yields `Compose`-wrapped
+structure, and `emapS` sees the same triangle element behind one
+`getCompose`:
+
+```haskell eval
+T.toDynamic (emapS @'[TriangleDim] @'[Vector 3] (fmap (\(RGB r' g' b' ) -> (r' + g' + b') / 3) . getCompose) gTris)
+```
+
+`dimUngroup` is the exact inverse. (If you prefer a `newtype
+Triangle a = Triangle (Vector 3 (RGB a))` for the element view, it
+works too — a newtype does not unify with its contents, so `coerce`
+it at the formula boundary; only the *shape* entry needs to be the
+`Compose` spelling, because dimension sizes are computed by the
+closed `ToNat` family, which cannot see through user newtypes.)
+
 ### Recurrence: `vscan`
 
 The same door admits JAX's other structural primitive. `vscan` folds
@@ -315,6 +357,71 @@ lets you pick a point on it — including the middle: group nodes by
 depth, `dimDown` each level into a batch axis, and process level by
 level, which recovers most of the batching without giving up the
 typed structure.
+
+## Which tool when?
+
+This chapter and the [staged chapter](11-graded-and-staged.html) have
+accumulated a family of ways to "apply a function under a dimension",
+and they can blur together. Two questions separate them:
+
+1. **What is the element** — a scalar, a small *static* structure
+   (vertices, gates, channels), or a whole slice of arbitrary size?
+2. **Is the function transparent** — a polymorphic formula the
+   library can reinterpret at the tensor type — **or opaque** — an
+   ordinary monomorphic Haskell function it cannot look inside?
+
+Transparent functions execute *once*, as fused whole-tensor kernels,
+whatever the batch size. Opaque functions must be *called once per
+position*. Everything below is placed by those two answers.
+
+| You write | Element | Function | Execution | Reach for it when |
+|---|---|---|---|---|
+| plain ops: `t + u`, `matmul`, `sigmoid` | — | fixed op | fused / broadcast | the operation already exists and broadcasts; **always the first choice** |
+| `sumNamedDim @d`, `meanNamedDim @d`, … | one axis | fixed op | one kernel | reducing or sorting *one dimension, addressed by name*, wherever it sits |
+| `emap`, `ezipWith` | scalar | transparent formula | one kernel per operation in the formula | a per-element formula with branching (`whereE`) that should double as its own `Float` reference |
+| `emapS`, `ezipWithS` | static structure | transparent formula | as `emap`, plus one `select`/`stack` per position of the structure | per-vertex / per-gate math: pattern match fields, fold over the structure, still no batch loop |
+| `gbindV` | scalar + output index | transparent formula | one formula evaluation per *inner* index | generating new dimensions whose values depend on the output position |
+| `vmap`, `vmap2` | whole slice | **opaque** | one call per position | somebody else's function, a whole model forward, or slices whose shapes differ between the two arguments |
+| `vscan` | whole slice | **opaque** | sequential by definition | recurrences: RNN cells, cumulative statistics along an axis |
+| `dimUp` / `dimDown` | — | — | `unbind` / `stack` | positions need *different code by name* (gates), or structure enters/leaves the tensor (tree children) |
+| `dimGroup` / `dimUngroup` | — | — | free (`reshape`) | renaming: two axes become one named compound axis, or back |
+
+Concrete tasks, mapped:
+
+- *Scale and shift every value; add two tensors* — plain ops. If you
+  find yourself writing `vmap (\x -> x * 2)`, stop: pointwise
+  operations broadcast on their own.
+- *Mean over the class axis, wherever it is in the shape* —
+  `meanNamedDim @Classes`. No `vmap`, no transposes.
+- *A custom activation with a branch, trusted because the same code
+  runs per-element at `Float` in the tests* — `emap`
+  ([chapter 11](11-graded-and-staged.html)'s worked NMS example is
+  this at scale).
+- *Per-vertex color math on a batch of triangles* — `emapS`, as
+  above: field names and folds instead of slice arithmetic, one
+  interpretation for the whole batch.
+- *Run a trained per-example forward pass under a `Batch` dimension*
+  — `vmap (forward model)`. The model is opaque; per-position calls
+  are the honest price, and they are cheap when each call is a whole
+  forward pass.
+- *Exponential moving average over a time axis; unrolling an RNN
+  cell* — `vscan`. Sequential is what a recurrence *means*; no tool
+  removes that.
+- *Four LSTM gates, each with its own nonlinearity* — one fused
+  matmul, then `dimUp` and field names (the Tree-LSTM below).
+- *Give `'[Vector 3, RGB]` a single name* — `type TriangleDim =
+  Compose (Vector 3) RGB` and `dimGroup`. Purely a naming operation;
+  the data never moves.
+
+Rules of thumb, compressed: **prefer the highest row that fits.**
+Moving down the table trades fusion for generality — `emap` beats
+`emapS` beats `vmap` in kernels launched, and `vmap` beats manual
+loops in nothing but convenience. The structured tools (`emapS`,
+`dimUp`) are for *small, static* structure; if the "structure" has
+thousands of positions, it is a tensor dimension and should stay one.
+And when a formula can be written transparently, it should be — not
+only for fusion, but because the `Float` instantiation is the
+reference implementation your tests get for free.
 
 ## Lineage
 

--- a/hasktorch/doc/12-dimensions.md
+++ b/hasktorch/doc/12-dimensions.md
@@ -23,6 +23,7 @@ positions differently.
 ```haskell top hide
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -42,6 +43,7 @@ import GHC.Generics (Generic)
 import Torch.HList
 import qualified Torch.Typed as T
 import Torch.Typed.Representable
+import Torch.Typed.Staged (emapS)
 ```
 
 ```haskell top hide
@@ -51,7 +53,7 @@ instance AskInliterate Tensor
 ## Channels by name
 
 ```haskell top
-data RGB a = RGB { r :: a, g :: a, b :: a } deriving (Show, Generic, Default)
+data RGB a = RGB { r :: a, g :: a, b :: a } deriving (Show, Generic, Functor, Default)
 ```
 
 ```haskell do
@@ -175,8 +177,42 @@ boundary), and in exchange the function may be anything at all,
 including shape-changing. Transparent and fast, or opaque and
 general: JAX's `vmap` refuses the choice by *tracing* — every
 function is made transparent at run time, then rewritten by batching
-rules. Doing that for whole-tensor functions here is the natural
-extension of the staged chapter's move, not a current feature.
+rules.
+
+There is a middle point, and it ships: when the element structure is
+*small and static*, tracing is unnecessary because the structure can
+simply be unrolled. `emapS` (from `Torch.Typed.Staged`) reads the
+trailing dimensions of a tensor as the inside of a compound element.
+A batch of triangles — three vertices, each an RGB value — is
+`'[Vector 2, Vector 3, RGB]`, or equally a 2-vector of `Triangle a =
+Vector 3 (RGB a)` elements, and a polymorphic function on `Triangle`
+runs once, vectorized over the batch:
+
+```haskell do
+let tris = tabulate (\(k :. i :. c :. HNil) ->
+                       fromIntegral (fromEnum k) * 100 + fromIntegral (fromEnum i) * 10 + fromIntegral (fromEnum c))
+             :: T.NamedTensor '( 'T.CPU, 0) 'T.Float '[Vector 2, Vector 3, RGB]
+    lum = emapS @'[Vector 3, RGB] @'[Vector 3]
+            (fmap (\(RGB r' g' b') -> (r' + g' + b') / 3))
+            tris
+```
+
+```haskell eval
+T.toDynamic lum
+```
+
+The formula pattern-matches on fields and folds over vertices like
+any Haskell function — but because it is polymorphic
+(`forall a. (Floating a, Cond a) => Triangle a -> Vector 3 a`), it is
+interpreted once at the tensor type: each scalar operation in it is
+one whole-batch kernel, nine `select`s in, three `stack`s out, and
+*no* per-batch-element loop. The same formula at `a = Float` is the
+per-triangle reference implementation — the oracle discipline as
+always. `ezipWithS` is the two-argument version (per-vertex distances
+between two batches of triangles, say). What remains genuinely out of
+reach without tracing is `vmap`-fusing an *arbitrary opaque* slice
+function; for the structured-element case, unrolling gets you there
+today.
 
 ### Recurrence: `vscan`
 

--- a/hasktorch/doc/12-dimensions.md
+++ b/hasktorch/doc/12-dimensions.md
@@ -36,7 +36,7 @@ import Torch (Tensor)
 ```
 
 ```haskell top
-import Data.Default.Class (Default)
+import Data.Default.Class (Default, def)
 import Data.Vector.Sized (Vector)
 import GHC.Generics (Generic)
 import Torch.HList
@@ -110,6 +110,125 @@ T.toDynamic gu
 
 After the split, each gate takes its *own* nonlinearity —
 `sigmoid gi`, `tanh gu` — selected by field name, not by offset.
+
+## `vmap`, `scan`, `grad`: the JAX trio
+
+Once a dimension can move between tensor and structure, JAX's `vmap`
+is one composition away, and `Torch.Typed.Representable` provides it:
+
+```haskell
+vmap :: (NamedTensor device dtype shape  -> NamedTensor device' dtype' shape')
+     ->  NamedTensor device dtype (f ': shape)
+     ->  NamedTensor device' dtype' (f ': shape')
+```
+
+`vmap g` applies `g` to every position of the outermost dimension,
+with *per-position semantics*: each slice is handed to `g` on its
+own, exactly as if you had written `dimDown . fmap g . dimUp` — that
+equation is the specification, and the test suite holds `vmap` to it.
+The function may change the shape under the mapped dimension; the
+dimension itself survives in the type. Summing away the pixel axis of
+each channel of the image from above:
+
+```haskell do
+let sums = vmap (T.sumNamedDim @(Vector 4)) img
+```
+
+```haskell eval
+T.toDynamic sums
+```
+
+The input had shape `'[RGB, Vector 4]`, the per-channel function maps
+`'[Vector 4]` to a scalar `'[]`, and the result is `'[RGB]` — the
+compiler tracked the mapped axis through the whole trip, with no
+annotation needed. `vmap2` is the two-argument version, zipping along
+a shared dimension whose *type* is what guarantees the two sides
+agree in length.
+
+For this particular job, though, named dimensions already made `vmap`
+unnecessary: `sumNamedDim` targets its dimension by *name*, wherever
+it sits, so the reduction works directly on the full tensor —
+
+```haskell eval
+T.toDynamic (T.sumNamedDim @(Vector 4) img)
+```
+
+— and that is the general pattern. Name-directed operations
+(`sumNamedDim`, `meanNamedDim`, `sortNamedDim`, …) and broadcasting
+pointwise math cover the cases JAX users reach for `vmap` first.
+`vmap` earns its keep when the per-slice function is a *black box* —
+a whole forward pass under a `Batch` dimension, an arbitrary pipeline
+somebody else wrote.
+
+### `vmap` and `emap` are the same idea, split by transparency
+
+The [staged chapter](11-graded-and-staged.html)'s `emap` also lifts a
+function over "everything under a dimension" — there, a scalar
+formula over every element. The difference is what the lifted
+function *is*. `emap` takes a polymorphic formula
+(`forall a. (Floating a, Cond a) => a -> a`), which it can interpret
+symbolically: one interpretation at the tensor type runs the whole
+thing as a handful of fused, vectorized kernels. `vmap` takes an
+opaque Haskell function, which it cannot look inside — so it must
+call it once per position (an `unbind` and a `stack` at the
+boundary), and in exchange the function may be anything at all,
+including shape-changing. Transparent and fast, or opaque and
+general: JAX's `vmap` refuses the choice by *tracing* — every
+function is made transparent at run time, then rewritten by batching
+rules. Doing that for whole-tensor functions here is the natural
+extension of the staged chapter's move, not a current feature.
+
+### Recurrence: `vscan`
+
+The same door admits JAX's other structural primitive. `vscan` folds
+a carry along the dimension and stacks the intermediate carries — a
+recurrence, processed sequentially because that is what a recurrence
+means:
+
+```haskell
+vscan :: (carry -> slice -> carry) -> carry
+      -> NamedTensor device dtype (f ': shape) -> NamedTensor device' dtype' (f ': shape')
+```
+
+Running sums along the channel axis:
+
+```haskell do
+let running = vscan (+) def img
+```
+
+```haskell eval
+T.toDynamic running
+```
+
+The rows are `r`, `r + g`, `r + g + b`: the last position of a scan
+is the fold. An RNN unrolled over a `Vector n` time axis is exactly
+`vscan cell h0`.
+
+### Differentiating through it all
+
+`unbind` and `stack` are ordinary autograd ops, so gradients flow
+through `vmap` and `vscan` with nothing special. Weighting the pixel
+axis with a trainable parameter and pushing a scalar loss backwards:
+
+```haskell do
+w <- T.makeIndependent (T.ones :: T.CPUTensor 'T.Float '[4])
+let wn = T.fromUnnamed (T.toDependent w) :: T.NamedTensor '( 'T.CPU, 0) 'T.Float '[Vector 4]
+    total = T.sumNamedDim @(Vector 4) (T.sumNamedDim @RGB (vmap (\c -> c * wn) img))
+    gw :. HNil = T.grad (T.toUnnamed total) (w :. HNil)
+```
+
+```haskell eval
+T.toDynamic gw
+```
+
+The loss is `img · w` summed over every channel and pixel, so its
+gradient in `w` is the per-pixel sums over channels — the same
+numbers the scan's last row just showed. One seam is visible in this snippet and worth
+naming: the parameter enters the named world through
+`fromUnnamed`, because parameters (`Parameter`, `makeIndependent`)
+live in the positional typed API and there is no named parameter type
+yet. That conversion is internals showing through — the missing
+piece, not the idiom.
 
 ## Trees: the dimension that cannot be an axis
 

--- a/hasktorch/src/Torch/TensorFactories.hs
+++ b/hasktorch/src/Torch/TensorFactories.hs
@@ -2,6 +2,7 @@
 
 module Torch.TensorFactories where
 
+import Data.Default.Class
 import Foreign.ForeignPtr
 import System.IO.Unsafe
 import Torch.Dimname
@@ -256,6 +257,13 @@ ones' = mkDefaultFactory ones
 
 zeros' :: [Int] -> Tensor
 zeros' = mkDefaultFactory zeros
+
+-- | The default tensor is a zero-dimensional zero.  This mainly serves
+-- generic machinery that needs a placeholder tensor to replace (e.g. building
+-- a record of tensors with "Torch.Lens"), mirroring the typed
+-- @Default (Tensor device dtype shape)@ instance in "Torch.Typed.Factories".
+instance Default Tensor where
+  def = zeros' []
 
 randIO' :: [Int] -> IO Tensor
 randIO' = mkDefaultFactory randIO

--- a/hasktorch/src/Torch/Typed/Functional.hs
+++ b/hasktorch/src/Torch/Typed/Functional.hs
@@ -368,6 +368,30 @@ meanNamedDim input = unsafePerformIO $ ATen.cast2 ATen.Managed.mean_tl input _di
   where
     _dim = natValI @(FindDim dim shape)
 
+-- | Computes the sum and reduces the tensor over the specified named
+-- dimension.  The dimension is addressed by its type, wherever it sits in
+-- the shape.
+--
+-- >>> import Torch.Typed.Factories
+-- >>> import Data.Default.Class
+-- >>> t = def :: NamedTensor '( D.CPU, 0) 'D.Float '[Vector 3, Vector 4, Vector 5]
+-- >>> dtype &&& shape $ sumNamedDim @(Vector 4) t
+-- (Float,[3,5])
+sumNamedDim ::
+  forall dim shape' shape dtype dtype' device.
+  ( KnownNat (FindDim dim shape),
+    shape' ~ DropNamedValue shape dim,
+    SumDTypeIsValid device dtype,
+    dtype' ~ SumDType dtype
+  ) =>
+  -- | input
+  NamedTensor device dtype shape ->
+  -- | output
+  NamedTensor device dtype' shape'
+sumNamedDim input = unsafePerformIO $ ATen.cast2 ATen.Managed.sum_tl input _dim
+  where
+    _dim = natValI @(FindDim dim shape)
+
 -- | Computes the mean and optionally reduces the tensor over the specified dimension.
 --
 -- See https://pytorch.org/docs/stable/torch.html#torch.mean for more information.

--- a/hasktorch/src/Torch/Typed/Representable.hs
+++ b/hasktorch/src/Torch/Typed/Representable.hs
@@ -52,6 +52,20 @@ module Torch.Typed.Representable
     -- same names.
     dimUp,
     dimDown,
+
+    -- * Mapping under a dimension
+    --
+    -- | 'vmap' applies a function on tensors of shape @shape@ to every
+    -- position of a tensor of shape @f ': shape@ — JAX's @vmap@, with the
+    -- mapped dimension tracked in the type.  Semantically it is
+    --
+    -- > vmap g == dimDown . fmap g . dimUp
+    --
+    -- for any 'Functor' @f@, but it never materialises the @f@-structure, so
+    -- it needs no instances and @f@ may change nothing but the type.
+    vmap,
+    vmap2,
+    vscan,
   )
 where
 
@@ -221,3 +235,79 @@ dimDown =
     . F.stack (F.Dim 0)
     . map toDynamic
     . flattenValues (types @(NamedTensor device dtype shape))
+
+-- | Map a tensor function over the outermost dimension, with per-position
+-- semantics: each slice is passed to the function on its own, exactly as if
+-- the dimension were a Haskell structure.  The function may change the
+-- shape, dtype, and device of the slices; the mapped dimension @f@ is
+-- preserved.
+--
+-- Use it when the function does /not/ already broadcast — a per-example
+-- model applied under a @Batch@ dimension, a reduction applied under a time
+-- dimension.  Pointwise operations broadcast on their own and need no
+-- 'vmap'.
+--
+-- The cost model is honest rather than clever: one call of the function per
+-- position (libtorch @unbind@ / @stack@ at the boundary, no copies of the
+-- slices themselves).  That is negligible when the function is a whole
+-- forward pass and wasteful when it is a single op — there is no batching-
+-- rule rewriter behind it.
+vmap ::
+  forall f shape shape' dtype dtype' device device'.
+  (NamedTensor device dtype shape -> NamedTensor device' dtype' shape') ->
+  NamedTensor device dtype (f ': shape) ->
+  NamedTensor device' dtype' (f ': shape')
+vmap g =
+  fromUnnamed
+    . UnsafeMkTensor
+    . F.stack (F.Dim 0)
+    . map (toDynamic . g . fromUnnamed . UnsafeMkTensor)
+    . flip I.unbind 0
+    . toDynamic
+
+-- | Zip two tensors along a shared outermost dimension.  The dimension @f@
+-- being the same type on both sides is what guarantees the slice counts
+-- match.
+vmap2 ::
+  forall f shapeA shapeB shape' dtypeA dtypeB dtype' device device'.
+  ( NamedTensor device dtypeA shapeA ->
+    NamedTensor device dtypeB shapeB ->
+    NamedTensor device' dtype' shape'
+  ) ->
+  NamedTensor device dtypeA (f ': shapeA) ->
+  NamedTensor device dtypeB (f ': shapeB) ->
+  NamedTensor device' dtype' (f ': shape')
+vmap2 g t u =
+  fromUnnamed . UnsafeMkTensor . F.stack (F.Dim 0) $
+    zipWith
+      (\a b -> toDynamic (g (fromUnnamed (UnsafeMkTensor a)) (fromUnnamed (UnsafeMkTensor b))))
+      (I.unbind (toDynamic t) 0)
+      (I.unbind (toDynamic u) 0)
+
+-- | Carry state along the outermost dimension — JAX's @scan@.  The step
+-- function folds a carry through the positions in order, and the carries are
+-- stacked as the result, one per position: the outermost slice of the result
+-- at the last position is the fold's final value.
+--
+-- This is the shape of recurrence — an RNN unrolled over a @Vector n@ time
+-- axis is @vscan cell h0@ — and like 'vmap' it is honest about cost: the
+-- positions are processed sequentially, which is what a recurrence means.
+-- Gradients flow through it; @unbind@ and @stack@ are ordinary autograd ops.
+vscan ::
+  forall f shape shape' dtype dtype' device.
+  ( NamedTensor device dtype' shape' ->
+    NamedTensor device dtype shape ->
+    NamedTensor device dtype' shape'
+  ) ->
+  NamedTensor device dtype' shape' ->
+  NamedTensor device dtype (f ': shape) ->
+  NamedTensor device dtype' (f ': shape')
+vscan step c0 =
+  fromUnnamed
+    . UnsafeMkTensor
+    . F.stack (F.Dim 0)
+    . map toDynamic
+    . tail
+    . scanl (\c x -> step c (fromUnnamed (UnsafeMkTensor x))) c0
+    . flip I.unbind 0
+    . toDynamic

--- a/hasktorch/src/Torch/Typed/Representable.hs
+++ b/hasktorch/src/Torch/Typed/Representable.hs
@@ -52,6 +52,8 @@ module Torch.Typed.Representable
     -- same names.
     dimUp,
     dimDown,
+    dimGroup,
+    dimUngroup,
 
     -- * Mapping under a dimension
     --
@@ -71,6 +73,7 @@ where
 
 import Data.Default.Class (Default (..))
 import Data.Finite (Finite, getFinite, packFinite)
+import Data.Functor.Compose (Compose (..))
 import Data.Kind (Type)
 import Data.Proxy (Proxy (..))
 import Data.Vector.Sized (Vector)
@@ -205,6 +208,45 @@ instance HasTypes a t => HasTypes (Vector n a) t where
 
 instance (KnownNat n, Default a) => Default (Vector n a) where
   def = V.replicate def
+
+-- ('HasTypes' needs no such instance: 'Compose' is 'Generic', so the generic
+-- traversal already reaches through it.)
+instance Default (f (g a)) => Default (Compose f g a) where
+  def = Compose def
+
+-- | Merge two adjacent dimensions under a leading (batch) dimension into one
+-- named by their composition: @'[Batch n, Vector 3, RGB]@ becomes
+-- @'[Batch n, Compose (Vector 3) RGB]@, a dimension of size @3 * 3@.  A
+-- partially applied type constructor is a legal shape entry, so the composite
+-- can be named with an ordinary nullary synonym:
+--
+-- > type Triangle = Compose (Vector 3) RGB
+-- > dimGroup t :: NamedTensor device dtype '[Batch n, Triangle]
+--
+-- The leading dimension stays put — the same convention as 'vmap' and
+-- 'Torch.Typed.Staged.emapS', whose compound elements this names.  The data
+-- does not move (this is a @reshape@), and the flat index order is row-major,
+-- matching hasktorch-naperian's @Log (Compose f g) = (Log f, Log g)@.
+dimGroup ::
+  forall b f g shape device dtype.
+  NamedTensor device dtype (b ': f ': g ': shape) ->
+  NamedTensor device dtype (b ': Compose f g ': shape)
+dimGroup t =
+  case D.shape (toDynamic t) of
+    (n : a : b' : rest) -> fromUnnamed (UnsafeMkTensor (D.reshape (n : (a * b') : rest) (toDynamic t)))
+    _ -> error "dimGroup: tensor has fewer than three dimensions"
+
+-- | Split a composed dimension back into its two factors.  Inverse of
+-- 'dimGroup'.
+dimUngroup ::
+  forall b f g shape device dtype.
+  (KnownNat (ToNat f), KnownNat (ToNat g)) =>
+  NamedTensor device dtype (b ': Compose f g ': shape) ->
+  NamedTensor device dtype (b ': f ': g ': shape)
+dimUngroup t =
+  case D.shape (toDynamic t) of
+    (n : _ : rest) -> fromUnnamed (UnsafeMkTensor (D.reshape (n : natValI @(ToNat f) : natValI @(ToNat g) : rest) (toDynamic t)))
+    _ -> error "dimUngroup: tensor has fewer than two dimensions"
 
 -- | Move the outermost dimension out of the tensor: the result is the
 -- dimension's functor, holding one smaller tensor per position.  With

--- a/hasktorch/src/Torch/Typed/Staged.hs
+++ b/hasktorch/src/Torch/Typed/Staged.hs
@@ -47,15 +47,37 @@ module Torch.Typed.Staged
     emap,
     ezipWith,
 
+    -- * Structured elements
+    --
+    -- | 'emapS' and 'ezipWithS' generalize 'emap'\/'ezipWith' from scalar
+    -- elements to /structured/ elements: the trailing dimensions of a tensor
+    -- are read as the inside of a compound element.  A batch of triangles,
+    -- each described by three vertices with RGB values, is
+    -- @'[Batch n, Vector 3, RGB]@ — or equally a tensor of shape
+    -- @'[Batch n]@ whose elements are @Vector 3 (RGB a)@.  The 'Nested'
+    -- family maps between the two readings.
+    Nested,
+    ExplodeShape (..),
+    emapS,
+    ezipWithS,
+
     -- * Staged graded bind
     gbindV,
   )
 where
 
+import Data.Default.Class (Default (..))
+import Data.Kind (Type)
+import Data.Maybe (fromJust)
 import Data.Proxy (Proxy (..))
+import Data.Vector.Sized (Vector)
+import qualified Data.Vector.Sized as V
+import GHC.TypeLits (KnownNat)
 import Torch.Elementwise (Cond (..))
 import qualified Torch.Functional as F
+import qualified Torch.Functional.Internal as I
 import Torch.HList (HList, type (++))
+import Torch.Lens (HasTypes, flattenValues, replaceValues, types)
 import qualified Torch.Tensor as D
 import Torch.Typed.Graded (TensorMonad, fromNamed, toNamed)
 import Torch.Typed.Representable
@@ -81,6 +103,90 @@ ezipWith ::
   NamedTensor device dtype shape ->
   NamedTensor device dtype shape
 ezipWith f x y = fromUnnamed . UnsafeMkTensor $ f (toDynamic x) (toDynamic y)
+
+-- | The element type a trailing shape describes: @Nested '[Vector 3, RGB] a@
+-- is @Vector 3 (RGB a)@.  Because the family reduces structurally, formulas
+-- may be written against ordinary type synonyms like
+-- @type Triangle a = Vector 3 (RGB a)@.
+type family Nested (shape :: Shape) (a :: Type) :: Type where
+  Nested '[] a = a
+  Nested (f ': fs) a = f (Nested fs a)
+
+-- | Shapes whose dimensions can be unrolled into (and re-rolled from) actual
+-- Haskell structure, one tensor component per position.  The tensors handled
+-- here always keep one leading batch dimension; 'explode' peels the trailing
+-- dimensions off into structure, so each component has the batch dimension
+-- only.
+class ExplodeShape (sh :: Shape) where
+  explode :: D.Tensor -> Nested sh D.Tensor
+  implode :: Nested sh D.Tensor -> D.Tensor
+
+instance ExplodeShape '[] where
+  explode = id
+  implode = id
+
+instance (KnownNat n, ExplodeShape fs) => ExplodeShape (Vector n ': fs) where
+  explode t = fromJust . V.fromList $ map (explode @fs) (I.unbind t 1)
+  implode v = F.stack (F.Dim 1) (map (implode @fs) (V.toList v))
+
+instance
+  {-# OVERLAPS #-}
+  ( Default (g (Nested fs D.Tensor)),
+    HasTypes (g (Nested fs D.Tensor)) (Nested fs D.Tensor),
+    ExplodeShape fs
+  ) =>
+  ExplodeShape (g ': fs)
+  where
+  explode t = replaceValues (types @(Nested fs D.Tensor)) def (map (explode @fs) (I.unbind t 1))
+  implode s = F.stack (F.Dim 1) (map (implode @fs) (flattenValues (types @(Nested fs D.Tensor)) s))
+
+-- | 'emap' with structured elements.  The trailing dimensions @sh@ of the
+-- input are unrolled into the Haskell structure @'Nested' sh a@, the
+-- polymorphic function runs /once/ at @a = Tensor@ — every scalar operation
+-- in it becomes one whole-batch kernel — and the resulting structure's
+-- dimensions @sh'@ are rolled back into the tensor.  The structure may change
+-- shape: averaging the channels of each vertex is
+--
+-- > emapS (fmap (\(RGB r g b) -> (r + g + b) / 3))
+-- >   :: NamedTensor device dtype '[Batch n, Vector 3, RGB]
+-- >   -> NamedTensor device dtype '[Batch n, Vector 3]
+--
+-- and structural operations (folds over vertices, permutations, pattern
+-- matching on fields) are ordinary Haskell on the structure, still vectorized
+-- over the batch.
+--
+-- Cost: the structure is unrolled positionally — @numel sh@ @select@s in, one
+-- kernel per scalar operation in the formula, @numel sh'@ tensors stacked
+-- out.  This is the fusion of 'emap' extended to compound elements, and like
+-- 'gbindV' it suits /small, static/ element structures (vertices, channels,
+-- gates); it is not for structures with thousands of positions.  Where
+-- 'Torch.Typed.Representable.vmap' calls an opaque slice function once per
+-- batch position, 'emapS' runs a transparent one once in total.
+--
+-- The result shape @sh'@ is generally not inferable from the formula (the
+-- 'Nested' family is not injective), so annotate the result or apply the
+-- shapes with type applications: @emapS \@sh \@sh'@.
+emapS ::
+  forall sh sh' b dtype device.
+  (ExplodeShape sh, ExplodeShape sh') =>
+  (forall a. (Floating a, Cond a) => Nested sh a -> Nested sh' a) ->
+  NamedTensor device dtype (b ': sh) ->
+  NamedTensor device dtype (b ': sh')
+emapS f =
+  fromUnnamed . UnsafeMkTensor . implode @sh' . f @D.Tensor . explode @sh . toDynamic
+
+-- | 'ezipWith' with structured elements: the two-argument 'emapS'.  The two
+-- inputs share the batch dimension but may have different element structures.
+ezipWithS ::
+  forall shA shB sh' b dtype device.
+  (ExplodeShape shA, ExplodeShape shB, ExplodeShape sh') =>
+  (forall a. (Floating a, Cond a) => Nested shA a -> Nested shB a -> Nested sh' a) ->
+  NamedTensor device dtype (b ': shA) ->
+  NamedTensor device dtype (b ': shB) ->
+  NamedTensor device dtype (b ': sh')
+ezipWithS f x y =
+  fromUnnamed . UnsafeMkTensor . implode @sh' $
+    f @D.Tensor (explode @shA (toDynamic x)) (explode @shB (toDynamic y))
 
 -- | Staged version of 'Torch.Typed.Graded.gbind'.  Definitionally,
 --

--- a/hasktorch/src/Torch/Typed/Tensor.hs
+++ b/hasktorch/src/Torch/Typed/Tensor.hs
@@ -39,6 +39,7 @@ import Foreign.ForeignPtr
 import Foreign.Storable
 import GHC.Exts
 import GHC.Generics
+import Data.Functor.Compose (Compose)
 import GHC.TypeLits
 import qualified Torch.DType as D
 import qualified Torch.Device as D
@@ -160,6 +161,9 @@ type family ToNat (shape :: Size) :: Nat where
   ToNat (K1 _ _) = 1
   ToNat U1 = 1
   ToNat (Vector n) = n
+  -- A composed dimension is the product of its factors, following
+  -- hasktorch-naperian's @Size (Compose f g) = Size f * Size g@.
+  ToNat (Compose f g) = ToNat f * ToNat g
   ToNat a = ToNat (Rep (a ()))
 
 type family ToNats (shape :: Shape) :: [Nat] where

--- a/hasktorch/test/Torch/Typed/RepresentableSpec.hs
+++ b/hasktorch/test/Torch/Typed/RepresentableSpec.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -30,7 +31,10 @@ import qualified Torch.Device as D
 import Torch.HList
 import qualified Torch.Tensor as D
 import qualified Data.Vector.Sized as V
-import Torch.Typed.Factories ()
+import Torch.Typed.Autograd (grad)
+import Torch.Typed.Factories (ones)
+import Torch.Typed.Functional (sumNamedDim)
+import Torch.Typed.Parameter (makeIndependent, toDependent)
 import Torch.Typed.Representable
 import Torch.Typed.Tensor
 
@@ -41,7 +45,7 @@ data RGB a = RGB
     g :: a,
     b :: a
   }
-  deriving (Show, Eq, Generic, Default)
+  deriving (Show, Eq, Generic, Default, Functor)
 
 -- 'ToNat' is derived from 'Generic', so a user-defined structure needs no
 -- registration to be usable as a dimension.
@@ -113,3 +117,27 @@ spec = do
       let t = tabulate (\(i :. j :. HNil) -> fromIntegral (fromEnum i) * 10 + fromIntegral (fromEnum j)) :: NamedTensor '(D.CPU, 0) 'D.Float '[Vector 3, RGB]
           rows = dimUp t :: Vector 3 (NamedTensor '(D.CPU, 0) 'D.Float '[RGB])
       (D.asValue (toDynamic (V.index rows 1)) :: [Float]) `shouldBe` [10, 11, 12]
+  describe "vmap" $ do
+    -- rows r=[0,1], g=[10,11], b=[20,21]
+    let t = tabulate (\(i :. j :. HNil) -> fromIntegral (fromEnum i) * 10 + fromIntegral (fromEnum j)) :: NamedTensor '(D.CPU, 0) 'D.Float '[RGB, Vector 2]
+    it "matches its specification, dimDown . fmap g . dimUp" $ do
+      let g :: NamedTensor '(D.CPU, 0) 'D.Float '[Vector 2] -> NamedTensor '(D.CPU, 0) 'D.Float '[Vector 2]
+          g x = fromUnnamed (toUnnamed x * toUnnamed x)
+      (D.asValue (toDynamic (vmap g t)) :: [[Float]])
+        `shouldBe` (D.asValue (toDynamic (dimDown (fmap g (dimUp t)))) :: [[Float]])
+    it "maps a reduction, changing the shape under the mapped dimension" $ do
+      let sums = vmap (sumNamedDim @(Vector 2)) t :: NamedTensor '(D.CPU, 0) 'D.Float '[RGB]
+      (D.asValue (toDynamic sums) :: [Float]) `shouldBe` [1, 21, 41]
+    it "vmap2 zips along the shared dimension" $ do
+      let s = vmap2 (\a b -> a + b) t t :: NamedTensor '(D.CPU, 0) 'D.Float '[RGB, Vector 2]
+      (D.asValue (toDynamic s) :: [[Float]]) `shouldBe` [[0, 2], [20, 22], [40, 42]]
+    it "vscan carries state along the dimension" $ do
+      let s = vscan (+) (def :: NamedTensor '(D.CPU, 0) 'D.Float '[Vector 2]) t
+      (D.asValue (toDynamic s) :: [[Float]]) `shouldBe` [[0, 1], [10, 12], [30, 33]]
+    it "gradients flow through vmap" $ do
+      w <- makeIndependent (ones :: Tensor '(D.CPU, 0) 'D.Float '[2])
+      let wn = fromUnnamed (toDependent w) :: NamedTensor '(D.CPU, 0) 'D.Float '[Vector 2]
+          total = sumNamedDim @(Vector 2) (sumNamedDim @RGB (vmap (\c -> c * wn) t))
+          gw :. HNil = grad (toUnnamed total) (w :. HNil)
+      -- d/dw_j of sum_{c,j} t_{c,j} * w_j is the column sums of t
+      (D.asValue (toDynamic gw) :: [Float]) `shouldBe` [30, 33]

--- a/hasktorch/test/Torch/Typed/RepresentableSpec.hs
+++ b/hasktorch/test/Torch/Typed/RepresentableSpec.hs
@@ -21,6 +21,7 @@ module Torch.Typed.RepresentableSpec (spec) where
 
 import Data.Default.Class
 import Data.Finite (Finite)
+import Data.Functor.Compose (Compose (..))
 import Data.Proxy
 import Data.Vector.Sized (Vector)
 import GHC.Generics
@@ -64,6 +65,9 @@ testElem ::
 testElem = id
 
 type Image = NamedTensor '(D.CPU, 0) 'D.Float '[Batch 2, RGB]
+
+-- a compound dimension named by an ordinary nullary synonym
+type Triangle = Compose (Vector 3) RGB
 
 spec :: Spec
 spec = do
@@ -141,3 +145,22 @@ spec = do
           gw :. HNil = grad (toUnnamed total) (w :. HNil)
       -- d/dw_j of sum_{c,j} t_{c,j} * w_j is the column sums of t
       (D.asValue (toDynamic gw) :: [Float]) `shouldBe` [30, 33]
+  describe "dimGroup and dimUngroup" $ do
+    let tri = tabulate (\(k :. i :. c :. HNil) -> fromIntegral (fromEnum k) * 100 + fromIntegral (fromEnum i) * 10 + fromIntegral (fromEnum c)) :: NamedTensor '(D.CPU, 0) 'D.Float '[Batch 2, Vector 3, RGB]
+    it "a Compose dimension has the product size" $ do
+      dimsOf (Proxy @(NamedTensor '(D.CPU, 0) 'D.Float '[Batch 2, Triangle]))
+        `shouldBe` [2, 9]
+    it "dimGroup merges two dimensions without moving data" $ do
+      let grouped = dimGroup tri :: NamedTensor '(D.CPU, 0) 'D.Float '[Batch 2, Triangle]
+      shape grouped `shouldBe` [2, 9]
+      (D.asValue (D.reshape [-1] (toDynamic grouped)) :: [Float])
+        `shouldBe` (D.asValue (D.reshape [-1] (toDynamic tri)) :: [Float])
+    it "dimUngroup is the inverse of dimGroup" $ do
+      let roundtrip = dimUngroup (dimGroup tri) :: NamedTensor '(D.CPU, 0) 'D.Float '[Batch 2, Vector 3, RGB]
+      shape roundtrip `shouldBe` [2, 3, 3]
+      (D.asValue (D.reshape [-1] (toDynamic roundtrip)) :: [Float])
+        `shouldBe` (D.asValue (D.reshape [-1] (toDynamic tri)) :: [Float])
+    it "indexes the grouped dimension flat, row-major" $ do
+      -- flat position 5 is (vertex 1, channel 2)
+      let grouped = dimGroup tri :: NamedTensor '(D.CPU, 0) 'D.Float '[Batch 2, Triangle]
+      index grouped (1 :. 5 :. HNil) `shouldBe` 112

--- a/hasktorch/test/Torch/Typed/StagedSpec.hs
+++ b/hasktorch/test/Torch/Typed/StagedSpec.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE KindSignatures #-}
@@ -12,6 +14,8 @@
 
 module Torch.Typed.StagedSpec (spec) where
 
+import Data.Default.Class (Default)
+import qualified Data.Vector.Sized as V
 import Data.Vector.Sized (Vector)
 import GHC.Generics
 import GHC.TypeLits
@@ -32,7 +36,11 @@ data RGB a = RGB
     g :: a,
     b :: a
   }
-  deriving (Show, Eq, Generic)
+  deriving (Show, Eq, Generic, Functor, Default)
+
+-- The element view of '[Vector 3, RGB]: an ordinary type synonym is enough,
+-- because Nested reduces structurally.
+type Triangle a = Vector 3 (RGB a)
 
 type M = TensorMonad '(D.CPU, 0) 'D.Float
 
@@ -86,6 +94,25 @@ stagedG ::
   M '[Batch 2, RGB]
 stagedG k = gbindV @'[RGB] baseT k
 
+-- a batch of two triangles: tri[k,i,c] = k*100 + i*10 + c
+tri :: NamedTensor '(D.CPU, 0) 'D.Float '[Batch 2, Vector 3, RGB]
+tri = tabulateList @'[Batch 2, Vector 3, RGB] @'D.Float @'(D.CPU, 0) (\[k, i, c] -> fromIntegral (k * 100 + i * 10 + c))
+
+-- structured formulas, each written once, polymorphically
+
+sLum :: (Floating a, Cond a) => Triangle a -> Vector 3 a
+sLum = fmap (\(RGB r' g' b') -> (r' + g' + b') / 3)
+
+sCentroid :: (Floating a, Cond a) => Triangle a -> RGB a
+sCentroid = fmap (/ 3) . foldr1 addRGB
+  where
+    addRGB (RGB x y z) (RGB x' y' z') = RGB (x + x') (y + y') (z + z')
+
+sDist2 :: (Floating a, Cond a) => Triangle a -> Triangle a -> Vector 3 a
+sDist2 =
+  V.zipWith
+    (\(RGB x y z) (RGB x' y' z') -> (x - x') ^ 2 + (y - y') ^ 2 + (z - z') ^ 2)
+
 spec :: Spec
 spec = do
   describe "Staged element-wise ops" $ do
@@ -103,6 +130,28 @@ spec = do
     it "emap preserves shape and dtype" $ do
       shape (emap fPoly timg) `shouldBe` [2, 3]
       dtype (emap fPoly timg) `shouldBe` D.Float
+  describe "structured elements (emapS / ezipWithS)" $ do
+    it "emapS id is the identity" $ do
+      elemsOf (emapS @'[Vector 3, RGB] @'[Vector 3, RGB] id tri) `shouldBe` elemsOf tri
+    it "structural operations work: vertex reversal" $ do
+      elemsOf (emapS @'[Vector 3, RGB] @'[Vector 3, RGB] V.reverse tri)
+        `shouldBe` [20, 21, 22, 10, 11, 12, 0, 1, 2, 120, 121, 122, 110, 111, 112, 100, 101, 102]
+    it "changes the element structure: per-vertex channel mean" $ do
+      let out = emapS @'[Vector 3, RGB] @'[Vector 3] sLum tri
+      shape out `shouldBe` [2, 3]
+      elemsOf out `shouldBe` [1, 11, 21, 101, 111, 121]
+    it "folds over the structure: centroid of the vertices" $ do
+      elemsOf (emapS @'[Vector 3, RGB] @'[RGB] sCentroid tri)
+        `shouldBe` [10, 11, 12, 110, 111, 112]
+    it "agrees with the same formula instantiated per element at a = Float" $ do
+      let idx k i c = indexList tri [k, i, c]
+          refK k = V.toList (sLum (V.generate (\i -> RGB (idx k (fromEnum i) 0) (idx k (fromEnum i) 1) (idx k (fromEnum i) 2))))
+      elemsOf (emapS @'[Vector 3, RGB] @'[Vector 3] sLum tri)
+        `shouldBe` (refK 0 ++ refK 1)
+    it "ezipWithS: squared distance between corresponding vertices" $ do
+      let shifted = emapS @'[Vector 3, RGB] @'[Vector 3, RGB] (fmap (fmap (+ 1))) tri
+      elemsOf (ezipWithS @'[Vector 3, RGB] @'[Vector 3, RGB] @'[Vector 3] sDist2 tri shifted)
+        `shouldBe` [3, 3, 3, 3, 3, 3]
   describe "gbindV vs gbind (oracle)" $ do
     it "satisfies gbindV m k == gbind m (fromNamed . tabulate . k) (affine)" $ do
       elemsOf (toNamed (stagedG kAffine)) `shouldBe` elemsOf (toNamed (oracleG kAffine))

--- a/hasktorch/test/Torch/Typed/StagedSpec.hs
+++ b/hasktorch/test/Torch/Typed/StagedSpec.hs
@@ -15,6 +15,7 @@
 module Torch.Typed.StagedSpec (spec) where
 
 import Data.Default.Class (Default)
+import Data.Functor.Compose (Compose (..))
 import qualified Data.Vector.Sized as V
 import Data.Vector.Sized (Vector)
 import GHC.Generics
@@ -152,6 +153,10 @@ spec = do
       let shifted = emapS @'[Vector 3, RGB] @'[Vector 3, RGB] (fmap (fmap (+ 1))) tri
       elemsOf (ezipWithS @'[Vector 3, RGB] @'[Vector 3, RGB] @'[Vector 3] sDist2 tri shifted)
         `shouldBe` [3, 3, 3, 3, 3, 3]
+    it "works over a grouped Compose dimension" $ do
+      let grouped = dimGroup tri :: NamedTensor '(D.CPU, 0) 'D.Float '[Batch 2, Compose (Vector 3) RGB]
+          out = emapS @'[Compose (Vector 3) RGB] @'[Vector 3] (sLum . getCompose) grouped
+      elemsOf out `shouldBe` elemsOf (emapS @'[Vector 3, RGB] @'[Vector 3] sLum tri)
   describe "gbindV vs gbind (oracle)" $ do
     it "satisfies gbindV m k == gbind m (fromNamed . tabulate . k) (affine)" $ do
       elemsOf (toNamed (stagedG kAffine)) `shouldBe` elemsOf (toNamed (oracleG kAffine))


### PR DESCRIPTION
The Naperian dimension machinery already moved dimensions between tensor and structure; this adds the JAX-style structural primitives on top of it:

- vmap g applies g per position of the outermost named dimension, specified (and tested) as dimDown . fmap g . dimUp, but implemented without materialising the functor, so it needs no instances and g may change shape, dtype, and device.  vmap2 zips along a shared dimension whose type guarantees the lengths agree.
- vscan folds a carry along the dimension and stacks the intermediate carries - the recurrence primitive; an RNN over a Vector n time axis is vscan cell h0.
- sumNamedDim joins meanNamedDim in Torch.Typed.Functional so named reductions need no toUnnamed/fromUnnamed round trip; the tutorial treats those as internals, not everyday API.

Gradients flow through all of them (unbind/stack are autograd ops), covered by a grad-through-vmap test.  The Moving Dimensions chapter gains a section on the trio, including an honest account of the cost model (per-position calls, no batching-rule rewriter) and of how vmap and the staged chapter's emap are the same lifting split by function transparency.