### PR TITLE
Add value-threaded PureGenerator and multinomial sampling

### DIFF
--- a/hasktorch/hasktorch.cabal
+++ b/hasktorch/hasktorch.cabal
@@ -61,6 +61,7 @@ library
                     , Torch.Typed.Auxiliary
                     , Torch.Typed.Factories
                     , Torch.Typed.Functional
+                    , Torch.Typed.Random
                     , Torch.Typed.NN
                     , Torch.Typed.NN.Convolution
                     , Torch.Typed.NN.Normalization
@@ -178,6 +179,7 @@ test-suite spec
                     , Torch.Typed.TensorSpec0
                     , Torch.Typed.TensorSpec1
                     , Torch.Typed.FactoriesSpec
+                    , Torch.Typed.RandomSpec
                     , Torch.Typed.FunctionalSpec0
                     , Torch.Typed.FunctionalSpec1
                     , Torch.Typed.FunctionalSpec2

--- a/hasktorch/src/Torch/Random.hs
+++ b/hasktorch/src/Torch/Random.hs
@@ -13,6 +13,10 @@ module Torch.Random
     randint',
     normal,
     normal',
+    PureGenerator,
+    mkPureGenerator,
+    withPureGenerator,
+    multinomial,
   )
 where
 
@@ -28,6 +32,7 @@ import Torch.Device
 import Torch.Internal.Cast
 import Torch.Internal.Class (Castable (..))
 import qualified Torch.Internal.Const as ATen
+import qualified Torch.Internal.Managed.Native as ATen
 import qualified Torch.Internal.Managed.TensorFactories as LibTorch
 import qualified Torch.Internal.Managed.Type.Generator as ATen
 import qualified Torch.Internal.Type as ATen
@@ -42,23 +47,23 @@ newtype Generator = UnsafeGenerator
   }
   deriving (Eq, Show)
 
-mkGenerator :: Device -> Word64 -> IO Generator
-mkGenerator device seed =
+newGeneratorPtr :: Device -> Word64 -> IO (ForeignPtr ATen.Generator)
+newGeneratorPtr device seed =
   case device of
-    Device CPU _ -> do
-      genPtr <- ATen.newCPUGenerator seed
-      genenerator <- newTVarIO (Right genPtr)
-      return $ UnsafeGenerator genenerator
+    Device CPU _ -> ATen.newCPUGenerator seed
     Device CUDA idx -> do
       genPtr <- ATen.newCUDAGenerator (fromIntegral idx)
       ATen.generator_set_current_seed genPtr seed
-      genenerator <- newTVarIO (Right genPtr)
-      return $ UnsafeGenerator genenerator
+      return genPtr
     Device MPS _ -> do
       genPtr <- ATen.newMPSGenerator
       ATen.generator_set_current_seed genPtr seed
-      genenerator <- newTVarIO (Right genPtr)
-      return $ UnsafeGenerator genenerator
+      return genPtr
+
+mkGenerator :: Device -> Word64 -> IO Generator
+mkGenerator device seed = do
+  genPtr <- newGeneratorPtr device seed
+  UnsafeGenerator <$> newTVarIO (Right genPtr)
 
 type RandomGenFunc = ForeignPtr ATen.IntArray -> ForeignPtr ATen.Generator -> ForeignPtr ATen.TensorOptions -> IO (ForeignPtr ATen.Tensor)
 
@@ -82,16 +87,7 @@ generatorFactory func size options (UnsafeGenerator generator) =
         Left v -> return (Left v)
     genPtr <- case mGenerator of
       Right gen -> return gen
-      Left (seed, device) -> case device of
-        Device CPU _ -> ATen.newCPUGenerator seed
-        Device CUDA idx -> do
-          gen <- ATen.newCUDAGenerator (fromIntegral idx)
-          ATen.generator_set_current_seed gen seed
-          return gen
-        Device MPS _ -> do
-          gen <- ATen.newMPSGenerator
-          ATen.generator_set_current_seed gen seed
-          return gen
+      Left (seed, device) -> newGeneratorPtr device seed
     tensor <- cast3 func size genPtr options
     nextGenenerator <- newTVarIO (Right genPtr)
     return (tensor, UnsafeGenerator nextGenenerator)
@@ -206,3 +202,40 @@ normal' ::
   -- | output
   (Tensor, Generator)
 normal' mean std size = normal mean std size defaultOpts
+
+-- | An RNG generator threaded as an immutable value: never mutated in place,
+-- advanced by cloning on each draw (see 'withPureGenerator').
+newtype PureGenerator = UnsafePureGenerator (ForeignPtr ATen.Generator)
+
+-- | The wrapped pointer is an allocation address, not a description of the RNG
+-- stream, so rendering it would make output vary between runs of the same
+-- program. 'Generator' elides its contents for the same reason.
+instance Show PureGenerator where
+  show _ = "PureGenerator"
+
+mkPureGenerator :: Device -> Word64 -> IO PureGenerator
+mkPureGenerator device seed = UnsafePureGenerator <$> newGeneratorPtr device seed
+
+-- | Draw from a 'PureGenerator', returning the result together with the
+-- generator to use for the next draw. The argument is left untouched: ATen
+-- advances a generator in place, so the draw runs against a clone.
+withPureGenerator :: PureGenerator -> (ForeignPtr ATen.Generator -> IO a) -> (a, PureGenerator)
+withPureGenerator (UnsafePureGenerator g) action = unsafePerformIO $ do
+  g' <- ATen.generator_clone g
+  a <- action g'
+  pure (a, UnsafePureGenerator g')
+{-# NOINLINE withPureGenerator #-}
+
+multinomial ::
+  -- | t
+  Tensor ->
+  -- | num_samples
+  Int ->
+  -- | replacement
+  Bool ->
+  -- | generator
+  PureGenerator ->
+  -- | output
+  (Tensor, PureGenerator)
+multinomial probs numSamples replacement gen =
+  withPureGenerator gen (\g -> cast4 ATen.multinomial_tlbG probs numSamples replacement g)

--- a/hasktorch/src/Torch/Typed.hs
+++ b/hasktorch/src/Torch/Typed.hs
@@ -11,6 +11,7 @@ module Torch.Typed
     module Torch.Typed.NN,
     module Torch.Typed.Optim,
     module Torch.Typed.Parameter,
+    module Torch.Typed.Random,
     module Torch.Typed.Serialize,
     module Torch.Typed.Tensor,
     module Torch.Typed.Vision,
@@ -38,6 +39,7 @@ import Torch.Typed.Functional
 import Torch.Typed.NN
 import Torch.Typed.Optim
 import Torch.Typed.Parameter hiding (parameterToDType, parameterToDevice)
+import Torch.Typed.Random
 import Torch.Typed.Serialize
 import Torch.Typed.Tensor hiding (toDType, toDevice)
 import Torch.Typed.Vision

--- a/hasktorch/src/Torch/Typed/Random.hs
+++ b/hasktorch/src/Torch/Typed/Random.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE NoStarIsType #-}
+
+module Torch.Typed.Random where
+
+import Data.Word (Word64)
+import GHC.TypeLits
+import qualified Torch.DType as D
+import qualified Torch.Device as D
+import qualified Torch.Random as D
+import Torch.Typed.Auxiliary
+import Torch.Typed.Tensor
+
+newtype PureGenerator (device :: (D.DeviceType, Nat)) = UnsafePureGenerator D.PureGenerator
+
+mkPureGenerator :: forall device. KnownDevice device => Word64 -> IO (PureGenerator device)
+mkPureGenerator seed = UnsafePureGenerator <$> D.mkPureGenerator (deviceVal @device) seed
+
+-- | The shape multinomial sampling produces: the trailing dimension is
+-- replaced by the number of samples drawn, the leading batch dimensions are
+-- carried through.
+type family MultinomialShape (samples :: Nat) (shape :: [Nat]) :: [Nat] where
+  MultinomialShape samples '[n] = '[samples]
+  MultinomialShape samples (m ': ns) = m ': MultinomialShape samples ns
+
+-- | Sample indices from the categorical distributions along the last dimension
+-- of the input. ATen draws only from floating point probabilities.
+multinomial ::
+  forall samples shape dtype device.
+  ( KnownNat samples,
+    DTypeIsFloatingPoint device dtype
+  ) =>
+  -- | replacement
+  Bool ->
+  -- | input
+  Tensor device dtype shape ->
+  -- | generator
+  PureGenerator device ->
+  -- | output
+  (Tensor device 'D.Int64 (MultinomialShape samples shape), PureGenerator device)
+multinomial replacement input (UnsafePureGenerator g) =
+  let (out, g') = D.multinomial (toDynamic input) (natValI @samples) replacement g
+   in (UnsafeMkTensor out, UnsafePureGenerator g')

--- a/hasktorch/test/RandomSpec.hs
+++ b/hasktorch/test/RandomSpec.hs
@@ -19,3 +19,24 @@ spec = do
         (t3, _) = randn' [5] generator
     shape t2 `shouldBe` [4]
     ((asValue t) :: [Float]) `shouldBe` take 4 (asValue t3)
+  it "multinomial is a pure function of the generator value" $ do
+    g <- mkPureGenerator (Device CPU 0) 0
+    let probs = asTensor ([0.1, 0.2, 0.3, 0.4] :: [Float])
+        (a, _) = multinomial probs 5 True g
+        (b, _) = multinomial probs 5 True g
+    (asValue a :: [Int]) `shouldBe` (asValue b :: [Int])
+  it "multinomial is reproducible across generators from one seed" $ do
+    g1 <- mkPureGenerator (Device CPU 0) 0
+    g2 <- mkPureGenerator (Device CPU 0) 0
+    let probs = asTensor ([0.1, 0.2, 0.3, 0.4] :: [Float])
+        (a1, g1') = multinomial probs 5 True g1
+        (b1, _) = multinomial probs 5 True g1'
+        (a2, g2') = multinomial probs 5 True g2
+        (b2, _) = multinomial probs 5 True g2'
+    (asValue a1 :: [Int], asValue b1 :: [Int])
+      `shouldBe` (asValue a2 :: [Int], asValue b2 :: [Int])
+  it "multinomial respects the distribution" $ do
+    g <- mkPureGenerator (Device CPU 0) 0
+    let probs = asTensor ([0, 1, 0, 0] :: [Float])
+        (t, _) = multinomial probs 10 True g
+    (asValue t :: [Int]) `shouldBe` replicate 10 1

--- a/hasktorch/test/Spec.hs
+++ b/hasktorch/test/Spec.hs
@@ -42,6 +42,7 @@ import qualified Torch.Typed.NN.TransformerSpec
 import qualified Torch.Typed.NNSpec
 import qualified Torch.Typed.NamedTensorSpec
 import qualified Torch.Typed.OptimSpec
+import qualified Torch.Typed.RandomSpec
 import qualified Torch.Typed.RepresentableSpec
 import qualified Torch.Typed.NMSSpec
 import qualified Torch.Typed.StagedSpec
@@ -93,6 +94,7 @@ main = hspec $ do
   Torch.Typed.NNSpec.spec
   Torch.Typed.NamedTensorSpec.spec
   Torch.Typed.OptimSpec.spec
+  Torch.Typed.RandomSpec.spec
   Torch.Typed.RepresentableSpec.spec
   Torch.Typed.NMSSpec.spec
   Torch.Typed.StagedSpec.spec

--- a/hasktorch/test/Torch/Typed/RandomSpec.hs
+++ b/hasktorch/test/Torch/Typed/RandomSpec.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Torch.Typed.RandomSpec
+  ( Torch.Typed.RandomSpec.spec,
+  )
+where
+
+import Test.Hspec (Spec, describe, it)
+import Test.QuickCheck ()
+import Torch.Typed
+import Torch.Typed.AuxiliarySpec
+
+spec :: Spec
+spec = foldMap spec' availableDevices
+
+spec' :: Device -> Spec
+spec' device =
+  describe ("for " <> show device) $ do
+    it "multinomial" $ case device of
+      Device {deviceType = CPU, deviceIndex = 0} -> do
+        g <- mkPureGenerator @'( 'CPU, 0) 0
+        let probs = ones :: Tensor '( 'CPU, 0) 'Float '[4]
+            (t, _) = multinomial @3 True probs g
+        checkDynamicTensorAttributes t
+      Device {deviceType = CUDA, deviceIndex = 0} -> do
+        g <- mkPureGenerator @'( 'CUDA, 0) 0
+        let probs = ones :: Tensor '( 'CUDA, 0) 'Float '[4]
+            (t, _) = multinomial @3 True probs g
+        checkDynamicTensorAttributes t
+      Device {deviceType = MPS, deviceIndex = 0} -> do
+        g <- mkPureGenerator @'( 'MPS, 0) 0
+        let probs = ones :: Tensor '( 'MPS, 0) 'Float '[4]
+            (t, _) = multinomial @3 True probs g
+        checkDynamicTensorAttributes t


### PR DESCRIPTION
Torch.Random's Generator mutates the underlying ATen generator in place, so two draws from the same Generator value disagree and a sequence is not reproducible from its seed alone.

PureGenerator threads the RNG as an immutable value instead: withPureGenerator clones the ATen generator before each draw and advances only the clone, so the input is never mutated and a given PureGenerator value always produces the same output. Cloning also preserves the stream position, so the returned generator continues the same stream rather than starting a reseeded one. Adds multinomial on top of it.

Torch.Typed.Random is the typed counterpart, following the one typed module per untyped module layout the rest of Torch.Typed uses. It tags PureGenerator with a device, requires floating point probabilities, and derives the output shape with MultinomialShape, which replaces the trailing dimension with the sample count.

Extracts newGeneratorPtr for the device dispatch that mkGenerator and generatorFactory each spelled out separately, so the two generator types construct their ATen handles the same way.