### PR TITLE
Write the attention chapter's equations in real KaTeX

### DIFF
--- a/hasktorch/doc/13-attention.md
+++ b/hasktorch/doc/13-attention.md
@@ -17,9 +17,9 @@ learns.
 
 A paper writes attention as
 
-> M ∈ ℝ^{s×s},  M_{ij} = 0 if j ≤ i, −∞ otherwise
->
-> Attention(Q, K, V) = softmax(QKᵀ/√d + M) V
+$$M \in \mathbb{R}^{s \times s}, \qquad M_{ij} = 0 \text{ if } j \le i, \text{ and } -\infty \text{ otherwise}$$
+
+$$\mathrm{Attention}(Q, K, V) = \mathrm{softmax}\left(\frac{Q K^{\top}}{\sqrt{d}} + M\right) V$$
 
 and the code says exactly that. The mask is a tensor *defined by its
 formula*, through `tabulate`:
@@ -31,8 +31,8 @@ causalMask = toUnnamed (tabulateList @'[Vector S, Vector S] @'D.Float @Dev mask)
     mask [i, j] = if j <= i then 0 else -1 / 0
 ```
 
-and attention is its equation, with the ℝ^{s×e} annotations moved
-into the type where the compiler can read them:
+and attention is its equation, with the paper's ℝ shape annotations
+moved into the type where the compiler can read them:
 
 ```haskell
 attend :: T '[S, E] -> T '[S, E] -> T '[S, E] -> T '[S, E]
@@ -83,4 +83,4 @@ The practical reading order is therefore: understand this chapter's
 sixty lines first, then read the library transformer as "the same
 equations, made reusable" — and let the types tell you which of its
 parameters is which, because every shape annotation in its long
-signatures is one of the ℝ^{...} superscripts from the paper, checked.
+signatures is one of the paper's ℝ superscripts, checked.


### PR DESCRIPTION
The two display equations were unicode pseudo-notation with literal ^{}/_{} markup, which the page's KaTeX auto-render has no way to recognize, so they showed up as unformatted almost-LaTeX.  Rewrite them as $$ display math, which survives cheapskate untouched and is one of auto-render's default delimiters (chapter 6 already renders its equations this way).  The LaTeX deliberately avoids backslash-punctuation sequences (\\ row separators, \!) that cheapskate's escape handling would eat.  The two inline R^{s×e} mentions in prose become words, since inline \( \) delimiters do not survive cheapskate.